### PR TITLE
fix(runtime): persist subagent thinking steps to DB

### DIFF
--- a/crates/runtime/src/orchestrator/subagent.rs
+++ b/crates/runtime/src/orchestrator/subagent.rs
@@ -358,6 +358,20 @@ impl SubagentRunner for Orchestrator {
                             agent_id = %spawn.agent_id,
                             "Subagent emitted thinking step"
                         );
+                        // Persist to DB so thinking is preserved for trace
+                        // inspection, matching the behavior of the other two
+                        // turn variants.
+                        let thinking_msg = {
+                            let mut m = Message::assistant(
+                                conversation_id,
+                                format!("<think>{text}</think>"),
+                            );
+                            m.turn = base_turn + iteration as i64 + 1;
+                            m
+                        };
+                        if let Err(e) = conv_store.save_message(&thinking_msg).await {
+                            warn!("Failed to persist subagent thinking step: {e}");
+                        }
                         history.push(ChatHistoryMessage::Text {
                             role: ChatRole::Assistant,
                             content: text,

--- a/crates/runtime/src/orchestrator/tests.rs
+++ b/crates/runtime/src/orchestrator/tests.rs
@@ -1804,3 +1804,72 @@ fn value_to_params_map_non_object_returns_empty() {
         assert!(map.is_empty(), "non-object {val} should produce empty map");
     }
 }
+
+// ── Thinking persistence tests ────────────────────────────────────────────────
+
+/// Ollama response with empty content but non-empty thinking — triggers
+/// LlmResponse::Thinking in the LLM client parser.
+fn ollama_thinking(thought: &str) -> Value {
+    json!({
+        "model": "test",
+        "message": { "role": "assistant", "content": "", "thinking": thought },
+        "done": true
+    })
+}
+
+#[tokio::test]
+async fn subagent_thinking_step_persisted_to_db() {
+    let server = MockServer::start().await;
+
+    // First call: LLM returns a thinking step (empty content + thinking field).
+    Mock::given(method("POST"))
+        .and(path("/api/chat"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(ollama_thinking("deep thought")))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+
+    // Second call: LLM returns a normal final answer.
+    Mock::given(method("POST"))
+        .and(path("/api/chat"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(ollama_answer("done")))
+        .mount(&server)
+        .await;
+
+    let (orch, storage) = build(&server.uri()).await;
+
+    let spawn = AgentSpawn {
+        agent_id: "thinking-agent".into(),
+        task: "think about it".into(),
+        system_prompt: None,
+        model: None,
+        allowed_tools: vec![],
+    };
+
+    let report = orch.run_subagent(spawn, 0).await.unwrap();
+    assert_eq!(report.status, AgentReportStatus::Completed);
+
+    // Retrieve the subagent's conversation_id from the agent record.
+    let agent_store = storage.agent_store();
+    let record = agent_store
+        .get("thinking-agent")
+        .await
+        .unwrap()
+        .expect("agent record should exist");
+    let conv_id =
+        Uuid::parse_str(&record.conversation_id).expect("conversation_id should be a valid UUID");
+
+    // Load persisted messages and verify the thinking step is present.
+    let conv_store = storage.conversation_store();
+    let messages = conv_store.load_history(conv_id).await.unwrap();
+    let thinking_msg = messages.iter().find(|m| m.content.contains("<think>"));
+    assert!(
+        thinking_msg.is_some(),
+        "thinking step should be persisted to DB; messages: {:?}",
+        messages.iter().map(|m| &m.content).collect::<Vec<_>>()
+    );
+    assert!(
+        thinking_msg.unwrap().content.contains("deep thought"),
+        "persisted thinking message should contain the thought text"
+    );
+}


### PR DESCRIPTION
## Summary

- Subagent thinking steps (`LlmResponse::Thinking`) were only kept in memory, unlike the other two turn variants which persist them wrapped in `<think>` tags
- Adds DB persistence matching `run_turn_with_tools_impl` and `run_turn_core`
- Adds `subagent_thinking_step_persisted_to_db` test that verifies the message is queryable via `load_history`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Thinking steps are now properly persisted in conversation history, consistent with how responses and tool calls are stored.

* **Tests**
  * Added test coverage for thinking step persistence functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->