### PR TITLE
refactor(storage): extract OTel exporters into opentelemetry-exporter-sqlite crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,6 +509,7 @@ dependencies = [
  "dirs",
  "opentelemetry",
  "opentelemetry-appender-tracing",
+ "opentelemetry-exporter-sqlite",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "serde_json",
@@ -545,12 +546,8 @@ dependencies = [
  "async-trait",
  "chrono",
  "dirs",
- "futures",
- "opentelemetry",
- "opentelemetry_sdk",
  "serde",
  "serde_json",
- "sha2",
  "sqlx",
  "tokio",
  "tracing",
@@ -3770,6 +3767,21 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "opentelemetry-exporter-sqlite"
+version = "0.1.28"
+dependencies = [
+ "chrono",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "serde_json",
+ "sha2",
+ "sqlx",
+ "tokio",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "crates/web-ui",
     "crates/a2a-proto",
     "crates/a2a-json-schema",
+    "crates/opentelemetry-exporter-sqlite",
 ]
 default-members = [
     "crates/interface-cli",
@@ -127,6 +128,7 @@ slack-morphism = { version = "2", features = ["hyper"] }
 tokio-tungstenite = { version = "0.28", features = ["rustls-tls-native-roots"] }
 mattermost_api = "0.8"
 # Internal crates
+opentelemetry-exporter-sqlite = { path = "crates/opentelemetry-exporter-sqlite" }
 core = { path = "crates/core" }
 skills = { path = "crates/skills" }
 llm = { path = "crates/llm" }

--- a/crates/opentelemetry-exporter-sqlite/Cargo.toml
+++ b/crates/opentelemetry-exporter-sqlite/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "opentelemetry-exporter-sqlite"
+version = "0.1.28"
+license.workspace = true
+edition.workspace = true
+description = "OpenTelemetry SQLite exporters for spans, logs, and metrics"
+
+[dependencies]
+chrono = { workspace = true }
+opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+sqlx = { workspace = true }
+tracing = { workspace = true }
+uuid = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/crates/opentelemetry-exporter-sqlite/src/lib.rs
+++ b/crates/opentelemetry-exporter-sqlite/src/lib.rs
@@ -1,0 +1,82 @@
+//! SQLite-backed OpenTelemetry exporters for spans, logs, and metrics.
+//!
+//! Each exporter persists telemetry data into a local SQLite database using
+//! the schema managed by `assistant-storage`.
+
+pub mod log;
+pub mod metric;
+pub mod span;
+
+pub use log::SqliteLogExporter;
+pub use metric::SqliteMetricExporter;
+pub use span::SqliteSpanExporter;
+
+/// Test-only helpers — provides an in-memory SQLite pool with the tables
+/// the exporters need, sourced from the shared `migrations/` directory via
+/// `include_str!`.
+#[cfg(test)]
+pub(crate) mod test_utils {
+    use sqlx::SqlitePool;
+
+    /// Create an in-memory SQLite pool with only the tables the exporters
+    /// require.  Migration SQL is pulled from the workspace `migrations/`
+    /// directory at compile time so there is a single source of truth.
+    pub async fn test_pool() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+
+        sqlx::query("PRAGMA journal_mode=WAL;")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("PRAGMA busy_timeout = 5000;")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        // Stub tables referenced by migration 009 (legacy data migration).
+        // The SELECT from execution_traces is a no-op on an empty table, and
+        // the FK on conversations is satisfied by the stub.
+        sqlx::query("CREATE TABLE IF NOT EXISTS conversations (id TEXT PRIMARY KEY)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS execution_traces (
+                id TEXT PRIMARY KEY, conversation_id TEXT, turn INTEGER,
+                action_skill TEXT, error TEXT, observation TEXT,
+                duration_ms INTEGER DEFAULT 0, created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                action_params TEXT DEFAULT '{}'
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // 009 — distributed_traces (spans)
+        sqlx::raw_sql(include_str!(
+            "../../../migrations/009_distributed_traces.sql"
+        ))
+        .execute(&pool)
+        .await
+        .unwrap();
+        // 010 — add token-usage columns to distributed_traces
+        sqlx::raw_sql(include_str!(
+            "../../../migrations/010_trace_token_usage.sql"
+        ))
+        .execute(&pool)
+        .await
+        .unwrap();
+        // 011 — logs
+        sqlx::raw_sql(include_str!("../../../migrations/011_logs.sql"))
+            .execute(&pool)
+            .await
+            .unwrap();
+        // 015 — metrics (resources, metric_scopes, metric_points)
+        sqlx::raw_sql(include_str!("../../../migrations/015_metrics.sql"))
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        pool
+    }
+}

--- a/crates/opentelemetry-exporter-sqlite/src/log.rs
+++ b/crates/opentelemetry-exporter-sqlite/src/log.rs
@@ -178,7 +178,6 @@ fn any_value_to_json(value: &AnyValue) -> serde_json::Value {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::StorageLayer;
     use opentelemetry::logs::{
         AnyValue, LogRecord as _, Logger as _, LoggerProvider as _, Severity,
     };
@@ -253,8 +252,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_export_persists_exact_count() {
-        let storage = StorageLayer::new_in_memory().await.unwrap();
-        let exporter = SqliteLogExporter::new(storage.pool.clone());
+        let pool = crate::test_utils::test_pool().await;
+        let exporter = SqliteLogExporter::new(pool.clone());
 
         let items: Vec<(SdkLogRecord, InstrumentationScope)> = vec![
             make_log(Severity::Info, "msg-1", "app"),
@@ -266,14 +265,14 @@ mod tests {
 
         exporter.export(batch).await.unwrap();
 
-        let count = row_count(&storage.pool, "logs").await;
+        let count = row_count(&pool, "logs").await;
         assert_eq!(count, 3, "exporter must produce exactly one row per record");
     }
 
     #[tokio::test]
     async fn test_export_preserves_severity_and_body() {
-        let storage = StorageLayer::new_in_memory().await.unwrap();
-        let exporter = SqliteLogExporter::new(storage.pool.clone());
+        let pool = crate::test_utils::test_pool().await;
+        let exporter = SqliteLogExporter::new(pool.clone());
 
         let items: Vec<(SdkLogRecord, InstrumentationScope)> = vec![make_log(
             Severity::Warn,
@@ -288,7 +287,7 @@ mod tests {
             sqlx::query_as::<_, (Option<i32>, Option<String>, Option<String>, Option<String>)>(
                 "SELECT severity_number, severity_text, body, target FROM logs LIMIT 1",
             )
-            .fetch_one(&storage.pool)
+            .fetch_one(&pool)
             .await
             .unwrap();
 
@@ -300,8 +299,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_export_preserves_trace_context() {
-        let storage = StorageLayer::new_in_memory().await.unwrap();
-        let exporter = SqliteLogExporter::new(storage.pool.clone());
+        let pool = crate::test_utils::test_pool().await;
+        let exporter = SqliteLogExporter::new(pool.clone());
 
         let items: Vec<(SdkLogRecord, InstrumentationScope)> = vec![make_log_with_trace(
             Severity::Info,
@@ -316,7 +315,7 @@ mod tests {
         let row = sqlx::query_as::<_, (Option<String>, Option<String>)>(
             "SELECT trace_id, span_id FROM logs LIMIT 1",
         )
-        .fetch_one(&storage.pool)
+        .fetch_one(&pool)
         .await
         .unwrap();
 
@@ -326,8 +325,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_export_without_trace_context_stores_null() {
-        let storage = StorageLayer::new_in_memory().await.unwrap();
-        let exporter = SqliteLogExporter::new(storage.pool.clone());
+        let pool = crate::test_utils::test_pool().await;
+        let exporter = SqliteLogExporter::new(pool.clone());
 
         let items: Vec<(SdkLogRecord, InstrumentationScope)> =
             vec![make_log(Severity::Debug, "no span", "test")];
@@ -338,7 +337,7 @@ mod tests {
         let row = sqlx::query_as::<_, (Option<String>, Option<String>)>(
             "SELECT trace_id, span_id FROM logs LIMIT 1",
         )
-        .fetch_one(&storage.pool)
+        .fetch_one(&pool)
         .await
         .unwrap();
 

--- a/crates/opentelemetry-exporter-sqlite/src/metric.rs
+++ b/crates/opentelemetry-exporter-sqlite/src/metric.rs
@@ -656,11 +656,10 @@ fn otel_value_to_json(value: &Value) -> serde_json::Value {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::StorageLayer;
 
     #[tokio::test]
     async fn resource_upsert_is_idempotent() {
-        let storage = StorageLayer::new_in_memory().await.unwrap();
+        let pool = crate::test_utils::test_pool().await;
 
         let resource = Resource::builder_empty()
             .with_attributes([
@@ -669,7 +668,7 @@ mod tests {
             ])
             .build();
 
-        let mut conn = storage.pool.acquire().await.unwrap();
+        let mut conn = pool.acquire().await.unwrap();
         let id1 = SqliteMetricExporter::ensure_resource(&mut *conn, &resource)
             .await
             .unwrap();
@@ -679,7 +678,7 @@ mod tests {
         assert_eq!(id1, id2, "same resource must return same id");
 
         let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM resources")
-            .fetch_one(&storage.pool)
+            .fetch_one(&pool)
             .await
             .unwrap();
         assert_eq!(count, 1, "only one resource row should exist");
@@ -687,13 +686,13 @@ mod tests {
 
     #[tokio::test]
     async fn scope_upsert_is_idempotent() {
-        let storage = StorageLayer::new_in_memory().await.unwrap();
+        let pool = crate::test_utils::test_pool().await;
 
         let scope = InstrumentationScope::builder("test-scope")
             .with_version("1.0")
             .build();
 
-        let mut conn = storage.pool.acquire().await.unwrap();
+        let mut conn = pool.acquire().await.unwrap();
         let id1 = SqliteMetricExporter::ensure_scope(&mut *conn, &scope)
             .await
             .unwrap();

--- a/crates/opentelemetry-exporter-sqlite/src/span.rs
+++ b/crates/opentelemetry-exporter-sqlite/src/span.rs
@@ -200,7 +200,6 @@ fn status_fields(status: &opentelemetry::trace::Status) -> (&'static str, Option
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::StorageLayer;
     use opentelemetry::trace::{SpanContext, SpanKind, Status, TraceFlags, TraceId, TraceState};
     use opentelemetry::InstrumentationScope;
     use opentelemetry_sdk::trace::{SpanData, SpanEvents, SpanLinks};
@@ -259,8 +258,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_export_persists_exact_count() {
-        let storage = StorageLayer::new_in_memory().await.unwrap();
-        let exporter = SqliteSpanExporter::new(storage.pool.clone());
+        let pool = crate::test_utils::test_pool().await;
+        let exporter = SqliteSpanExporter::new(pool.clone());
 
         let batch = vec![
             make_span("span-1", Some("bash"), Status::Ok),
@@ -270,14 +269,14 @@ mod tests {
 
         exporter.export(batch).await.unwrap();
 
-        let count = row_count(&storage.pool, "distributed_traces").await;
+        let count = row_count(&pool, "distributed_traces").await;
         assert_eq!(count, 3, "exporter must produce exactly one row per span");
     }
 
     #[tokio::test]
     async fn test_export_preserves_tool_metadata() {
-        let storage = StorageLayer::new_in_memory().await.unwrap();
-        let exporter = SqliteSpanExporter::new(storage.pool.clone());
+        let pool = crate::test_utils::test_pool().await;
+        let exporter = SqliteSpanExporter::new(pool.clone());
 
         let batch = vec![make_span("execute_tool bash", Some("bash"), Status::Ok)];
         exporter.export(batch).await.unwrap();
@@ -285,7 +284,7 @@ mod tests {
         let row = sqlx::query_as::<_, (String, Option<String>, Option<String>)>(
             "SELECT name, tool_name, tool_status FROM distributed_traces LIMIT 1",
         )
-        .fetch_one(&storage.pool)
+        .fetch_one(&pool)
         .await
         .unwrap();
 
@@ -296,8 +295,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_export_records_duration() {
-        let storage = StorageLayer::new_in_memory().await.unwrap();
-        let exporter = SqliteSpanExporter::new(storage.pool.clone());
+        let pool = crate::test_utils::test_pool().await;
+        let exporter = SqliteSpanExporter::new(pool.clone());
 
         let now = SystemTime::now();
         let trace_id = TraceId::from(uuid::Uuid::new_v4().as_u128());
@@ -328,7 +327,7 @@ mod tests {
         exporter.export(vec![span]).await.unwrap();
 
         let dur: i64 = sqlx::query_scalar("SELECT duration_ms FROM distributed_traces LIMIT 1")
-            .fetch_one(&storage.pool)
+            .fetch_one(&pool)
             .await
             .unwrap();
 
@@ -337,8 +336,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_export_captures_error_status() {
-        let storage = StorageLayer::new_in_memory().await.unwrap();
-        let exporter = SqliteSpanExporter::new(storage.pool.clone());
+        let pool = crate::test_utils::test_pool().await;
+        let exporter = SqliteSpanExporter::new(pool.clone());
 
         let batch = vec![make_span(
             "failing",
@@ -351,7 +350,7 @@ mod tests {
 
         let attrs_str: String =
             sqlx::query_scalar("SELECT attributes FROM distributed_traces LIMIT 1")
-                .fetch_one(&storage.pool)
+                .fetch_one(&pool)
                 .await
                 .unwrap();
         let attrs: serde_json::Value = serde_json::from_str(&attrs_str).unwrap();

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -9,6 +9,7 @@ description = "ReAct orchestrator and safety gate for the assistant runtime"
 assistant-core = { path = "../core" }
 assistant-llm = { path = "../llm" }
 assistant-storage = { path = "../storage" }
+opentelemetry-exporter-sqlite = { path = "../opentelemetry-exporter-sqlite" }
 assistant-skills = { path = "../skills" }
 assistant-tool-executor = { path = "../tool-executor" }
 async-trait = { workspace = true }

--- a/crates/runtime/src/telemetry.rs
+++ b/crates/runtime/src/telemetry.rs
@@ -1,9 +1,9 @@
 use std::time::Duration;
 
 use anyhow::Result;
-use assistant_storage::{SqliteLogExporter, SqliteMetricExporter, SqliteSpanExporter};
 use opentelemetry::{global, KeyValue};
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
+use opentelemetry_exporter_sqlite::{SqliteLogExporter, SqliteMetricExporter, SqliteSpanExporter};
 use opentelemetry_sdk::{
     logs::{BatchLogProcessor, SdkLoggerProvider},
     metrics::{PeriodicReader, SdkMeterProvider},

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -16,11 +16,7 @@ chrono = { workspace = true }
 tracing = { workspace = true }
 sqlx = { workspace = true }
 dirs = { workspace = true }
-opentelemetry = { workspace = true }
-opentelemetry_sdk = { workspace = true }
-futures = { workspace = true }
 async-trait = { workspace = true }
-sha2 = { workspace = true }
 serde = { workspace = true }
 
 [dev-dependencies]

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -1,32 +1,26 @@
 pub mod agents;
 pub mod conversations;
-pub mod log_telemetry;
 pub mod logs;
 pub mod memory_chunks;
 pub mod message_bus;
-pub mod metric_telemetry;
 pub mod metrics;
 pub mod refinements;
 pub mod registry;
 pub mod scheduled_tasks;
-pub mod telemetry;
 pub mod traces;
 pub mod webhooks;
 
 pub use agents::{AgentRecord, AgentStatus, AgentStore};
 pub use conversations::{ConversationRecord, ConversationStore};
-pub use log_telemetry::SqliteLogExporter;
 pub use logs::{LogStats, LogStore, RecordedLog};
 pub use memory_chunks::{FtsMatch, MemoryChunkStore, StoredChunk};
 pub use message_bus::SqliteMessageBus;
-pub use metric_telemetry::SqliteMetricExporter;
 pub use metrics::{
     MetricsStore, MetricsSummary, ModelTokenUsage, ResourceRecord, TimeSeriesPoint, ToolUsageStats,
 };
 pub use refinements::{RefinementStatus, RefinementsStore, SkillRefinement};
 pub use registry::SkillRegistry;
 pub use scheduled_tasks::{ScheduledTask, ScheduledTaskStore};
-pub use telemetry::SqliteSpanExporter;
 pub use traces::{RecordedSpan, TraceStats, TraceStore, TraceSummary};
 pub use webhooks::{WebhookRecord, WebhookStore};
 


### PR DESCRIPTION
## Summary

- Extract `SqliteSpanExporter`, `SqliteLogExporter`, and `SqliteMetricExporter` from `assistant-storage` into a new `opentelemetry-exporter-sqlite` crate with zero app-level dependencies
- Tests use `include_str!` to pull migration SQL from the shared `migrations/` directory — single source of truth, no dependency on `assistant-storage`
- Remove `opentelemetry`, `opentelemetry_sdk`, `sha2`, and `futures` from `assistant-storage`, shrinking the dep tree for the 7 downstream crates that never used the exporter types

## Motivation

The three OTel SQLite exporters are self-contained — they only need a `SqlitePool` and OTel SDK types. Keeping them in `assistant-storage` forced every downstream crate (CLI, Slack, Mattermost, MCP server, tool-executor, web-ui, integration-tests) to transitively compile OpenTelemetry even though only `assistant-runtime` uses the exporters.

## Changes

| File | Change |
|------|--------|
| `crates/opentelemetry-exporter-sqlite/` | New crate with `span.rs`, `log.rs`, `metric.rs`, `lib.rs` |
| `crates/opentelemetry-exporter-sqlite/src/lib.rs` | `test_utils` module with `include_str!` migrations for self-contained tests |
| `crates/storage/src/lib.rs` | Remove `telemetry`, `log_telemetry`, `metric_telemetry` modules and re-exports |
| `crates/storage/Cargo.toml` | Remove `opentelemetry`, `opentelemetry_sdk`, `sha2`, `futures` |
| `crates/runtime/Cargo.toml` | Add `opentelemetry-exporter-sqlite` dependency |
| `crates/runtime/src/telemetry.rs` | Import from `opentelemetry_exporter_sqlite` instead of `assistant_storage` |
| `Cargo.toml` | Register new crate in workspace members and dependencies |

## Testing

All 129 tests pass across the 3 affected crates:
- `opentelemetry-exporter-sqlite`: 12 tests
- `assistant-storage`: 72 tests  
- `assistant-runtime`: 45 tests

`make lint` and `make format` clean.