### PR TITLE
fix(packaging): correct web-ui binary name and add EnvironmentFile

### DIFF
--- a/packaging/nfpm-assistant.yaml.tpl
+++ b/packaging/nfpm-assistant.yaml.tpl
@@ -18,6 +18,12 @@ contents:
     file_info:
       mode: 0755
 
+  # Web UI binary
+  - src: BIN_DIR_PLACEHOLDER/assistant-web-ui
+    dst: /usr/local/bin/assistant-web-ui
+    file_info:
+      mode: 0755
+
   # Default config template — never overwritten on upgrade
   - src: BIN_DIR_PLACEHOLDER/config.toml.example
     dst: /etc/assistant/config.toml.example

--- a/packaging/systemd/user/assistant-web-ui.service
+++ b/packaging/systemd/user/assistant-web-ui.service
@@ -6,7 +6,10 @@ After=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/assistant web-ui
+# Load token and optional overrides from user config.
+# Create this file with: echo 'ASSISTANT_WEB_TOKEN=<your-token>' > ~/.config/assistant/web-ui.env
+EnvironmentFile=-%h/.config/assistant/web-ui.env
+ExecStart=/usr/local/bin/assistant-web-ui
 Restart=always
 RestartSec=5
 


### PR DESCRIPTION
## Summary

- **Fix ExecStart**: the systemd unit called `assistant web-ui` (non-existent subcommand) instead of the standalone `assistant-web-ui` binary — the service would always fail to start
- **Ship the binary**: add `assistant-web-ui` to the nfpm package contents so it's actually installed to `/usr/local/bin/`
- **Add EnvironmentFile**: the unit now loads `~/.config/assistant/web-ui.env` (with `-` prefix so a missing file is not fatal), giving users a straightforward way to set `ASSISTANT_WEB_TOKEN` without needing a manual systemd override

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Web UI is now available as a standalone executable binary
  * Web UI can be configured via environment variables loaded from a user config file

* **Chores**
  * Updated packaging configuration to include Web UI binary distribution
  * Modified systemd service to support loading environment-based configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->