### PR TITLE
feat(runtime): enforce allowed-tools restrictions from loaded skills

### DIFF
--- a/crates/runtime/src/orchestrator.rs
+++ b/crates/runtime/src/orchestrator.rs
@@ -653,7 +653,7 @@ impl Orchestrator {
             .prepare_history(user_message, conversation_id, attachments)
             .await?;
 
-        // 4. Load global tool specs and merge with extensions for LLM tool listing.
+        // 4. Provider capabilities — used to filter tool specs each iteration.
         //    Extension specs come first so the LLM sees them prominently.
         //
         //    When a `reply` extension tool is present, suppress any global tools
@@ -662,16 +662,6 @@ impl Orchestrator {
         //    into replying to the channel root instead of the active thread.
         let has_reply_ext = ext_specs.iter().any(|s| s.name.contains("reply"));
         let provider_caps = self.llm.capabilities();
-        let global_specs = Self::filter_tool_specs(self.executor.to_specs(), &provider_caps);
-        let all_specs: Vec<ToolSpec> = ext_specs
-            .iter()
-            .cloned()
-            .chain(
-                global_specs
-                    .into_iter()
-                    .filter(|s| !has_reply_ext || !s.name.contains("post")),
-            )
-            .collect();
 
         let base_system_prompt = self.compose_system_prompt().await;
         // When extension tools are present, guide the LLM to use them.
@@ -754,17 +744,37 @@ impl Orchestrator {
         let mut turn_ended = false;
         let mut replied = false;
         let mut turn_attachments: Vec<Attachment> = Vec::new();
+        // Tracks tool restrictions imposed by the most recently loaded skill.
+        let mut active_allowed_tools: Option<Vec<String>> = None;
 
         // 5. Tool-calling loop.
         for iteration in 0..self.max_iterations {
             debug!(iteration, "Extension-tools loop iteration");
+
+            // Recompute global tool specs each iteration — when a skill with
+            // `allowed-tools` was loaded, only advertise those global tools.
+            // Extension tools are always available regardless of skill
+            // restrictions (they are interface concerns, not skill concerns).
+            let global_specs = Self::filter_tool_specs(
+                self.executor.to_specs_filtered(&active_allowed_tools),
+                &provider_caps,
+            );
+            let all_specs: Vec<ToolSpec> = ext_specs
+                .iter()
+                .cloned()
+                .chain(
+                    global_specs
+                        .into_iter()
+                        .filter(|s| !has_reply_ext || !s.name.contains("post")),
+                )
+                .collect();
 
             let ctx = ExecutionContext {
                 conversation_id,
                 turn: iteration as i64,
                 interface: interface.clone(),
                 interactive: false,
-                allowed_tools: None,
+                allowed_tools: active_allowed_tools.clone(),
                 depth: 0,
             };
 
@@ -1172,6 +1182,13 @@ impl Orchestrator {
                                         "tool_observation",
                                         output.content.clone(),
                                     ));
+                                    // When load-skill returns an allowed_tools
+                                    // restriction, activate it for subsequent
+                                    // iterations.
+                                    if name == "load-skill" {
+                                        active_allowed_tools =
+                                            extract_allowed_tools(output.data.as_ref());
+                                    }
                                     // Collect any attachments from the global tool.
                                     if !output.attachments.is_empty() {
                                         turn_attachments.extend(output.attachments);
@@ -1307,26 +1324,35 @@ impl Orchestrator {
             .prepare_history(user_message, conversation_id, Vec::new())
             .await?;
 
-        // 4. Load all registered tool specs.
+        // 4. Provider capabilities (used to filter tool specs each iteration).
         let provider_caps = self.llm.capabilities();
-        let tool_specs = Self::filter_tool_specs(self.executor.to_specs(), &provider_caps);
 
         // 5. Build the system prompt fresh from disk.
         let system_prompt = self.compose_system_prompt().await;
 
         // 6. Tool-calling loop.
         let mut turn_attachments: Vec<Attachment> = Vec::new();
+        // Tracks tool restrictions imposed by the most recently loaded skill.
+        let mut active_allowed_tools: Option<Vec<String>> = None;
 
         for iteration in 0..self.max_iterations {
             let iteration_span = info_span!("turn_iteration", iteration);
             debug!(parent: &iteration_span, iteration, "Tool-calling loop iteration");
+
+            // Recompute tool specs each iteration — when a skill with
+            // `allowed-tools` was loaded, only advertise those tools to
+            // the LLM.
+            let tool_specs = Self::filter_tool_specs(
+                self.executor.to_specs_filtered(&active_allowed_tools),
+                &provider_caps,
+            );
 
             let ctx = ExecutionContext {
                 conversation_id,
                 turn: iteration as i64,
                 interface: interface.clone(),
                 interactive: matches!(interface, Interface::Cli),
-                allowed_tools: None,
+                allowed_tools: active_allowed_tools.clone(),
                 depth: 0,
             };
 
@@ -1517,6 +1543,13 @@ impl Orchestrator {
                                     "tool_observation",
                                     output.content.clone(),
                                 ));
+                                // When load-skill returns an allowed_tools
+                                // restriction, activate it for subsequent
+                                // iterations.
+                                if name == "load-skill" {
+                                    active_allowed_tools =
+                                        extract_allowed_tools(output.data.as_ref());
+                                }
                                 // Collect any attachments from the tool output.
                                 if !output.attachments.is_empty() {
                                     turn_attachments.extend(output.attachments);
@@ -1617,22 +1650,30 @@ impl Orchestrator {
             .await?;
 
         let provider_caps = self.llm.capabilities();
-        let tool_specs = Self::filter_tool_specs(self.executor.to_specs(), &provider_caps);
 
         let system_prompt = self.compose_system_prompt().await;
 
         let mut turn_attachments: Vec<Attachment> = Vec::new();
+        // Tracks tool restrictions imposed by the most recently loaded skill.
+        let mut active_allowed_tools: Option<Vec<String>> = None;
 
         for iteration in 0..self.max_iterations {
             let iteration_span = info_span!("turn_iteration", iteration);
             debug!(parent: &iteration_span, iteration, "Streaming tool-calling loop iteration");
+
+            // Recompute tool specs each iteration — when a skill with
+            // `allowed-tools` was loaded, only advertise those tools.
+            let tool_specs = Self::filter_tool_specs(
+                self.executor.to_specs_filtered(&active_allowed_tools),
+                &provider_caps,
+            );
 
             let ctx = ExecutionContext {
                 conversation_id,
                 turn: iteration as i64,
                 interface: interface.clone(),
                 interactive: matches!(interface, Interface::Cli),
-                allowed_tools: None,
+                allowed_tools: active_allowed_tools.clone(),
                 depth: 0,
             };
 
@@ -1817,6 +1858,13 @@ impl Orchestrator {
                                     "tool_observation",
                                     output.content.clone(),
                                 ));
+                                // When load-skill returns an allowed_tools
+                                // restriction, activate it for subsequent
+                                // iterations.
+                                if name == "load-skill" {
+                                    active_allowed_tools =
+                                        extract_allowed_tools(output.data.as_ref());
+                                }
                                 // Collect any attachments from the tool output.
                                 if !output.attachments.is_empty() {
                                     turn_attachments.extend(output.attachments);
@@ -2659,6 +2707,22 @@ impl SubagentRunner for Orchestrator {
 /// the model directly.
 fn tool_result_content(content: &str, _data: Option<&serde_json::Value>) -> String {
     content.to_string()
+}
+
+/// Extract an `allowed_tools` list from the structured data returned by
+/// `load-skill`.  Returns `Some(list)` when the skill declared a non-empty
+/// allowlist, or `None` to lift any previous restriction.
+fn extract_allowed_tools(data: Option<&serde_json::Value>) -> Option<Vec<String>> {
+    let arr = data?.get("allowed_tools")?.as_array()?;
+    let tools: Vec<String> = arr
+        .iter()
+        .filter_map(|v| v.as_str().map(|s| s.to_string()))
+        .collect();
+    if tools.is_empty() {
+        None
+    } else {
+        Some(tools)
+    }
 }
 
 /// Create an OpenTelemetry context carrying a conversation-level root span.
@@ -4697,5 +4761,36 @@ mod tests {
             .unwrap()
             .expect("agent record should exist");
         assert_eq!(record.status, assistant_storage::AgentStatus::Failed);
+    }
+
+    // ── allowed-tools tests ──────────────────────────────────────────────────
+
+    #[test]
+    fn extract_allowed_tools_parses_list() {
+        let data = json!({ "allowed_tools": ["bash", "file-read"] });
+        let result = super::extract_allowed_tools(Some(&data));
+        assert_eq!(
+            result,
+            Some(vec!["bash".to_string(), "file-read".to_string()])
+        );
+    }
+
+    #[test]
+    fn extract_allowed_tools_returns_none_for_empty_list() {
+        let data = json!({ "allowed_tools": [] });
+        let result = super::extract_allowed_tools(Some(&data));
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn extract_allowed_tools_returns_none_for_no_data() {
+        assert_eq!(super::extract_allowed_tools(None), None);
+    }
+
+    #[test]
+    fn extract_allowed_tools_returns_none_for_missing_key() {
+        let data = json!({ "other_field": 42 });
+        let result = super::extract_allowed_tools(Some(&data));
+        assert_eq!(result, None);
     }
 }

--- a/crates/tool-executor/src/builtins/load_skill.rs
+++ b/crates/tool-executor/src/builtins/load_skill.rs
@@ -59,7 +59,15 @@ impl ToolHandler for LoadSkillHandler {
                         skill_name
                     )))
                 } else {
-                    Ok(ToolOutput::success(skill.body.clone()))
+                    let mut output = ToolOutput::success(skill.body.clone());
+                    // Propagate the skill's allowed-tools list as structured
+                    // data so the orchestrator can enforce tool restrictions.
+                    if !skill.allowed_tools.is_empty() {
+                        output = output.with_data(serde_json::json!({
+                            "allowed_tools": skill.allowed_tools,
+                        }));
+                    }
+                    Ok(output)
                 }
             }
             None => Ok(ToolOutput::error(format!(
@@ -67,5 +75,89 @@ impl ToolHandler for LoadSkillHandler {
                 skill_name
             ))),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assistant_core::types::Interface;
+    use assistant_skills::SkillDef;
+    use assistant_storage::StorageLayer;
+    use std::path::PathBuf;
+    use uuid::Uuid;
+
+    fn test_ctx() -> ExecutionContext {
+        ExecutionContext {
+            conversation_id: Uuid::new_v4(),
+            turn: 0,
+            interface: Interface::Cli,
+            interactive: false,
+            allowed_tools: None,
+            depth: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn load_skill_with_allowed_tools_includes_data() {
+        let storage = StorageLayer::new_in_memory().await.unwrap();
+        let registry = Arc::new(SkillRegistry::new(storage.pool.clone()).await.unwrap());
+
+        let skill = SkillDef {
+            name: "restricted".into(),
+            description: "A restricted skill".into(),
+            license: None,
+            compatibility: None,
+            allowed_tools: vec!["bash".into(), "file-read".into()],
+            metadata: HashMap::new(),
+            body: "# Restricted skill body".into(),
+            dir: PathBuf::from("/tmp/restricted"),
+            source: assistant_skills::SkillSource::Builtin,
+        };
+        registry.register(skill).await.unwrap();
+
+        let handler = LoadSkillHandler::new(registry);
+        let mut params = HashMap::new();
+        params.insert("name".into(), serde_json::json!("restricted"));
+
+        let output = handler.run(params, &test_ctx()).await.unwrap();
+        assert!(output.success);
+        assert_eq!(output.content, "# Restricted skill body");
+
+        let data = output.data.expect("should have structured data");
+        let tools = data["allowed_tools"].as_array().expect("should be array");
+        assert_eq!(tools.len(), 2);
+        assert_eq!(tools[0], "bash");
+        assert_eq!(tools[1], "file-read");
+    }
+
+    #[tokio::test]
+    async fn load_skill_without_allowed_tools_has_no_data() {
+        let storage = StorageLayer::new_in_memory().await.unwrap();
+        let registry = Arc::new(SkillRegistry::new(storage.pool.clone()).await.unwrap());
+
+        let skill = SkillDef {
+            name: "open".into(),
+            description: "An open skill".into(),
+            license: None,
+            compatibility: None,
+            allowed_tools: vec![],
+            metadata: HashMap::new(),
+            body: "# Open skill body".into(),
+            dir: PathBuf::from("/tmp/open"),
+            source: assistant_skills::SkillSource::Builtin,
+        };
+        registry.register(skill).await.unwrap();
+
+        let handler = LoadSkillHandler::new(registry);
+        let mut params = HashMap::new();
+        params.insert("name".into(), serde_json::json!("open"));
+
+        let output = handler.run(params, &test_ctx()).await.unwrap();
+        assert!(output.success);
+        assert!(
+            output.data.is_none(),
+            "should not have data when no allowed_tools"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- When a skill declares `allowed-tools` in its SKILL.md frontmatter, the orchestrator now restricts which tools the LLM can see and invoke for the remainder of that turn
- `load-skill` handler propagates the allowed-tools list via `ToolOutput::with_data()` so the orchestrator can pick it up without a registry lookup
- All three turn loops (`run_turn`, `run_turn_streaming`, `run_turn_with_tools_impl`) track `active_allowed_tools` across iterations, recomputing tool specs via `to_specs_filtered` and setting `ExecutionContext.allowed_tools` for executor-level enforcement
- Extension tools (reply, react, end_turn) are always available regardless of skill restrictions -- they are interface concerns, not skill concerns
- 6 new unit tests covering `extract_allowed_tools` parsing and `LoadSkillHandler` data propagation

Closes #83