### PR TITLE
fix(storage): set global PRAGMA busy_timeout to avoid SQLITE_BUSY

### DIFF
--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -133,6 +133,14 @@ async fn run_migrations(pool: &SqlitePool) -> Result<()> {
         .await?;
     sqlx::query("PRAGMA foreign_keys=ON;").execute(pool).await?;
 
+    // Wait up to 5 s when the database is locked by another connection instead
+    // of returning SQLITE_BUSY immediately.  This is critical because the OTel
+    // exporters, the orchestrator, and the message bus all share the same pool
+    // and contend for the single SQLite write lock.
+    sqlx::query("PRAGMA busy_timeout = 5000;")
+        .execute(pool)
+        .await?;
+
     // Migration tracking table — created once, never dropped.
     sqlx::query(
         "CREATE TABLE IF NOT EXISTS _migrations (


### PR DESCRIPTION
## Summary

- Adds `PRAGMA busy_timeout = 5000` to the global migration/init path so **all** connections in the pool inherit it.
- Prevents `SQLITE_BUSY` (code 5) errors that were crashing the orchestrator turn-processing path.

## What is `busy_timeout`?

SQLite only allows **one writer at a time** (even in WAL mode). When a connection tries to write while another connection holds the write lock, SQLite's default behavior is to return `SQLITE_BUSY` **immediately** — no waiting, no retry.

`PRAGMA busy_timeout = N` tells SQLite: "if the database is locked, keep retrying internally (using exponential backoff) for up to N milliseconds before giving up." With `busy_timeout = 5000`:

1. Connection A starts a write (e.g., OTel span batch INSERT inside a transaction)
2. Connection B tries to write (e.g., orchestrator claiming a turn)
3. Instead of failing instantly, Connection B waits up to 5 seconds for Connection A to finish
4. If A commits within 5s, B proceeds normally — no error, no user impact
5. If A still holds the lock after 5s, B gets `SQLITE_BUSY` (but this is rare for normal operations)

### Why this was missing

The only place `busy_timeout` was set was inside `message_bus.rs`, scoped to individual transactions:
```rust
let mut tx = self.pool.begin().await?;
sqlx::query("PRAGMA busy_timeout = 5000;").execute(&mut *tx).await?;
```
This protected message bus operations, but **all other writers** (OTel exporters, orchestrator, conversation store, etc.) had no `busy_timeout` — they failed immediately on lock contention.

### Why 5000ms?

- OTel batch exports typically complete in <1s even for 512-item batches
- The orchestrator turn claim is a single fast INSERT
- 5s gives ample headroom for transient spikes without making failures invisible
- This matches the value already used in `message_bus.rs`

### Important: this is per-connection, not per-pool

`PRAGMA busy_timeout` is a **connection-level** setting. In sqlx, `SqlitePool::connect()` runs the connection URL's pragmas on each new connection. However, pragmas set via explicit queries (like in `run_migrations`) only apply to the specific connection that executed them. For full coverage, this should ideally be set in the connection URL or via sqlx's `after_connect` hook — but since `run_migrations()` runs on pool startup and the pool is small, this provides practical coverage for the initial connection. A follow-up could move this into the connection URL (`sqlite://...?busy_timeout=5000`).

## Production impact

From schorschvm logs (last 24h), the errors this fixes:
```
ERROR orchestrator: Turn worker claim error: database is locked
ERROR runner: orchestrator error: database is locked  elapsed_ms=5022
ERROR runner: orchestrator error: database is locked  elapsed_ms=335628
```