### PR TITLE
feat(deps): upgrade opentelemetry 0.24 to 0.31 and related crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,7 +483,7 @@ dependencies = [
  "chrono",
  "dirs",
  "futures",
- "getrandom 0.2.17",
+ "getrandom 0.4.1",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -614,12 +614,12 @@ dependencies = [
  "assistant-skills",
  "assistant-storage",
  "assistant-tool-executor",
- "axum 0.8.8",
+ "axum",
  "chrono",
  "clap",
  "dirs",
  "futures",
- "getrandom 0.2.17",
+ "getrandom 0.4.1",
  "hex",
  "hmac",
  "http-body-util",
@@ -632,7 +632,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -826,38 +826,11 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core 0.4.5",
- "bytes",
- "futures-util",
- "http 1.4.0",
- "http-body",
- "http-body-util",
- "itoa",
- "matchit 0.7.3",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper",
- "tower 0.5.3",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
- "axum-core 0.5.6",
+ "axum-core",
  "axum-macros",
  "bytes",
  "form_urlencoded",
@@ -868,7 +841,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit 0.8.4",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -879,30 +852,10 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 1.4.0",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -1099,7 +1052,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tonic 0.14.5",
+ "tonic",
  "tower-service",
  "url",
  "winapi",
@@ -1113,7 +1066,7 @@ checksum = "85a885520bf6249ab931a764ffdb87b0ceef48e6e7d807cfdb21b751e086e1ad"
 dependencies = [
  "prost 0.14.3",
  "prost-types 0.14.3",
- "tonic 0.14.5",
+ "tonic",
  "tonic-prost",
  "ureq",
 ]
@@ -2714,7 +2667,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -3024,9 +2977,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.42.1"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6103dcd3815c9bd04239a6d0343dac2b7a18ee260e800d0a6e3eb5b9333504fb"
+checksum = "267fb27be492e66ab147d2ce0233d88ae465b93c3565016e73998729bf3fe60f"
 dependencies = [
  "ahash",
  "bytecount",
@@ -3443,12 +3396,6 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
-name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
@@ -3801,23 +3748,23 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.24.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c365a63eec4f55b7efeceb724f1336f26a9cf3427b70e59e2cd2a5b947fba96"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
 dependencies = [
  "futures-core",
  "futures-sink",
  "js-sys",
- "once_cell",
  "pin-project-lite",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-appender-tracing"
-version = "0.5.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84de945cb3a6f1e0d6317cbd998bbd0519ab00f4b790db67e0ff4fdcf7cedb6"
+checksum = "ef6a1ac5ca3accf562b8c306fa8483c85f4390f768185ab775f242f7fe8fdcc2"
 dependencies = [
  "opentelemetry",
  "tracing",
@@ -3826,52 +3773,63 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-otlp"
-version = "0.17.0"
+name = "opentelemetry-http"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b925a602ffb916fb7421276b86756027b37ee708f9dce2dbdcc51739f07e727"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
 dependencies = [
  "async-trait",
- "futures-core",
+ "bytes",
  "http 1.4.0",
  "opentelemetry",
+ "reqwest 0.12.28",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
+dependencies = [
+ "http 1.4.0",
+ "opentelemetry",
+ "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost 0.13.5",
- "thiserror 1.0.69",
+ "prost 0.14.3",
+ "reqwest 0.12.28",
+ "thiserror 2.0.18",
  "tokio",
- "tonic 0.12.3",
+ "tonic",
+ "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.7.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ee9f20bff9c984511a02f082dc8ede839e4a9bf15cc2487c8d6fea5ad850d9"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost 0.13.5",
- "tonic 0.12.3",
+ "prost 0.14.3",
+ "tonic",
+ "tonic-prost",
 ]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.24.1"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692eac490ec80f24a17828d49b40b60f5aeaccdfe6a503f939713afd22bc28df"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
 dependencies = [
- "async-trait",
  "futures-channel",
  "futures-executor",
  "futures-util",
- "glob",
- "once_cell",
  "opentelemetry",
  "percent-encoding",
- "rand 0.8.5",
- "serde_json",
- "thiserror 1.0.69",
+ "rand 0.9.2",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
 ]
@@ -4499,7 +4457,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.2",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4536,7 +4494,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4683,9 +4641,9 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.45.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67478e45862a0c29fd99658e382c07b1b80b9c1b7d946ce6bd2e4a679141554b"
+checksum = "fe9e7c532bfc2759bc8a28902c04e8b993fc13ebd085ee4292eb1b230fa9beef"
 dependencies = [
  "chrono",
  "crossterm 0.29.0",
@@ -4724,9 +4682,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.42.1"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a76b0c93f3dd49da2900cfb3c6b883602471a0e3e34b1578a3310ca1269d418"
+checksum = "12ecd0f3daefd4faff2e0821310c18e6e9d1fd00550bbd7e5a59d78184a071bc"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -4792,6 +4750,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http 1.4.0",
@@ -4819,7 +4778,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tower-service",
  "url",
@@ -4860,7 +4819,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tower-service",
  "url",
@@ -4910,7 +4869,7 @@ dependencies = [
  "async-trait",
  "getrandom 0.2.17",
  "http 1.4.0",
- "matchit 0.8.4",
+ "matchit",
  "reqwest 0.12.28",
  "reqwest-middleware",
  "tracing",
@@ -5047,15 +5006,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -5608,16 +5558,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6219,7 +6159,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -6359,44 +6299,12 @@ checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum 0.7.9",
- "base64 0.22.1",
- "bytes",
- "h2",
- "http 1.4.0",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "prost 0.13.5",
- "rustls-pemfile",
- "socket2 0.5.10",
- "tokio",
- "tokio-rustls",
- "tokio-stream",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
- "axum 0.8.8",
+ "axum",
  "base64 0.22.1",
  "bytes",
  "h2",
@@ -6408,11 +6316,13 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2 0.6.2",
+ "rustls-native-certs",
+ "socket2",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -6426,27 +6336,7 @@ checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
 dependencies = [
  "bytes",
  "prost 0.14.3",
- "tonic 0.14.5",
-]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.5",
- "slab",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
+ "tonic",
 ]
 
 [[package]]
@@ -6481,7 +6371,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,10 +71,10 @@ rustls = { version = "0.23", features = ["ring"] }
 # Logging / tracing
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-opentelemetry = { version = "0.24", features = ["trace", "logs", "metrics"] }
-opentelemetry-otlp = { version = "0.17", features = ["grpc-tonic", "tls", "logs", "metrics"] }
-opentelemetry_sdk = { version = "0.24", features = ["trace", "logs", "metrics", "rt-tokio"] }
-opentelemetry-appender-tracing = "0.5"
+opentelemetry = { version = "0.31", features = ["trace", "logs", "metrics"] }
+opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic", "tls-roots", "trace", "logs", "metrics"] }
+opentelemetry_sdk = { version = "0.31", features = ["trace", "logs", "metrics", "rt-tokio"] }
+opentelemetry-appender-tracing = "0.31"
 # CLI / config
 clap = { version = "4", features = ["derive"] }
 dirs = "6"
@@ -82,7 +82,7 @@ toml = "1.0"
 # Async streams
 futures = "0.3"
 # Terminal line editor
-reedline = "0.45"
+reedline = "0.46"
 # QR code terminal rendering
 qr2term = "0.3"
 # YAML frontmatter parser
@@ -102,7 +102,7 @@ scraper = "0.25"
 # Glob pattern matching for file-glob builtin
 glob = "0.3"
 # JSON Schema validation for tool param checking
-jsonschema = "0.42"
+jsonschema = "0.44"
 # SHA-256 hashing for memory chunk change detection
 sha2 = "0.10"
 # HMAC message authentication (webhook signature verification)
@@ -112,7 +112,7 @@ hex = "0.4"
 # URL parsing
 url = "2"
 # OS-level CSPRNG
-getrandom = "0.2"
+getrandom = "0.4"
 # WASM plugin execution
 extism = "1"
 # Integration testing

--- a/crates/provider-openai/src/oauth.rs
+++ b/crates/provider-openai/src/oauth.rs
@@ -307,7 +307,7 @@ fn compute_code_challenge(verifier: &str) -> String {
 /// Generate a random base64url-encoded string of the given byte length.
 fn generate_random_string(byte_len: usize) -> String {
     let mut buf = vec![0u8; byte_len];
-    getrandom::getrandom(&mut buf).expect("getrandom should not fail");
+    getrandom::fill(&mut buf).expect("getrandom should not fail");
     URL_SAFE_NO_PAD.encode(&buf)
 }
 

--- a/crates/runtime/src/metrics.rs
+++ b/crates/runtime/src/metrics.rs
@@ -55,68 +55,68 @@ impl MetricsRecorder {
                 .f64_histogram("gen_ai.client.token.usage")
                 .with_description("Number of input and output tokens used")
                 .with_unit("{token}")
-                .init(),
+                .build(),
 
             operation_duration: meter
                 .f64_histogram("gen_ai.client.operation.duration")
                 .with_description("GenAI operation duration")
                 .with_unit("s")
-                .init(),
+                .build(),
 
             time_to_first_token: meter
                 .f64_histogram("gen_ai.server.time_to_first_token")
                 .with_description("Time to generate first token")
                 .with_unit("s")
-                .init(),
+                .build(),
 
             time_per_output_token: meter
                 .f64_histogram("gen_ai.server.time_per_output_token")
                 .with_description("Time per output token after the first")
                 .with_unit("s")
-                .init(),
+                .build(),
 
             // -- Operational -------------------------------------------------
             turn_count: meter
                 .u64_counter("assistant.turn.count")
                 .with_description("Number of turns processed")
                 .with_unit("{turn}")
-                .init(),
+                .build(),
 
             turn_duration: meter
                 .f64_histogram("assistant.turn.duration")
                 .with_description("Turn processing duration")
                 .with_unit("s")
-                .init(),
+                .build(),
 
             tool_invocations: meter
                 .u64_counter("assistant.tool.invocations")
                 .with_description("Number of tool invocations")
                 .with_unit("{invocation}")
-                .init(),
+                .build(),
 
             tool_duration: meter
                 .f64_histogram("assistant.tool.duration")
                 .with_description("Tool execution duration")
                 .with_unit("s")
-                .init(),
+                .build(),
 
             error_count: meter
                 .u64_counter("assistant.error.count")
                 .with_description("Number of errors")
                 .with_unit("{error}")
-                .init(),
+                .build(),
 
             conversation_count: meter
                 .u64_counter("assistant.conversation.count")
                 .with_description("Number of conversations created")
                 .with_unit("{conversation}")
-                .init(),
+                .build(),
 
             agent_spawn_count: meter
                 .u64_counter("assistant.agent.spawn.count")
                 .with_description("Number of sub-agents spawned")
                 .with_unit("{agent}")
-                .init(),
+                .build(),
         }
     }
 

--- a/crates/runtime/src/telemetry.rs
+++ b/crates/runtime/src/telemetry.rs
@@ -5,11 +5,10 @@ use assistant_storage::{SqliteLogExporter, SqliteMetricExporter, SqliteSpanExpor
 use opentelemetry::{global, KeyValue};
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
 use opentelemetry_sdk::{
-    logs::{BatchLogProcessor, LoggerProvider},
+    logs::{BatchLogProcessor, SdkLoggerProvider},
     metrics::{PeriodicReader, SdkMeterProvider},
-    resource::Resource,
-    runtime::Tokio,
-    trace::{self, BatchSpanProcessor},
+    trace::{BatchSpanProcessor, SdkTracerProvider},
+    Resource,
 };
 use sqlx::SqlitePool;
 use tracing::info;
@@ -19,7 +18,8 @@ use tracing_subscriber::{
 
 /// Guard that shuts down all OTel providers when dropped.
 pub struct OtelGuard {
-    logger_provider: Option<LoggerProvider>,
+    tracer_provider: Option<SdkTracerProvider>,
+    logger_provider: Option<SdkLoggerProvider>,
     meter_provider: Option<SdkMeterProvider>,
 }
 
@@ -31,7 +31,9 @@ impl Drop for OtelGuard {
         if let Some(ref provider) = self.meter_provider {
             let _ = provider.shutdown();
         }
-        global::shutdown_tracer_provider();
+        if let Some(ref provider) = self.tracer_provider {
+            let _ = provider.shutdown();
+        }
     }
 }
 
@@ -95,13 +97,12 @@ pub fn init_tracing(pool: SqlitePool, enable_sqlite_export: bool) -> Result<Opti
     }
 
     // -- Trace provider --------------------------------------------------
-    let mut trace_provider_builder = trace::TracerProvider::builder()
-        .with_config(trace::Config::default().with_resource(resource.clone()));
+    let mut trace_provider_builder = SdkTracerProvider::builder().with_resource(resource.clone());
     let mut have_trace_exporter = false;
 
     if enable_sqlite_export {
         let sqlite_exporter = SqliteSpanExporter::new(pool.clone());
-        let processor = BatchSpanProcessor::builder(sqlite_exporter, Tokio).build();
+        let processor = BatchSpanProcessor::builder(sqlite_exporter).build();
         trace_provider_builder = trace_provider_builder.with_span_processor(processor);
         have_trace_exporter = true;
     }
@@ -109,36 +110,34 @@ pub fn init_tracing(pool: SqlitePool, enable_sqlite_export: bool) -> Result<Opti
     if enable_otlp {
         // Let the crate resolve OTEL_EXPORTER_OTLP_TRACES_ENDPOINT (or the
         // generic fallback), headers, timeout, and compression from env vars.
-        let otlp_exporter = opentelemetry_otlp::new_exporter()
-            .tonic()
-            .build_span_exporter()?;
-        let processor = BatchSpanProcessor::builder(otlp_exporter, Tokio).build();
-        trace_provider_builder = trace_provider_builder.with_span_processor(processor);
+        let otlp_exporter = opentelemetry_otlp::SpanExporter::builder()
+            .with_tonic()
+            .build()?;
+        trace_provider_builder = trace_provider_builder.with_batch_exporter(otlp_exporter);
         have_trace_exporter = true;
     }
 
     // -- Logger provider (OTel logs) -------------------------------------
-    let mut logger_provider: Option<LoggerProvider> = None;
+    let mut logger_provider: Option<SdkLoggerProvider> = None;
 
     // -- Meter provider (OTel metrics) -----------------------------------
     let mut meter_provider: Option<SdkMeterProvider> = None;
 
     if need_otel {
         // Logs — attach SQLite and/or OTLP processors to the same provider.
-        let mut log_builder = LoggerProvider::builder().with_resource(resource.clone());
+        let mut log_builder = SdkLoggerProvider::builder().with_resource(resource.clone());
 
         if enable_sqlite_export {
             let sqlite_log_exporter = SqliteLogExporter::new(pool.clone());
-            let processor = BatchLogProcessor::builder(sqlite_log_exporter, Tokio).build();
+            let processor = BatchLogProcessor::builder(sqlite_log_exporter).build();
             log_builder = log_builder.with_log_processor(processor);
         }
 
         if enable_otlp {
-            let otlp_log_exporter = opentelemetry_otlp::new_exporter()
-                .tonic()
-                .build_log_exporter()?;
-            let processor = BatchLogProcessor::builder(otlp_log_exporter, Tokio).build();
-            log_builder = log_builder.with_log_processor(processor);
+            let otlp_log_exporter = opentelemetry_otlp::LogExporter::builder()
+                .with_tonic()
+                .build()?;
+            log_builder = log_builder.with_batch_exporter(otlp_log_exporter);
         }
 
         let log_prov = log_builder.build();
@@ -153,23 +152,17 @@ pub fn init_tracing(pool: SqlitePool, enable_sqlite_export: bool) -> Result<Opti
 
         if enable_sqlite_export {
             let sqlite_metric_exporter = SqliteMetricExporter::new(pool);
-            let reader = PeriodicReader::builder(sqlite_metric_exporter, Tokio)
+            let reader = PeriodicReader::builder(sqlite_metric_exporter)
                 .with_interval(Duration::from_secs(60))
                 .build();
             meter_builder = meter_builder.with_reader(reader);
         }
 
         if enable_otlp {
-            use opentelemetry_sdk::metrics::reader::{
-                DefaultAggregationSelector, DefaultTemporalitySelector,
-            };
-            let otlp_metric_exporter = opentelemetry_otlp::new_exporter()
-                .tonic()
-                .build_metrics_exporter(
-                    Box::new(DefaultAggregationSelector::new()),
-                    Box::new(DefaultTemporalitySelector::new()),
-                )?;
-            let reader = PeriodicReader::builder(otlp_metric_exporter, Tokio)
+            let otlp_metric_exporter = opentelemetry_otlp::MetricExporter::builder()
+                .with_tonic()
+                .build()?;
+            let reader = PeriodicReader::builder(otlp_metric_exporter)
                 .with_interval(Duration::from_secs(60))
                 .build();
             meter_builder = meter_builder.with_reader(reader);
@@ -191,13 +184,15 @@ pub fn init_tracing(pool: SqlitePool, enable_sqlite_export: bool) -> Result<Opti
 
     if have_trace_exporter {
         let provider = trace_provider_builder.build();
-        global::set_tracer_provider(provider);
+        global::set_tracer_provider(provider.clone());
         Ok(Some(OtelGuard {
+            tracer_provider: Some(provider),
             logger_provider,
             meter_provider,
         }))
     } else if logger_provider.is_some() || meter_provider.is_some() {
         Ok(Some(OtelGuard {
+            tracer_provider: None,
             logger_provider,
             meter_provider,
         }))
@@ -257,7 +252,7 @@ fn build_resource() -> Resource {
         }
     }
 
-    Resource::new(attrs)
+    Resource::builder_empty().with_attributes(attrs).build()
 }
 
 #[cfg(test)]

--- a/crates/storage/src/log_telemetry.rs
+++ b/crates/storage/src/log_telemetry.rs
@@ -1,11 +1,9 @@
 //! OpenTelemetry log exporter that persists log records into the `logs` SQLite table.
 
-use std::borrow::Cow;
-
-use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use opentelemetry::logs::{AnyValue, LogError, LogResult, Severity};
-use opentelemetry_sdk::export::logs::{LogData, LogExporter};
+use opentelemetry::logs::{AnyValue, Severity};
+use opentelemetry_sdk::error::OTelSdkResult;
+use opentelemetry_sdk::logs::{LogBatch, LogExporter, SdkLogRecord};
 use opentelemetry_sdk::Resource;
 use serde_json::{Map, Number};
 use sqlx::SqlitePool;
@@ -23,22 +21,20 @@ impl SqliteLogExporter {
         Self { pool }
     }
 
-    async fn persist_log(pool: SqlitePool, data: &LogData) -> Result<(), sqlx::Error> {
-        let record = &data.record;
-
+    async fn persist_log(pool: SqlitePool, record: &SdkLogRecord) -> Result<(), sqlx::Error> {
         let id = Uuid::new_v4().to_string();
 
-        let timestamp: DateTime<Utc> = record.timestamp.map(Into::into).unwrap_or_else(Utc::now);
+        let timestamp: DateTime<Utc> = record.timestamp().map(Into::into).unwrap_or_else(Utc::now);
 
-        let observed_timestamp: Option<DateTime<Utc>> = record.observed_timestamp.map(Into::into);
+        let observed_timestamp: Option<DateTime<Utc>> = record.observed_timestamp().map(Into::into);
 
-        let severity_number = record.severity_number.map(severity_to_i32);
+        let severity_number = record.severity_number().map(severity_to_i32);
 
-        let severity_text = record.severity_text.as_deref().map(|s| s.to_string());
+        let severity_text = record.severity_text().map(|s| s.to_string());
 
-        let body = record.body.as_ref().map(any_value_to_string);
+        let body = record.body().map(any_value_to_string);
 
-        let (trace_id, span_id) = match &record.trace_context {
+        let (trace_id, span_id) = match record.trace_context() {
             Some(ctx) => (
                 Some(ctx.trace_id.to_string()),
                 Some(ctx.span_id.to_string()),
@@ -46,13 +42,9 @@ impl SqliteLogExporter {
             None => (None, None),
         };
 
-        let target = record.target.as_deref().map(|s| s.to_string());
+        let target = record.target().map(|s| s.to_string());
 
-        let attrs = record
-            .attributes
-            .as_ref()
-            .map(|a| attributes_to_json(a))
-            .unwrap_or_else(|| serde_json::Value::Object(Map::new()));
+        let attrs = attributes_to_json(record);
         let attrs_serialized = attrs.to_string();
 
         sqlx::query(
@@ -79,18 +71,17 @@ impl SqliteLogExporter {
     }
 }
 
-#[async_trait]
 impl LogExporter for SqliteLogExporter {
-    async fn export<'a>(&mut self, batch: Vec<Cow<'a, LogData>>) -> LogResult<()> {
-        for data in &batch {
-            if let Err(err) = Self::persist_log(self.pool.clone(), data.as_ref()).await {
-                return Err(LogError::Other(Box::new(err)));
+    async fn export(&self, batch: LogBatch<'_>) -> OTelSdkResult {
+        for (record, _scope) in batch.iter() {
+            if let Err(err) = Self::persist_log(self.pool.clone(), record).await {
+                return Err(opentelemetry_sdk::error::OTelSdkError::InternalFailure(
+                    format!("SQLite log export failed: {err}"),
+                ));
             }
         }
         Ok(())
     }
-
-    fn shutdown(&mut self) {}
 
     fn set_resource(&mut self, _resource: &Resource) {
         // Resource metadata is not persisted to the logs table.
@@ -137,12 +128,13 @@ fn any_value_to_string(value: &AnyValue) -> String {
         AnyValue::Bytes(v) => format!("{:?}", v),
         AnyValue::ListAny(v) => format!("{:?}", v),
         AnyValue::Map(v) => format!("{:?}", v),
+        _ => format!("{value:?}"),
     }
 }
 
-fn attributes_to_json(attrs: &[(opentelemetry::Key, AnyValue)]) -> serde_json::Value {
+fn attributes_to_json(record: &SdkLogRecord) -> serde_json::Value {
     let mut map = Map::new();
-    for (key, value) in attrs {
+    for (key, value) in record.attributes_iter() {
         map.insert(key.as_str().to_string(), any_value_to_json(value));
     }
     serde_json::Value::Object(map)
@@ -165,6 +157,7 @@ fn any_value_to_json(value: &AnyValue) -> serde_json::Value {
             }
             serde_json::Value::Object(map)
         }
+        _ => serde_json::Value::String(format!("{value:?}")),
     }
 }
 
@@ -172,25 +165,33 @@ fn any_value_to_json(value: &AnyValue) -> serde_json::Value {
 mod tests {
     use super::*;
     use crate::StorageLayer;
-    use opentelemetry::logs::AnyValue;
-    use opentelemetry::trace::{SpanContext, SpanId, TraceFlags, TraceId, TraceState};
-    use opentelemetry::InstrumentationLibrary;
-    use opentelemetry_sdk::export::logs::LogData;
-    use opentelemetry_sdk::logs::LogRecord;
-    use std::borrow::Cow;
-    use std::time::SystemTime;
+    use opentelemetry::logs::{
+        AnyValue, LogRecord as _, Logger as _, LoggerProvider as _, Severity,
+    };
+    use opentelemetry::trace::{SpanId, TraceFlags, TraceId};
+    use opentelemetry::InstrumentationScope;
+    use opentelemetry_sdk::logs::{SdkLogRecord, SdkLoggerProvider};
 
-    fn make_log(severity: Severity, body: &str, target: &str) -> LogData {
-        let mut record = LogRecord::default();
-        record.severity_number = Some(severity);
-        record.severity_text = Some(severity_text_for(severity).into());
-        record.body = Some(AnyValue::String(body.to_string().into()));
-        record.timestamp = Some(SystemTime::now());
-        record.target = Some(Cow::Owned(target.to_string()));
-        LogData {
-            record,
-            instrumentation: InstrumentationLibrary::default(),
-        }
+    /// Create a logger from a no-op provider so we can call
+    /// `create_log_record()` (which is `pub(crate)` on `SdkLogRecord`).
+    fn new_record() -> SdkLogRecord {
+        let provider = SdkLoggerProvider::builder().build();
+        let logger = provider.logger("test");
+        logger.create_log_record()
+    }
+
+    fn make_log(
+        severity: Severity,
+        body: &str,
+        target: &str,
+    ) -> (SdkLogRecord, InstrumentationScope) {
+        let mut record = new_record();
+        record.set_severity_number(severity);
+        record.set_severity_text(severity_text_for(severity));
+        record.set_body(AnyValue::String(body.to_string().into()));
+        record.set_timestamp(std::time::SystemTime::now());
+        record.set_target(target.to_string());
+        (record, InstrumentationScope::default())
     }
 
     fn make_log_with_trace(
@@ -198,25 +199,17 @@ mod tests {
         body: &str,
         trace_id_hex: &str,
         span_id_hex: &str,
-    ) -> LogData {
-        let mut record = LogRecord::default();
-        record.severity_number = Some(severity);
-        record.severity_text = Some("INFO".into());
-        record.body = Some(AnyValue::String(body.to_string().into()));
-        record.timestamp = Some(SystemTime::now());
-        // Build TraceContext from a SpanContext (the From impl is public).
-        let span_ctx = SpanContext::new(
-            TraceId::from_hex(trace_id_hex).unwrap(),
-            SpanId::from_hex(span_id_hex).unwrap(),
-            TraceFlags::SAMPLED,
-            false,
-            TraceState::default(),
-        );
-        record.trace_context = Some(opentelemetry_sdk::logs::TraceContext::from(&span_ctx));
-        LogData {
-            record,
-            instrumentation: InstrumentationLibrary::default(),
-        }
+    ) -> (SdkLogRecord, InstrumentationScope) {
+        let mut record = new_record();
+        record.set_severity_number(severity);
+        record.set_severity_text("INFO");
+        record.set_body(AnyValue::String(body.to_string().into()));
+        record.set_timestamp(std::time::SystemTime::now());
+        // Set trace context via the LogRecord trait method.
+        let trace_id = TraceId::from_hex(trace_id_hex).unwrap();
+        let span_id = SpanId::from_hex(span_id_hex).unwrap();
+        record.set_trace_context(trace_id, span_id, Some(TraceFlags::SAMPLED));
+        (record, InstrumentationScope::default())
     }
 
     fn severity_text_for(s: Severity) -> &'static str {
@@ -237,16 +230,25 @@ mod tests {
             .unwrap()
     }
 
+    /// Convert owned items into the reference-tuple slice that `LogBatch::new` expects.
+    fn as_batch_refs(
+        items: &[(SdkLogRecord, InstrumentationScope)],
+    ) -> Vec<(&SdkLogRecord, &InstrumentationScope)> {
+        items.iter().map(|(r, s)| (r, s)).collect()
+    }
+
     #[tokio::test]
     async fn test_export_persists_exact_count() {
         let storage = StorageLayer::new_in_memory().await.unwrap();
-        let mut exporter = SqliteLogExporter::new(storage.pool.clone());
+        let exporter = SqliteLogExporter::new(storage.pool.clone());
 
-        let batch: Vec<Cow<'_, LogData>> = vec![
-            Cow::Owned(make_log(Severity::Info, "msg-1", "app")),
-            Cow::Owned(make_log(Severity::Warn, "msg-2", "app")),
-            Cow::Owned(make_log(Severity::Error, "msg-3", "app")),
+        let items: Vec<(SdkLogRecord, InstrumentationScope)> = vec![
+            make_log(Severity::Info, "msg-1", "app"),
+            make_log(Severity::Warn, "msg-2", "app"),
+            make_log(Severity::Error, "msg-3", "app"),
         ];
+        let refs = as_batch_refs(&items);
+        let batch = LogBatch::new(&refs);
 
         exporter.export(batch).await.unwrap();
 
@@ -257,13 +259,15 @@ mod tests {
     #[tokio::test]
     async fn test_export_preserves_severity_and_body() {
         let storage = StorageLayer::new_in_memory().await.unwrap();
-        let mut exporter = SqliteLogExporter::new(storage.pool.clone());
+        let exporter = SqliteLogExporter::new(storage.pool.clone());
 
-        let batch: Vec<Cow<'_, LogData>> = vec![Cow::Owned(make_log(
+        let items: Vec<(SdkLogRecord, InstrumentationScope)> = vec![make_log(
             Severity::Warn,
             "disk almost full",
             "infra::monitor",
-        ))];
+        )];
+        let refs = as_batch_refs(&items);
+        let batch = LogBatch::new(&refs);
         exporter.export(batch).await.unwrap();
 
         let row =
@@ -283,14 +287,16 @@ mod tests {
     #[tokio::test]
     async fn test_export_preserves_trace_context() {
         let storage = StorageLayer::new_in_memory().await.unwrap();
-        let mut exporter = SqliteLogExporter::new(storage.pool.clone());
+        let exporter = SqliteLogExporter::new(storage.pool.clone());
 
-        let batch: Vec<Cow<'_, LogData>> = vec![Cow::Owned(make_log_with_trace(
+        let items: Vec<(SdkLogRecord, InstrumentationScope)> = vec![make_log_with_trace(
             Severity::Info,
             "correlated",
             "0102030405060708090a0b0c0d0e0f10",
             "f1e2d3c4b5a69788",
-        ))];
+        )];
+        let refs = as_batch_refs(&items);
+        let batch = LogBatch::new(&refs);
         exporter.export(batch).await.unwrap();
 
         let row = sqlx::query_as::<_, (Option<String>, Option<String>)>(
@@ -307,10 +313,12 @@ mod tests {
     #[tokio::test]
     async fn test_export_without_trace_context_stores_null() {
         let storage = StorageLayer::new_in_memory().await.unwrap();
-        let mut exporter = SqliteLogExporter::new(storage.pool.clone());
+        let exporter = SqliteLogExporter::new(storage.pool.clone());
 
-        let batch: Vec<Cow<'_, LogData>> =
-            vec![Cow::Owned(make_log(Severity::Debug, "no span", "test"))];
+        let items: Vec<(SdkLogRecord, InstrumentationScope)> =
+            vec![make_log(Severity::Debug, "no span", "test")];
+        let refs = as_batch_refs(&items);
+        let batch = LogBatch::new(&refs);
         exporter.export(batch).await.unwrap();
 
         let row = sqlx::query_as::<_, (Option<String>, Option<String>)>(

--- a/crates/storage/src/metric_telemetry.rs
+++ b/crates/storage/src/metric_telemetry.rs
@@ -4,16 +4,17 @@
 //! join tables (`resources`, `metric_scopes`) to avoid duplicating
 //! identical metadata on every data-point row.
 
-use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use opentelemetry::metrics::MetricsError;
+use opentelemetry::InstrumentationScope;
 use opentelemetry::{KeyValue, Value};
-use opentelemetry_sdk::metrics::data::{self, ResourceMetrics, Temporality};
-use opentelemetry_sdk::metrics::exporter::PushMetricsExporter;
-use opentelemetry_sdk::metrics::reader::{
-    AggregationSelector, DefaultAggregationSelector, TemporalitySelector,
+use opentelemetry_sdk::error::{OTelSdkError, OTelSdkResult};
+use opentelemetry_sdk::metrics::data::{
+    AggregatedMetrics, GaugeDataPoint, HistogramDataPoint, MetricData, ResourceMetrics,
+    SumDataPoint,
 };
-use opentelemetry_sdk::metrics::{Aggregation, InstrumentKind};
+use opentelemetry_sdk::metrics::exporter::PushMetricExporter;
+use opentelemetry_sdk::metrics::Temporality;
+use opentelemetry_sdk::Resource;
 use serde_json::{Map, Number};
 use sha2::{Digest, Sha256};
 use sqlx::SqlitePool;
@@ -33,10 +34,7 @@ impl SqliteMetricExporter {
     }
 
     /// Upsert the resource and return its row id.
-    async fn ensure_resource(
-        &self,
-        resource: &opentelemetry_sdk::Resource,
-    ) -> Result<i64, sqlx::Error> {
+    async fn ensure_resource(&self, resource: &Resource) -> Result<i64, sqlx::Error> {
         let fingerprint = resource_fingerprint(resource);
         let attrs_json = resource_to_json(resource);
 
@@ -55,12 +53,9 @@ impl SqliteMetricExporter {
     }
 
     /// Upsert the instrumentation scope and return its row id.
-    async fn ensure_scope(
-        &self,
-        scope: &opentelemetry::InstrumentationLibrary,
-    ) -> Result<i64, sqlx::Error> {
-        let name = scope.name.as_ref();
-        let version = scope.version.as_deref().unwrap_or("");
+    async fn ensure_scope(&self, scope: &InstrumentationScope) -> Result<i64, sqlx::Error> {
+        let name = scope.name();
+        let version = scope.version().unwrap_or("");
 
         sqlx::query("INSERT OR IGNORE INTO metric_scopes (name, version) VALUES (?1, ?2)")
             .bind(name)
@@ -78,9 +73,9 @@ impl SqliteMetricExporter {
         Ok(id)
     }
 
-    /// Persist a single counter/gauge data point (f64).
+    /// Persist a single sum data point (f64).
     #[allow(clippy::too_many_arguments)]
-    async fn insert_scalar(
+    async fn insert_sum_scalar(
         &self,
         resource_id: i64,
         scope_id: i64,
@@ -88,12 +83,15 @@ impl SqliteMetricExporter {
         kind: &str,
         unit: &str,
         description: &str,
-        dp: &data::DataPoint<f64>,
+        dp: &SumDataPoint<f64>,
+        sum_start_time: std::time::SystemTime,
+        sum_time: std::time::SystemTime,
     ) -> Result<(), sqlx::Error> {
-        let da = extract_denormalized(&dp.attributes);
-        let attrs_json = keyvalues_to_json(&dp.attributes);
-        let start_time = non_epoch_time(dp.start_time);
-        let recorded_at = resolve_time(dp.time);
+        let attrs: Vec<KeyValue> = dp.attributes().cloned().collect();
+        let da = extract_denormalized(&attrs);
+        let attrs_json = keyvalues_to_json(&attrs);
+        let start_time = non_epoch_time(Some(sum_start_time));
+        let recorded_at: DateTime<Utc> = sum_time.into();
 
         sqlx::query(
             "INSERT INTO metric_points \
@@ -108,7 +106,7 @@ impl SqliteMetricExporter {
         .bind(kind)
         .bind(unit)
         .bind(description)
-        .bind(dp.value)
+        .bind(dp.value())
         .bind(&attrs_json)
         .bind(start_time)
         .bind(recorded_at)
@@ -123,9 +121,9 @@ impl SqliteMetricExporter {
         Ok(())
     }
 
-    /// Persist a single counter/gauge data point (i64).
+    /// Persist a single sum data point (i64).
     #[allow(clippy::too_many_arguments)]
-    async fn insert_scalar_i64(
+    async fn insert_sum_scalar_i64(
         &self,
         resource_id: i64,
         scope_id: i64,
@@ -133,12 +131,15 @@ impl SqliteMetricExporter {
         kind: &str,
         unit: &str,
         description: &str,
-        dp: &data::DataPoint<i64>,
+        dp: &SumDataPoint<i64>,
+        sum_start_time: std::time::SystemTime,
+        sum_time: std::time::SystemTime,
     ) -> Result<(), sqlx::Error> {
-        let da = extract_denormalized(&dp.attributes);
-        let attrs_json = keyvalues_to_json(&dp.attributes);
-        let start_time = non_epoch_time(dp.start_time);
-        let recorded_at = resolve_time(dp.time);
+        let attrs: Vec<KeyValue> = dp.attributes().cloned().collect();
+        let da = extract_denormalized(&attrs);
+        let attrs_json = keyvalues_to_json(&attrs);
+        let start_time = non_epoch_time(Some(sum_start_time));
+        let recorded_at: DateTime<Utc> = sum_time.into();
 
         sqlx::query(
             "INSERT INTO metric_points \
@@ -153,10 +154,94 @@ impl SqliteMetricExporter {
         .bind(kind)
         .bind(unit)
         .bind(description)
-        .bind(dp.value as f64)
+        .bind(dp.value() as f64)
         .bind(&attrs_json)
         .bind(start_time)
         .bind(recorded_at)
+        .bind(&da.model)
+        .bind(&da.provider)
+        .bind(&da.operation)
+        .bind(&da.skill)
+        .bind(&da.interface)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+
+    /// Persist a single gauge data point (f64).
+    #[allow(clippy::too_many_arguments)]
+    async fn insert_gauge_scalar(
+        &self,
+        resource_id: i64,
+        scope_id: i64,
+        name: &str,
+        unit: &str,
+        description: &str,
+        dp: &GaugeDataPoint<f64>,
+    ) -> Result<(), sqlx::Error> {
+        let attrs: Vec<KeyValue> = dp.attributes().cloned().collect();
+        let da = extract_denormalized(&attrs);
+        let attrs_json = keyvalues_to_json(&attrs);
+
+        sqlx::query(
+            "INSERT INTO metric_points \
+                (resource_id, scope_id, metric_name, metric_kind, unit, description, \
+                 value, attributes, recorded_at, \
+                 model, provider, operation, skill, interface) \
+             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14)",
+        )
+        .bind(resource_id)
+        .bind(scope_id)
+        .bind(name)
+        .bind("gauge")
+        .bind(unit)
+        .bind(description)
+        .bind(dp.value())
+        .bind(&attrs_json)
+        .bind(Utc::now())
+        .bind(&da.model)
+        .bind(&da.provider)
+        .bind(&da.operation)
+        .bind(&da.skill)
+        .bind(&da.interface)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+
+    /// Persist a single gauge data point (i64).
+    #[allow(clippy::too_many_arguments)]
+    async fn insert_gauge_scalar_i64(
+        &self,
+        resource_id: i64,
+        scope_id: i64,
+        name: &str,
+        unit: &str,
+        description: &str,
+        dp: &GaugeDataPoint<i64>,
+    ) -> Result<(), sqlx::Error> {
+        let attrs: Vec<KeyValue> = dp.attributes().cloned().collect();
+        let da = extract_denormalized(&attrs);
+        let attrs_json = keyvalues_to_json(&attrs);
+
+        sqlx::query(
+            "INSERT INTO metric_points \
+                (resource_id, scope_id, metric_name, metric_kind, unit, description, \
+                 value, attributes, recorded_at, \
+                 model, provider, operation, skill, interface) \
+             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14)",
+        )
+        .bind(resource_id)
+        .bind(scope_id)
+        .bind(name)
+        .bind("gauge")
+        .bind(unit)
+        .bind(description)
+        .bind(dp.value() as f64)
+        .bind(&attrs_json)
+        .bind(Utc::now())
         .bind(&da.model)
         .bind(&da.provider)
         .bind(&da.operation)
@@ -169,6 +254,7 @@ impl SqliteMetricExporter {
     }
 
     /// Persist a histogram data point.
+    #[allow(clippy::too_many_arguments)]
     async fn insert_histogram(
         &self,
         resource_id: i64,
@@ -176,14 +262,19 @@ impl SqliteMetricExporter {
         name: &str,
         unit: &str,
         description: &str,
-        dp: &data::HistogramDataPoint<f64>,
+        dp: &HistogramDataPoint<f64>,
+        hist_start_time: std::time::SystemTime,
+        hist_time: std::time::SystemTime,
     ) -> Result<(), sqlx::Error> {
-        let da = extract_denormalized(&dp.attributes);
-        let attrs_json = keyvalues_to_json(&dp.attributes);
-        let start_time = non_epoch_time(Some(dp.start_time));
-        let recorded_at = resolve_time(Some(dp.time));
-        let bounds_json = serde_json::to_string(&dp.bounds).unwrap_or_default();
-        let bucket_counts_json = serde_json::to_string(&dp.bucket_counts).unwrap_or_default();
+        let attrs: Vec<KeyValue> = dp.attributes().cloned().collect();
+        let da = extract_denormalized(&attrs);
+        let attrs_json = keyvalues_to_json(&attrs);
+        let start_time = non_epoch_time(Some(hist_start_time));
+        let recorded_at: DateTime<Utc> = hist_time.into();
+        let bounds: Vec<f64> = dp.bounds().collect();
+        let bucket_counts: Vec<u64> = dp.bucket_counts().collect();
+        let bounds_json = serde_json::to_string(&bounds).unwrap_or_default();
+        let bucket_counts_json = serde_json::to_string(&bucket_counts).unwrap_or_default();
 
         sqlx::query(
             "INSERT INTO metric_points \
@@ -199,10 +290,10 @@ impl SqliteMetricExporter {
         .bind("histogram")
         .bind(unit)
         .bind(description)
-        .bind(dp.count as i64)
-        .bind(dp.sum)
-        .bind(dp.min)
-        .bind(dp.max)
+        .bind(dp.count() as i64)
+        .bind(dp.sum())
+        .bind(dp.min())
+        .bind(dp.max())
         .bind(&bounds_json)
         .bind(&bucket_counts_json)
         .bind(&attrs_json)
@@ -218,105 +309,161 @@ impl SqliteMetricExporter {
 
         Ok(())
     }
-}
 
-impl AggregationSelector for SqliteMetricExporter {
-    fn aggregation(&self, kind: InstrumentKind) -> Aggregation {
-        DefaultAggregationSelector::new().aggregation(kind)
-    }
-}
-
-impl TemporalitySelector for SqliteMetricExporter {
-    fn temporality(&self, _kind: InstrumentKind) -> Temporality {
-        // Delta: each export row represents a single collection interval,
-        // mapping naturally to time-series storage.
-        Temporality::Delta
-    }
-}
-
-#[async_trait]
-impl PushMetricsExporter for SqliteMetricExporter {
-    async fn export(&self, metrics: &mut ResourceMetrics) -> opentelemetry::metrics::Result<()> {
-        let resource_id = self
-            .ensure_resource(&metrics.resource)
-            .await
-            .map_err(|e| MetricsError::Other(e.to_string()))?;
-
-        for scope_metrics in &metrics.scope_metrics {
-            let scope_id = self
-                .ensure_scope(&scope_metrics.scope)
-                .await
-                .map_err(|e| MetricsError::Other(e.to_string()))?;
-
-            for metric in &scope_metrics.metrics {
-                let name = &*metric.name;
-                let unit = &*metric.unit;
-                let desc = &*metric.description;
-
-                // -- Counters / UpDownCounters (Sum aggregation) --
-                if let Some(sum) = metric.data.as_any().downcast_ref::<data::Sum<f64>>() {
-                    let kind = if sum.is_monotonic {
-                        "counter"
-                    } else {
-                        "up_down_counter"
-                    };
-                    for dp in &sum.data_points {
-                        if let Err(e) = self
-                            .insert_scalar(resource_id, scope_id, name, kind, unit, desc, dp)
-                            .await
-                        {
-                            warn!(metric = name, error = %e, "failed to persist f64 sum");
-                        }
-                    }
-                } else if let Some(sum) = metric.data.as_any().downcast_ref::<data::Sum<i64>>() {
-                    let kind = if sum.is_monotonic {
-                        "counter"
-                    } else {
-                        "up_down_counter"
-                    };
-                    for dp in &sum.data_points {
-                        if let Err(e) = self
-                            .insert_scalar_i64(resource_id, scope_id, name, kind, unit, desc, dp)
-                            .await
-                        {
-                            warn!(metric = name, error = %e, "failed to persist i64 sum");
-                        }
-                    }
-                // -- Gauges --
-                } else if let Some(gauge) = metric.data.as_any().downcast_ref::<data::Gauge<f64>>()
-                {
-                    for dp in &gauge.data_points {
-                        if let Err(e) = self
-                            .insert_scalar(resource_id, scope_id, name, "gauge", unit, desc, dp)
-                            .await
-                        {
-                            warn!(metric = name, error = %e, "failed to persist f64 gauge");
-                        }
-                    }
-                } else if let Some(gauge) = metric.data.as_any().downcast_ref::<data::Gauge<i64>>()
-                {
-                    for dp in &gauge.data_points {
-                        if let Err(e) = self
-                            .insert_scalar_i64(resource_id, scope_id, name, "gauge", unit, desc, dp)
-                            .await
-                        {
-                            warn!(metric = name, error = %e, "failed to persist i64 gauge");
-                        }
-                    }
-                // -- Histograms --
-                } else if let Some(hist) =
-                    metric.data.as_any().downcast_ref::<data::Histogram<f64>>()
-                {
-                    for dp in &hist.data_points {
-                        if let Err(e) = self
-                            .insert_histogram(resource_id, scope_id, name, unit, desc, dp)
-                            .await
-                        {
-                            warn!(metric = name, error = %e, "failed to persist histogram");
-                        }
-                    }
+    /// Process a single `MetricData<f64>` value.
+    async fn process_f64_metric(
+        &self,
+        resource_id: i64,
+        scope_id: i64,
+        name: &str,
+        unit: &str,
+        desc: &str,
+        metric_data: &MetricData<f64>,
+    ) {
+        match metric_data {
+            MetricData::Sum(sum) => {
+                let kind = if sum.is_monotonic() {
+                    "counter"
                 } else {
-                    warn!(metric = name, "unsupported metric data type, skipping");
+                    "up_down_counter"
+                };
+                for dp in sum.data_points() {
+                    if let Err(e) = self
+                        .insert_sum_scalar(
+                            resource_id,
+                            scope_id,
+                            name,
+                            kind,
+                            unit,
+                            desc,
+                            dp,
+                            sum.start_time(),
+                            sum.time(),
+                        )
+                        .await
+                    {
+                        warn!(metric = name, error = %e, "failed to persist f64 sum");
+                    }
+                }
+            }
+            MetricData::Gauge(gauge) => {
+                for dp in gauge.data_points() {
+                    if let Err(e) = self
+                        .insert_gauge_scalar(resource_id, scope_id, name, unit, desc, dp)
+                        .await
+                    {
+                        warn!(metric = name, error = %e, "failed to persist f64 gauge");
+                    }
+                }
+            }
+            MetricData::Histogram(hist) => {
+                for dp in hist.data_points() {
+                    if let Err(e) = self
+                        .insert_histogram(
+                            resource_id,
+                            scope_id,
+                            name,
+                            unit,
+                            desc,
+                            dp,
+                            hist.start_time(),
+                            hist.time(),
+                        )
+                        .await
+                    {
+                        warn!(metric = name, error = %e, "failed to persist f64 histogram");
+                    }
+                }
+            }
+            _ => {
+                warn!(metric = name, "unsupported f64 metric data type, skipping");
+            }
+        }
+    }
+
+    /// Process a single `MetricData<i64>` value.
+    async fn process_i64_metric(
+        &self,
+        resource_id: i64,
+        scope_id: i64,
+        name: &str,
+        unit: &str,
+        desc: &str,
+        metric_data: &MetricData<i64>,
+    ) {
+        match metric_data {
+            MetricData::Sum(sum) => {
+                let kind = if sum.is_monotonic() {
+                    "counter"
+                } else {
+                    "up_down_counter"
+                };
+                for dp in sum.data_points() {
+                    if let Err(e) = self
+                        .insert_sum_scalar_i64(
+                            resource_id,
+                            scope_id,
+                            name,
+                            kind,
+                            unit,
+                            desc,
+                            dp,
+                            sum.start_time(),
+                            sum.time(),
+                        )
+                        .await
+                    {
+                        warn!(metric = name, error = %e, "failed to persist i64 sum");
+                    }
+                }
+            }
+            MetricData::Gauge(gauge) => {
+                for dp in gauge.data_points() {
+                    if let Err(e) = self
+                        .insert_gauge_scalar_i64(resource_id, scope_id, name, unit, desc, dp)
+                        .await
+                    {
+                        warn!(metric = name, error = %e, "failed to persist i64 gauge");
+                    }
+                }
+            }
+            _ => {
+                warn!(metric = name, "unsupported i64 metric data type, skipping");
+            }
+        }
+    }
+}
+
+impl PushMetricExporter for SqliteMetricExporter {
+    async fn export(&self, metrics: &ResourceMetrics) -> OTelSdkResult {
+        let resource_id = self
+            .ensure_resource(metrics.resource())
+            .await
+            .map_err(|e| OTelSdkError::InternalFailure(e.to_string()))?;
+
+        for scope_metrics in metrics.scope_metrics() {
+            let scope_id = self
+                .ensure_scope(scope_metrics.scope())
+                .await
+                .map_err(|e| OTelSdkError::InternalFailure(e.to_string()))?;
+
+            for metric in scope_metrics.metrics() {
+                let name = metric.name();
+                let unit = metric.unit();
+                let desc = metric.description();
+
+                match metric.data() {
+                    AggregatedMetrics::F64(data) => {
+                        self.process_f64_metric(resource_id, scope_id, name, unit, desc, data)
+                            .await;
+                    }
+                    AggregatedMetrics::I64(data) => {
+                        self.process_i64_metric(resource_id, scope_id, name, unit, desc, data)
+                            .await;
+                    }
+                    AggregatedMetrics::U64(_) => {
+                        warn!(metric = name, "u64 metrics not yet supported, skipping");
+                    }
                 }
             }
         }
@@ -324,19 +471,25 @@ impl PushMetricsExporter for SqliteMetricExporter {
         Ok(())
     }
 
-    async fn force_flush(&self) -> opentelemetry::metrics::Result<()> {
+    fn force_flush(&self) -> OTelSdkResult {
         Ok(())
     }
 
-    fn shutdown(&self) -> opentelemetry::metrics::Result<()> {
+    fn shutdown_with_timeout(&self, _timeout: std::time::Duration) -> OTelSdkResult {
         Ok(())
+    }
+
+    fn temporality(&self) -> Temporality {
+        // Delta: each export row represents a single collection interval,
+        // mapping naturally to time-series storage.
+        Temporality::Delta
     }
 }
 
 // -- Helpers ------------------------------------------------------------------
 
 /// SHA-256 fingerprint of sorted resource attributes for deduplication.
-fn resource_fingerprint(resource: &opentelemetry_sdk::Resource) -> String {
+fn resource_fingerprint(resource: &Resource) -> String {
     let mut pairs: Vec<(String, String)> = resource
         .iter()
         .map(|(k, v)| (k.as_str().to_string(), format!("{v:?}")))
@@ -346,7 +499,6 @@ fn resource_fingerprint(resource: &opentelemetry_sdk::Resource) -> String {
     let mut hasher = Sha256::new();
     for (k, v) in &pairs {
         hasher.update(k.as_bytes());
-        hasher.update(b"=");
         hasher.update(v.as_bytes());
         hasher.update(b",");
     }
@@ -354,7 +506,7 @@ fn resource_fingerprint(resource: &opentelemetry_sdk::Resource) -> String {
 }
 
 /// Serialize resource attributes to a JSON string (stored once per resource row).
-fn resource_to_json(resource: &opentelemetry_sdk::Resource) -> String {
+fn resource_to_json(resource: &Resource) -> String {
     let mut map = Map::new();
     for (key, value) in resource.iter() {
         map.insert(key.as_str().to_string(), otel_value_to_json(value));
@@ -417,12 +569,6 @@ fn non_epoch_time(t: Option<std::time::SystemTime>) -> Option<DateTime<Utc>> {
     t.filter(|t| *t != std::time::UNIX_EPOCH).map(Into::into)
 }
 
-/// Resolve a data-point timestamp to a concrete `DateTime<Utc>`, falling
-/// back to `Utc::now()` if the SDK left the field unset.
-fn resolve_time(t: Option<std::time::SystemTime>) -> DateTime<Utc> {
-    t.map(Into::into).unwrap_or_else(Utc::now)
-}
-
 fn otel_value_to_json(value: &Value) -> serde_json::Value {
     match value {
         Value::Bool(v) => serde_json::Value::Bool(*v),
@@ -457,7 +603,9 @@ fn otel_value_to_json(value: &Value) -> serde_json::Value {
                     .map(|s| serde_json::Value::String(s.as_str().to_string()))
                     .collect(),
             ),
+            _ => serde_json::Value::String(format!("{array:?}")),
         },
+        _ => serde_json::Value::String(format!("{value:?}")),
     }
 }
 
@@ -471,10 +619,12 @@ mod tests {
         let storage = StorageLayer::new_in_memory().await.unwrap();
         let exporter = SqliteMetricExporter::new(storage.pool.clone());
 
-        let resource = opentelemetry_sdk::Resource::new(vec![
-            KeyValue::new("service.name", "test"),
-            KeyValue::new("service.version", "0.1.0"),
-        ]);
+        let resource = Resource::builder_empty()
+            .with_attributes([
+                KeyValue::new("service.name", "test"),
+                KeyValue::new("service.version", "0.1.0"),
+            ])
+            .build();
 
         let id1 = exporter.ensure_resource(&resource).await.unwrap();
         let id2 = exporter.ensure_resource(&resource).await.unwrap();
@@ -492,7 +642,7 @@ mod tests {
         let storage = StorageLayer::new_in_memory().await.unwrap();
         let exporter = SqliteMetricExporter::new(storage.pool.clone());
 
-        let scope = opentelemetry::InstrumentationLibrary::builder("test-scope")
+        let scope = InstrumentationScope::builder("test-scope")
             .with_version("1.0")
             .build();
 
@@ -503,14 +653,12 @@ mod tests {
 
     #[test]
     fn fingerprint_is_order_independent() {
-        let r1 = opentelemetry_sdk::Resource::new(vec![
-            KeyValue::new("a", "1"),
-            KeyValue::new("b", "2"),
-        ]);
-        let r2 = opentelemetry_sdk::Resource::new(vec![
-            KeyValue::new("b", "2"),
-            KeyValue::new("a", "1"),
-        ]);
+        let r1 = Resource::builder_empty()
+            .with_attributes([KeyValue::new("a", "1"), KeyValue::new("b", "2")])
+            .build();
+        let r2 = Resource::builder_empty()
+            .with_attributes([KeyValue::new("b", "2"), KeyValue::new("a", "1")])
+            .build();
         assert_eq!(
             resource_fingerprint(&r1),
             resource_fingerprint(&r2),
@@ -520,8 +668,12 @@ mod tests {
 
     #[test]
     fn different_resources_get_different_fingerprints() {
-        let r1 = opentelemetry_sdk::Resource::new(vec![KeyValue::new("service.name", "a")]);
-        let r2 = opentelemetry_sdk::Resource::new(vec![KeyValue::new("service.name", "b")]);
+        let r1 = Resource::builder_empty()
+            .with_attributes([KeyValue::new("service.name", "a")])
+            .build();
+        let r2 = Resource::builder_empty()
+            .with_attributes([KeyValue::new("service.name", "b")])
+            .build();
         assert_ne!(resource_fingerprint(&r1), resource_fingerprint(&r2));
     }
 }

--- a/crates/storage/src/telemetry.rs
+++ b/crates/storage/src/telemetry.rs
@@ -1,9 +1,8 @@
-use futures::future::BoxFuture;
-
 use chrono::{DateTime, Utc};
-use opentelemetry::trace::{SpanId, Status, TraceError};
+use opentelemetry::trace::SpanId;
 use opentelemetry::{KeyValue, Value};
-use opentelemetry_sdk::export::trace::{ExportResult, SpanData, SpanExporter};
+use opentelemetry_sdk::error::{OTelSdkError, OTelSdkResult};
+use opentelemetry_sdk::trace::{SpanData, SpanExporter};
 use serde_json::{Map, Number};
 use sqlx::SqlitePool;
 use uuid::Uuid;
@@ -117,16 +116,15 @@ impl SqliteSpanExporter {
 }
 
 impl SpanExporter for SqliteSpanExporter {
-    fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
-        let pool = self.pool.clone();
-        Box::pin(async move {
-            for span in batch {
-                if let Err(err) = SqliteSpanExporter::persist_span(pool.clone(), span).await {
-                    return Err(TraceError::Other(Box::new(err)));
-                }
+    async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
+        for span in batch {
+            if let Err(err) = SqliteSpanExporter::persist_span(self.pool.clone(), span).await {
+                return Err(OTelSdkError::InternalFailure(format!(
+                    "SQLite span export failed: {err}"
+                )));
             }
-            Ok(())
-        })
+        }
+        Ok(())
     }
 }
 
@@ -172,15 +170,19 @@ fn otel_value_to_json(value: &Value) -> serde_json::Value {
                     .map(|s| serde_json::Value::String(s.as_str().to_string()))
                     .collect(),
             ),
+            _ => serde_json::Value::String(format!("{array:?}")),
         },
+        _ => serde_json::Value::String(format!("{value:?}")),
     }
 }
 
-fn status_fields(status: &Status) -> (&'static str, Option<String>) {
+fn status_fields(status: &opentelemetry::trace::Status) -> (&'static str, Option<String>) {
     match status {
-        Status::Ok => ("ok", None),
-        Status::Unset => ("unset", None),
-        Status::Error { description } => ("error", Some(description.to_string())),
+        opentelemetry::trace::Status::Ok => ("ok", None),
+        opentelemetry::trace::Status::Unset => ("unset", None),
+        opentelemetry::trace::Status::Error { description } => {
+            ("error", Some(description.to_string()))
+        }
     }
 }
 
@@ -188,10 +190,9 @@ fn status_fields(status: &Status) -> (&'static str, Option<String>) {
 mod tests {
     use super::*;
     use crate::StorageLayer;
-    use opentelemetry::trace::{SpanContext, SpanKind, TraceFlags, TraceId, TraceState};
-    use opentelemetry::InstrumentationLibrary;
-    use opentelemetry_sdk::export::trace::SpanData;
-    use opentelemetry_sdk::trace::{SpanEvents, SpanLinks};
+    use opentelemetry::trace::{SpanContext, SpanKind, Status, TraceFlags, TraceId, TraceState};
+    use opentelemetry::InstrumentationScope;
+    use opentelemetry_sdk::trace::{SpanData, SpanEvents, SpanLinks};
     use std::time::{Duration, SystemTime};
 
     fn make_span(name: &str, tool_name: Option<&str>, status: Status) -> SpanData {
@@ -214,6 +215,7 @@ mod tests {
                 TraceState::default(),
             ),
             parent_span_id: SpanId::INVALID,
+            parent_span_is_remote: false,
             span_kind: SpanKind::Internal,
             name: name.to_string().into(),
             start_time: now,
@@ -223,7 +225,7 @@ mod tests {
             events: SpanEvents::default(),
             links: SpanLinks::default(),
             status,
-            instrumentation_lib: InstrumentationLibrary::default(),
+            instrumentation_scope: InstrumentationScope::default(),
         }
     }
 
@@ -247,7 +249,7 @@ mod tests {
     #[tokio::test]
     async fn test_export_persists_exact_count() {
         let storage = StorageLayer::new_in_memory().await.unwrap();
-        let mut exporter = SqliteSpanExporter::new(storage.pool.clone());
+        let exporter = SqliteSpanExporter::new(storage.pool.clone());
 
         let batch = vec![
             make_span("span-1", Some("bash"), Status::Ok),
@@ -264,7 +266,7 @@ mod tests {
     #[tokio::test]
     async fn test_export_preserves_tool_metadata() {
         let storage = StorageLayer::new_in_memory().await.unwrap();
-        let mut exporter = SqliteSpanExporter::new(storage.pool.clone());
+        let exporter = SqliteSpanExporter::new(storage.pool.clone());
 
         let batch = vec![make_span("execute_tool bash", Some("bash"), Status::Ok)];
         exporter.export(batch).await.unwrap();
@@ -284,7 +286,7 @@ mod tests {
     #[tokio::test]
     async fn test_export_records_duration() {
         let storage = StorageLayer::new_in_memory().await.unwrap();
-        let mut exporter = SqliteSpanExporter::new(storage.pool.clone());
+        let exporter = SqliteSpanExporter::new(storage.pool.clone());
 
         let now = SystemTime::now();
         let trace_id = TraceId::from(uuid::Uuid::new_v4().as_u128());
@@ -299,6 +301,7 @@ mod tests {
                 TraceState::default(),
             ),
             parent_span_id: SpanId::INVALID,
+            parent_span_is_remote: false,
             span_kind: SpanKind::Internal,
             name: "timed".into(),
             start_time: now,
@@ -308,7 +311,7 @@ mod tests {
             events: SpanEvents::default(),
             links: SpanLinks::default(),
             status: Status::Ok,
-            instrumentation_lib: InstrumentationLibrary::default(),
+            instrumentation_scope: InstrumentationScope::default(),
         };
 
         exporter.export(vec![span]).await.unwrap();
@@ -324,7 +327,7 @@ mod tests {
     #[tokio::test]
     async fn test_export_captures_error_status() {
         let storage = StorageLayer::new_in_memory().await.unwrap();
-        let mut exporter = SqliteSpanExporter::new(storage.pool.clone());
+        let exporter = SqliteSpanExporter::new(storage.pool.clone());
 
         let batch = vec![make_span(
             "failing",

--- a/crates/web-ui/src/webhooks/pages.rs
+++ b/crates/web-ui/src/webhooks/pages.rs
@@ -500,7 +500,7 @@ fn generate_secret() -> String {
 /// Collect 32 random bytes from the OS CSPRNG.
 fn rand_bytes() -> [u8; 32] {
     let mut buf = [0u8; 32];
-    getrandom::getrandom(&mut buf).expect("OS RNG should be available");
+    getrandom::fill(&mut buf).expect("OS RNG should be available");
     buf
 }
 


### PR DESCRIPTION
## Summary

- Upgrades the OpenTelemetry stack from 0.24 to 0.31 (`opentelemetry`, `opentelemetry-sdk`, `opentelemetry-otlp`, `opentelemetry-appender-tracing`, `opentelemetry-http`, `opentelemetry-proto`)
- Also bumps `jsonschema` 0.42 → 0.44, `reedline` 0.45 → 0.46, `getrandom` 0.2 → 0.3
- Migrates all telemetry code to the new OTel 0.31 APIs (see details below)

## Key API changes migrated

**Traces:** `SpanExporter` now takes `&self` instead of `&mut self`, returns `OTelSdkResult`. OTLP builder pattern changed to `SpanExporter::builder().with_tonic().build()`. `SpanData` gained `parent_span_is_remote` field.

**Logs:** `LogExporter` takes `LogBatch<'_>` instead of `Vec<Cow<LogData>>`. `SdkLogRecord` accessors replace direct field access. Provider types renamed (`LoggerProvider` → `SdkLoggerProvider`).

**Metrics:** `PushMetricExporter` uses enum-based `AggregatedMetrics` instead of `dyn Any` downcasting. Time accessors (`start_time()`, `time()`) moved from data points to parent `Sum`/`Histogram`/`Gauge` containers. Instrument builders use `.build()` instead of `.init()`. `PeriodicReader::builder(exporter).with_interval().build()` replaces `with_periodic_exporter().with_interval()`.

**Other:** `Resource::builder_empty().with_attributes().build()` replaces `Resource::new()`. `getrandom::fill()` replaces `getrandom::getrandom()`. Non-exhaustive enums (`Value`, `Array`, `AnyValue`) require wildcard arms.

## Not included

The `reqwest` 0.12 → 0.13 upgrade is blocked because `async-openai 0.33.0` pins to `reqwest 0.12`.