### PR TITLE
fix(runtime): use tokio::fs for BOOT.md and HEARTBEAT.md reads

### DIFF
--- a/crates/runtime/src/orchestrator/mod.rs
+++ b/crates/runtime/src/orchestrator/mod.rs
@@ -255,7 +255,8 @@ impl Orchestrator {
             return Ok(false);
         }
 
-        let raw = std::fs::read_to_string(boot_path)
+        let raw = tokio::fs::read_to_string(boot_path)
+            .await
             .map_err(|e| anyhow::anyhow!("Failed to read BOOT.md: {e}"))?;
 
         // Strip HTML comments and whitespace — an empty/comment-only file is

--- a/crates/runtime/src/scheduler.rs
+++ b/crates/runtime/src/scheduler.rs
@@ -141,7 +141,7 @@ async fn run_heartbeat(orchestrator: &Orchestrator) -> Result<()> {
         return Ok(());
     }
 
-    let raw = std::fs::read_to_string(heartbeat_path)?;
+    let raw = tokio::fs::read_to_string(heartbeat_path).await?;
     let prompt = strip_html_comments(&raw);
 
     if prompt.is_empty() {


### PR DESCRIPTION
## Summary

- `run_boot` used `std::fs::read_to_string` for BOOT.md and `run_heartbeat` used it for HEARTBEAT.md — both inside async functions, blocking the tokio runtime
- Switched to `tokio::fs::read_to_string().await` for non-blocking I/O