### PR TITLE
fix: use literal version strings in a2a crates for release-please compatibility

### DIFF
--- a/crates/a2a-json-schema/Cargo.toml
+++ b/crates/a2a-json-schema/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "assistant-a2a-json-schema"
 description = "A2A protocol JSON Schema definitions and Rust types"
-version.workspace = true
+version = "0.1.15"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/a2a-proto/Cargo.toml
+++ b/crates/a2a-proto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "assistant-a2a-proto"
 description = "A2A protocol protobuf definitions"
-version.workspace = true
+version = "0.1.15"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Summary

- Replace `version.workspace = true` with literal `version = "0.1.15"` in `crates/a2a-proto/Cargo.toml` and `crates/a2a-json-schema/Cargo.toml`
- Fixes release-please `value at path package.version is not tagged` error that has blocked the last 3 release runs

The release-please Rust updater cannot parse TOML dotted-key workspace inheritance. All other workspace crates already use literal version strings.