### PR TITLE
fix(slack): set presence on every reconnect so bot appears online

### DIFF
--- a/crates/interface-slack/src/runner.rs
+++ b/crates/interface-slack/src/runner.rs
@@ -1216,20 +1216,8 @@ impl SlackInterface {
         let bot_token = SlackApiToken::new(bot_token_str.into());
         let app_token = SlackApiToken::new(app_token_str.into());
 
-        // Mark the bot as active. This may silently fail for some bot token
-        // configurations; that is acceptable.
-        let session = client.open_session(&bot_token);
-        if let Err(e) = session
-            .users_set_presence(&SlackApiUsersSetPresenceRequest::new("auto".to_string()))
-            .await
-        {
-            debug!(error = %e, "users.setPresence(auto) failed (missing_scope is expected for most bot tokens)");
-        } else {
-            info!("Presence set to auto");
-        }
-
         // Resolve the bot's own user ID via auth.test so we can detect @-mentions.
-        let bot_user_id = match session.auth_test().await {
+        let bot_user_id = match client.open_session(&bot_token).auth_test().await {
             Ok(resp) => {
                 let uid = resp.user_id.to_string();
                 info!(bot_user_id = %uid, "Resolved bot identity via auth.test");
@@ -1357,6 +1345,18 @@ impl SlackInterface {
             };
 
             if connected {
+                // Mark the bot as active on every (re)connect so it appears
+                // online in the Slack sidebar.
+                let session = client.open_session(&bot_token);
+                if let Err(e) = session
+                    .users_set_presence(&SlackApiUsersSetPresenceRequest::new("auto".to_string()))
+                    .await
+                {
+                    debug!(error = %e, "users.setPresence(auto) failed (missing_scope is expected for most bot tokens)");
+                } else {
+                    info!("Presence set to auto");
+                }
+
                 // Race the event-serve loop against shutdown.
                 let clean_close = tokio::select! {
                     _ = socket_mode_listener.serve() => {


### PR DESCRIPTION
## Summary

- Moves the `users_set_presence("auto")` call from a one-time pre-loop invocation into the reconnect loop, so the bot's presence is re-set on every successful (re)connection
- Fixes the bot appearing offline in the Slack sidebar after a WebSocket disconnect/reconnect cycle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed potential startup failures by deferring bot presence initialization to reconnection events instead of startup.
  * Improved bot identity resolution for more reliable mention handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->