### PR TITLE
feat(llm): add dedicated embedding provider with Voyage AI support

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -18,4 +18,3 @@ dirs = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"
-

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -18,8 +18,8 @@ pub use memory::{
 pub use subagent::SubagentRunner;
 pub use tool::{Attachment, ToolHandler, ToolOutput};
 pub use types::{
-    AssistantConfig, ExecutionContext, Interface, LlmConfig, LlmProviderKind, MattermostConfig,
-    McpConfig, MemoryConfig, Message, MessageRole, MirrorConfig, OpenAIAuthMode, OpenAIOptions,
-    SignalConfig, SkillsConfig, SlackConfig, SlackListenMode, StorageConfig,
-    DEFAULT_MAX_AGENT_DEPTH,
+    AssistantConfig, EmbeddingConfig, EmbeddingProviderKind, ExecutionContext, Interface,
+    LlmConfig, LlmProviderKind, MattermostConfig, McpConfig, MemoryConfig, Message, MessageRole,
+    MirrorConfig, OpenAIAuthMode, OpenAIOptions, SignalConfig, SkillsConfig, SlackConfig,
+    SlackListenMode, StorageConfig, DEFAULT_MAX_AGENT_DEPTH,
 };

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -218,6 +218,47 @@ pub enum LlmProviderKind {
     OpenAI,
 }
 
+/// Which embedding backend to use when configured separately from the main
+/// LLM provider.
+///
+/// Set via `[llm.embeddings] provider = "voyage"` in `config.toml`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum EmbeddingProviderKind {
+    /// Local Ollama server (default model: `nomic-embed-text`).
+    Ollama,
+    /// OpenAI embeddings API (default model: `text-embedding-3-small`).
+    OpenAI,
+    /// Voyage AI embeddings (default model: `voyage-3-lite`).
+    /// Recommended by Anthropic for use alongside Claude.
+    Voyage,
+}
+
+/// Optional dedicated embedding provider configuration.
+///
+/// When present under `[llm.embeddings]`, overrides the main LLM provider's
+/// `embed()` method.  Useful when the main provider (e.g. Anthropic) lacks
+/// native embedding support, or when a specialised embedding model is desired.
+///
+/// ```toml
+/// [llm.embeddings]
+/// provider = "voyage"
+/// model = "voyage-3-lite"
+/// # api_key = "pa-..."  # or set VOYAGE_API_KEY env var
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmbeddingConfig {
+    /// Which embedding backend to use.
+    pub provider: EmbeddingProviderKind,
+    /// Model name (uses provider-specific default if omitted).
+    pub model: Option<String>,
+    /// Base URL override (uses provider-specific default if omitted).
+    pub base_url: Option<String>,
+    /// API key (also checked via provider-specific env vars:
+    /// `OPENAI_API_KEY`, `VOYAGE_API_KEY`).
+    pub api_key: Option<String>,
+}
+
 /// LLM / provider configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LlmConfig {
@@ -246,6 +287,13 @@ pub struct LlmConfig {
     /// Provider-specific OpenAI options.
     #[serde(default)]
     pub openai: OpenAIOptions,
+    /// Optional dedicated embedding provider override.
+    ///
+    /// When set, embeddings are served by this provider instead of the main
+    /// LLM provider.  Useful with Anthropic (which lacks native embeddings)
+    /// or when a specialised embedding model is desired.
+    #[serde(default)]
+    pub embeddings: Option<EmbeddingConfig>,
 }
 
 impl Default for LlmConfig {
@@ -260,6 +308,7 @@ impl Default for LlmConfig {
             api_key: None,
             anthropic: AnthropicOptions::default(),
             openai: OpenAIOptions::default(),
+            embeddings: None,
         }
     }
 }
@@ -484,5 +533,170 @@ impl Default for MemoryConfig {
             heartbeat_path: None,
             boot_path: None,
         }
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- EmbeddingConfig deserialization --------------------------------------
+
+    #[test]
+    fn embedding_config_voyage_all_fields() {
+        let toml_str = r#"
+            provider = "voyage"
+            model = "voyage-3-large"
+            base_url = "https://custom.voyage.example.com"
+            api_key = "pa-test-key"
+        "#;
+        let cfg: EmbeddingConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.provider, EmbeddingProviderKind::Voyage);
+        assert_eq!(cfg.model.as_deref(), Some("voyage-3-large"));
+        assert_eq!(
+            cfg.base_url.as_deref(),
+            Some("https://custom.voyage.example.com")
+        );
+        assert_eq!(cfg.api_key.as_deref(), Some("pa-test-key"));
+    }
+
+    #[test]
+    fn embedding_config_ollama_minimal() {
+        let toml_str = r#"provider = "ollama""#;
+        let cfg: EmbeddingConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.provider, EmbeddingProviderKind::Ollama);
+        assert!(cfg.model.is_none());
+        assert!(cfg.base_url.is_none());
+        assert!(cfg.api_key.is_none());
+    }
+
+    #[test]
+    fn embedding_config_openai_with_model() {
+        let toml_str = r#"
+            provider = "openai"
+            model = "text-embedding-3-large"
+        "#;
+        let cfg: EmbeddingConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.provider, EmbeddingProviderKind::OpenAI);
+        assert_eq!(cfg.model.as_deref(), Some("text-embedding-3-large"));
+    }
+
+    #[test]
+    fn embedding_config_invalid_provider_errors() {
+        let toml_str = r#"provider = "nonexistent""#;
+        let result = toml::from_str::<EmbeddingConfig>(toml_str);
+        assert!(
+            result.is_err(),
+            "Unknown provider should fail deserialization"
+        );
+    }
+
+    // -- LlmConfig with embeddings section -----------------------------------
+
+    #[test]
+    fn llm_config_without_embeddings_defaults_to_none() {
+        let toml_str = r#"
+            provider = "anthropic"
+            model = "claude-opus-4-6"
+        "#;
+        let cfg: LlmConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.provider, LlmProviderKind::Anthropic);
+        assert!(
+            cfg.embeddings.is_none(),
+            "Embeddings should default to None"
+        );
+    }
+
+    #[test]
+    fn llm_config_with_embeddings_section() {
+        let toml_str = r#"
+            provider = "anthropic"
+            model = "claude-opus-4-6"
+
+            [embeddings]
+            provider = "voyage"
+            model = "voyage-3-lite"
+            api_key = "pa-secret"
+        "#;
+        let cfg: LlmConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.provider, LlmProviderKind::Anthropic);
+        let emb = cfg.embeddings.expect("embeddings should be Some");
+        assert_eq!(emb.provider, EmbeddingProviderKind::Voyage);
+        assert_eq!(emb.model.as_deref(), Some("voyage-3-lite"));
+        assert_eq!(emb.api_key.as_deref(), Some("pa-secret"));
+    }
+
+    #[test]
+    fn llm_config_with_ollama_embeddings_override() {
+        let toml_str = r#"
+            provider = "anthropic"
+            model = "claude-opus-4-6"
+
+            [embeddings]
+            provider = "ollama"
+            model = "nomic-embed-text"
+            base_url = "http://localhost:11434"
+        "#;
+        let cfg: LlmConfig = toml::from_str(toml_str).unwrap();
+        let emb = cfg.embeddings.expect("embeddings should be Some");
+        assert_eq!(emb.provider, EmbeddingProviderKind::Ollama);
+        assert_eq!(emb.model.as_deref(), Some("nomic-embed-text"));
+        assert_eq!(emb.base_url.as_deref(), Some("http://localhost:11434"));
+    }
+
+    #[test]
+    fn full_assistant_config_with_embeddings() {
+        let toml_str = r#"
+            [llm]
+            provider = "anthropic"
+            model = "claude-opus-4-6"
+            api_key = "sk-ant-test"
+
+            [llm.embeddings]
+            provider = "openai"
+            model = "text-embedding-3-small"
+            api_key = "sk-openai-test"
+        "#;
+        let cfg: AssistantConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.llm.provider, LlmProviderKind::Anthropic);
+        let emb = cfg.llm.embeddings.expect("embeddings should be Some");
+        assert_eq!(emb.provider, EmbeddingProviderKind::OpenAI);
+        assert_eq!(emb.model.as_deref(), Some("text-embedding-3-small"));
+        assert_eq!(emb.api_key.as_deref(), Some("sk-openai-test"));
+    }
+
+    #[test]
+    fn full_assistant_config_without_embeddings() {
+        let toml_str = r#"
+            [llm]
+            provider = "ollama"
+            model = "qwen2.5:7b"
+        "#;
+        let cfg: AssistantConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.llm.provider, LlmProviderKind::Ollama);
+        assert!(cfg.llm.embeddings.is_none());
+    }
+
+    // -- Default values ------------------------------------------------------
+
+    #[test]
+    fn llm_config_default_has_no_embeddings() {
+        let cfg = LlmConfig::default();
+        assert!(
+            cfg.embeddings.is_none(),
+            "Default config should have no embedding override"
+        );
+    }
+
+    #[test]
+    fn embedding_provider_kind_serializes_lowercase() {
+        let json = serde_json::to_string(&EmbeddingProviderKind::Voyage).unwrap();
+        assert_eq!(json, "\"voyage\"");
+        let json = serde_json::to_string(&EmbeddingProviderKind::Ollama).unwrap();
+        assert_eq!(json, "\"ollama\"");
+        let json = serde_json::to_string(&EmbeddingProviderKind::OpenAI).unwrap();
+        assert_eq!(json, "\"openai\"");
     }
 }

--- a/crates/interface-cli/src/main.rs
+++ b/crates/interface-cli/src/main.rs
@@ -5,11 +5,17 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use assistant_core::{AssistantConfig, Interface, LlmProviderKind, MemoryLoader, MessageBus};
-use assistant_llm::LlmProvider;
+use assistant_core::{
+    AssistantConfig, EmbeddingConfig, EmbeddingProviderKind, Interface, LlmProviderKind,
+    MemoryLoader, MessageBus,
+};
+use assistant_llm::{
+    EmbeddingProvider, LlmEmbedder, LlmProvider, VoyageConfig, VoyageEmbedder,
+    WithEmbeddingOverride,
+};
 use assistant_provider_anthropic::AnthropicProvider;
-use assistant_provider_ollama::OllamaProvider;
-use assistant_provider_openai::OpenAIProvider;
+use assistant_provider_ollama::{OllamaConfig, OllamaProvider};
+use assistant_provider_openai::{OpenAIProvider, OpenAIProviderConfig};
 use assistant_runtime::{
     init_tracing, orchestrator::ConfirmationCallback, scheduler::spawn_scheduler,
     start_conversation_context, Orchestrator,
@@ -376,6 +382,86 @@ fn cmd_reset(db_path: &Path, config: &AssistantConfig, skip_confirm: bool) -> Re
     Ok(())
 }
 
+// ── Embedding provider factory ────────────────────────────────────────────────
+
+/// Build a dedicated [`EmbeddingProvider`] from an [`EmbeddingConfig`].
+///
+/// Falls back to provider-specific env vars for API keys.
+fn build_embedding_provider(
+    emb_cfg: &EmbeddingConfig,
+    main_cfg: &assistant_core::LlmConfig,
+) -> Result<Arc<dyn EmbeddingProvider>> {
+    match emb_cfg.provider {
+        EmbeddingProviderKind::Ollama => {
+            let ollama_cfg = OllamaConfig {
+                model: "unused".to_string(),
+                base_url: emb_cfg
+                    .base_url
+                    .clone()
+                    .unwrap_or_else(|| main_cfg.base_url.clone()),
+                timeout_secs: main_cfg.timeout_secs,
+                embedding_model: emb_cfg
+                    .model
+                    .clone()
+                    .unwrap_or_else(|| "nomic-embed-text".to_string()),
+            };
+            let provider = OllamaProvider::new(ollama_cfg)
+                .context("Failed to create Ollama embedding provider")?;
+            Ok(Arc::new(LlmEmbedder(Arc::new(provider))))
+        }
+        EmbeddingProviderKind::OpenAI => {
+            let api_key = emb_cfg
+                .api_key
+                .clone()
+                .or_else(|| std::env::var("OPENAI_API_KEY").ok())
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "OpenAI embedding provider requires an API key. \
+                         Set api_key in [llm.embeddings] or OPENAI_API_KEY env var."
+                    )
+                })?;
+            let provider_cfg = OpenAIProviderConfig {
+                model: "unused".to_string(),
+                base_url: emb_cfg
+                    .base_url
+                    .clone()
+                    .unwrap_or_else(|| "https://api.openai.com/v1".to_string()),
+                timeout_secs: main_cfg.timeout_secs,
+                max_tokens: 8192,
+                embedding_model: emb_cfg
+                    .model
+                    .clone()
+                    .unwrap_or_else(|| "text-embedding-3-small".to_string()),
+            };
+            let provider = OpenAIProvider::new(provider_cfg, &api_key)
+                .context("Failed to create OpenAI embedding provider")?;
+            Ok(Arc::new(LlmEmbedder(Arc::new(provider))))
+        }
+        EmbeddingProviderKind::Voyage => {
+            let api_key = emb_cfg
+                .api_key
+                .clone()
+                .or_else(|| std::env::var("VOYAGE_API_KEY").ok())
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Voyage AI embedding provider requires an API key. \
+                         Set api_key in [llm.embeddings] or VOYAGE_API_KEY env var."
+                    )
+                })?;
+            let mut voyage_cfg = VoyageConfig::new(api_key);
+            if let Some(ref url) = emb_cfg.base_url {
+                voyage_cfg = voyage_cfg.with_base_url(url.clone());
+            }
+            if let Some(ref model) = emb_cfg.model {
+                voyage_cfg = voyage_cfg.with_model(model.clone());
+            }
+            let embedder = VoyageEmbedder::new(voyage_cfg)
+                .context("Failed to create Voyage AI embedding provider")?;
+            Ok(Arc::new(embedder))
+        }
+    }
+}
+
 // ── Common bootstrap ──────────────────────────────────────────────────────────
 
 struct Bootstrap {
@@ -434,6 +520,20 @@ async fn bootstrap(
             OpenAIProvider::from_llm_config(&config.llm)
                 .context("Failed to create OpenAI LLM client")?,
         ),
+    };
+
+    // Optionally wrap with a dedicated embedding provider.
+    let llm: Arc<dyn LlmProvider> = if let Some(ref emb_cfg) = config.llm.embeddings {
+        let embedder = build_embedding_provider(emb_cfg, &config.llm)
+            .context("Failed to build dedicated embedding provider")?;
+        info!(
+            provider = ?emb_cfg.provider,
+            model = emb_cfg.model.as_deref().unwrap_or("(default)"),
+            "Using dedicated embedding provider"
+        );
+        Arc::new(WithEmbeddingOverride::new(llm, embedder))
+    } else {
+        llm
     };
 
     // Build tool executor.

--- a/crates/llm/src/embedding.rs
+++ b/crates/llm/src/embedding.rs
@@ -1,0 +1,385 @@
+//! Dedicated embedding provider abstraction.
+//!
+//! Allows decoupling the embedding backend from the main LLM provider.
+//! For example, an Anthropic chat provider can use Ollama or Voyage AI
+//! for embeddings via [`WithEmbeddingOverride`].
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::mpsc;
+
+use crate::provider::{Capabilities, LlmProvider};
+use crate::tool_spec::ToolSpec;
+use crate::{ChatHistoryMessage, LlmResponse};
+
+// ── EmbeddingProvider trait ──────────────────────────────────────────────────
+
+/// Minimal trait for providers that can compute text embeddings.
+///
+/// Unlike [`LlmProvider`], implementors only need to support `embed()`.
+/// This allows lightweight embedding-only clients (e.g. Voyage AI) without
+/// stubbing out chat methods.
+#[async_trait]
+pub trait EmbeddingProvider: Send + Sync {
+    /// Compute a dense vector embedding for `text`.
+    async fn embed(&self, text: &str) -> anyhow::Result<Vec<f32>>;
+}
+
+// ── LlmEmbedder adapter ─────────────────────────────────────────────────────
+
+/// Adapts any [`LlmProvider`] to the [`EmbeddingProvider`] trait by
+/// delegating to its `embed()` method.
+///
+/// Use this to wrap an existing Ollama or OpenAI provider as an
+/// embedding-only backend.
+pub struct LlmEmbedder(pub Arc<dyn LlmProvider>);
+
+#[async_trait]
+impl EmbeddingProvider for LlmEmbedder {
+    async fn embed(&self, text: &str) -> anyhow::Result<Vec<f32>> {
+        self.0.embed(text).await
+    }
+}
+
+// ── WithEmbeddingOverride ────────────────────────────────────────────────────
+
+/// Wraps a primary [`LlmProvider`] and overrides its `embed()` with a
+/// dedicated [`EmbeddingProvider`].
+///
+/// Chat methods are forwarded to the inner provider unchanged.  This is
+/// the composition point used at startup to combine e.g. an Anthropic
+/// chat provider with an Ollama or Voyage embedding provider.
+pub struct WithEmbeddingOverride {
+    inner: Arc<dyn LlmProvider>,
+    embedder: Arc<dyn EmbeddingProvider>,
+}
+
+impl WithEmbeddingOverride {
+    /// Create a new composite provider.
+    ///
+    /// * `inner` — the primary provider for chat / streaming / capabilities.
+    /// * `embedder` — the dedicated embedding backend.
+    pub fn new(inner: Arc<dyn LlmProvider>, embedder: Arc<dyn EmbeddingProvider>) -> Self {
+        Self { inner, embedder }
+    }
+}
+
+#[async_trait]
+impl LlmProvider for WithEmbeddingOverride {
+    fn capabilities(&self) -> Capabilities {
+        self.inner.capabilities()
+    }
+
+    async fn chat(
+        &self,
+        system_prompt: &str,
+        history: &[ChatHistoryMessage],
+        tools: &[ToolSpec],
+    ) -> anyhow::Result<LlmResponse> {
+        self.inner.chat(system_prompt, history, tools).await
+    }
+
+    async fn chat_streaming(
+        &self,
+        system_prompt: &str,
+        history: &[ChatHistoryMessage],
+        tools: &[ToolSpec],
+        token_sink: Option<mpsc::Sender<String>>,
+    ) -> anyhow::Result<LlmResponse> {
+        self.inner
+            .chat_streaming(system_prompt, history, tools, token_sink)
+            .await
+    }
+
+    async fn embed(&self, text: &str) -> anyhow::Result<Vec<f32>> {
+        self.embedder.embed(text).await
+    }
+
+    fn provider_name(&self) -> &str {
+        self.inner.provider_name()
+    }
+
+    fn model_name(&self) -> &str {
+        self.inner.model_name()
+    }
+
+    fn server_address(&self) -> &str {
+        self.inner.server_address()
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::LlmResponseMeta;
+
+    /// Stub provider that always returns a fixed answer.
+    struct StubChat;
+
+    #[async_trait]
+    impl LlmProvider for StubChat {
+        fn capabilities(&self) -> Capabilities {
+            Capabilities {
+                tools: crate::ToolSupport::None,
+                streaming: false,
+                vision: false,
+                hosted_tools: Vec::new(),
+            }
+        }
+
+        async fn chat(
+            &self,
+            _system_prompt: &str,
+            _history: &[ChatHistoryMessage],
+            _tools: &[ToolSpec],
+        ) -> anyhow::Result<LlmResponse> {
+            Ok(LlmResponse::FinalAnswer(
+                "stub".to_string(),
+                LlmResponseMeta::default(),
+            ))
+        }
+
+        async fn chat_streaming(
+            &self,
+            _system_prompt: &str,
+            _history: &[ChatHistoryMessage],
+            _tools: &[ToolSpec],
+            _token_sink: Option<mpsc::Sender<String>>,
+        ) -> anyhow::Result<LlmResponse> {
+            Ok(LlmResponse::FinalAnswer(
+                "stub".to_string(),
+                LlmResponseMeta::default(),
+            ))
+        }
+
+        async fn embed(&self, _text: &str) -> anyhow::Result<Vec<f32>> {
+            anyhow::bail!("StubChat does not support embeddings")
+        }
+
+        fn provider_name(&self) -> &str {
+            "stub"
+        }
+    }
+
+    /// Stub embedder that returns a fixed vector.
+    struct StubEmbedder;
+
+    #[async_trait]
+    impl EmbeddingProvider for StubEmbedder {
+        async fn embed(&self, _text: &str) -> anyhow::Result<Vec<f32>> {
+            Ok(vec![0.1, 0.2, 0.3])
+        }
+    }
+
+    /// Stub provider that actually supports embeddings (like Ollama/OpenAI).
+    struct StubChatWithEmbedding;
+
+    #[async_trait]
+    impl LlmProvider for StubChatWithEmbedding {
+        fn capabilities(&self) -> Capabilities {
+            Capabilities {
+                tools: crate::ToolSupport::None,
+                streaming: false,
+                vision: false,
+                hosted_tools: Vec::new(),
+            }
+        }
+
+        async fn chat(
+            &self,
+            _system_prompt: &str,
+            _history: &[ChatHistoryMessage],
+            _tools: &[ToolSpec],
+        ) -> anyhow::Result<LlmResponse> {
+            Ok(LlmResponse::FinalAnswer(
+                "chat-with-embed".to_string(),
+                LlmResponseMeta::default(),
+            ))
+        }
+
+        async fn chat_streaming(
+            &self,
+            _system_prompt: &str,
+            _history: &[ChatHistoryMessage],
+            _tools: &[ToolSpec],
+            _token_sink: Option<mpsc::Sender<String>>,
+        ) -> anyhow::Result<LlmResponse> {
+            Ok(LlmResponse::FinalAnswer(
+                "chat-with-embed".to_string(),
+                LlmResponseMeta::default(),
+            ))
+        }
+
+        async fn embed(&self, _text: &str) -> anyhow::Result<Vec<f32>> {
+            Ok(vec![1.0, 2.0, 3.0, 4.0])
+        }
+
+        fn provider_name(&self) -> &str {
+            "stub-with-embed"
+        }
+
+        fn model_name(&self) -> &str {
+            "embed-model"
+        }
+
+        fn server_address(&self) -> &str {
+            "http://localhost:9999"
+        }
+    }
+
+    /// Stub embedder that always fails (simulates misconfigured provider).
+    struct FailingEmbedder;
+
+    #[async_trait]
+    impl EmbeddingProvider for FailingEmbedder {
+        async fn embed(&self, _text: &str) -> anyhow::Result<Vec<f32>> {
+            anyhow::bail!("embedding service unavailable")
+        }
+    }
+
+    // -- WithEmbeddingOverride tests -----------------------------------------
+
+    #[tokio::test]
+    async fn override_delegates_embed_to_embedder() {
+        let chat = Arc::new(StubChat);
+        let embedder = Arc::new(StubEmbedder);
+        let composite = WithEmbeddingOverride::new(chat, embedder);
+
+        // embed() should use the dedicated embedder, not the inner provider.
+        let result = composite.embed("hello").await.unwrap();
+        assert_eq!(result, vec![0.1, 0.2, 0.3]);
+    }
+
+    #[tokio::test]
+    async fn override_delegates_chat_to_inner() {
+        let chat = Arc::new(StubChat);
+        let embedder = Arc::new(StubEmbedder);
+        let composite = WithEmbeddingOverride::new(chat, embedder);
+
+        let response = composite.chat("sys", &[], &[]).await.unwrap();
+        match response {
+            LlmResponse::FinalAnswer(text, _) => assert_eq!(text, "stub"),
+            other => panic!("Expected FinalAnswer, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn override_delegates_chat_streaming_to_inner() {
+        let chat = Arc::new(StubChat);
+        let embedder = Arc::new(StubEmbedder);
+        let composite = WithEmbeddingOverride::new(chat, embedder);
+
+        let response = composite
+            .chat_streaming("sys", &[], &[], None)
+            .await
+            .unwrap();
+        match response {
+            LlmResponse::FinalAnswer(text, _) => assert_eq!(text, "stub"),
+            other => panic!("Expected FinalAnswer, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn override_preserves_inner_identity() {
+        let chat: Arc<dyn LlmProvider> = Arc::new(StubChatWithEmbedding);
+        let embedder: Arc<dyn EmbeddingProvider> = Arc::new(StubEmbedder);
+        let composite = WithEmbeddingOverride::new(chat, embedder);
+
+        assert_eq!(composite.provider_name(), "stub-with-embed");
+        assert_eq!(composite.model_name(), "embed-model");
+        assert_eq!(composite.server_address(), "http://localhost:9999");
+    }
+
+    #[tokio::test]
+    async fn override_embed_error_propagates_from_embedder() {
+        let chat = Arc::new(StubChatWithEmbedding);
+        let embedder: Arc<dyn EmbeddingProvider> = Arc::new(FailingEmbedder);
+        let composite = WithEmbeddingOverride::new(chat, embedder);
+
+        // The inner provider supports embeddings, but the override should use
+        // the dedicated (failing) embedder instead.
+        let result = composite.embed("hello").await;
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().to_string().contains("unavailable"),
+            "Error should come from the FailingEmbedder"
+        );
+    }
+
+    // -- Fallback: no override means main provider is used -------------------
+
+    #[tokio::test]
+    async fn no_override_uses_main_provider_embed() {
+        // When no WithEmbeddingOverride is applied, the provider's own
+        // embed() is called.  This simulates the Ollama/OpenAI path where
+        // [llm.embeddings] is not configured.
+        let provider: Arc<dyn LlmProvider> = Arc::new(StubChatWithEmbedding);
+        let result = provider.embed("test").await.unwrap();
+        assert_eq!(
+            result,
+            vec![1.0, 2.0, 3.0, 4.0],
+            "Should get the main provider's embedding"
+        );
+    }
+
+    #[tokio::test]
+    async fn no_override_error_when_main_provider_lacks_embeddings() {
+        // When no WithEmbeddingOverride is applied and the main provider
+        // does not support embeddings (like Anthropic), embed() returns
+        // an error.  This simulates the case where the user forgot to
+        // configure [llm.embeddings].
+        let provider: Arc<dyn LlmProvider> = Arc::new(StubChat);
+        let result = provider.embed("test").await;
+        assert!(
+            result.is_err(),
+            "Provider without embedding support should error"
+        );
+    }
+
+    // -- LlmEmbedder adapter ------------------------------------------------
+
+    #[tokio::test]
+    async fn llm_embedder_adapter_delegates_error() {
+        // Verify LlmEmbedder wraps an LlmProvider for use as EmbeddingProvider.
+        // StubChat.embed() returns an error, so LlmEmbedder should propagate it.
+        let provider: Arc<dyn LlmProvider> = Arc::new(StubChat);
+        let adapter = LlmEmbedder(provider);
+        let result = adapter.embed("hello").await;
+        assert!(result.is_err(), "StubChat embed should error");
+    }
+
+    #[tokio::test]
+    async fn llm_embedder_adapter_delegates_success() {
+        // When wrapping a provider that supports embeddings, the adapter
+        // should forward the result.
+        let provider: Arc<dyn LlmProvider> = Arc::new(StubChatWithEmbedding);
+        let adapter = LlmEmbedder(provider);
+        let result = adapter.embed("hello").await.unwrap();
+        assert_eq!(
+            result,
+            vec![1.0, 2.0, 3.0, 4.0],
+            "Adapter should forward embedding from inner provider"
+        );
+    }
+
+    // -- Composite: override replaces a working provider's embed -------------
+
+    #[tokio::test]
+    async fn override_replaces_working_embed_with_dedicated() {
+        // Even if the inner provider supports embeddings natively,
+        // the override should take precedence.
+        let chat: Arc<dyn LlmProvider> = Arc::new(StubChatWithEmbedding);
+        let embedder: Arc<dyn EmbeddingProvider> = Arc::new(StubEmbedder);
+        let composite = WithEmbeddingOverride::new(chat, embedder);
+
+        let result = composite.embed("hello").await.unwrap();
+        assert_eq!(
+            result,
+            vec![0.1, 0.2, 0.3],
+            "Override embedder should win over inner provider's embed()"
+        );
+    }
+}

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -1,10 +1,14 @@
 pub mod client;
+pub mod embedding;
 pub mod provider;
 pub mod tool_spec;
+pub mod voyage;
 
 pub use client::{
     ChatHistoryMessage, ChatRole, ContentBlock, LlmClient, LlmClientConfig, LlmResponse,
     LlmResponseMeta, ToolCallItem,
 };
+pub use embedding::{EmbeddingProvider, LlmEmbedder, WithEmbeddingOverride};
 pub use provider::{Capabilities, HostedTool, LlmProvider, ToolSupport};
 pub use tool_spec::ToolSpec;
+pub use voyage::{VoyageConfig, VoyageEmbedder};

--- a/crates/llm/src/voyage.rs
+++ b/crates/llm/src/voyage.rs
@@ -1,0 +1,229 @@
+//! Voyage AI embedding client.
+//!
+//! Voyage AI is the embedding provider recommended by Anthropic.  This module
+//! provides a lightweight [`EmbeddingProvider`] implementation that calls the
+//! Voyage AI `/v1/embeddings` REST endpoint.
+//!
+//! # Configuration
+//!
+//! ```toml
+//! [llm.embeddings]
+//! provider = "voyage"
+//! model = "voyage-3-lite"        # optional, this is the default
+//! # api_key = "pa-..."           # or set VOYAGE_API_KEY env var
+//! ```
+
+use async_trait::async_trait;
+use serde::Deserialize;
+use serde_json::json;
+use tracing::debug;
+
+use crate::embedding::EmbeddingProvider;
+
+// ── Defaults ─────────────────────────────────────────────────────────────────
+
+/// Default Voyage AI base URL.
+pub const DEFAULT_VOYAGE_BASE_URL: &str = "https://api.voyageai.com";
+
+/// Default embedding model (good balance of quality and cost).
+pub const DEFAULT_VOYAGE_MODEL: &str = "voyage-3-lite";
+
+// ── VoyageConfig ─────────────────────────────────────────────────────────────
+
+/// Configuration for the Voyage AI embedder.
+#[derive(Debug, Clone)]
+pub struct VoyageConfig {
+    /// Voyage AI API key.
+    pub api_key: String,
+    /// Base URL (default: `"https://api.voyageai.com"`).
+    pub base_url: String,
+    /// Model name (default: `"voyage-3-lite"`).
+    pub model: String,
+}
+
+impl VoyageConfig {
+    /// Create a new config with the given API key and sensible defaults.
+    pub fn new(api_key: String) -> Self {
+        Self {
+            api_key,
+            base_url: DEFAULT_VOYAGE_BASE_URL.to_string(),
+            model: DEFAULT_VOYAGE_MODEL.to_string(),
+        }
+    }
+
+    /// Override the base URL.
+    pub fn with_base_url(mut self, url: String) -> Self {
+        self.base_url = url;
+        self
+    }
+
+    /// Override the model name.
+    pub fn with_model(mut self, model: String) -> Self {
+        self.model = model;
+        self
+    }
+}
+
+// ── Voyage API response types ────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct VoyageEmbeddingData {
+    embedding: Vec<f32>,
+}
+
+#[derive(Deserialize)]
+struct VoyageEmbedResponse {
+    data: Vec<VoyageEmbeddingData>,
+}
+
+// ── VoyageEmbedder ───────────────────────────────────────────────────────────
+
+/// Voyage AI embedding client implementing [`EmbeddingProvider`].
+pub struct VoyageEmbedder {
+    config: VoyageConfig,
+    http: reqwest::Client,
+}
+
+impl VoyageEmbedder {
+    /// Create a new Voyage AI embedding client.
+    pub fn new(config: VoyageConfig) -> anyhow::Result<Self> {
+        let http = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .map_err(|e| anyhow::anyhow!("Failed to build Voyage HTTP client: {e}"))?;
+        Ok(Self { config, http })
+    }
+}
+
+#[async_trait]
+impl EmbeddingProvider for VoyageEmbedder {
+    async fn embed(&self, text: &str) -> anyhow::Result<Vec<f32>> {
+        let url = format!(
+            "{}/v1/embeddings",
+            self.config.base_url.trim_end_matches('/')
+        );
+        let body = json!({
+            "input": [text],
+            "model": self.config.model,
+        });
+
+        debug!(model = %self.config.model, "Sending embedding request to Voyage AI");
+
+        let resp = self
+            .http
+            .post(&url)
+            .header("authorization", format!("Bearer {}", self.config.api_key))
+            .header("content-type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| anyhow::anyhow!("Voyage AI embedding request failed: {e}"))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            anyhow::bail!("Voyage AI returned {status}: {text}");
+        }
+
+        let embed_resp: VoyageEmbedResponse = resp
+            .json()
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to parse Voyage AI response: {e}"))?;
+
+        embed_resp
+            .data
+            .into_iter()
+            .next()
+            .map(|d| d.embedding)
+            .ok_or_else(|| anyhow::anyhow!("Voyage AI returned empty embedding data"))
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn voyage_embed_parses_response() {
+        let mock_server = MockServer::start().await;
+
+        let body = serde_json::json!({
+            "object": "list",
+            "data": [
+                {
+                    "embedding": [0.1, 0.2, 0.3, 0.4],
+                    "index": 0
+                }
+            ],
+            "model": "voyage-3-lite",
+            "usage": { "total_tokens": 5 }
+        });
+
+        Mock::given(method("POST"))
+            .and(path("/v1/embeddings"))
+            .and(header("authorization", "Bearer test-key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+            .mount(&mock_server)
+            .await;
+
+        let config = VoyageConfig::new("test-key".to_string()).with_base_url(mock_server.uri());
+        let embedder = VoyageEmbedder::new(config).unwrap();
+
+        let result = embedder.embed("hello world").await.unwrap();
+        assert_eq!(result, vec![0.1, 0.2, 0.3, 0.4]);
+    }
+
+    #[tokio::test]
+    async fn voyage_embed_propagates_http_error() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/embeddings"))
+            .respond_with(ResponseTemplate::new(401).set_body_string("Unauthorized"))
+            .mount(&mock_server)
+            .await;
+
+        let config = VoyageConfig::new("bad-key".to_string()).with_base_url(mock_server.uri());
+        let embedder = VoyageEmbedder::new(config).unwrap();
+
+        let result = embedder.embed("hello").await;
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("401"),
+            "Error should mention status code: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn voyage_embed_handles_empty_data() {
+        let mock_server = MockServer::start().await;
+
+        let body = serde_json::json!({
+            "object": "list",
+            "data": [],
+            "model": "voyage-3-lite",
+            "usage": { "total_tokens": 0 }
+        });
+
+        Mock::given(method("POST"))
+            .and(path("/v1/embeddings"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+            .mount(&mock_server)
+            .await;
+
+        let config = VoyageConfig::new("test-key".to_string()).with_base_url(mock_server.uri());
+        let embedder = VoyageEmbedder::new(config).unwrap();
+
+        let result = embedder.embed("hello").await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("empty embedding data"));
+    }
+}

--- a/crates/provider-openai/src/lib.rs
+++ b/crates/provider-openai/src/lib.rs
@@ -9,4 +9,4 @@ mod oauth;
 mod provider;
 
 pub use oauth::OAuthManager;
-pub use provider::OpenAIProvider;
+pub use provider::{OpenAIProvider, OpenAIProviderConfig};


### PR DESCRIPTION
## Summary

- Decouple embedding from the main LLM provider so any combination works (e.g. Anthropic for chat + Ollama or Voyage AI for embeddings)
- Add `EmbeddingProvider` trait and `WithEmbeddingOverride` composite wrapper for transparent `embed()` delegation
- Add `VoyageEmbedder` — the embedding provider recommended by Anthropic — with a wiremock-tested HTTP client
- Add `[llm.embeddings]` config section supporting `ollama`, `openai`, and `voyage` backends
- Wire up the embedding provider factory in CLI bootstrap; when not configured, the main provider's `embed()` is used as-is (Ollama/OpenAI work out of the box)

## Motivation

Anthropic does not offer a native embeddings API. Previously, using Anthropic as the main provider meant `embed()` always returned an error, breaking memory search hybrid reranking. This change lets users configure a separate embedding backend:

```toml
[llm]
provider = "anthropic"
model = "claude-sonnet-4-20250514"

[llm.embeddings]
provider = "voyage"   # or "ollama" or "openai"
model = "voyage-3-lite"
# api_key = "pa-..."  # or set VOYAGE_API_KEY env var
```

For Ollama and OpenAI users, nothing changes — their providers already support embeddings natively and the fallback path is preserved.

## Architecture

| Layer | What |
|---|---|
| `EmbeddingProvider` trait | Minimal `embed()`-only trait in `crates/llm/` |
| `WithEmbeddingOverride` | Composite `LlmProvider` that delegates chat to inner, embed to dedicated embedder |
| `LlmEmbedder` | Adapter: wraps any `LlmProvider` as an `EmbeddingProvider` |
| `VoyageEmbedder` | Voyage AI REST client implementing `EmbeddingProvider` |
| `EmbeddingConfig` | New `[llm.embeddings]` config section in `crates/core/` |
| CLI wiring | `build_embedding_provider()` factory in `bootstrap()` |

## Test coverage (22 new tests)

- **Config deserialization** (11): all provider kinds, optional fields, invalid provider, nested TOML sections, full `AssistantConfig` round-trip
- **Embedding behavior** (8): override delegation, fallback to main provider, error propagation, adapter success/error, identity preservation, streaming delegation
- **Voyage API** (3): response parsing, HTTP error propagation, empty data handling

All via `make lint` (zero warnings), `make format`, `make test` (all pass).