### PR TITLE
fix(interface-slack): strip cite tags and convert markdown tables in mrkdwn output

### DIFF
--- a/crates/interface-slack/src/tools.rs
+++ b/crates/interface-slack/src/tools.rs
@@ -411,6 +411,23 @@ fn strip_cite_tags(input: &str) -> String {
         match input[pos..].find("<cite") {
             Some(open_rel) => {
                 let open_abs = pos + open_rel;
+                // The character right after `<cite` must be a tag boundary
+                // (whitespace, `>`, or `/`) so we don't match `<cited>` etc.
+                let after = open_abs + "<cite".len();
+                if after < input.len() {
+                    let boundary = input.as_bytes()[after];
+                    if boundary != b' '
+                        && boundary != b'>'
+                        && boundary != b'/'
+                        && boundary != b'\t'
+                        && boundary != b'\n'
+                    {
+                        // Not a real `<cite` tag — copy the `<` and keep scanning.
+                        result.push_str(&input[pos..open_abs + 1]);
+                        pos = open_abs + 1;
+                        continue;
+                    }
+                }
                 // Copy everything before the tag.
                 result.push_str(&input[pos..open_abs]);
 
@@ -846,6 +863,13 @@ mod tests {
     #[test]
     fn no_cite_tags_unchanged() {
         assert_eq!(strip_cite_tags("Hello world"), "Hello world");
+    }
+
+    #[test]
+    fn cited_tag_not_stripped() {
+        // `<cited>` is not `<cite …>` — must not be treated as a cite tag.
+        let input = "<cited>foo</cited>";
+        assert_eq!(strip_cite_tags(input), input);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Strip `<cite index="...">...</cite>` tags from LLM responses before posting to Slack, preserving the inner text. RAG/search models (e.g. Perplexity) embed these for source attribution — they're meaningful in the provider's UI but render as raw HTML in Slack.
- Convert markdown tables (2+ consecutive `|`-prefixed lines) to fenced code blocks so Slack renders them monospaced with aligned columns. Single `|`-lines are left alone to avoid false positives.
- `slack-morphism` has no `Table` block variant, so Block Kit tables are not viable; the code-block approach works reliably within the existing text pipeline.

## Changes

**`crates/interface-slack/src/tools.rs`**

| Change | Details |
|--------|---------|
| `strip_cite_tags()` | New function — removes `<cite>` tags, keeps inner content. Handles multiple tags, complex index attributes, unclosed/malformed tags gracefully. |
| Pipeline wiring | `strip_cite_tags` called after `strip_think_tags`, before `markdown_to_mrkdwn` |
| Table detection in `markdown_to_mrkdwn` | At line start, collects consecutive `\|`-lines and wraps in `` ``` `` fence. Requires ≥2 lines to trigger. |
| 10 new tests | 6 for cite tag stripping, 4 for table conversion |

## Testing

All 73 tests pass (`cargo test -p assistant-interface-slack`). Clippy clean, formatted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Table-like content in Markdown is now formatted as code blocks in Slack messages for improved readability.

* **Bug Fixes**
  * Cite tags are now stripped from model outputs for cleaner formatting.

* **Tests**
  * Added test coverage for output formatting improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->