### PR TITLE
fix(packaging): restart services on upgrade instead of leaving them dead

### DIFF
--- a/packaging/scripts/postinstall.sh
+++ b/packaging/scripts/postinstall.sh
@@ -7,7 +7,23 @@ if command -v systemctl >/dev/null 2>&1; then
     systemctl daemon-reload 2>/dev/null || true
 fi
 
-cat <<'MSG'
+# On upgrade: re-enable and restart services that were previously enabled.
+# On fresh install: just print instructions.
+action="${1:-configure}"
+
+if [ "$action" = "configure" ] && [ -n "$2" ]; then
+    # $2 is set to the old version on upgrade — restart services.
+    for user_id in $(loginctl list-sessions --no-legend 2>/dev/null | awk '{print $3}' | sort -u); do
+        for svc in assistant-slack assistant-mattermost assistant-web-ui; do
+            # Only restart if the unit file exists and was previously enabled.
+            if systemctl --user -M "${user_id}@.host" is-enabled "$svc" 2>/dev/null | grep -q enabled; then
+                systemctl --user -M "${user_id}@.host" daemon-reload 2>/dev/null || true
+                systemctl --user -M "${user_id}@.host" restart "$svc" 2>/dev/null || true
+            fi
+        done
+    done
+else
+    cat <<'MSG'
 
 assistant has been installed.  To run the Slack or Mattermost bot as a
 background service for your user account:
@@ -28,3 +44,4 @@ background service for your user account:
     journalctl --user -u assistant-mattermost -f
 
 MSG
+fi

--- a/packaging/scripts/preremove.sh
+++ b/packaging/scripts/preremove.sh
@@ -1,13 +1,20 @@
 #!/bin/sh
 set -e
 
-# Stop and disable user services before the binary is removed.
+# Stop user services before the binary is removed/upgraded.
 # systemctl --user cannot be run as root, so we use loginctl to find
 # active sessions and stop the units on behalf of each user.
+#
+# On upgrade ($1 = "upgrade") we only stop — the postinst will restart.
+# On full remove ($1 = "remove") we also disable.
+action="${1:-remove}"
+
 for user_id in $(loginctl list-sessions --no-legend 2>/dev/null | awk '{print $3}' | sort -u); do
-    for svc in assistant-slack assistant-mattermost; do
-        systemctl --user -M "${user_id}@.host" stop    "$svc" 2>/dev/null || true
-        systemctl --user -M "${user_id}@.host" disable "$svc" 2>/dev/null || true
+    for svc in assistant-slack assistant-mattermost assistant-web-ui; do
+        systemctl --user -M "${user_id}@.host" stop "$svc" 2>/dev/null || true
+        if [ "$action" = "remove" ]; then
+            systemctl --user -M "${user_id}@.host" disable "$svc" 2>/dev/null || true
+        fi
     done
 done
 


### PR DESCRIPTION
## Summary

- `prerm` now only stops (not disables) services on upgrade; still disables on full remove
- `postinst` detects upgrades and restarts any previously-enabled services
- Adds `assistant-web-ui` to both scripts (was missing)

## Problem

When the bot triggered `sudo apt install -y assistant` to self-update, the `.deb` package's `prerm` script stopped **and disabled** the service. The `postinst` only printed first-install instructions without restarting. Result: bot stayed dead after every package upgrade.

## Fix

- `prerm`: checks `$1` — on `upgrade` only stops, on `remove` also disables
- `postinst`: checks `$2` (old version) — on upgrade, iterates logged-in users and restarts any enabled services; on fresh install, prints setup instructions as before