### PR TITLE
chore: add self-update guidance to MEMORY.md template

### DIFF
--- a/crates/core/templates/MEMORY.md
+++ b/crates/core/templates/MEMORY.md
@@ -6,6 +6,12 @@ _Important facts, decisions, and context that should survive across sessions._
 
 ## Preferences
 
+## Self-Update
+
+- Always update via `apt`, never build from source
+- **Must run detached from your own process** — use `systemd-run --no-block` or `nohup`/`setsid`, otherwise apt will kill the process mid-upgrade when the service is restarted
+- Example: `sudo systemd-run --no-block apt-get install -y assistant`
+
 ## Open threads
 
 ---


### PR DESCRIPTION
## Why

Agents running as systemd services (like `assistant-slack.service`) must never self-update by building from source or running `apt` synchronously within their own process.

When `apt` installs a new version of the `assistant` package, systemd restarts the service — which kills the running process mid-upgrade, leaving things in a broken state.

## What

Adds a `## Self-Update` section to the `MEMORY.md` template so every new agent instance bootstraps with this knowledge baked in:

- Always use `apt`, never build from source
- Always detach apt from the agent's own process using `systemd-run --no-block` or `nohup`/`setsid`
- Includes a concrete example command

This mirrors what's already documented in the live `MEMORY.md` on the running instance, but ensures it's also present in the template for fresh deployments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new guidance on safe self-update procedures, including recommended approaches and example commands for updating the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->