### PR TITLE
fix(packaging): use Restart=always so services recover after self-update

### DIFF
--- a/packaging/systemd/user/assistant-mattermost.service
+++ b/packaging/systemd/user/assistant-mattermost.service
@@ -7,7 +7,7 @@ After=network-online.target
 [Service]
 Type=simple
 ExecStart=/usr/local/bin/assistant mattermost
-Restart=on-failure
+Restart=always
 RestartSec=5
 
 # All log output goes to the user journal.

--- a/packaging/systemd/user/assistant-slack.service
+++ b/packaging/systemd/user/assistant-slack.service
@@ -7,7 +7,7 @@ After=network-online.target
 [Service]
 Type=simple
 ExecStart=/usr/local/bin/assistant slack
-Restart=on-failure
+Restart=always
 RestartSec=5
 
 # All log output goes to the user journal.

--- a/packaging/systemd/user/assistant-web-ui.service
+++ b/packaging/systemd/user/assistant-web-ui.service
@@ -7,7 +7,7 @@ After=network-online.target
 [Service]
 Type=simple
 ExecStart=/usr/local/bin/assistant web-ui
-Restart=on-failure
+Restart=always
 RestartSec=5
 
 # All log output goes to the user journal.


### PR DESCRIPTION
## Summary

- Changes `Restart=on-failure` to `Restart=always` in all three systemd user services (slack, mattermost, web-ui)

## Problem

When the bot self-updates via the `bash` tool, it replaces the binary and exits cleanly (code 0). With `Restart=on-failure`, systemd only restarts on non-zero exit codes, so the service stays dead until manually started.

## Fix

`Restart=always` ensures systemd restarts the service regardless of exit status. The existing `RestartSec=5` provides a 5-second cooldown between restarts.

Already applied live on schorschvm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated service restart configuration for Mattermost, Slack, and Web UI assistants to enable continuous automatic recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->