### PR TITLE
feat(llm,runtime,cli): stream LLM output token-by-token in the CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tracing",
  "url",
 ]

--- a/crates/interface-cli/src/main.rs
+++ b/crates/interface-cli/src/main.rs
@@ -1,9 +1,6 @@
 use std::io::{self, Write as IoWrite};
 use std::path::{Path, PathBuf};
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
-};
+use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use assistant_core::{skill::SkillSource, AssistantConfig, Interface};
@@ -198,21 +195,51 @@ async fn cmd_review(storage: &StorageLayer, registry: &SkillRegistry) -> Result<
     Ok(())
 }
 
+// ── Token printer ─────────────────────────────────────────────────────────────
+
+/// Spawn a background task that prints streaming tokens to stdout as they
+/// arrive via `token_rx`.  The first token clears the spinner line before
+/// printing, giving a seamless transition.  Returns the join handle; the
+/// task exits automatically when the sender is dropped.
+fn start_token_printer(
+    mut token_rx: tokio::sync::mpsc::UnboundedReceiver<String>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut first = true;
+        let mut stdout = io::stdout();
+        while let Some(token) = token_rx.recv().await {
+            if first {
+                // Clear any spinner residue on the current line.
+                print!("\r");
+                first = false;
+            }
+            print!("{token}");
+            let _ = stdout.flush();
+        }
+        // Ensure the answer ends on its own line.
+        if !first {
+            println!();
+            let _ = stdout.flush();
+        }
+    })
+}
+
 // ── Spinner ───────────────────────────────────────────────────────────────────
 
-/// Spawn a background task that prints a spinner until `stop` is set to `true`.
-/// Returns the `Arc<AtomicBool>` stop flag and the task join handle.
-/// Call `stop.store(true, Ordering::Relaxed)` then await the handle to cleanly stop.
-fn start_spinner() -> (Arc<AtomicBool>, tokio::task::JoinHandle<()>) {
-    let stop = Arc::new(AtomicBool::new(false));
-    let stop_clone = stop.clone();
+/// Spawn a background task that prints a spinner.  Used during tool-call
+/// iterations where the LLM produces no content tokens.
+fn start_spinner() -> (
+    tokio::sync::watch::Sender<bool>,
+    tokio::task::JoinHandle<()>,
+) {
+    let (stop_tx, mut stop_rx) = tokio::sync::watch::channel(false);
     let handle = tokio::spawn(async move {
         let frames = ['-', '\\', '|', '/'];
         let mut i = 0usize;
         let mut stdout = io::stdout();
         loop {
-            if stop_clone.load(Ordering::Relaxed) {
-                // Clear the spinner line
+            if *stop_rx.borrow() {
+                // Clear the spinner line.
                 print!("\r   \r");
                 let _ = stdout.flush();
                 break;
@@ -220,10 +247,17 @@ fn start_spinner() -> (Arc<AtomicBool>, tokio::task::JoinHandle<()>) {
             print!("\r{} ", frames[i % frames.len()]);
             let _ = stdout.flush();
             i += 1;
-            tokio::time::sleep(std::time::Duration::from_millis(120)).await;
+            tokio::select! {
+                _ = tokio::time::sleep(std::time::Duration::from_millis(120)) => {}
+                _ = stop_rx.changed() => {
+                    print!("\r   \r");
+                    let _ = stdout.flush();
+                    break;
+                }
+            }
         }
     });
-    (stop, handle)
+    (stop_tx, handle)
 }
 
 // ── Print help ────────────────────────────────────────────────────────────────
@@ -430,22 +464,28 @@ async fn main() -> Result<()> {
                     continue;
                 }
 
-                // Normal user input — run through the orchestrator.
-                let (stop_spinner, spinner_handle) = start_spinner();
-                let turn_result = orchestrator
-                    .run_turn(input, conversation_id, Interface::Cli)
-                    .await;
-                stop_spinner.store(true, Ordering::Relaxed);
-                let _ = spinner_handle.await;
+                // Normal user input — run through the orchestrator with streaming.
+                let (token_tx, token_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
 
-                match turn_result {
-                    Ok(result) => {
-                        println!("\n{}\n", result.answer);
-                    }
-                    Err(e) => {
-                        eprintln!("\nError: {e}\n");
-                    }
+                // Show a spinner while the LLM is working (e.g. during tool calls).
+                let (stop_spinner, spinner_handle) = start_spinner();
+
+                // Print tokens as they arrive; spinner clears on the first token.
+                let printer_handle = start_token_printer(token_rx);
+
+                let turn_result = orchestrator
+                    .run_turn_streaming(input, conversation_id, Interface::Cli, token_tx)
+                    .await;
+
+                // Stop spinner (no-op if tokens already cleared it).
+                let _ = stop_spinner.send(true);
+                let _ = spinner_handle.await;
+                let _ = printer_handle.await;
+
+                if let Err(e) = turn_result {
+                    eprintln!("\nError: {e}\n");
                 }
+                println!();
             }
 
             Ok(Signal::CtrlC) => {

--- a/crates/llm/Cargo.toml
+++ b/crates/llm/Cargo.toml
@@ -20,6 +20,8 @@ reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-feature
 regex = "1"
 # URL parsing (same version as ollama-rs dependency)
 url = "2"
+# Stream utilities (used by ollama-rs; needed here for StreamExt)
+tokio-stream = "0.1"
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/llm/src/client.rs
+++ b/crates/llm/src/client.rs
@@ -164,6 +164,39 @@ impl LlmClient {
         }
     }
 
+    /// Send a chat turn, streaming content tokens to `token_tx` as they arrive.
+    ///
+    /// For native tool-call mode: content tokens are sent as each chunk arrives
+    /// from the Ollama streaming endpoint. Tool-call responses typically have
+    /// empty content, so no tokens are forwarded for those turns.
+    ///
+    /// For ReAct mode: the full response is accumulated, then parsed. If the
+    /// result is a `FinalAnswer`, the answer text is sent as a single token.
+    ///
+    /// Returns the parsed [`LlmResponse`] once the model is done.
+    pub async fn chat_stream(
+        &self,
+        system_prompt: &str,
+        history: &[ChatHistoryMessage],
+        skills: &[&SkillDef],
+        token_tx: &tokio::sync::mpsc::UnboundedSender<String>,
+    ) -> anyhow::Result<LlmResponse> {
+        match self.effective_mode() {
+            ToolCallMode::Native => {
+                self.chat_native_stream(system_prompt, history, skills, token_tx)
+                    .await
+            }
+            ToolCallMode::React => {
+                self.chat_react_stream(system_prompt, history, skills, token_tx)
+                    .await
+            }
+            ToolCallMode::Auto => {
+                self.chat_auto_stream(system_prompt, history, skills, token_tx)
+                    .await
+            }
+        }
+    }
+
     // ── Mode resolution ───────────────────────────────────────────────────────
 
     fn effective_mode(&self) -> ToolCallMode {
@@ -339,6 +372,202 @@ impl LlmClient {
         let raw_text = response.message.content;
         let step = ReActParser::parse(&raw_text);
         Ok(react_step_to_response(step))
+    }
+
+    // ── Streaming native (via reqwest) ───────────────────────────────────────
+
+    /// Streaming variant of [`chat_native`].  Content tokens are forwarded to
+    /// `token_tx` as each NDJSON chunk arrives.  Tool-call responses typically
+    /// carry empty content, so nothing will be forwarded during tool turns.
+    async fn chat_native_stream(
+        &self,
+        system_prompt: &str,
+        history: &[ChatHistoryMessage],
+        skills: &[&SkillDef],
+        token_tx: &tokio::sync::mpsc::UnboundedSender<String>,
+    ) -> anyhow::Result<LlmResponse> {
+        debug!(
+            model = %self.config.model,
+            skills = skills.len(),
+            "Sending native streaming request to Ollama"
+        );
+
+        let messages = build_json_messages(system_prompt, history);
+        let tools: Vec<Value> = skills.iter().map(|s| skill_to_tool_json(s)).collect();
+
+        let body = json!({
+            "model": self.config.model,
+            "messages": messages,
+            "tools": tools,
+            "stream": true,
+        });
+
+        let url = format!("{}/api/chat", self.config.base_url.trim_end_matches('/'));
+
+        let resp = self
+            .http
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .context("HTTP streaming request to Ollama /api/chat failed")?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            anyhow::bail!("Ollama returned {status}: {text}");
+        }
+
+        let mut content_buf = String::new();
+        let mut tool_calls_buf: Vec<Value> = Vec::new();
+        let mut line_buf = String::new();
+        let mut resp = resp;
+
+        while let Some(chunk) = resp.chunk().await? {
+            let chunk_str = String::from_utf8_lossy(&chunk);
+            line_buf.push_str(&chunk_str);
+
+            // Process all complete newline-delimited JSON lines.
+            while let Some(pos) = line_buf.find('\n') {
+                let line = line_buf[..pos].trim().to_string();
+                line_buf = line_buf[pos + 1..].to_string();
+
+                if line.is_empty() {
+                    continue;
+                }
+
+                if let Ok(json) = serde_json::from_str::<Value>(&line) {
+                    // Forward content tokens immediately.
+                    if let Some(content) = json.pointer("/message/content").and_then(|v| v.as_str())
+                    {
+                        if !content.is_empty() {
+                            content_buf.push_str(content);
+                            let _ = token_tx.send(content.to_string());
+                        }
+                    }
+                    // Accumulate tool calls (appear near end of stream).
+                    if let Some(tcs) = json
+                        .pointer("/message/tool_calls")
+                        .and_then(|v| v.as_array())
+                    {
+                        tool_calls_buf.extend(tcs.iter().cloned());
+                    }
+                }
+            }
+        }
+
+        // Determine final response type from accumulated data.
+        if let Some(first) = tool_calls_buf.first() {
+            let name = first
+                .pointer("/function/name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let params = first
+                .pointer("/function/arguments")
+                .cloned()
+                .unwrap_or(Value::Object(serde_json::Map::new()));
+
+            if !name.is_empty() {
+                debug!(skill = %name, "Native streaming: tool call received");
+                return Ok(LlmResponse::ToolCall { name, params });
+            }
+        }
+
+        debug!("Native streaming: final answer received");
+        Ok(LlmResponse::FinalAnswer(content_buf))
+    }
+
+    // ── Streaming ReAct (via ollama-rs) ──────────────────────────────────────
+
+    /// Streaming variant of [`chat_react`].  The full text is accumulated from
+    /// the stream before parsing.  If the result is a `FinalAnswer`, the answer
+    /// text is forwarded to `token_tx` as a single chunk.  Raw ReAct-format
+    /// content (THOUGHT/ACTION markers) is not forwarded to avoid confusing UI.
+    async fn chat_react_stream(
+        &self,
+        system_prompt: &str,
+        history: &[ChatHistoryMessage],
+        skills: &[&SkillDef],
+        token_tx: &tokio::sync::mpsc::UnboundedSender<String>,
+    ) -> anyhow::Result<LlmResponse> {
+        use tokio_stream::StreamExt as _;
+
+        debug!(
+            model = %self.config.model,
+            "Sending ReAct streaming request to Ollama"
+        );
+
+        let react_system = if system_prompt.is_empty() {
+            build_system_prompt(skills)
+        } else {
+            format!("{}\n\n{}", system_prompt, build_system_prompt(skills))
+        };
+
+        let messages = build_ollama_messages(&react_system, history);
+        let request = ChatMessageRequest::new(self.config.model.clone(), messages);
+
+        let mut stream = self
+            .ollama
+            .send_chat_messages_stream(request)
+            .await
+            .map_err(|e| anyhow::anyhow!("Ollama streaming chat request failed: {e}"))?;
+
+        let mut raw_text = String::new();
+        while let Some(Ok(res)) = stream.next().await {
+            raw_text.push_str(&res.message.content);
+        }
+
+        let step = ReActParser::parse(&raw_text);
+
+        // Only forward the clean answer text, not raw ReAct markers.
+        if let ReActStep::Answer(ref text) = step {
+            let _ = token_tx.send(text.clone());
+        }
+
+        Ok(react_step_to_response(step))
+    }
+
+    // ── Streaming auto mode ───────────────────────────────────────────────────
+
+    async fn chat_auto_stream(
+        &self,
+        system_prompt: &str,
+        history: &[ChatHistoryMessage],
+        skills: &[&SkillDef],
+        token_tx: &tokio::sync::mpsc::UnboundedSender<String>,
+    ) -> anyhow::Result<LlmResponse> {
+        debug!("Auto streaming: trying native tool-calling first");
+
+        match self
+            .chat_native_stream(system_prompt, history, skills, token_tx)
+            .await
+        {
+            Ok(response @ LlmResponse::ToolCall { .. }) => {
+                self.set_tool_call_capable(true);
+                debug!("Auto streaming: model supports native tool-calling");
+                Ok(response)
+            }
+            Ok(LlmResponse::FinalAnswer(text)) if ReActParser::looks_like_react(&text) => {
+                warn!(
+                    "Auto streaming: native response looks like ReAct \
+                     — switching to ReAct for this session"
+                );
+                self.set_tool_call_capable(false);
+                // Re-parse without a second LLM call; tokens already forwarded.
+                Ok(react_step_to_response(ReActParser::parse(&text)))
+            }
+            Ok(response) => {
+                self.set_tool_call_capable(true);
+                Ok(response)
+            }
+            Err(err) => {
+                warn!(%err, "Auto streaming: native failed, falling back to ReAct");
+                self.set_tool_call_capable(false);
+                self.chat_react_stream(system_prompt, history, skills, token_tx)
+                    .await
+            }
+        }
     }
 }
 

--- a/crates/runtime/src/orchestrator.rs
+++ b/crates/runtime/src/orchestrator.rs
@@ -110,6 +110,35 @@ impl ReactOrchestrator {
         conversation_id: Uuid,
         interface: Interface,
     ) -> Result<TurnResult> {
+        self.run_turn_internal(user_message, conversation_id, interface, None)
+            .await
+    }
+
+    /// Process one turn of the conversation, streaming final-answer tokens to
+    /// `token_tx` as they arrive from the LLM.
+    ///
+    /// Tokens are forwarded only for the final answer step.  During tool-call
+    /// iterations the native Ollama endpoint produces empty content, so nothing
+    /// is forwarded then.  Drop or close the receiver once this method returns
+    /// to signal the end of the stream.
+    pub async fn run_turn_streaming(
+        &self,
+        user_message: &str,
+        conversation_id: Uuid,
+        interface: Interface,
+        token_tx: tokio::sync::mpsc::UnboundedSender<String>,
+    ) -> Result<TurnResult> {
+        self.run_turn_internal(user_message, conversation_id, interface, Some(token_tx))
+            .await
+    }
+
+    async fn run_turn_internal(
+        &self,
+        user_message: &str,
+        conversation_id: Uuid,
+        interface: Interface,
+        token_tx: Option<tokio::sync::mpsc::UnboundedSender<String>>,
+    ) -> Result<TurnResult> {
         info!(
             conversation_id = %conversation_id,
             interface = ?interface,
@@ -160,7 +189,13 @@ impl ReactOrchestrator {
                 interactive: matches!(interface, Interface::Cli),
             };
 
-            let response = self.llm.chat(system_prompt, &history, &skill_refs).await?;
+            let response = if let Some(ref tx) = token_tx {
+                self.llm
+                    .chat_stream(system_prompt, &history, &skill_refs, tx)
+                    .await?
+            } else {
+                self.llm.chat(system_prompt, &history, &skill_refs).await?
+            };
 
             match response {
                 // ── Final answer ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #6

- **`assistant-llm`**: Add `LlmClient::chat_stream` that accepts an unbounded `mpsc` sender and forwards content tokens as they arrive from Ollama.
  - **Native mode** (most common): streams NDJSON chunks via reqwest; tool-call responses carry empty content so nothing is forwarded during those turns; final answers are emitted token-by-token.
  - **ReAct mode**: accumulates the full response then forwards only the clean answer text (raw `THOUGHT:`/`ACTION:` markers are not forwarded).
  - **Auto mode**: follows the same detection logic as the existing `chat_auto`.

- **`assistant-runtime`**: Add `ReactOrchestrator::run_turn_streaming` that threads an unbounded sender through the ReAct loop via a shared `run_turn_internal` helper. The existing `run_turn` is preserved for callers that don't need streaming (MCP server, tests).

- **`assistant-cli`**: Replace `AtomicBool`-spinner + blocking `run_turn` with:
  - A `watch`-channel spinner that stops cleanly when signalled.
  - A `start_token_printer` task that prints tokens as they arrive and clears the spinner line on the first token, giving a seamless transition from spinner → streamed output.

## Test plan

- [ ] `cargo clippy --workspace -- -D warnings` — no warnings
- [ ] `cargo test --workspace --lib` — all unit tests pass
- [ ] Manual smoke test: run `cargo run -p assistant-cli`, ask a question, verify tokens appear progressively
- [ ] Tool-call path: ask something that requires a skill (e.g. "what time is it"), verify spinner shows during tool execution and tokens stream for the final answer