### PR TITLE
fix(packaging): use /run/systemd/users instead of loginctl for service restart

### DIFF
--- a/packaging/scripts/postinstall.sh
+++ b/packaging/scripts/postinstall.sh
@@ -13,7 +13,20 @@ action="${1:-configure}"
 
 if [ "$action" = "configure" ] && [ -n "$2" ]; then
     # $2 is set to the old version on upgrade — restart services.
-    for user_id in $(loginctl list-sessions --no-legend 2>/dev/null | awk '{print $3}' | sort -u); do
+    #
+    # loginctl list-sessions is unreliable in non-interactive dpkg contexts
+    # (e.g. during a self-triggered apt upgrade). Instead, iterate over
+    # /run/systemd/users/ which lists UIDs of all active user manager instances.
+    for uid_path in /run/systemd/users/*; do
+        user_id=$(basename "$uid_path")
+        # Skip non-numeric entries (e.g. root = 0 is fine, but skip any stray files)
+        case "$user_id" in
+            *[!0-9]*) continue ;;
+        esac
+        # Skip root and system users (UID < 1000)
+        if [ "$user_id" -lt 1000 ] 2>/dev/null; then
+            continue
+        fi
         for svc in assistant-slack assistant-mattermost assistant-web-ui; do
             # Only restart if the unit file exists and was previously enabled.
             if systemctl --user -M "${user_id}@.host" is-enabled "$svc" 2>/dev/null | grep -q enabled; then

--- a/packaging/scripts/preremove.sh
+++ b/packaging/scripts/preremove.sh
@@ -9,7 +9,16 @@ set -e
 # On full remove ($1 = "remove") we also disable.
 action="${1:-remove}"
 
-for user_id in $(loginctl list-sessions --no-legend 2>/dev/null | awk '{print $3}' | sort -u); do
+for uid_path in /run/systemd/users/*; do
+    user_id=$(basename "$uid_path")
+    # Skip non-numeric entries
+    case "$user_id" in
+        *[!0-9]*) continue ;;
+    esac
+    # Skip root and system users (UID < 1000)
+    if [ "$user_id" -lt 1000 ] 2>/dev/null; then
+        continue
+    fi
     for svc in assistant-slack assistant-mattermost assistant-web-ui; do
         systemctl --user -M "${user_id}@.host" stop "$svc" 2>/dev/null || true
         if [ "$action" = "remove" ]; then


### PR DESCRIPTION
## Summary

- **Problem:** `loginctl list-sessions` returns no results in non-interactive dpkg contexts (e.g. during a self-triggered apt upgrade from within the running service), causing postinstall to skip the restart loop entirely and leaving the bot dead after upgrading itself.
- **Fix:** Switch to iterating `/run/systemd/users/` which reliably lists active systemd user manager instances by UID, regardless of how dpkg was invoked.
- Applied consistently to both `postinstall.sh` and `preremove.sh`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of user discovery during installation and removal processes, particularly in non-interactive environments.
  * Enhanced filtering to properly exclude system and root users from per-user service management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->