### PR TITLE
chore(runtime): remove unused disabled_skills feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ ollama pull qwen2.5:14b
 | `memory-write`  | Write a persistent key/value entry                                 | builtin |
 | `memory-search` | Substring-search across memory entries                             | builtin |
 | `web-fetch`     | Fetch a URL and return page text                                   | builtin |
-| `bash`          | Run a bash command (mutating; ask for confirmation on risky turns)  | builtin |
+| `bash`          | Run a bash command (mutating; ask for confirmation on risky turns) | builtin |
 | `list-skills`   | List all registered skills                                         | builtin |
 | `self-analyze`  | Analyse execution traces and propose SKILL.md improvements         | builtin |
 | `schedule-task` | Register a recurring cron-style prompt                             | builtin |
@@ -177,8 +177,6 @@ model = "qwen2.5:7b"          # any Ollama model with tool-calling support
 base_url = "http://localhost:11434"
 max_iterations = 80
 
-[skills]
-disabled = []                   # optional list of tool names to disable
 ```
 
 For cloud providers, set the provider and API key:
@@ -192,7 +190,7 @@ api_key  = "sk-ant-..."       # or set ANTHROPIC_API_KEY env var
 
 #### Embeddings
 
-Ollama and OpenAI support embeddings natively.  When using Anthropic (which
+Ollama and OpenAI support embeddings natively. When using Anthropic (which
 lacks built-in embeddings), configure a dedicated embedding provider:
 
 ```toml

--- a/config.toml
+++ b/config.toml
@@ -156,9 +156,6 @@ timeout_secs = 120
 # skills are picked up automatically.
 # extra_dirs = ["~/.claude/skills", "./.claude/skills"]
 
-# Skills to disable (by name)
-# disabled = []
-
 [mcp]
 # Enable the MCP server
 enabled = true

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -550,16 +550,12 @@ pub struct SkillsConfig {
     /// Defaults cover Claude Code / NanoClaw shared skill folders.
     #[serde(default = "default_skill_extra_dirs")]
     pub extra_dirs: Vec<String>,
-    /// Skills to disable globally.
-    #[serde(default)]
-    pub disabled: Vec<String>,
 }
 
 impl Default for SkillsConfig {
     fn default() -> Self {
         Self {
             extra_dirs: default_skill_extra_dirs(),
-            disabled: Vec::new(),
         }
     }
 }

--- a/crates/interface-slack/src/runner.rs
+++ b/crates/interface-slack/src/runner.rs
@@ -13,9 +13,8 @@
 //!
 //! # Safety
 //!
-//! Skills listed in `disabled_skills` are blocked before dispatch.
-//! Additionally, `allowed_channels` and `allowed_users` allowlists are
-//! checked before dispatching.
+//! `allowed_channels` and `allowed_users` allowlists are checked before
+//! dispatching.
 //!
 //! # Thread conversation context
 //!

--- a/crates/runtime/src/orchestrator/mod.rs
+++ b/crates/runtime/src/orchestrator/mod.rs
@@ -116,9 +116,9 @@ fn parse_interface(s: &str) -> Interface {
 /// 3. Load all registered tool specs from the executor.
 /// 4. Repeatedly call the LLM until it returns a `FinalAnswer` or the
 ///    iteration limit is reached.
-/// 5. For each `ToolCall` response: check disabled-skills list, optionally
-///    confirm with the user, execute the tool, emit an OpenTelemetry span,
-///    and append an `OBSERVATION` to the conversation history.
+/// 5. For each `ToolCall` response: optionally confirm with the user,
+///    execute the tool, emit an OpenTelemetry span, and append an
+///    `OBSERVATION` to the conversation history.
 /// 6. Persist the final assistant message and return [`TurnResult`].
 pub struct Orchestrator {
     llm: Arc<dyn LlmProvider>,
@@ -128,7 +128,6 @@ pub struct Orchestrator {
     /// Durable message bus for decoupled inter-component communication.
     bus: Arc<dyn MessageBus>,
     max_iterations: usize,
-    disabled_skills: Vec<String>,
     confirmation_callback: Option<Arc<dyn ConfirmationCallback>>,
     /// Memory loader used to rebuild the system prompt at the start of every
     /// turn so that writes made by memory tools are reflected immediately.
@@ -156,8 +155,8 @@ impl Orchestrator {
     /// * `llm` — the LLM client (Ollama wrapper)
     /// * `storage` — the SQLite storage layer
     /// * `executor` — tool executor (dispatches to all registered ToolHandlers)
-    /// * `config` — assistant configuration (controls iteration limit, disabled
-    ///   skills, and trace logging)
+    /// * `config` — assistant configuration (controls iteration limit and trace
+    ///   logging)
     pub fn new(
         llm: Arc<dyn LlmProvider>,
         storage: Arc<StorageLayer>,
@@ -175,7 +174,6 @@ impl Orchestrator {
             registry,
             bus,
             max_iterations: config.llm.max_iterations,
-            disabled_skills: config.skills.disabled.clone(),
             confirmation_callback: None,
             memory_loader,
             trace_content: config.mirror.trace_content,
@@ -266,9 +264,6 @@ impl Orchestrator {
     ///
     /// Extension tools are injected by the calling interface (e.g. Slack,
     /// Mattermost) and are checked before the global tool executor.  They
-    /// bypass the disabled-skills list — the interface is responsible for vetting
-    /// them before passing them in.
-    ///
     /// Unlike [`run_turn`] / [`run_turn_streaming`], this method does **not**
     /// return the final answer; replies are expected to happen as side-effects
     /// of the extension tool calls (e.g. `reply`).  If the LLM emits a
@@ -802,23 +797,6 @@ impl Orchestrator {
                                 tool = %name,
                                 source = "builtin"
                             );
-                            if let Some(reason) = self
-                                .reject_if_disabled(
-                                    &name,
-                                    &mut history,
-                                    &conv_store,
-                                    conversation_id,
-                                    turn_index,
-                                )
-                                .instrument(builtin_span.clone())
-                                .await
-                            {
-                                otel_span.set_attribute(KeyValue::new("tool_status", "blocked"));
-                                otel_span.set_attribute(KeyValue::new("tool_error", reason));
-                                otel_span.end();
-                                continue;
-                            }
-
                             // Confirmation gate.
                             let requires_confirm = self
                                 .executor
@@ -1174,24 +1152,6 @@ impl Orchestrator {
                             &turn_cx,
                         );
 
-                        // Disabled-tools gate.
-                        if let Some(reason) = self
-                            .reject_if_disabled(
-                                &name,
-                                &mut history,
-                                &conv_store,
-                                conversation_id,
-                                turn_index,
-                            )
-                            .instrument(iteration_span.clone())
-                            .await
-                        {
-                            otel_span.set_attribute(KeyValue::new("tool_status", "blocked"));
-                            otel_span.set_attribute(KeyValue::new("tool_error", reason));
-                            otel_span.end();
-                            continue;
-                        }
-
                         // Confirmation gate.
                         let requires_confirm = self
                             .executor
@@ -1421,27 +1381,6 @@ impl Orchestrator {
             return true;
         }
         false
-    }
-
-    async fn reject_if_disabled(
-        &self,
-        name: &str,
-        history: &mut Vec<ChatHistoryMessage>,
-        conv_store: &ConversationStore,
-        conversation_id: Uuid,
-        turn_idx: i64,
-    ) -> Option<String> {
-        if !self.disabled_skills.iter().any(|s| s == name) {
-            return None;
-        }
-        let observation = format!("Tool '{name}' is disabled by configuration.");
-        warn!(%observation);
-        crate::history::append_tool_result(history, name, &observation);
-        let tr_msg = Self::make_tool_result_message(conversation_id, turn_idx, name, &observation);
-        if let Err(e) = conv_store.save_message(&tr_msg).await {
-            warn!("Failed to persist tool-result message: {e}");
-        }
-        Some(observation)
     }
 
     fn make_tool_call_message(


### PR DESCRIPTION
## Summary

- Remove the `disabled_skills` config option (`[skills] disabled = [...]`) and all associated code
- The feature was never actively used: default was `[]`, config example was commented out, zero test coverage
- It was also inconsistently applied (missing from subagent tool dispatch)

### Files changed

- `crates/core/src/types.rs` — remove `SkillsConfig.disabled` field
- `crates/runtime/src/orchestrator/mod.rs` — remove field, constructor line, `reject_if_disabled()` method, and both call sites (-71 lines)
- `config.toml` — remove commented-out `disabled = []`
- `README.md` — remove `disabled = []` from config example
- `crates/interface-slack/src/runner.rs` — update safety doc comment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the skills system by removing the configuration option to disable individual skills. All available skills are now enabled and cannot be disabled through configuration.

* **Documentation**
  * Updated README, configuration examples, and safety documentation to reflect the removal of the disabled skills feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->