### PR TITLE
fix(ci): use inline version strings for release-please compatibility

### DIFF
--- a/crates/provider-anthropic/Cargo.toml
+++ b/crates/provider-anthropic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assistant-provider-anthropic"
-version.workspace = true
+version = "0.1.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/skills/Cargo.toml
+++ b/crates/skills/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assistant-skills"
-version.workspace = true
+version = "0.1.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/tool-executor/Cargo.toml
+++ b/crates/tool-executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assistant-tool-executor"
-version.workspace = true
+version = "0.1.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Summary

- Replace `version.workspace = true` with explicit `version = "0.1.5"` in 3 crates: `skills`, `provider-anthropic`, and `tool-executor`
- Fixes release-please CI failure: `value at path package.version is not tagged` ([run #22411315931](https://github.com/cedricziel/assistant/actions/runs/22411315931))
- release-please's Rust strategy expects a version string at `package.version` in each workspace member's `Cargo.toml`, but `version.workspace = true` is a boolean TOML value it cannot parse

## Root cause

The Rust release-please strategy iterates all workspace members and tries to bump `package.version`. Three crates used `version.workspace = true` (workspace-inherited version), which is a TOML table/boolean rather than a tagged string value, causing the parser to fail.

## Changes

| File | Before | After |
|------|--------|-------|
| `crates/skills/Cargo.toml` | `version.workspace = true` | `version = "0.1.5"` |
| `crates/provider-anthropic/Cargo.toml` | `version.workspace = true` | `version = "0.1.5"` |
| `crates/tool-executor/Cargo.toml` | `version.workspace = true` | `version = "0.1.5"` |

`cargo check --workspace` passes cleanly.