### PR TITLE
fix(runtime): record max_iterations error in metrics

### DIFF
--- a/crates/runtime/src/orchestrator/mod.rs
+++ b/crates/runtime/src/orchestrator/mod.rs
@@ -622,6 +622,8 @@ impl Orchestrator {
         }
 
         crate::history::persist_error_recovery(&conv_store, conversation_id).await;
+        self.metrics
+            .record_error("max_iterations", "run_turn_with_tools");
         anyhow::bail!(
             "Max iterations ({}) reached without a final answer",
             self.max_iterations
@@ -872,6 +874,12 @@ impl Orchestrator {
 
         // Reached iteration limit.
         crate::history::persist_error_recovery(&conv_store, conversation_id).await;
+        let label = if streaming {
+            "run_turn_streaming"
+        } else {
+            "run_turn"
+        };
+        self.metrics.record_error("max_iterations", label);
         anyhow::bail!(
             "Max iterations ({}) reached without a final answer",
             self.max_iterations

--- a/crates/runtime/src/orchestrator/subagent.rs
+++ b/crates/runtime/src/orchestrator/subagent.rs
@@ -382,6 +382,7 @@ impl SubagentRunner for Orchestrator {
 
             // Reached iteration limit.
             crate::history::persist_error_recovery(&conv_store, conversation_id).await;
+            self.metrics.record_error("max_iterations", "run_subagent");
             let msg = format!(
                 "Subagent '{}' reached max iterations ({}) without a final answer",
                 spawn.agent_id, self.max_iterations

--- a/crates/runtime/src/orchestrator/tests.rs
+++ b/crates/runtime/src/orchestrator/tests.rs
@@ -1873,3 +1873,79 @@ async fn subagent_thinking_step_persisted_to_db() {
         "persisted thinking message should contain the thought text"
     );
 }
+
+// ── Max-iterations error tests ────────────────────────────────────────────────
+
+#[tokio::test]
+async fn run_turn_max_iterations_returns_error() {
+    let server = MockServer::start().await;
+
+    // LLM always returns tool calls, never a final answer.
+    Mock::given(method("POST"))
+        .and(path("/api/chat"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(ollama_tool_calls(&["unknown-tool"])),
+        )
+        .mount(&server)
+        .await;
+
+    let mut config = AssistantConfig::default();
+    config.memory.enabled = false;
+    config.llm.max_iterations = 2;
+    let (orch, _) = build_with_config(&server.uri(), config).await;
+
+    let result = orch
+        .run_turn("trigger loop", Uuid::new_v4(), Interface::Cli, None)
+        .await;
+
+    match result {
+        Ok(_) => panic!("should fail when max iterations reached"),
+        Err(e) => {
+            let err_msg = e.to_string();
+            assert!(
+                err_msg.contains("Max iterations"),
+                "error should mention max iterations: {err_msg}"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn subagent_max_iterations_returns_failed_status() {
+    let server = MockServer::start().await;
+
+    // LLM always returns tool calls, never a final answer.
+    Mock::given(method("POST"))
+        .and(path("/api/chat"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(ollama_tool_calls(&["unknown-tool"])),
+        )
+        .mount(&server)
+        .await;
+
+    let mut config = AssistantConfig::default();
+    config.memory.enabled = false;
+    config.llm.max_iterations = 2;
+    let (orch, _) = build_with_config(&server.uri(), config).await;
+
+    let spawn = AgentSpawn {
+        agent_id: "loop-agent".into(),
+        task: "infinite loop".into(),
+        system_prompt: None,
+        model: None,
+        allowed_tools: vec![],
+    };
+
+    let report = orch.run_subagent(spawn, 0).await.unwrap();
+
+    assert_eq!(
+        report.status,
+        AgentReportStatus::Failed,
+        "subagent should report Failed when max iterations reached"
+    );
+    assert!(
+        report.content.contains("max iterations"),
+        "error should mention max iterations: {}",
+        report.content
+    );
+}


### PR DESCRIPTION
## Summary

- All three turn variants bail when the iteration limit is reached but none recorded the error in metrics — LLM errors were tracked but iteration exhaustion was invisible to dashboards
- Adds `record_error("max_iterations", ...)` before each bail path
- Adds `run_turn_max_iterations_returns_error` and `subagent_max_iterations_returns_failed_status` tests using `max_iterations = 2`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced error tracking and observability when agent iteration limits are reached in orchestration workflows.

* **Tests**
  * Added tests for iteration limit error scenarios to verify proper error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->