### PR TITLE
docs: document [llm.embeddings] config and update workspace tables

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,13 +26,16 @@ Install hooks after cloning: `make install-hooks`.
 
 ## Workspace Structure
 
-12 crates under `crates/`, one root crate. Edition 2021, resolver 2.
+Multiple crates under `crates/`, one root crate. Edition 2021, resolver 2.
 
 | Crate (package name)             | Path                          | Purpose                                              |
 |----------------------------------|-------------------------------|------------------------------------------------------|
 | `assistant-core`                 | `crates/core`                 | Shared types, ToolHandler trait, MessageBus trait      |
-| `assistant-llm`                  | `crates/llm`                  | LlmProvider trait, LlmClient, prompt builder          |
+| `assistant-llm`                  | `crates/llm`                  | LlmProvider trait, EmbeddingProvider, LlmClient       |
 | `assistant-provider-ollama`      | `crates/provider-ollama`      | Ollama LlmProvider implementation                     |
+| `assistant-provider-anthropic`   | `crates/provider-anthropic`   | Anthropic LlmProvider implementation                  |
+| `assistant-provider-openai`      | `crates/provider-openai`      | OpenAI LlmProvider implementation                     |
+| `assistant-skills`               | `crates/skills`               | Skill parsing, validation, embedded builtins          |
 | `assistant-storage`              | `crates/storage`              | SQLite (sqlx), SkillRegistry, TraceStore, MessageBus  |
 | `assistant-runtime`              | `crates/runtime`              | Orchestrator (main ReAct loop), SafetyGate, Scheduler |
 | `assistant-tool-executor`        | `crates/tool-executor`        | ToolHandler registry, builtin tools, dispatch         |
@@ -41,12 +44,13 @@ Install hooks after cloning: `make install-hooks`.
 | `assistant-interface-slack`      | `crates/interface-slack`      | Slack bot library                                     |
 | `assistant-interface-mattermost` | `crates/interface-mattermost` | Mattermost bot library                                |
 | `assistant-interface-signal`     | `crates/interface-signal`     | Signal interface stub (feature-gated)                 |
+| `assistant-web-ui`               | `crates/web-ui`               | Trace analysis web UI + A2A protocol server           |
 | `assistant-integration-tests`    | `crates/integration-tests`    | End-to-end smoke tests                                |
 
 Dependency order (no cycles):
 ```
 interface-cli -> runtime -> llm -> core
-                    |         '-> provider-ollama
+                    |         '-> provider-ollama, provider-anthropic, provider-openai
                     |-> storage -> core
                     |-> tool-executor -> core, storage, llm
                     '-> mcp-server, interface-slack, interface-mattermost (optional features)

--- a/README.md
+++ b/README.md
@@ -172,14 +172,34 @@ Copy `config.toml` to `~/.assistant/config.toml` and edit:
 
 ```toml
 [llm]
-# Conservative default (≤ 8 GB VRAM). For 12 GB VRAM, try qwen2.5:14b.
+provider = "ollama"            # "ollama" (default), "anthropic", or "openai"
 model = "qwen2.5:7b"          # any Ollama model with tool-calling support
 base_url = "http://localhost:11434"
-tool_call_mode = "auto"        # "auto" | "native" | "react"
-max_iterations = 10
+max_iterations = 80
 
 [skills]
 disabled = []                   # optional list of tool names to disable
+```
+
+For cloud providers, set the provider and API key:
+
+```toml
+[llm]
+provider = "anthropic"
+model    = "claude-sonnet-4-20250514"
+api_key  = "sk-ant-..."       # or set ANTHROPIC_API_KEY env var
+```
+
+#### Embeddings
+
+Ollama and OpenAI support embeddings natively.  When using Anthropic (which
+lacks built-in embeddings), configure a dedicated embedding provider:
+
+```toml
+[llm.embeddings]
+provider = "voyage"            # "ollama", "openai", or "voyage"
+model    = "voyage-3-lite"     # optional, provider-specific default used
+# api_key = "pa-..."          # or set VOYAGE_API_KEY env var
 ```
 
 ## Workspace layout
@@ -187,9 +207,11 @@ disabled = []                   # optional list of tool names to disable
 ```
 assistant/
 ├── crates/
-│   ├── core/                  # SkillDef, parser, shared types
-│   ├── llm/                   # LlmProvider trait + LlmClient
-│   ├── provider-ollama/       # Ollama backend (native tool-call + ReAct)
+│   ├── core/                  # Shared types, ToolHandler trait, MessageBus
+│   ├── llm/                   # LlmProvider trait, EmbeddingProvider, LlmClient
+│   ├── provider-ollama/       # Ollama backend (native tool-call + embeddings)
+│   ├── provider-anthropic/    # Anthropic backend (Claude models)
+│   ├── provider-openai/       # OpenAI backend (GPT models + embeddings)
 │   ├── storage/               # SQLite, SkillRegistry, trace store, memory store
 │   ├── runtime/               # ReAct orchestrator, scheduler
 │   ├── tool-executor/         # Builtin tool registry + skill installer
@@ -198,7 +220,7 @@ assistant/
 │   ├── interface-slack/       # Slack Socket Mode library + slack-post skill
 │   ├── interface-mattermost/  # Mattermost WebSocket library
 │   ├── interface-signal/      # Signal interface (feature-gated, separate binary)
-│   └── web-ui/                # Optional trace analysis web UI
+│   └── web-ui/                # Trace analysis web UI + A2A protocol server
 ├── docker/                    # Dockerfiles (all build the unified assistant binary)
 ├── migrations/                # SQLite migration files
 ├── skills/                    # Built-in SKILL.md definitions

--- a/config.toml
+++ b/config.toml
@@ -54,6 +54,32 @@ timeout_secs = 120
 # blocked_domains = []
 # citations.enabled = true
 
+# ── Dedicated embedding provider ──────────────────────────────────────────────
+# Ollama and OpenAI support embeddings natively — no extra config needed.
+# For Anthropic (which has no built-in embeddings), or when you want a
+# specialised embedding model, add an [llm.embeddings] section.
+#
+# Supported providers: "ollama", "openai", "voyage"
+# API keys fall back to env vars: OPENAI_API_KEY, VOYAGE_API_KEY
+#
+# Voyage AI (recommended by Anthropic):
+# [llm.embeddings]
+# provider = "voyage"
+# model    = "voyage-3-lite"          # default; also voyage-3, voyage-3-large
+# # api_key = "pa-..."               # or set VOYAGE_API_KEY env var
+#
+# Ollama (use your local server for embeddings while chatting via Anthropic):
+# [llm.embeddings]
+# provider = "ollama"
+# model    = "nomic-embed-text"       # default
+# base_url = "http://localhost:11434"
+#
+# OpenAI:
+# [llm.embeddings]
+# provider = "openai"
+# model    = "text-embedding-3-small" # default; also text-embedding-3-large
+# # api_key = "sk-..."               # or set OPENAI_API_KEY env var
+
 # ── OpenAI cloud provider ─────────────────────────────────────────────────────
 # To use OpenAI instead of a local Ollama model, replace the [llm] block above
 # with (or uncomment) the following:


### PR DESCRIPTION
## Summary

- Add embedding provider examples to `config.toml` (Voyage AI, Ollama, OpenAI) with env var fallback notes
- Update README.md configuration section with provider selection, Anthropic example, and `[llm.embeddings]` usage
- Bring AGENTS.md workspace table up to date (add `provider-anthropic`, `provider-openai`, `skills`, `web-ui`; mention `EmbeddingProvider` in llm crate description) and fix dependency graph

Follow-up to #109 which added the embedding provider infrastructure.