### PR TITLE
docs(templates): mention TOOLS.md in AGENTS.md and SOUL.md

### DIFF
--- a/crates/core/templates/AGENTS.md
+++ b/crates/core/templates/AGENTS.md
@@ -17,6 +17,7 @@ You wake up fresh each session. These files are your continuity:
 
 - **Daily notes:** `~/.assistant/memory/YYYY-MM-DD.md` — raw log of what happened each day
 - **Long-term:** `~/.assistant/MEMORY.md` — curated facts, preferences, and decisions that survive indefinitely
+- **Tools notes:** `~/.assistant/TOOLS.md` — environment-specific setup (SSH hosts, devices, API endpoints)
 
 ### Write It Down — No "Mental Notes"!
 
@@ -53,6 +54,7 @@ Use `file-edit` for surgical edits to MEMORY.md, or `file-write` to rewrite sect
 
 - `memory-get target=notes/YYYY-MM-DD` — read a specific day's notes
 - `memory-get target=memory` — read MEMORY.md
+- `memory-get target=tools` — read your environment-specific tool notes
 - `memory-search query="natural language"` — search across all memory
 
 ---

--- a/crates/core/templates/SOUL.md
+++ b/crates/core/templates/SOUL.md
@@ -26,7 +26,7 @@ Be the assistant you'd actually want running on your own machine. Concise when t
 
 ## Continuity
 
-Each session, you wake up fresh. SOUL.md, IDENTITY.md, USER.md, and MEMORY.md are your persistent memory — loaded at the start of every turn.
+Each session, you wake up fresh. SOUL.md, IDENTITY.md, USER.md, TOOLS.md, and MEMORY.md are your persistent memory — loaded at the start of every turn.
 
 **You must actively maintain your memory. Don't wait to be asked.**
 
@@ -41,7 +41,7 @@ Each session, you wake up fresh. SOUL.md, IDENTITY.md, USER.md, and MEMORY.md ar
 
 **For durable facts and preferences** (things that survive indefinitely), update MEMORY.md with `file-write` or `file-edit`.
 
-**To read memory**: `memory-get target=soul|identity|user|memory|notes/YYYY-MM-DD`
+**To read memory**: `memory-get target=soul|identity|user|tools|memory|notes/YYYY-MM-DD`
 **To search memory**: `memory-search query="natural language"`
 
 If you change this file, tell the user. It's your soul, and they should know.


### PR DESCRIPTION
## Summary

- Add TOOLS.md to the file inventory in AGENTS.md so the agent knows it exists as a continuity file
- Add `memory-get target=tools` to the reading memory sections in both AGENTS.md and SOUL.md
- List TOOLS.md in the SOUL.md Continuity section alongside the other persistent files

Noticed while comparing deployed templates on schorschvm against the new defaults -- the agent had no instructions telling it about TOOLS.md.