### PR TITLE
feat(web-ui): add PWA support for installable offline-capable app

### DIFF
--- a/crates/web-ui/src/main.rs
+++ b/crates/web-ui/src/main.rs
@@ -5,6 +5,7 @@ mod chat;
 pub mod common;
 mod legacy;
 mod logs;
+mod pwa;
 mod traces;
 mod webhooks;
 
@@ -216,7 +217,9 @@ async fn main() -> Result<()> {
         .route("/login", get(auth::login_page).post(auth::login_submit))
         .route("/logout", post(auth::logout))
         // A2A agent card is public per spec — callers need it to discover auth.
-        .merge(a2a::public_router().with_state(a2a_state.clone()));
+        .merge(a2a::public_router().with_state(a2a_state.clone()))
+        // PWA assets must be public so the browser can fetch them before auth.
+        .merge(pwa::pwa_router());
 
     // -- Router: protected routes (auth required) --------------------------
     let protected_routes = Router::new()

--- a/crates/web-ui/src/pwa/icon-maskable.svg
+++ b/crates/web-ui/src/pwa/icon-maskable.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <!-- Maskable icon: safe zone is inner 80% (51.2px padding each side) -->
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#64cafe"/>
+      <stop offset="100%" stop-color="#8b5dff"/>
+    </linearGradient>
+  </defs>
+  <!-- Full bleed background for maskable -->
+  <rect width="512" height="512" fill="url(#bg)"/>
+  <text x="256" y="330" text-anchor="middle" font-family="Inter, system-ui, -apple-system, sans-serif" font-weight="700" font-size="260" fill="#030712">A</text>
+</svg>

--- a/crates/web-ui/src/pwa/icon.svg
+++ b/crates/web-ui/src/pwa/icon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#64cafe"/>
+      <stop offset="100%" stop-color="#8b5dff"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="96" fill="url(#bg)"/>
+  <text x="256" y="340" text-anchor="middle" font-family="Inter, system-ui, -apple-system, sans-serif" font-weight="700" font-size="300" fill="#030712">A</text>
+</svg>

--- a/crates/web-ui/src/pwa/manifest.webmanifest
+++ b/crates/web-ui/src/pwa/manifest.webmanifest
@@ -1,0 +1,26 @@
+{
+  "name": "Assistant",
+  "short_name": "Assistant",
+  "description": "AI Assistant - Chat, Traces, Logs & Analytics",
+  "start_url": "/chat",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#030712",
+  "theme_color": "#020611",
+  "orientation": "any",
+  "categories": ["productivity", "utilities"],
+  "icons": [
+    {
+      "src": "/pwa/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/pwa/icon-maskable.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
+    }
+  ]
+}

--- a/crates/web-ui/src/pwa/mod.rs
+++ b/crates/web-ui/src/pwa/mod.rs
@@ -1,0 +1,103 @@
+//! PWA (Progressive Web App) asset routes.
+//!
+//! Serves the web app manifest, service worker, icons, and offline page.
+//! All assets are embedded into the binary via `include_str!()` /
+//! `include_bytes!()` — no external static-file directory required.
+//!
+//! # Cache versioning
+//!
+//! The service worker template contains an `__APP_VERSION__` placeholder that
+//! is replaced at startup:
+//!
+//! - **Release builds**: `CARGO_PKG_VERSION` (e.g. `0.1.21`) — caches
+//!   invalidate on every version bump.
+//! - **Debug builds**: `CARGO_PKG_VERSION-dev.<startup_ts>` — caches
+//!   invalidate on every server restart so developers never see stale pages.
+
+use std::sync::LazyLock;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::http::header;
+use axum::response::{Html, IntoResponse, Response};
+use axum::routing::get;
+use axum::Router;
+
+// -- Embedded assets ---------------------------------------------------------
+
+const MANIFEST: &str = include_str!("manifest.webmanifest");
+const SW_TEMPLATE: &str = include_str!("sw.js");
+const OFFLINE_PAGE: &str = include_str!("offline.html");
+const ICON_SVG: &str = include_str!("icon.svg");
+const ICON_MASKABLE_SVG: &str = include_str!("icon-maskable.svg");
+
+/// Service worker with `__APP_VERSION__` replaced once at process start.
+static SERVICE_WORKER: LazyLock<String> = LazyLock::new(|| {
+    let version = if cfg!(debug_assertions) {
+        let ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        format!("{}-dev.{}", env!("CARGO_PKG_VERSION"), ts)
+    } else {
+        env!("CARGO_PKG_VERSION").to_string()
+    };
+    SW_TEMPLATE.replace("__APP_VERSION__", &version)
+});
+
+// -- Route handlers ----------------------------------------------------------
+
+async fn manifest() -> Response {
+    (
+        [(header::CONTENT_TYPE, "application/manifest+json")],
+        MANIFEST,
+    )
+        .into_response()
+}
+
+/// The service worker **must** be served from the root scope (`/sw.js`) so it
+/// can intercept fetch events for all routes.  We still keep the source under
+/// `src/pwa/` for organisational clarity.
+async fn service_worker() -> Response {
+    (
+        [
+            (header::CONTENT_TYPE, "text/javascript"),
+            // Allow the SW to control the entire origin.
+            (
+                header::HeaderName::from_static("service-worker-allowed"),
+                "/",
+            ),
+            // Always revalidate — the browser compares byte-for-byte and
+            // only reinstalls when the content has actually changed.
+            (header::CACHE_CONTROL, "no-cache"),
+        ],
+        SERVICE_WORKER.as_str(),
+    )
+        .into_response()
+}
+
+async fn offline() -> Html<&'static str> {
+    Html(OFFLINE_PAGE)
+}
+
+async fn icon() -> Response {
+    ([(header::CONTENT_TYPE, "image/svg+xml")], ICON_SVG).into_response()
+}
+
+async fn icon_maskable() -> Response {
+    ([(header::CONTENT_TYPE, "image/svg+xml")], ICON_MASKABLE_SVG).into_response()
+}
+
+// -- Router ------------------------------------------------------------------
+
+/// Public PWA routes (no auth required).
+///
+/// Mount this **outside** the auth middleware so the browser can always fetch
+/// the manifest, service worker, icons, and offline fallback.
+pub fn pwa_router() -> Router {
+    Router::new()
+        .route("/sw.js", get(service_worker))
+        .route("/pwa/manifest.webmanifest", get(manifest))
+        .route("/pwa/icon.svg", get(icon))
+        .route("/pwa/icon-maskable.svg", get(icon_maskable))
+        .route("/pwa/offline", get(offline))
+}

--- a/crates/web-ui/src/pwa/offline.html
+++ b/crates/web-ui/src/pwa/offline.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#020611">
+  <title>Offline - Assistant</title>
+  <style>
+    :root { color-scheme: dark; }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+      background: #030712;
+      color: #e5e9f0;
+      height: 100dvh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .offline-card {
+      text-align: center;
+      max-width: 400px;
+      padding: 40px 24px;
+    }
+    .offline-icon {
+      width: 64px;
+      height: 64px;
+      margin: 0 auto 24px;
+      color: #5a7396;
+    }
+    h1 {
+      font-size: 1.4rem;
+      font-weight: 600;
+      margin-bottom: 12px;
+      color: #e5e9f0;
+    }
+    p {
+      font-size: 0.95rem;
+      color: #8aa5d8;
+      line-height: 1.5;
+      margin-bottom: 24px;
+    }
+    .btn-retry {
+      display: inline-block;
+      background: rgba(110, 198, 255, 0.12);
+      border: 1px solid rgba(110, 198, 255, 0.25);
+      border-radius: 8px;
+      color: #6ec6ff;
+      padding: 10px 24px;
+      font-size: 0.9rem;
+      font-family: inherit;
+      cursor: pointer;
+      transition: background 0.15s;
+    }
+    .btn-retry:hover {
+      background: rgba(110, 198, 255, 0.2);
+    }
+  </style>
+</head>
+<body>
+  <div class="offline-card">
+    <svg class="offline-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <line x1="1" y1="1" x2="23" y2="23"/>
+      <path d="M16.72 11.06A10.94 10.94 0 0 1 19 12.55"/>
+      <path d="M5 12.55a10.94 10.94 0 0 1 5.17-2.39"/>
+      <path d="M10.71 5.05A16 16 0 0 1 22.56 9"/>
+      <path d="M1.42 9a15.91 15.91 0 0 1 4.7-2.88"/>
+      <path d="M8.53 16.11a6 6 0 0 1 6.95 0"/>
+      <line x1="12" y1="20" x2="12.01" y2="20"/>
+    </svg>
+    <h1>You're offline</h1>
+    <p>
+      Assistant needs a network connection to load this page.
+      Previously visited pages may still be available.
+    </p>
+    <button class="btn-retry" onclick="window.location.reload()">
+      Try again
+    </button>
+  </div>
+</body>
+</html>

--- a/crates/web-ui/src/pwa/sw.js
+++ b/crates/web-ui/src/pwa/sw.js
@@ -1,0 +1,152 @@
+// -- Assistant PWA Service Worker (full offline) --
+//
+// Cache strategy:
+//   - Static PWA assets (manifest, icons): cache-first
+//   - CDN scripts (htmx): cache-first
+//   - HTML pages: network-first, fall back to cache, then offline page
+//   - Non-GET / SSE streams: network-only (pass through)
+
+// Replaced at serve-time by the Rust handler:
+//   Release builds → CARGO_PKG_VERSION (e.g. "0.1.21")
+//   Debug  builds → CARGO_PKG_VERSION + startup timestamp (e.g. "0.1.21-dev.1740700000")
+const CACHE_VERSION = "__APP_VERSION__";
+const STATIC_CACHE = `assistant-static-${CACHE_VERSION}`;
+const PAGE_CACHE = `assistant-pages-${CACHE_VERSION}`;
+const CDN_CACHE = `assistant-cdn-${CACHE_VERSION}`;
+
+const STATIC_ASSETS = [
+  "/pwa/manifest.webmanifest",
+  "/pwa/icon.svg",
+  "/pwa/icon-maskable.svg",
+  "/pwa/offline",
+];
+
+const CDN_ASSETS = [
+  "https://unpkg.com/htmx.org@2.0.4/dist/htmx.min.js",
+  "https://unpkg.com/htmx-ext-sse@2.2.2/sse.js",
+];
+
+// -- Install: pre-cache app shell -------------------------------------------
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    Promise.all([
+      caches
+        .open(STATIC_CACHE)
+        .then((cache) => cache.addAll(STATIC_ASSETS)),
+      caches.open(CDN_CACHE).then((cache) => cache.addAll(CDN_ASSETS)),
+    ]).then(() => self.skipWaiting()),
+  );
+});
+
+// -- Activate: purge old caches ---------------------------------------------
+
+self.addEventListener("activate", (event) => {
+  const CURRENT = [STATIC_CACHE, PAGE_CACHE, CDN_CACHE];
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter(
+              (key) => key.startsWith("assistant-") && !CURRENT.includes(key),
+            )
+            .map((key) => caches.delete(key)),
+        ),
+      )
+      .then(() => self.clients.claim()),
+  );
+});
+
+// -- Fetch: route to appropriate strategy -----------------------------------
+
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  // Skip non-GET requests (POST, DELETE, etc.)
+  if (request.method !== "GET") return;
+
+  // Skip SSE streaming endpoints — these must stay live
+  if (url.pathname.includes("/stream")) return;
+
+  // Skip htmx partial requests — let them go to network
+  if (request.headers.get("HX-Request") === "true") return;
+
+  // CDN assets (different origin): cache-first
+  if (url.origin !== self.location.origin) {
+    event.respondWith(cacheFirst(request, CDN_CACHE));
+    return;
+  }
+
+  // Static PWA assets: cache-first
+  if (url.pathname.startsWith("/pwa/")) {
+    event.respondWith(cacheFirst(request, STATIC_CACHE));
+    return;
+  }
+
+  // Login/logout: network-only (auth flow must not be cached)
+  if (url.pathname === "/login" || url.pathname === "/logout") return;
+
+  // A2A protocol endpoints: network-only
+  if (
+    url.pathname.startsWith("/.well-known/") ||
+    url.pathname.startsWith("/message/") ||
+    url.pathname.startsWith("/tasks")
+  ) {
+    return;
+  }
+
+  // HTML pages: network-first with cache fallback
+  const accept = request.headers.get("Accept") || "";
+  if (accept.includes("text/html") || !url.pathname.includes(".")) {
+    event.respondWith(networkFirst(request, PAGE_CACHE));
+    return;
+  }
+});
+
+// -- Strategies --------------------------------------------------------------
+
+async function cacheFirst(request, cacheName) {
+  const cached = await caches.match(request);
+  if (cached) return cached;
+
+  try {
+    const response = await fetch(request);
+    if (response.ok) {
+      const cache = await caches.open(cacheName);
+      cache.put(request, response.clone());
+    }
+    return response;
+  } catch (_err) {
+    return new Response("Offline", {
+      status: 503,
+      statusText: "Service Unavailable",
+    });
+  }
+}
+
+async function networkFirst(request, cacheName) {
+  try {
+    const response = await fetch(request);
+    if (response.ok && response.status !== 401) {
+      const cache = await caches.open(cacheName);
+      cache.put(request, response.clone());
+    }
+    return response;
+  } catch (_err) {
+    // Network failed — try cache
+    const cached = await caches.match(request);
+    if (cached) return cached;
+
+    // Nothing cached — return the offline page for navigation requests
+    const offlinePage = await caches.match("/pwa/offline");
+    if (offlinePage) return offlinePage;
+
+    return new Response("Offline", {
+      status: 503,
+      statusText: "Service Unavailable",
+    });
+  }
+}

--- a/crates/web-ui/templates/base.html
+++ b/crates/web-ui/templates/base.html
@@ -2,8 +2,20 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <title>{% block title %}{% endblock %} - Assistant</title>
+
+  <!-- PWA -->
+  <link rel="manifest" href="/pwa/manifest.webmanifest">
+  <meta name="theme-color" content="#020611">
+  <meta name="color-scheme" content="dark">
+
+  <!-- Apple PWA -->
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <meta name="apple-mobile-web-app-title" content="Assistant">
+  <link rel="apple-touch-icon" href="/pwa/icon.svg">
+
   <script src="https://unpkg.com/htmx.org@2.0.4/dist/htmx.min.js"></script>
   <script src="https://unpkg.com/htmx-ext-sse@2.2.2/sse.js"></script>
   <style>
@@ -471,6 +483,17 @@
     function toggleDrawer() {
       document.getElementById('drawer').classList.toggle('open');
       document.getElementById('drawerBackdrop').classList.toggle('open');
+    }
+
+    // -- Service Worker registration --
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', function() {
+        navigator.serviceWorker.register('/sw.js', { scope: '/' })
+          .then(function(reg) {
+            // Check for updates periodically (every 60s)
+            setInterval(function() { reg.update(); }, 60000);
+          });
+      });
     }
   </script>
   {% block extra_js %}{% endblock %}


### PR DESCRIPTION
## Summary

- Adds full Progressive Web App infrastructure to the web UI so users can install it as a standalone app with offline support
- Service worker implements three-tier caching: cache-first for static/CDN assets, network-first for HTML pages, network-only for auth/SSE/A2A
- Cache versioning uses `CARGO_PKG_VERSION` in release builds and appends a startup timestamp in debug builds so dev server restarts always bust caches

## New files

| File | Purpose |
|------|---------|
| `src/pwa/mod.rs` | Route handlers serving all PWA assets (embedded via `include_str!`) |
| `src/pwa/manifest.webmanifest` | Web app manifest (`display: standalone`, SVG icons) |
| `src/pwa/sw.js` | Service worker with full offline caching + `__APP_VERSION__` placeholder |
| `src/pwa/offline.html` | Offline fallback page matching the dark theme |
| `src/pwa/icon.svg` | Brand icon (rounded rect with gradient) |
| `src/pwa/icon-maskable.svg` | Maskable variant (full-bleed for adaptive icons) |

## Modified files

- `src/main.rs` — register `pwa` module, merge `pwa_router()` into public routes
- `templates/base.html` — add manifest link, `theme-color`, Apple PWA meta tags, SW registration script