### PR TITLE
refactor(runtime): extract OTel span helpers to otel_spans module

### DIFF
--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1,10 +1,12 @@
 pub mod bootstrap;
 pub mod metrics;
 pub mod orchestrator;
+pub(crate) mod otel_spans;
 pub mod scheduler;
 pub mod telemetry;
 
 pub use metrics::MetricsRecorder;
-pub use orchestrator::{start_conversation_context, Orchestrator, TurnResult};
+pub use orchestrator::{Orchestrator, TurnResult};
+pub use otel_spans::start_conversation_context;
 pub use scheduler::spawn_scheduler;
 pub use telemetry::{init_tracing, OtelGuard};

--- a/crates/runtime/src/orchestrator.rs
+++ b/crates/runtime/src/orchestrator.rs
@@ -14,7 +14,7 @@ use assistant_core::{
 };
 use assistant_llm::{
     Capabilities, ChatHistoryMessage, ChatRole, ContentBlock, HostedTool, LlmProvider, LlmResponse,
-    LlmResponseMeta, ToolSpec,
+    ToolSpec,
 };
 use assistant_skills::SkillDef as SpecSkillDef;
 use assistant_storage::{conversations::ConversationStore, SkillRegistry, StorageLayer};
@@ -768,7 +768,7 @@ impl Orchestrator {
                 depth: 0,
             };
 
-            let mut llm_span = start_llm_span(
+            let mut llm_span = crate::otel_spans::start_llm_span(
                 self.llm.as_ref(),
                 iteration,
                 &turn_cx,
@@ -793,7 +793,7 @@ impl Orchestrator {
                     return Err(e);
                 }
             };
-            finish_llm_span(
+            crate::otel_spans::finish_llm_span(
                 &mut llm_span,
                 response.meta(),
                 &response,
@@ -935,7 +935,7 @@ impl Orchestrator {
                         let name = tool_call_item.name;
                         let params = tool_call_item.params;
                         let turn_index = base_turn + iteration as i64 + 1;
-                        let mut otel_span = start_tool_span(
+                        let mut otel_span = crate::otel_spans::start_tool_span(
                             conversation_id,
                             iteration,
                             turn_index,
@@ -1330,7 +1330,7 @@ impl Orchestrator {
                 depth: 0,
             };
 
-            let mut llm_span = start_llm_span(
+            let mut llm_span = crate::otel_spans::start_llm_span(
                 self.llm.as_ref(),
                 iteration,
                 &turn_cx,
@@ -1356,7 +1356,7 @@ impl Orchestrator {
                     return Err(e);
                 }
             };
-            finish_llm_span(
+            crate::otel_spans::finish_llm_span(
                 &mut llm_span,
                 response.meta(),
                 &response,
@@ -1417,7 +1417,7 @@ impl Orchestrator {
                         let name = tool_call_item.name;
                         let params = tool_call_item.params;
                         let turn_index = base_turn + iteration as i64 + 1;
-                        let mut otel_span = start_tool_span(
+                        let mut otel_span = crate::otel_spans::start_tool_span(
                             conversation_id,
                             iteration,
                             turn_index,
@@ -1636,7 +1636,7 @@ impl Orchestrator {
                 depth: 0,
             };
 
-            let mut llm_span = start_llm_span(
+            let mut llm_span = crate::otel_spans::start_llm_span(
                 self.llm.as_ref(),
                 iteration,
                 &turn_cx,
@@ -1667,7 +1667,7 @@ impl Orchestrator {
                     return Err(e);
                 }
             };
-            finish_llm_span(
+            crate::otel_spans::finish_llm_span(
                 &mut llm_span,
                 response.meta(),
                 &response,
@@ -1726,7 +1726,7 @@ impl Orchestrator {
                         let name = tool_call_item.name;
                         let params = tool_call_item.params;
                         let turn_index = base_turn + iteration as i64 + 1;
-                        let mut otel_span = start_tool_span(
+                        let mut otel_span = crate::otel_spans::start_tool_span(
                             conversation_id,
                             iteration,
                             turn_index,
@@ -2329,7 +2329,7 @@ impl SubagentRunner for Orchestrator {
                 };
 
                 // -- OTel: LLM span (child of agent span) ---------------------
-                let mut llm_span = start_llm_span(
+                let mut llm_span = crate::otel_spans::start_llm_span(
                     self.llm.as_ref(),
                     iteration,
                     &agent_cx,
@@ -2374,7 +2374,7 @@ impl SubagentRunner for Orchestrator {
                         };
                     }
                 };
-                finish_llm_span(
+                crate::otel_spans::finish_llm_span(
                     &mut llm_span,
                     response.meta(),
                     &response,
@@ -2472,7 +2472,7 @@ impl SubagentRunner for Orchestrator {
                             let turn_index = base_turn + iteration as i64 + 1;
 
                             // -- OTel: tool span (child of agent span) ---------
-                            let mut otel_span = start_tool_span(
+                            let mut otel_span = crate::otel_spans::start_tool_span(
                                 conversation_id,
                                 iteration,
                                 turn_index,
@@ -2659,232 +2659,6 @@ impl SubagentRunner for Orchestrator {
 /// the model directly.
 fn tool_result_content(content: &str, _data: Option<&serde_json::Value>) -> String {
     content.to_string()
-}
-
-/// Create an OpenTelemetry context carrying a conversation-level root span.
-///
-/// Callers that manage conversation lifetimes (e.g. the CLI REPL or Slack
-/// thread handler) should create this once per conversation and pass it to
-/// each `run_turn*` call so all turns within the conversation share a single
-/// trace.
-pub fn start_conversation_context(conversation_id: Uuid, interface: &Interface) -> OtelContext {
-    let tracer = global::tracer("assistant.orchestrator");
-    let mut span = tracer.start("conversation");
-    span.set_attribute(KeyValue::new(
-        "conversation_id",
-        conversation_id.to_string(),
-    ));
-    span.set_attribute(KeyValue::new("interface", format!("{:?}", interface)));
-    OtelContext::current().with_span(span)
-}
-
-fn start_tool_span(
-    conversation_id: Uuid,
-    iteration: usize,
-    turn: i64,
-    interface: &Interface,
-    tool_name: &str,
-    params: &serde_json::Value,
-    parent_cx: &OtelContext,
-) -> opentelemetry::global::BoxedSpan {
-    let tracer = global::tracer("assistant.orchestrator");
-    let span_name = format!("execute_tool {tool_name}");
-    let mut span = tracer.start_with_context(span_name, parent_cx);
-    span.set_attribute(KeyValue::new(
-        "conversation_id",
-        conversation_id.to_string(),
-    ));
-    span.set_attribute(KeyValue::new("iteration", iteration as i64));
-    span.set_attribute(KeyValue::new("turn", turn));
-    span.set_attribute(KeyValue::new("interface", format!("{:?}", interface)));
-    span.set_attribute(KeyValue::new("tool_name", tool_name.to_string()));
-    let params_json =
-        serde_json::to_string(params).unwrap_or_else(|_| "<unserializable>".to_string());
-    span.set_attribute(KeyValue::new("tool_params", params_json));
-    span
-}
-
-/// Create an OTel span for an LLM chat call, populated with GenAI semantic
-/// convention request-side attributes.
-///
-/// When `trace_content` is `true`, the span also records:
-/// - `gen_ai.system_instructions` — the full system prompt
-/// - `gen_ai.input.messages` — serialised chat history
-/// - `gen_ai.tool.definitions` — serialised tool spec list
-#[allow(clippy::too_many_arguments)]
-fn start_llm_span(
-    llm: &dyn LlmProvider,
-    iteration: usize,
-    parent_cx: &OtelContext,
-    trace_content: bool,
-    system_prompt: &str,
-    history: &[ChatHistoryMessage],
-    tools: &[ToolSpec],
-) -> opentelemetry::global::BoxedSpan {
-    let tracer = global::tracer("assistant.orchestrator");
-    let model = llm.model_name();
-    let span_name = format!("chat {model}");
-    let mut span = tracer.start_with_context(span_name, parent_cx);
-    span.set_attribute(KeyValue::new(
-        "gen_ai.system",
-        llm.provider_name().to_string(),
-    ));
-    span.set_attribute(KeyValue::new("gen_ai.request.model", model.to_string()));
-    span.set_attribute(KeyValue::new("gen_ai.operation.name", "chat"));
-    span.set_attribute(KeyValue::new(
-        "server.address",
-        llm.server_address().to_string(),
-    ));
-    span.set_attribute(KeyValue::new("iteration", iteration as i64));
-
-    if trace_content {
-        span.set_attribute(KeyValue::new(
-            "gen_ai.system_instructions",
-            system_prompt.to_string(),
-        ));
-        let input_json = serialize_history_for_span(history);
-        span.set_attribute(KeyValue::new("gen_ai.input.messages", input_json));
-        if !tools.is_empty() {
-            let tools_json = serde_json::to_string(
-                &tools
-                    .iter()
-                    .map(|t| {
-                        serde_json::json!({
-                            "name": t.name,
-                            "description": t.description,
-                        })
-                    })
-                    .collect::<Vec<_>>(),
-            )
-            .unwrap_or_default();
-            span.set_attribute(KeyValue::new("gen_ai.tool.definitions", tools_json));
-        }
-    }
-
-    span
-}
-
-/// Enrich an LLM span with GenAI semantic convention response-side attributes
-/// extracted from [`LlmResponseMeta`].
-///
-/// When `trace_content` is `true`, the assistant's output text is also recorded
-/// as `gen_ai.output.messages`.
-fn finish_llm_span(
-    span: &mut opentelemetry::global::BoxedSpan,
-    meta: &LlmResponseMeta,
-    response: &LlmResponse,
-    trace_content: bool,
-    metrics: Option<(&crate::MetricsRecorder, &str, std::time::Duration)>,
-) {
-    if let Some(model) = &meta.model {
-        span.set_attribute(KeyValue::new("gen_ai.response.model", model.clone()));
-    }
-    if let Some(id) = &meta.response_id {
-        span.set_attribute(KeyValue::new("gen_ai.response.id", id.clone()));
-    }
-    if let Some(reason) = &meta.finish_reason {
-        // OTel spec uses a string array; we record the single reason as a scalar.
-        span.set_attribute(KeyValue::new(
-            "gen_ai.response.finish_reasons",
-            reason.clone(),
-        ));
-    }
-    if let Some(input) = meta.input_tokens {
-        span.set_attribute(KeyValue::new("gen_ai.usage.input_tokens", input as i64));
-    }
-    if let Some(output) = meta.output_tokens {
-        span.set_attribute(KeyValue::new("gen_ai.usage.output_tokens", output as i64));
-    }
-
-    if trace_content {
-        let output_json = match response {
-            LlmResponse::FinalAnswer(text, _) => {
-                serde_json::json!([{"role": "assistant", "content": text}]).to_string()
-            }
-            LlmResponse::ToolCalls(calls, _) => {
-                let items: Vec<serde_json::Value> = calls
-                    .iter()
-                    .map(|c| {
-                        serde_json::json!({
-                            "role": "assistant",
-                            "tool_call": { "name": c.name, "arguments": c.params }
-                        })
-                    })
-                    .collect();
-                serde_json::Value::Array(items).to_string()
-            }
-            LlmResponse::Thinking(text, _) => {
-                serde_json::json!([{"role": "assistant", "thinking": text}]).to_string()
-            }
-        };
-        span.set_attribute(KeyValue::new("gen_ai.output.messages", output_json));
-    }
-
-    // -- Record OTel metrics alongside the span ---------------------------------
-    if let Some((recorder, provider_name, duration)) = metrics {
-        let model = meta.model.as_deref().unwrap_or("unknown");
-        let input = meta.input_tokens.unwrap_or(0);
-        let output = meta.output_tokens.unwrap_or(0);
-
-        recorder.record_token_usage(model, provider_name, "chat", input, output);
-        recorder.record_operation_duration(
-            model,
-            provider_name,
-            "chat",
-            duration.as_secs_f64(),
-            None,
-        );
-    }
-
-    span.end();
-}
-
-/// Serialise [`ChatHistoryMessage`] slices into a compact JSON string for span
-/// content capture.
-fn serialize_history_for_span(history: &[ChatHistoryMessage]) -> String {
-    let items: Vec<serde_json::Value> = history
-        .iter()
-        .map(|msg| match msg {
-            ChatHistoryMessage::Text { role, content } => {
-                let role_str = match role {
-                    ChatRole::System => "system",
-                    ChatRole::User => "user",
-                    ChatRole::Assistant => "assistant",
-                    ChatRole::Tool => "tool",
-                };
-                serde_json::json!({"role": role_str, "content": content})
-            }
-            ChatHistoryMessage::AssistantToolCalls(calls) => {
-                let tc: Vec<serde_json::Value> = calls
-                    .iter()
-                    .map(|c| serde_json::json!({"name": c.name, "arguments": c.params}))
-                    .collect();
-                serde_json::json!({"role": "assistant", "tool_calls": tc})
-            }
-            ChatHistoryMessage::MultimodalUser { content } => {
-                let blocks: Vec<serde_json::Value> = content
-                    .iter()
-                    .map(|block| match block {
-                        assistant_llm::ContentBlock::Text(t) => {
-                            serde_json::json!({"type": "text", "text": t})
-                        }
-                        assistant_llm::ContentBlock::Image { media_type, data } => {
-                            serde_json::json!({
-                                "type": "image",
-                                "media_type": media_type,
-                                "size_base64_chars": data.len(),
-                            })
-                        }
-                    })
-                    .collect();
-                serde_json::json!({"role": "user", "content": blocks})
-            }
-            ChatHistoryMessage::ToolResult { name, content } => {
-                serde_json::json!({"role": "tool", "name": name, "content": content})
-            }
-        })
-        .collect();
-    serde_json::Value::Array(items).to_string()
 }
 
 fn skill_location_string(skill: &SpecSkillDef) -> Option<String> {

--- a/crates/runtime/src/orchestrator_tests.rs
+++ b/crates/runtime/src/orchestrator_tests.rs
@@ -876,7 +876,7 @@ async fn empty_final_answer_not_persisted_in_run_turn() {
 
 #[test]
 fn serialize_history_multimodal_user_omits_base64_data() {
-    use super::serialize_history_for_span;
+    use crate::otel_spans::serialize_history_for_span;
     use assistant_llm::ContentBlock;
 
     let history = vec![ChatHistoryMessage::MultimodalUser {

--- a/crates/runtime/src/otel_spans.rs
+++ b/crates/runtime/src/otel_spans.rs
@@ -1,0 +1,241 @@
+//! OpenTelemetry span helpers for the orchestrator.
+//!
+//! These are pure functions that create and enrich OTel spans for
+//! LLM calls, tool executions, and conversation-level contexts.
+
+use assistant_core::Interface;
+use assistant_llm::{
+    ChatHistoryMessage, ChatRole, LlmProvider, LlmResponse, LlmResponseMeta, ToolSpec,
+};
+use opentelemetry::{
+    global,
+    trace::{Span as _, TraceContextExt, Tracer as _},
+    Context as OtelContext, KeyValue,
+};
+use uuid::Uuid;
+
+/// Create an OpenTelemetry context carrying a conversation-level root span.
+///
+/// Callers that manage conversation lifetimes (e.g. the CLI REPL or Slack
+/// thread handler) should create this once per conversation and pass it to
+/// each `run_turn*` call so all turns within the conversation share a single
+/// trace.
+pub fn start_conversation_context(conversation_id: Uuid, interface: &Interface) -> OtelContext {
+    let tracer = global::tracer("assistant.orchestrator");
+    let mut span = tracer.start("conversation");
+    span.set_attribute(KeyValue::new(
+        "conversation_id",
+        conversation_id.to_string(),
+    ));
+    span.set_attribute(KeyValue::new("interface", format!("{:?}", interface)));
+    OtelContext::current().with_span(span)
+}
+
+pub(crate) fn start_tool_span(
+    conversation_id: Uuid,
+    iteration: usize,
+    turn: i64,
+    interface: &Interface,
+    tool_name: &str,
+    params: &serde_json::Value,
+    parent_cx: &OtelContext,
+) -> opentelemetry::global::BoxedSpan {
+    let tracer = global::tracer("assistant.orchestrator");
+    let span_name = format!("execute_tool {tool_name}");
+    let mut span = tracer.start_with_context(span_name, parent_cx);
+    span.set_attribute(KeyValue::new(
+        "conversation_id",
+        conversation_id.to_string(),
+    ));
+    span.set_attribute(KeyValue::new("iteration", iteration as i64));
+    span.set_attribute(KeyValue::new("turn", turn));
+    span.set_attribute(KeyValue::new("interface", format!("{:?}", interface)));
+    span.set_attribute(KeyValue::new("tool_name", tool_name.to_string()));
+    let params_json =
+        serde_json::to_string(params).unwrap_or_else(|_| "<unserializable>".to_string());
+    span.set_attribute(KeyValue::new("tool_params", params_json));
+    span
+}
+
+/// Create an OTel span for an LLM chat call, populated with GenAI semantic
+/// convention request-side attributes.
+///
+/// When `trace_content` is `true`, the span also records:
+/// - `gen_ai.system_instructions` — the full system prompt
+/// - `gen_ai.input.messages` — serialised chat history
+/// - `gen_ai.tool.definitions` — serialised tool spec list
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn start_llm_span(
+    llm: &dyn LlmProvider,
+    iteration: usize,
+    parent_cx: &OtelContext,
+    trace_content: bool,
+    system_prompt: &str,
+    history: &[ChatHistoryMessage],
+    tools: &[ToolSpec],
+) -> opentelemetry::global::BoxedSpan {
+    let tracer = global::tracer("assistant.orchestrator");
+    let model = llm.model_name();
+    let span_name = format!("chat {model}");
+    let mut span = tracer.start_with_context(span_name, parent_cx);
+    span.set_attribute(KeyValue::new(
+        "gen_ai.system",
+        llm.provider_name().to_string(),
+    ));
+    span.set_attribute(KeyValue::new("gen_ai.request.model", model.to_string()));
+    span.set_attribute(KeyValue::new("gen_ai.operation.name", "chat"));
+    span.set_attribute(KeyValue::new(
+        "server.address",
+        llm.server_address().to_string(),
+    ));
+    span.set_attribute(KeyValue::new("iteration", iteration as i64));
+
+    if trace_content {
+        span.set_attribute(KeyValue::new(
+            "gen_ai.system_instructions",
+            system_prompt.to_string(),
+        ));
+        let input_json = serialize_history_for_span(history);
+        span.set_attribute(KeyValue::new("gen_ai.input.messages", input_json));
+        if !tools.is_empty() {
+            let tools_json = serde_json::to_string(
+                &tools
+                    .iter()
+                    .map(|t| {
+                        serde_json::json!({
+                            "name": t.name,
+                            "description": t.description,
+                        })
+                    })
+                    .collect::<Vec<_>>(),
+            )
+            .unwrap_or_default();
+            span.set_attribute(KeyValue::new("gen_ai.tool.definitions", tools_json));
+        }
+    }
+
+    span
+}
+
+/// Enrich an LLM span with GenAI semantic convention response-side attributes
+/// extracted from [`LlmResponseMeta`].
+///
+/// When `trace_content` is `true`, the assistant's output text is also recorded
+/// as `gen_ai.output.messages`.
+pub(crate) fn finish_llm_span(
+    span: &mut opentelemetry::global::BoxedSpan,
+    meta: &LlmResponseMeta,
+    response: &LlmResponse,
+    trace_content: bool,
+    metrics: Option<(&crate::MetricsRecorder, &str, std::time::Duration)>,
+) {
+    if let Some(model) = &meta.model {
+        span.set_attribute(KeyValue::new("gen_ai.response.model", model.clone()));
+    }
+    if let Some(id) = &meta.response_id {
+        span.set_attribute(KeyValue::new("gen_ai.response.id", id.clone()));
+    }
+    if let Some(reason) = &meta.finish_reason {
+        // OTel spec uses a string array; we record the single reason as a scalar.
+        span.set_attribute(KeyValue::new(
+            "gen_ai.response.finish_reasons",
+            reason.clone(),
+        ));
+    }
+    if let Some(input) = meta.input_tokens {
+        span.set_attribute(KeyValue::new("gen_ai.usage.input_tokens", input as i64));
+    }
+    if let Some(output) = meta.output_tokens {
+        span.set_attribute(KeyValue::new("gen_ai.usage.output_tokens", output as i64));
+    }
+
+    if trace_content {
+        let output_json = match response {
+            LlmResponse::FinalAnswer(text, _) => {
+                serde_json::json!([{"role": "assistant", "content": text}]).to_string()
+            }
+            LlmResponse::ToolCalls(calls, _) => {
+                let items: Vec<serde_json::Value> = calls
+                    .iter()
+                    .map(|c| {
+                        serde_json::json!({
+                            "role": "assistant",
+                            "tool_call": { "name": c.name, "arguments": c.params }
+                        })
+                    })
+                    .collect();
+                serde_json::Value::Array(items).to_string()
+            }
+            LlmResponse::Thinking(text, _) => {
+                serde_json::json!([{"role": "assistant", "thinking": text}]).to_string()
+            }
+        };
+        span.set_attribute(KeyValue::new("gen_ai.output.messages", output_json));
+    }
+
+    // -- Record OTel metrics alongside the span ---------------------------------
+    if let Some((recorder, provider_name, duration)) = metrics {
+        let model = meta.model.as_deref().unwrap_or("unknown");
+        let input = meta.input_tokens.unwrap_or(0);
+        let output = meta.output_tokens.unwrap_or(0);
+
+        recorder.record_token_usage(model, provider_name, "chat", input, output);
+        recorder.record_operation_duration(
+            model,
+            provider_name,
+            "chat",
+            duration.as_secs_f64(),
+            None,
+        );
+    }
+
+    span.end();
+}
+
+/// Serialise [`ChatHistoryMessage`] slices into a compact JSON string for span
+/// content capture.
+pub(crate) fn serialize_history_for_span(history: &[ChatHistoryMessage]) -> String {
+    let items: Vec<serde_json::Value> = history
+        .iter()
+        .map(|msg| match msg {
+            ChatHistoryMessage::Text { role, content } => {
+                let role_str = match role {
+                    ChatRole::System => "system",
+                    ChatRole::User => "user",
+                    ChatRole::Assistant => "assistant",
+                    ChatRole::Tool => "tool",
+                };
+                serde_json::json!({"role": role_str, "content": content})
+            }
+            ChatHistoryMessage::AssistantToolCalls(calls) => {
+                let tc: Vec<serde_json::Value> = calls
+                    .iter()
+                    .map(|c| serde_json::json!({"name": c.name, "arguments": c.params}))
+                    .collect();
+                serde_json::json!({"role": "assistant", "tool_calls": tc})
+            }
+            ChatHistoryMessage::MultimodalUser { content } => {
+                let blocks: Vec<serde_json::Value> = content
+                    .iter()
+                    .map(|block| match block {
+                        assistant_llm::ContentBlock::Text(t) => {
+                            serde_json::json!({"type": "text", "text": t})
+                        }
+                        assistant_llm::ContentBlock::Image { media_type, data } => {
+                            serde_json::json!({
+                                "type": "image",
+                                "media_type": media_type,
+                                "size_base64_chars": data.len(),
+                            })
+                        }
+                    })
+                    .collect();
+                serde_json::json!({"role": "user", "content": blocks})
+            }
+            ChatHistoryMessage::ToolResult { name, content } => {
+                serde_json::json!({"role": "tool", "name": name, "content": content})
+            }
+        })
+        .collect();
+    serde_json::Value::Array(items).to_string()
+}


### PR DESCRIPTION
## Summary

- Extract 5 OTel span helper functions to dedicated `otel_spans.rs` module (~230 lines)
- Re-export `start_conversation_context` from `lib.rs` for external consumers

Replaces auto-closed #155 (base branch deleted during stack merge).