### PR TITLE
chore(deps): replace all-cargo group with opentelemetry and reqwest groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,12 @@ updates:
       interval: weekly
       day: monday
     groups:
-      all-cargo:
+      opentelemetry:
         patterns:
-          - "*"
+          - "opentelemetry*"
+      reqwest:
+        patterns:
+          - "reqwest*"
 
   - package-ecosystem: docker
     directory: /docker


### PR DESCRIPTION
## Summary

- Replaces the single catch-all `all-cargo` dependabot group (`*`) with two focused groups: `opentelemetry` and `reqwest`
- This gives better control over which dependency bumps are grouped together, avoiding unrelated crate upgrades landing in the same PR