### PR TITLE
fix(ci): build and ship assistant-web-ui binary in release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -90,6 +90,14 @@ jobs:
             cargo build --release --target ${{ matrix.target }} -p assistant-cli
           fi
 
+      - name: Build assistant-web-ui
+        run: |
+          if [ "${{ matrix.use_cross }}" = "true" ]; then
+            cross build --release --target ${{ matrix.target }} -p assistant-web-ui
+          else
+            cargo build --release --target ${{ matrix.target }} -p assistant-web-ui
+          fi
+
       - name: Build assistant-signal (non-fatal)
         continue-on-error: true
         run: |
@@ -109,6 +117,10 @@ jobs:
           # Copy unified binary (Slack, Mattermost, MCP are subcommands of `assistant`)
           cp "target/${{ matrix.target }}/release/assistant" "${ARCHIVE}/" || \
             cp "target/${{ matrix.target }}/release/assistant.exe" "${ARCHIVE}/" 2>/dev/null || true
+
+          # Copy web-ui binary
+          cp "target/${{ matrix.target }}/release/assistant-web-ui" "${ARCHIVE}/" || \
+            cp "target/${{ matrix.target }}/release/assistant-web-ui.exe" "${ARCHIVE}/" 2>/dev/null || true
 
           # Copy signal binary if it was built (still a separate feature-gated binary)
           cp "target/${{ matrix.target }}/release/assistant-signal" "${ARCHIVE}/" 2>/dev/null || true


### PR DESCRIPTION
## Summary

- **Add build step** for `assistant-web-ui` in the release workflow (alongside `assistant-cli` and `assistant-signal`)
- **Include in archive** so nfpm packaging can find it at `BIN_DIR/assistant-web-ui`

This fixes the v0.1.19 release failure where the "Build OS packages" job failed with `assistant-web-ui: file does not exist`.