### PR TITLE
fix(runtime): scope turn workers by interface to prevent cross-service theft

### DIFF
--- a/crates/core/src/bus.rs
+++ b/crates/core/src/bus.rs
@@ -215,6 +215,8 @@ pub struct ClaimFilter {
     pub conversation_id: Option<Uuid>,
     /// Only claim messages in this batch.
     pub batch_id: Option<Uuid>,
+    /// Only claim messages for this interface (e.g. "Slack", "Web").
+    pub interface: Option<String>,
 }
 
 impl ClaimFilter {
@@ -242,12 +244,18 @@ impl ClaimFilter {
         self
     }
 
+    pub fn with_interface(mut self, iface: impl Into<String>) -> Self {
+        self.interface = Some(iface.into());
+        self
+    }
+
     /// Returns `true` if no filter criteria are set.
     pub fn is_empty(&self) -> bool {
         self.agent_id.is_none()
             && self.user_id.is_none()
             && self.conversation_id.is_none()
             && self.batch_id.is_none()
+            && self.interface.is_none()
     }
 }
 

--- a/crates/runtime/src/orchestrator.rs
+++ b/crates/runtime/src/orchestrator.rs
@@ -247,9 +247,28 @@ impl Orchestrator {
     /// });
     /// ```
     pub async fn run_worker(&self, worker_id: &str) {
-        info!(worker_id, "Turn worker started");
+        self.run_worker_filtered(worker_id, None).await;
+    }
+
+    /// Run a turn-processing worker that only claims messages for the given
+    /// interface.  Pass `None` to claim messages for any interface (the
+    /// original `run_worker` behaviour).
+    ///
+    /// When multiple services share the same SQLite database, each service
+    /// should scope its worker to its own interface so one service doesn't
+    /// steal turns from another.
+    pub async fn run_worker_filtered(&self, worker_id: &str, interface: Option<&str>) {
+        info!(worker_id, ?interface, "Turn worker started");
+        let filter = match interface {
+            Some(iface) => ClaimFilter::new().with_interface(iface),
+            None => ClaimFilter::default(),
+        };
         loop {
-            match self.bus.claim(topic::TURN_REQUEST, worker_id).await {
+            match self
+                .bus
+                .claim_filtered(topic::TURN_REQUEST, worker_id, &filter)
+                .await
+            {
                 Ok(Some(msg)) => {
                     let turn_req: bus_messages::TurnRequest =
                         match serde_json::from_value(msg.payload.clone()) {

--- a/crates/storage/src/message_bus.rs
+++ b/crates/storage/src/message_bus.rs
@@ -114,6 +114,11 @@ impl MessageBus for SqliteMessageBus {
         if let Some(ref batch) = filter.batch_id {
             where_clauses.push(format!("batch_id = ?{next_bind}"));
             extra_binds.push(batch.to_string());
+            next_bind += 1;
+        }
+        if let Some(ref iface) = filter.interface {
+            where_clauses.push(format!("interface = ?{next_bind}"));
+            extra_binds.push(iface.clone());
             // next_bind not needed after last, but keep for consistency
             let _ = next_bind;
         }
@@ -589,6 +594,57 @@ mod tests {
             .await
             .unwrap();
         assert!(result.is_none(), "should not match different agent");
+    }
+
+    #[tokio::test]
+    async fn test_claim_filtered_by_interface() {
+        let (_s, bus) = bus().await;
+
+        // Publish two messages: one for Slack, one for Web.
+        bus.publish(
+            PublishRequest::new("turn.request", serde_json::json!({"from": "slack"}))
+                .with_interface("Slack"),
+        )
+        .await
+        .unwrap();
+
+        bus.publish(
+            PublishRequest::new("turn.request", serde_json::json!({"from": "web"}))
+                .with_interface("Web"),
+        )
+        .await
+        .unwrap();
+
+        // Web worker should only get the Web message.
+        let web_msg = bus
+            .claim_filtered(
+                "turn.request",
+                "web-worker",
+                &ClaimFilter::new().with_interface("Web"),
+            )
+            .await
+            .unwrap()
+            .expect("web-worker should claim Web message");
+        assert_eq!(web_msg.payload["from"], "web");
+
+        // Web worker should NOT get the Slack message.
+        let none = bus
+            .claim_filtered(
+                "turn.request",
+                "web-worker",
+                &ClaimFilter::new().with_interface("Web"),
+            )
+            .await
+            .unwrap();
+        assert!(none.is_none(), "web-worker must not claim Slack message");
+
+        // Unscoped worker should still get the Slack message.
+        let slack_msg = bus
+            .claim_filtered("turn.request", "main-worker", &ClaimFilter::default())
+            .await
+            .unwrap()
+            .expect("unscoped worker should claim remaining Slack message");
+        assert_eq!(slack_msg.payload["from"], "slack");
     }
 
     // -- ack / nack / fail --------------------------------------------------

--- a/crates/web-ui/src/main.rs
+++ b/crates/web-ui/src/main.rs
@@ -250,10 +250,14 @@ async fn main() -> Result<()> {
     // Wire up subagent support (breaks the init-time circular dep).
     executor.set_subagent_runner(orchestrator.clone());
 
-    // 5. Spawn the turn-processing worker.
+    // 5. Spawn the turn-processing worker (scoped to Web interface only,
+    //    so it doesn't steal turns from Slack/Mattermost workers sharing
+    //    the same SQLite database).
     let worker_orch = orchestrator.clone();
     tokio::spawn(async move {
-        worker_orch.run_worker("web-worker").await;
+        worker_orch
+            .run_worker_filtered("web-worker", Some("Web"))
+            .await;
     });
 
     // -- Agent store (filesystem-backed) --


### PR DESCRIPTION
## Summary

- Add `interface` field to `ClaimFilter` so workers can scope message claiming by originating interface
- Add `run_worker_filtered()` to `Orchestrator` — accepts an optional interface filter
- Scope the web-ui's turn worker to `"Web"` only, preventing it from stealing Slack/Mattermost turns
- Add regression test verifying interface-scoped claiming works correctly

## Problem

When `assistant-web-ui` and the Slack bot share the same SQLite database, both run turn workers polling `bus_messages`. The web-ui's `web-worker` could claim a Slack turn request, run the LLM without Slack extension tools (registered only in the Slack process's memory), and silently drop the response — the user sees "is thinking…" but never gets a reply.

This was always a latent race condition but became consistently visible after switching providers (changed service restart timing).

## Changes

| File | Change |
|---|---|
| `crates/core/src/bus.rs` | `ClaimFilter.interface` field + `with_interface()` builder |
| `crates/storage/src/message_bus.rs` | Wire `interface` into `claim_filtered` SQL WHERE clause + test |
| `crates/runtime/src/orchestrator.rs` | `run_worker_filtered(worker_id, Option<&str>)` method |
| `crates/web-ui/src/main.rs` | `run_worker("web-worker")` → `run_worker_filtered("web-worker", Some("Web"))` |