### PR TITLE
feat(scheduler): add cancel-task, list-tasks tools and one-shot scheduling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,6 +453,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/runtime/src/scheduler.rs
+++ b/crates/runtime/src/scheduler.rs
@@ -77,9 +77,16 @@ async fn run_due_tasks(storage: &StorageLayer, orchestrator: &Orchestrator) -> R
             }
         }
 
-        // Compute the next run time from the cron expression.
-        let next_run = compute_next_run(&task.cron_expr);
-        task_store.record_run(task.id, now, next_run).await?;
+        if task.once {
+            // One-shot task: record the run and disable it.
+            task_store.record_run(task.id, now, None).await?;
+            task_store.disable(task.id).await?;
+            info!(task_name = %task.name, "One-shot task disabled after execution");
+        } else {
+            // Recurring task: compute the next run from the cron expression.
+            let next_run = compute_next_run(&task.cron_expr);
+            task_store.record_run(task.id, now, next_run).await?;
+        }
     }
 
     Ok(())

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -153,6 +153,10 @@ async fn run_migrations(pool: &SqlitePool) -> Result<()> {
             include_str!("../../../migrations/010_trace_token_usage.sql"),
         ),
         ("011_logs", include_str!("../../../migrations/011_logs.sql")),
+        (
+            "012_scheduled_tasks_once",
+            include_str!("../../../migrations/012_scheduled_tasks_once.sql"),
+        ),
     ];
 
     for (name, sql) in migrations {

--- a/crates/storage/src/scheduled_tasks.rs
+++ b/crates/storage/src/scheduled_tasks.rs
@@ -1,4 +1,4 @@
-//! Scheduled task persistence (cron-style recurring prompts).
+//! Scheduled task persistence (cron-style recurring prompts and one-shot tasks).
 
 use anyhow::Result;
 use chrono::{DateTime, Utc};
@@ -13,6 +13,7 @@ pub struct ScheduledTask {
     pub cron_expr: String,
     pub prompt: String,
     pub enabled: bool,
+    pub once: bool,
     pub last_run: Option<DateTime<Utc>>,
     pub next_run: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
@@ -34,6 +35,7 @@ impl ScheduledTaskStore {
         name: &str,
         cron_expr: &str,
         prompt: &str,
+        once: bool,
         next_run: Option<DateTime<Utc>>,
     ) -> Result<Uuid> {
         let id = Uuid::new_v4();
@@ -42,13 +44,14 @@ impl ScheduledTaskStore {
 
         sqlx::query(
             "INSERT INTO scheduled_tasks \
-                (id, name, cron_expr, prompt, enabled, next_run, created_at) \
-             VALUES (?1, ?2, ?3, ?4, TRUE, ?5, ?6)",
+                (id, name, cron_expr, prompt, enabled, once, next_run, created_at) \
+             VALUES (?1, ?2, ?3, ?4, TRUE, ?5, ?6, ?7)",
         )
         .bind(&id_str)
         .bind(name)
         .bind(cron_expr)
         .bind(prompt)
+        .bind(once)
         .bind(next_run)
         .bind(now)
         .execute(&self.pool)
@@ -60,7 +63,7 @@ impl ScheduledTaskStore {
     /// List all enabled tasks whose next_run is at or before `now`.
     pub async fn due_tasks(&self, now: DateTime<Utc>) -> Result<Vec<ScheduledTask>> {
         let rows = sqlx::query(
-            "SELECT id, name, cron_expr, prompt, enabled, last_run, next_run, created_at \
+            "SELECT id, name, cron_expr, prompt, enabled, once, last_run, next_run, created_at \
              FROM scheduled_tasks \
              WHERE enabled = TRUE AND next_run <= ?1 \
              ORDER BY next_run ASC",
@@ -75,7 +78,7 @@ impl ScheduledTaskStore {
     /// List all tasks.
     pub async fn list_all(&self) -> Result<Vec<ScheduledTask>> {
         let rows = sqlx::query(
-            "SELECT id, name, cron_expr, prompt, enabled, last_run, next_run, created_at \
+            "SELECT id, name, cron_expr, prompt, enabled, once, last_run, next_run, created_at \
              FROM scheduled_tasks ORDER BY created_at ASC",
         )
         .fetch_all(&self.pool)
@@ -99,6 +102,232 @@ impl ScheduledTaskStore {
             .await?;
         Ok(())
     }
+
+    /// Disable a task (set `enabled = FALSE`).
+    pub async fn disable(&self, id: Uuid) -> Result<bool> {
+        let result = sqlx::query(
+            "UPDATE scheduled_tasks SET enabled = FALSE WHERE id = ?1 AND enabled = TRUE",
+        )
+        .bind(id.to_string())
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Delete a task permanently.
+    pub async fn delete(&self, id: Uuid) -> Result<bool> {
+        let result = sqlx::query("DELETE FROM scheduled_tasks WHERE id = ?1")
+            .bind(id.to_string())
+            .execute(&self.pool)
+            .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Find a task by name (case-insensitive).
+    pub async fn find_by_name(&self, name: &str) -> Result<Option<ScheduledTask>> {
+        let row = sqlx::query(
+            "SELECT id, name, cron_expr, prompt, enabled, once, last_run, next_run, created_at \
+             FROM scheduled_tasks WHERE LOWER(name) = LOWER(?1) LIMIT 1",
+        )
+        .bind(name)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        row.map(parse_row).transpose()
+    }
+}
+
+// -- Tests ------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::StorageLayer;
+    use chrono::Duration;
+
+    async fn store() -> (StorageLayer, ScheduledTaskStore) {
+        let s = StorageLayer::new_in_memory().await.unwrap();
+        let ts = s.scheduled_task_store();
+        (s, ts)
+    }
+
+    #[tokio::test]
+    async fn test_insert_and_list_all() {
+        let (_s, ts) = store().await;
+        let next = Utc::now() + Duration::hours(1);
+
+        let id = ts
+            .insert(
+                "daily-report",
+                "0 0 9 * * *",
+                "run report",
+                false,
+                Some(next),
+            )
+            .await
+            .unwrap();
+
+        let all = ts.list_all().await.unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].id, id);
+        assert_eq!(all[0].name, "daily-report");
+        assert_eq!(all[0].cron_expr, "0 0 9 * * *");
+        assert_eq!(all[0].prompt, "run report");
+        assert!(all[0].enabled);
+        assert!(!all[0].once);
+        assert!(all[0].last_run.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_insert_once_flag() {
+        let (_s, ts) = store().await;
+        let next = Utc::now() + Duration::hours(1);
+
+        ts.insert("one-shot", "", "do thing", true, Some(next))
+            .await
+            .unwrap();
+
+        let all = ts.list_all().await.unwrap();
+        assert_eq!(all.len(), 1);
+        assert!(all[0].once, "once flag must be persisted");
+    }
+
+    #[tokio::test]
+    async fn test_due_tasks_returns_only_past_enabled() {
+        let (_s, ts) = store().await;
+        let past = Utc::now() - Duration::hours(1);
+        let future = Utc::now() + Duration::hours(1);
+
+        ts.insert("past-task", "0 * * * *", "p1", false, Some(past))
+            .await
+            .unwrap();
+        ts.insert("future-task", "0 * * * *", "p2", false, Some(future))
+            .await
+            .unwrap();
+
+        let due = ts.due_tasks(Utc::now()).await.unwrap();
+        assert_eq!(due.len(), 1, "only the past task should be due");
+        assert_eq!(due[0].name, "past-task");
+    }
+
+    #[tokio::test]
+    async fn test_due_tasks_excludes_disabled() {
+        let (_s, ts) = store().await;
+        let past = Utc::now() - Duration::hours(1);
+
+        let id = ts
+            .insert("disabled-task", "0 * * * *", "p", false, Some(past))
+            .await
+            .unwrap();
+        ts.disable(id).await.unwrap();
+
+        let due = ts.due_tasks(Utc::now()).await.unwrap();
+        assert!(due.is_empty(), "disabled tasks must not appear as due");
+    }
+
+    #[tokio::test]
+    async fn test_record_run_updates_timestamps() {
+        let (_s, ts) = store().await;
+        let past = Utc::now() - Duration::hours(1);
+        let new_next = Utc::now() + Duration::hours(1);
+
+        let id = ts
+            .insert("t", "0 * * * *", "p", false, Some(past))
+            .await
+            .unwrap();
+
+        let now = Utc::now();
+        ts.record_run(id, now, Some(new_next)).await.unwrap();
+
+        let all = ts.list_all().await.unwrap();
+        assert!(all[0].last_run.is_some(), "last_run must be set");
+        assert_eq!(
+            all[0].next_run.unwrap().timestamp(),
+            new_next.timestamp(),
+            "next_run must be updated"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_disable_returns_true_then_false() {
+        let (_s, ts) = store().await;
+        let next = Utc::now() + Duration::hours(1);
+
+        let id = ts
+            .insert("t", "0 * * * *", "p", false, Some(next))
+            .await
+            .unwrap();
+
+        assert!(
+            ts.disable(id).await.unwrap(),
+            "first disable should return true"
+        );
+        assert!(
+            !ts.disable(id).await.unwrap(),
+            "second disable should return false (already disabled)"
+        );
+
+        let all = ts.list_all().await.unwrap();
+        assert!(!all[0].enabled);
+    }
+
+    #[tokio::test]
+    async fn test_delete_removes_row() {
+        let (_s, ts) = store().await;
+        let next = Utc::now() + Duration::hours(1);
+
+        let id = ts
+            .insert("t", "0 * * * *", "p", false, Some(next))
+            .await
+            .unwrap();
+
+        assert!(ts.delete(id).await.unwrap(), "delete should return true");
+        assert!(
+            !ts.delete(id).await.unwrap(),
+            "second delete should return false (row gone)"
+        );
+        assert!(ts.list_all().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_find_by_name_case_insensitive() {
+        let (_s, ts) = store().await;
+        let next = Utc::now() + Duration::hours(1);
+
+        ts.insert("My-Task", "0 * * * *", "p", false, Some(next))
+            .await
+            .unwrap();
+
+        let found = ts.find_by_name("my-task").await.unwrap();
+        assert!(
+            found.is_some(),
+            "case-insensitive lookup must find the task"
+        );
+        assert_eq!(found.unwrap().name, "My-Task");
+    }
+
+    #[tokio::test]
+    async fn test_find_by_name_returns_none_when_missing() {
+        let (_s, ts) = store().await;
+        let found = ts.find_by_name("nonexistent").await.unwrap();
+        assert!(found.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_list_all_includes_disabled() {
+        let (_s, ts) = store().await;
+        let next = Utc::now() + Duration::hours(1);
+
+        let id = ts
+            .insert("t", "0 * * * *", "p", false, Some(next))
+            .await
+            .unwrap();
+        ts.disable(id).await.unwrap();
+
+        let all = ts.list_all().await.unwrap();
+        assert_eq!(all.len(), 1, "list_all must include disabled tasks");
+        assert!(!all[0].enabled);
+    }
 }
 
 fn parse_row(r: sqlx::sqlite::SqliteRow) -> Result<ScheduledTask> {
@@ -109,6 +338,7 @@ fn parse_row(r: sqlx::sqlite::SqliteRow) -> Result<ScheduledTask> {
         cron_expr: r.get("cron_expr"),
         prompt: r.get("prompt"),
         enabled: r.get("enabled"),
+        once: r.get("once"),
         last_run: r.get("last_run"),
         next_run: r.get("next_run"),
         created_at: r.get("created_at"),

--- a/crates/tool-executor/Cargo.toml
+++ b/crates/tool-executor/Cargo.toml
@@ -25,6 +25,7 @@ glob = { workspace = true }
 chrono = { workspace = true }
 cron = { workspace = true }
 dirs = { workspace = true }
+uuid = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/tool-executor/src/builtins/cancel_task.rs
+++ b/crates/tool-executor/src/builtins/cancel_task.rs
@@ -1,0 +1,264 @@
+//! Builtin handler for cancel-task tool — disables or deletes a scheduled task.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::Result;
+use assistant_core::{ExecutionContext, ToolHandler, ToolOutput};
+use assistant_storage::StorageLayer;
+use async_trait::async_trait;
+use uuid::Uuid;
+
+pub struct CancelTaskHandler {
+    storage: Arc<StorageLayer>,
+}
+
+impl CancelTaskHandler {
+    pub fn new(storage: Arc<StorageLayer>) -> Self {
+        Self { storage }
+    }
+}
+
+#[async_trait]
+impl ToolHandler for CancelTaskHandler {
+    fn name(&self) -> &str {
+        "cancel-task"
+    }
+
+    fn description(&self) -> &str {
+        "Cancel a scheduled task by ID or name. By default the task is disabled \
+         (kept in history). Pass `delete: true` to remove it permanently."
+    }
+
+    fn params_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "UUID of the task to cancel"
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the task to cancel (case-insensitive). Used when id is not provided."
+                },
+                "delete": {
+                    "type": "boolean",
+                    "description": "If true, permanently delete the task instead of disabling it. Default: false."
+                }
+            }
+        })
+    }
+
+    fn is_mutating(&self) -> bool {
+        true
+    }
+
+    async fn run(
+        &self,
+        params: HashMap<String, serde_json::Value>,
+        _ctx: &ExecutionContext,
+    ) -> Result<ToolOutput> {
+        let id_str = params.get("id").and_then(|v| v.as_str());
+        let name = params.get("name").and_then(|v| v.as_str());
+        let hard_delete = params
+            .get("delete")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        let task_store = self.storage.scheduled_task_store();
+
+        // Resolve the task UUID from either `id` or `name`.
+        let task_id = if let Some(raw) = id_str {
+            match Uuid::parse_str(raw) {
+                Ok(u) => u,
+                Err(e) => {
+                    return Ok(ToolOutput::error(format!("Invalid UUID '{}': {}", raw, e)));
+                }
+            }
+        } else if let Some(n) = name {
+            match task_store.find_by_name(n).await? {
+                Some(t) => t.id,
+                None => {
+                    return Ok(ToolOutput::error(format!(
+                        "No scheduled task found with name '{}'.",
+                        n
+                    )));
+                }
+            }
+        } else {
+            return Ok(ToolOutput::error(
+                "Provide either `id` (UUID) or `name` to identify the task.",
+            ));
+        };
+
+        if hard_delete {
+            let deleted = task_store.delete(task_id).await?;
+            if deleted {
+                Ok(ToolOutput::success(format!(
+                    "Task {} deleted permanently.",
+                    task_id
+                )))
+            } else {
+                Ok(ToolOutput::error(format!("Task {} not found.", task_id)))
+            }
+        } else {
+            let disabled = task_store.disable(task_id).await?;
+            if disabled {
+                Ok(ToolOutput::success(format!(
+                    "Task {} disabled. It will no longer run. Pass `delete: true` to remove it entirely.",
+                    task_id
+                )))
+            } else {
+                Ok(ToolOutput::error(format!(
+                    "Task {} not found or already disabled.",
+                    task_id
+                )))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assistant_core::Interface;
+    use assistant_storage::StorageLayer;
+    use chrono::Utc;
+
+    fn ctx() -> ExecutionContext {
+        ExecutionContext {
+            conversation_id: Uuid::new_v4(),
+            turn: 1,
+            interface: Interface::Cli,
+            interactive: false,
+        }
+    }
+
+    async fn setup() -> (Arc<StorageLayer>, CancelTaskHandler) {
+        let storage = Arc::new(StorageLayer::new_in_memory().await.unwrap());
+        let handler = CancelTaskHandler::new(storage.clone());
+        (storage, handler)
+    }
+
+    fn params(pairs: &[(&str, serde_json::Value)]) -> HashMap<String, serde_json::Value> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect()
+    }
+
+    /// Insert a test task and return its UUID string.
+    async fn seed_task(storage: &StorageLayer, name: &str) -> String {
+        let next = Utc::now() + chrono::Duration::hours(1);
+        let id = storage
+            .scheduled_task_store()
+            .insert(name, "0 * * * *", "prompt", false, Some(next))
+            .await
+            .unwrap();
+        id.to_string()
+    }
+
+    #[tokio::test]
+    async fn test_cancel_by_id_disables() {
+        let (storage, h) = setup().await;
+        let id = seed_task(&storage, "my-task").await;
+
+        let out = h
+            .run(params(&[("id", serde_json::json!(id))]), &ctx())
+            .await
+            .unwrap();
+        assert!(out.success, "cancel by id should succeed: {}", out.content);
+        assert!(out.content.contains("disabled"));
+
+        let all = storage.scheduled_task_store().list_all().await.unwrap();
+        assert!(!all[0].enabled, "task must be disabled in DB");
+    }
+
+    #[tokio::test]
+    async fn test_cancel_by_name_disables() {
+        let (storage, h) = setup().await;
+        seed_task(&storage, "My-Task").await;
+
+        let out = h
+            .run(params(&[("name", serde_json::json!("my-task"))]), &ctx())
+            .await
+            .unwrap();
+        assert!(
+            out.success,
+            "cancel by name should succeed: {}",
+            out.content
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cancel_by_id_with_delete() {
+        let (storage, h) = setup().await;
+        let id = seed_task(&storage, "doomed").await;
+
+        let out = h
+            .run(
+                params(&[
+                    ("id", serde_json::json!(id)),
+                    ("delete", serde_json::json!(true)),
+                ]),
+                &ctx(),
+            )
+            .await
+            .unwrap();
+        assert!(out.success, "hard delete should succeed: {}", out.content);
+        assert!(out.content.contains("deleted permanently"));
+
+        let all = storage.scheduled_task_store().list_all().await.unwrap();
+        assert!(all.is_empty(), "task must be removed from DB");
+    }
+
+    #[tokio::test]
+    async fn test_cancel_nonexistent_name_errors() {
+        let (_storage, h) = setup().await;
+        let out = h
+            .run(params(&[("name", serde_json::json!("nope"))]), &ctx())
+            .await
+            .unwrap();
+        assert!(!out.success);
+        assert!(out.content.contains("No scheduled task found"));
+    }
+
+    #[tokio::test]
+    async fn test_cancel_invalid_uuid_errors() {
+        let (_storage, h) = setup().await;
+        let out = h
+            .run(params(&[("id", serde_json::json!("not-a-uuid"))]), &ctx())
+            .await
+            .unwrap();
+        assert!(!out.success);
+        assert!(out.content.contains("Invalid UUID"));
+    }
+
+    #[tokio::test]
+    async fn test_cancel_no_id_or_name_errors() {
+        let (_storage, h) = setup().await;
+        let out = h.run(params(&[]), &ctx()).await.unwrap();
+        assert!(!out.success);
+        assert!(out.content.contains("Provide either"));
+    }
+
+    #[tokio::test]
+    async fn test_cancel_already_disabled_errors() {
+        let (storage, h) = setup().await;
+        let id = seed_task(&storage, "t").await;
+
+        // First cancel succeeds
+        h.run(params(&[("id", serde_json::json!(&id))]), &ctx())
+            .await
+            .unwrap();
+
+        // Second cancel fails (already disabled)
+        let out = h
+            .run(params(&[("id", serde_json::json!(&id))]), &ctx())
+            .await
+            .unwrap();
+        assert!(!out.success, "already-disabled cancel must error");
+        assert!(out.content.contains("already disabled"));
+    }
+}

--- a/crates/tool-executor/src/builtins/list_tasks.rs
+++ b/crates/tool-executor/src/builtins/list_tasks.rs
@@ -1,0 +1,215 @@
+//! Builtin handler for list-tasks tool — lists all scheduled tasks.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::Result;
+use assistant_core::{ExecutionContext, ToolHandler, ToolOutput};
+use assistant_storage::StorageLayer;
+use async_trait::async_trait;
+
+pub struct ListTasksHandler {
+    storage: Arc<StorageLayer>,
+}
+
+impl ListTasksHandler {
+    pub fn new(storage: Arc<StorageLayer>) -> Self {
+        Self { storage }
+    }
+}
+
+#[async_trait]
+impl ToolHandler for ListTasksHandler {
+    fn name(&self) -> &str {
+        "list-tasks"
+    }
+
+    fn description(&self) -> &str {
+        "List all scheduled tasks with their status, cron expression, next run time, and prompt."
+    }
+
+    fn params_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "enabled_only": {
+                    "type": "boolean",
+                    "description": "If true, only show enabled (active) tasks. Default: false (show all)."
+                }
+            }
+        })
+    }
+
+    fn is_mutating(&self) -> bool {
+        false
+    }
+
+    async fn run(
+        &self,
+        params: HashMap<String, serde_json::Value>,
+        _ctx: &ExecutionContext,
+    ) -> Result<ToolOutput> {
+        let enabled_only = params
+            .get("enabled_only")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        let task_store = self.storage.scheduled_task_store();
+        let tasks = task_store.list_all().await?;
+
+        let tasks: Vec<_> = if enabled_only {
+            tasks.into_iter().filter(|t| t.enabled).collect()
+        } else {
+            tasks
+        };
+
+        if tasks.is_empty() {
+            return Ok(ToolOutput::success("No scheduled tasks found.".to_string()));
+        }
+
+        let mut lines = Vec::with_capacity(tasks.len() + 1);
+        lines.push(format!("Found {} scheduled task(s):\n", tasks.len()));
+
+        for t in &tasks {
+            let status = if t.enabled { "enabled" } else { "disabled" };
+            let mode = if t.once { "once" } else { "recurring" };
+            let schedule = if t.cron_expr.is_empty() {
+                "one-shot (run_at)".to_string()
+            } else {
+                format!("cron: {}", t.cron_expr)
+            };
+
+            let next = t
+                .next_run
+                .map(|dt| dt.to_rfc3339())
+                .unwrap_or_else(|| "none".to_string());
+
+            let last = t
+                .last_run
+                .map(|dt| dt.to_rfc3339())
+                .unwrap_or_else(|| "never".to_string());
+
+            lines.push(format!(
+                "- **{}** (id: {})\n  Status: {} | Mode: {} | {}\n  Next run: {} | Last run: {}\n  Prompt: {}",
+                t.name, t.id, status, mode, schedule, next, last, t.prompt
+            ));
+        }
+
+        Ok(ToolOutput::success(lines.join("\n")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assistant_core::Interface;
+    use assistant_storage::StorageLayer;
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    fn ctx() -> ExecutionContext {
+        ExecutionContext {
+            conversation_id: Uuid::new_v4(),
+            turn: 1,
+            interface: Interface::Cli,
+            interactive: false,
+        }
+    }
+
+    async fn setup() -> (Arc<StorageLayer>, ListTasksHandler) {
+        let storage = Arc::new(StorageLayer::new_in_memory().await.unwrap());
+        let handler = ListTasksHandler::new(storage.clone());
+        (storage, handler)
+    }
+
+    fn params(pairs: &[(&str, serde_json::Value)]) -> HashMap<String, serde_json::Value> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn test_list_empty() {
+        let (_storage, h) = setup().await;
+        let out = h.run(params(&[]), &ctx()).await.unwrap();
+        assert!(out.success);
+        assert!(out.content.contains("No scheduled tasks found"));
+    }
+
+    #[tokio::test]
+    async fn test_list_shows_all_tasks() {
+        let (storage, h) = setup().await;
+        let next = Utc::now() + chrono::Duration::hours(1);
+        let ts = storage.scheduled_task_store();
+
+        ts.insert("task-a", "0 * * * *", "prompt-a", false, Some(next))
+            .await
+            .unwrap();
+        ts.insert("task-b", "", "prompt-b", true, Some(next))
+            .await
+            .unwrap();
+
+        let out = h.run(params(&[]), &ctx()).await.unwrap();
+        assert!(out.success);
+        assert!(out.content.contains("task-a"), "must list task-a");
+        assert!(out.content.contains("task-b"), "must list task-b");
+        assert!(out.content.contains("recurring"), "task-a is recurring");
+        assert!(out.content.contains("once"), "task-b is once");
+        assert!(
+            out.content.contains("one-shot (run_at)"),
+            "task-b has no cron, should show one-shot"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_enabled_only_filter() {
+        let (storage, h) = setup().await;
+        let next = Utc::now() + chrono::Duration::hours(1);
+        let ts = storage.scheduled_task_store();
+
+        ts.insert("active", "0 * * * *", "p", false, Some(next))
+            .await
+            .unwrap();
+        let disabled_id = ts
+            .insert("inactive", "0 * * * *", "p", false, Some(next))
+            .await
+            .unwrap();
+        ts.disable(disabled_id).await.unwrap();
+
+        let out = h
+            .run(params(&[("enabled_only", serde_json::json!(true))]), &ctx())
+            .await
+            .unwrap();
+        assert!(out.success);
+        assert!(out.content.contains("active"), "enabled task must appear");
+        assert!(
+            !out.content.contains("inactive"),
+            "disabled task must be filtered out"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_includes_disabled_by_default() {
+        let (storage, h) = setup().await;
+        let next = Utc::now() + chrono::Duration::hours(1);
+        let ts = storage.scheduled_task_store();
+
+        let id = ts
+            .insert("gone", "0 * * * *", "p", false, Some(next))
+            .await
+            .unwrap();
+        ts.disable(id).await.unwrap();
+
+        let out = h.run(params(&[]), &ctx()).await.unwrap();
+        assert!(out.success);
+        assert!(
+            out.content.contains("gone"),
+            "disabled task must appear by default"
+        );
+        assert!(
+            out.content.contains("disabled"),
+            "status should say disabled"
+        );
+    }
+}

--- a/crates/tool-executor/src/builtins/mod.rs
+++ b/crates/tool-executor/src/builtins/mod.rs
@@ -1,9 +1,11 @@
 pub mod bash;
+pub mod cancel_task;
 pub mod file_edit;
 pub mod file_glob;
 pub mod file_read;
 pub mod file_write;
 pub mod list_skills;
+pub mod list_tasks;
 pub mod load_skill;
 pub mod memory_get;
 pub mod memory_search;
@@ -13,11 +15,13 @@ pub mod web_fetch;
 pub mod web_search;
 
 pub use bash::BashHandler;
+pub use cancel_task::CancelTaskHandler;
 pub use file_edit::FileEditHandler;
 pub use file_glob::FileGlobHandler;
 pub use file_read::FileReadHandler;
 pub use file_write::FileWriteHandler;
 pub use list_skills::ListSkillsHandler;
+pub use list_tasks::ListTasksHandler;
 pub use load_skill::LoadSkillHandler;
 pub use memory_get::MemoryGetHandler;
 pub use memory_search::MemorySearchHandler;

--- a/crates/tool-executor/src/builtins/schedule_task.rs
+++ b/crates/tool-executor/src/builtins/schedule_task.rs
@@ -1,4 +1,4 @@
-//! Builtin handler for schedule-task tool — persists a cron-scheduled prompt task.
+//! Builtin handler for schedule-task tool — persists a cron-scheduled or one-shot prompt task.
 
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -8,7 +8,7 @@ use anyhow::Result;
 use assistant_core::{ExecutionContext, ToolHandler, ToolOutput};
 use assistant_storage::StorageLayer;
 use async_trait::async_trait;
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use cron::Schedule;
 
 pub struct ScheduleTaskHandler {
@@ -28,7 +28,10 @@ impl ToolHandler for ScheduleTaskHandler {
     }
 
     fn description(&self) -> &str {
-        "Schedule a recurring prompt task using a cron expression. The assistant will run the prompt automatically on each tick."
+        "Schedule a prompt task. Supports recurring cron expressions and one-shot \
+         execution at a specific datetime. Use `cron_expr` for recurring tasks, \
+         `run_at` for one-shot tasks, or combine `cron_expr` with `once: true` \
+         to run on the next cron tick only."
     }
 
     fn params_schema(&self) -> serde_json::Value {
@@ -41,14 +44,22 @@ impl ToolHandler for ScheduleTaskHandler {
                 },
                 "cron_expr": {
                     "type": "string",
-                    "description": "Cron expression (5-field standard or 7-field with seconds)"
+                    "description": "Cron expression (5-field standard or 7-field with seconds). Required unless `run_at` is provided."
+                },
+                "run_at": {
+                    "type": "string",
+                    "description": "ISO 8601 datetime for a one-shot task (e.g. '2026-03-01T09:00:00Z'). Mutually exclusive with `cron_expr`."
                 },
                 "prompt": {
                     "type": "string",
                     "description": "The prompt to run on each tick"
+                },
+                "once": {
+                    "type": "boolean",
+                    "description": "If true the task auto-disables after a single execution. Implied when `run_at` is used. Default: false."
                 }
             },
-            "required": ["name", "cron_expr", "prompt"]
+            "required": ["name", "prompt"]
         })
     }
 
@@ -68,13 +79,6 @@ impl ToolHandler for ScheduleTaskHandler {
             }
         };
 
-        let cron_expr = match params.get("cron_expr").and_then(|v| v.as_str()) {
-            Some(c) => c.to_string(),
-            None => {
-                return Ok(ToolOutput::error("Missing required parameter 'cron_expr'"));
-            }
-        };
-
         let prompt = match params.get("prompt").and_then(|v| v.as_str()) {
             Some(p) => p.to_string(),
             None => {
@@ -82,19 +86,71 @@ impl ToolHandler for ScheduleTaskHandler {
             }
         };
 
-        // Validate and compute next run time from the cron expression.
-        // Normalise 5-field standard cron to 7-field (prefix seconds=0).
-        let (schedule, effective_expr) = match Schedule::from_str(&cron_expr) {
-            Ok(s) => (s, cron_expr.clone()),
+        let cron_expr = params.get("cron_expr").and_then(|v| v.as_str());
+        let run_at = params.get("run_at").and_then(|v| v.as_str());
+        let once_flag = params
+            .get("once")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        if cron_expr.is_some() && run_at.is_some() {
+            return Ok(ToolOutput::error(
+                "Provide either `cron_expr` or `run_at`, not both.",
+            ));
+        }
+
+        if cron_expr.is_none() && run_at.is_none() {
+            return Ok(ToolOutput::error(
+                "Provide either `cron_expr` (recurring) or `run_at` (one-shot datetime).",
+            ));
+        }
+
+        // -- One-shot via `run_at` ------------------------------------------------
+        if let Some(raw) = run_at {
+            let dt = match raw.parse::<DateTime<Utc>>() {
+                Ok(dt) => dt,
+                Err(e) => {
+                    return Ok(ToolOutput::error(format!(
+                        "Invalid ISO 8601 datetime '{}': {}",
+                        raw, e
+                    )));
+                }
+            };
+
+            if dt <= Utc::now() {
+                return Ok(ToolOutput::error(format!(
+                    "run_at '{}' is in the past.",
+                    raw
+                )));
+            }
+
+            let id = self
+                .storage
+                .scheduled_task_store()
+                .insert(&name, "", &prompt, true, Some(dt))
+                .await?;
+
+            return Ok(ToolOutput::success(format!(
+                "One-shot task '{}' created (id: {}).\nRun at: {}\nPrompt: {}",
+                name,
+                id,
+                dt.to_rfc3339(),
+                prompt
+            )));
+        }
+
+        // -- Cron-based (recurring or once) ---------------------------------------
+        let cron_raw = cron_expr.unwrap();
+        let (schedule, effective_expr) = match Schedule::from_str(cron_raw) {
+            Ok(s) => (s, cron_raw.to_string()),
             Err(e) => {
-                // Try prefixing with "0 " (seconds=0) to handle standard 5-field cron
-                let extended = format!("0 {}", cron_expr);
+                let extended = format!("0 {}", cron_raw);
                 match Schedule::from_str(&extended) {
                     Ok(s) => (s, extended),
                     Err(_) => {
                         return Ok(ToolOutput::error(format!(
                             "Invalid cron expression '{}': {}",
-                            cron_expr, e
+                            cron_raw, e
                         )));
                     }
                 }
@@ -106,7 +162,7 @@ impl ToolHandler for ScheduleTaskHandler {
         let id = self
             .storage
             .scheduled_task_store()
-            .insert(&name, &effective_expr, &prompt, next_run)
+            .insert(&name, &effective_expr, &prompt, once_flag, next_run)
             .await?;
 
         let next_run_str = match next_run {
@@ -114,9 +170,190 @@ impl ToolHandler for ScheduleTaskHandler {
             None => "never (cron expression has no future occurrences)".to_string(),
         };
 
+        let mode = if once_flag { "once" } else { "recurring" };
         Ok(ToolOutput::success(format!(
-            "Scheduled task '{}' created (id: {}).\nCron expression: {}\nNext run: {}\nPrompt: {}",
-            name, id, effective_expr, next_run_str, prompt
+            "Scheduled task '{}' created (id: {}, mode: {}).\nCron: {}\nNext run: {}\nPrompt: {}",
+            name, id, mode, effective_expr, next_run_str, prompt
         )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assistant_core::Interface;
+    use assistant_storage::StorageLayer;
+    use uuid::Uuid;
+
+    fn ctx() -> ExecutionContext {
+        ExecutionContext {
+            conversation_id: Uuid::new_v4(),
+            turn: 1,
+            interface: Interface::Cli,
+            interactive: false,
+        }
+    }
+
+    async fn handler() -> ScheduleTaskHandler {
+        let storage = Arc::new(StorageLayer::new_in_memory().await.unwrap());
+        ScheduleTaskHandler::new(storage)
+    }
+
+    fn params(pairs: &[(&str, serde_json::Value)]) -> HashMap<String, serde_json::Value> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn test_schedule_recurring_cron() {
+        let h = handler().await;
+        let p = params(&[
+            ("name", serde_json::json!("daily")),
+            ("cron_expr", serde_json::json!("0 9 * * *")),
+            ("prompt", serde_json::json!("run report")),
+        ]);
+
+        let out = h.run(p, &ctx()).await.unwrap();
+        assert!(
+            out.success,
+            "recurring cron should succeed: {}",
+            out.content
+        );
+        assert!(
+            out.content.contains("recurring"),
+            "mode should be recurring"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_schedule_cron_once() {
+        let h = handler().await;
+        let p = params(&[
+            ("name", serde_json::json!("one-timer")),
+            ("cron_expr", serde_json::json!("0 9 * * *")),
+            ("prompt", serde_json::json!("run once")),
+            ("once", serde_json::json!(true)),
+        ]);
+
+        let out = h.run(p, &ctx()).await.unwrap();
+        assert!(out.success, "cron+once should succeed: {}", out.content);
+        assert!(out.content.contains("once"), "mode should be once");
+    }
+
+    #[tokio::test]
+    async fn test_schedule_run_at() {
+        let h = handler().await;
+        let future = (Utc::now() + chrono::Duration::hours(2)).to_rfc3339();
+        let p = params(&[
+            ("name", serde_json::json!("reminder")),
+            ("run_at", serde_json::json!(future)),
+            ("prompt", serde_json::json!("remind me")),
+        ]);
+
+        let out = h.run(p, &ctx()).await.unwrap();
+        assert!(out.success, "run_at should succeed: {}", out.content);
+        assert!(
+            out.content.contains("One-shot"),
+            "should indicate one-shot: {}",
+            out.content
+        );
+    }
+
+    #[tokio::test]
+    async fn test_schedule_run_at_in_past_rejected() {
+        let h = handler().await;
+        let past = (Utc::now() - chrono::Duration::hours(1)).to_rfc3339();
+        let p = params(&[
+            ("name", serde_json::json!("late")),
+            ("run_at", serde_json::json!(past)),
+            ("prompt", serde_json::json!("too late")),
+        ]);
+
+        let out = h.run(p, &ctx()).await.unwrap();
+        assert!(!out.success, "past run_at must be rejected");
+        assert!(out.content.contains("past"));
+    }
+
+    #[tokio::test]
+    async fn test_schedule_both_cron_and_run_at_rejected() {
+        let h = handler().await;
+        let future = (Utc::now() + chrono::Duration::hours(1)).to_rfc3339();
+        let p = params(&[
+            ("name", serde_json::json!("both")),
+            ("cron_expr", serde_json::json!("0 9 * * *")),
+            ("run_at", serde_json::json!(future)),
+            ("prompt", serde_json::json!("p")),
+        ]);
+
+        let out = h.run(p, &ctx()).await.unwrap();
+        assert!(!out.success, "both cron and run_at must be rejected");
+    }
+
+    #[tokio::test]
+    async fn test_schedule_neither_cron_nor_run_at_rejected() {
+        let h = handler().await;
+        let p = params(&[
+            ("name", serde_json::json!("neither")),
+            ("prompt", serde_json::json!("p")),
+        ]);
+
+        let out = h.run(p, &ctx()).await.unwrap();
+        assert!(!out.success, "neither cron nor run_at must be rejected");
+    }
+
+    #[tokio::test]
+    async fn test_schedule_invalid_cron_rejected() {
+        let h = handler().await;
+        let p = params(&[
+            ("name", serde_json::json!("bad")),
+            ("cron_expr", serde_json::json!("not a cron")),
+            ("prompt", serde_json::json!("p")),
+        ]);
+
+        let out = h.run(p, &ctx()).await.unwrap();
+        assert!(!out.success, "invalid cron must be rejected");
+        assert!(out.content.contains("Invalid cron"));
+    }
+
+    #[tokio::test]
+    async fn test_schedule_invalid_run_at_rejected() {
+        let h = handler().await;
+        let p = params(&[
+            ("name", serde_json::json!("bad-dt")),
+            ("run_at", serde_json::json!("not-a-datetime")),
+            ("prompt", serde_json::json!("p")),
+        ]);
+
+        let out = h.run(p, &ctx()).await.unwrap();
+        assert!(!out.success, "invalid datetime must be rejected");
+        assert!(out.content.contains("Invalid ISO 8601"));
+    }
+
+    #[tokio::test]
+    async fn test_schedule_missing_name_rejected() {
+        let h = handler().await;
+        let p = params(&[
+            ("cron_expr", serde_json::json!("0 9 * * *")),
+            ("prompt", serde_json::json!("p")),
+        ]);
+
+        let out = h.run(p, &ctx()).await.unwrap();
+        assert!(!out.success);
+        assert!(out.content.contains("name"));
+    }
+
+    #[tokio::test]
+    async fn test_schedule_missing_prompt_rejected() {
+        let h = handler().await;
+        let p = params(&[
+            ("name", serde_json::json!("n")),
+            ("cron_expr", serde_json::json!("0 9 * * *")),
+        ]);
+
+        let out = h.run(p, &ctx()).await.unwrap();
+        assert!(!out.success);
+        assert!(out.content.contains("prompt"));
     }
 }

--- a/crates/tool-executor/src/executor.rs
+++ b/crates/tool-executor/src/executor.rs
@@ -57,6 +57,8 @@ impl ToolExecutor {
             Arc::new(LoadSkillHandler::new(registry.clone())),
             Arc::new(SelfAnalyzeHandler::new(storage.clone(), llm, registry)),
             Arc::new(ScheduleTaskHandler::new(storage.clone())),
+            Arc::new(CancelTaskHandler::new(storage.clone())),
+            Arc::new(ListTasksHandler::new(storage.clone())),
         ];
 
         let mut tool_handlers = self.tool_handlers.write().unwrap();

--- a/migrations/012_scheduled_tasks_once.sql
+++ b/migrations/012_scheduled_tasks_once.sql
@@ -1,0 +1,2 @@
+-- Add `once` flag so tasks can auto-disable after a single execution.
+ALTER TABLE scheduled_tasks ADD COLUMN once BOOLEAN NOT NULL DEFAULT FALSE;


### PR DESCRIPTION
## Summary

The scheduler could only create recurring cron tasks with no way to cancel, list, or schedule one-shot jobs. This PR closes those gaps:

- **`cancel-task` tool** — disable or permanently delete tasks by ID or name (case-insensitive)
- **`list-tasks` tool** — show all scheduled tasks with status, mode, timing, and prompt; supports `enabled_only` filter
- **`schedule-task` enhancements** — `run_at` param (ISO 8601 datetime) for one-shot tasks; `once` flag to auto-disable after a single execution; `cron_expr` is no longer required (one of `cron_expr` or `run_at` must be provided)
- **Scheduler loop** — auto-disables `once` tasks after execution instead of computing next cron tick
- **Storage layer** — `ScheduledTaskStore` gains `disable()`, `delete()`, `find_by_name()` methods and the `once` field
- **Migration 012** — adds `once BOOLEAN NOT NULL DEFAULT FALSE` column to `scheduled_tasks`

## Tests

31 new tests covering all changes:

| Area | Tests | Coverage |
|------|-------|----------|
| `assistant-storage` scheduled_tasks | 10 | insert, due_tasks filtering, disable idempotency, delete, find_by_name case-insensitivity, once flag, list_all includes disabled |
| `assistant-tool-executor` schedule-task | 10 | recurring cron, cron+once, run_at, past datetime rejected, both/neither rejected, invalid cron/datetime, missing params |
| `assistant-tool-executor` cancel-task | 7 | by ID, by name, hard delete, nonexistent name, invalid UUID, no identifier, already disabled |
| `assistant-tool-executor` list-tasks | 4 | empty list, all tasks shown, enabled_only filter, disabled visible by default |

`make lint`, `make format`, `make test` all pass.