### PR TITLE
feat(skills): expose compatibility field in list-skills and declare requirements

### DIFF
--- a/crates/storage/src/registry.rs
+++ b/crates/storage/src/registry.rs
@@ -83,6 +83,9 @@ impl SkillRegistry {
     pub async fn load_embedded(&self) -> Result<()> {
         for def in assistant_skills::embedded_builtin_skills() {
             info!("Registering embedded builtin skill '{}'", def.name);
+            if let Some(compat) = &def.compatibility {
+                info!(skill = %def.name, compatibility = %compat, "Skill has runtime requirements");
+            }
             self.register(def).await?;
         }
         Ok(())

--- a/crates/tool-executor/src/builtins/list_skills.rs
+++ b/crates/tool-executor/src/builtins/list_skills.rs
@@ -49,18 +49,47 @@ impl ToolHandler for ListSkillsHandler {
         }
 
         // Build a formatted table
+        let has_compat = skills.iter().any(|s| s.compatibility.is_some());
+
         let mut lines: Vec<String> = Vec::new();
-        lines.push(format!("{:<24} {:<70} {}", "Name", "Description", "Source"));
-        lines.push(format!(
-            "{} {} {}",
-            "-".repeat(24),
-            "-".repeat(70),
-            "-".repeat(10)
-        ));
+        if has_compat {
+            lines.push(format!(
+                "{:<24} {:<60} {:<10} {}",
+                "Name", "Description", "Source", "Compatibility"
+            ));
+            lines.push(format!(
+                "{} {} {} {}",
+                "-".repeat(24),
+                "-".repeat(60),
+                "-".repeat(10),
+                "-".repeat(40),
+            ));
+        } else {
+            lines.push(format!("{:<24} {:<70} {}", "Name", "Description", "Source"));
+            lines.push(format!(
+                "{} {} {}",
+                "-".repeat(24),
+                "-".repeat(70),
+                "-".repeat(10),
+            ));
+        }
 
         for skill in &skills {
-            let desc = truncate(&skill.description, DESC_TRUNCATE);
-            lines.push(format!("{:<24} {:<70} {}", skill.name, desc, skill.source,));
+            let desc_len = if has_compat { 56 } else { DESC_TRUNCATE };
+            let desc = truncate(&skill.description, desc_len);
+            if has_compat {
+                let compat = skill
+                    .compatibility
+                    .as_deref()
+                    .map(|c| truncate(c, 40))
+                    .unwrap_or_default();
+                lines.push(format!(
+                    "{:<24} {:<60} {:<10} {}",
+                    skill.name, desc, skill.source, compat,
+                ));
+            } else {
+                lines.push(format!("{:<24} {:<70} {}", skill.name, desc, skill.source,));
+            }
         }
 
         lines.push(String::new());

--- a/skills/claude-code-agent/SKILL.md
+++ b/skills/claude-code-agent/SKILL.md
@@ -8,6 +8,7 @@ description: >
   Supports fire-and-forget async jobs (tmux-based, non-blocking) as well as
   quick blocking one-shot tasks and follow-up questions in the same session.
 license: MIT
+compatibility: "Requires: claude CLI (claude --version), tmux"
 ---
 
 # Claude Code Agent Skill

--- a/skills/playwright-cli/SKILL.md
+++ b/skills/playwright-cli/SKILL.md
@@ -6,6 +6,7 @@ description: >
   test web apps, or run any multi-step browser workflow. Requires no display
   (headless mode supported).
 license: MIT
+compatibility: "Requires: npx (@playwright/mcp)"
 ---
 
 # playwright-cli


### PR DESCRIPTION
## Summary

- Show a **Compatibility** column in `list-skills` output when any registered skill declares the field (adaptive layout -- column only appears when relevant)
- Add `compatibility` declarations to shipped skills: `claude-code-agent` (tmux, claude CLI) and `playwright-cli` (npx/@playwright/mcp)
- Log compatibility info at startup when registering embedded skills so operators can see missing requirements in logs

The `compatibility` field was already parsed from SKILL.md frontmatter and stored on `SkillDef` -- this PR surfaces it in the UI and fills in the values for skills with hard dependencies.

Closes #82