### PR TITLE
fix(transcription): use atomic nonce for unique temp file names

### DIFF
--- a/crates/transcription/src/converter.rs
+++ b/crates/transcription/src/converter.rs
@@ -5,10 +5,15 @@
 //! supported formats (WAV/MP3).
 
 use std::process::Stdio;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use anyhow::{bail, Context};
 use tokio::process::Command;
 use tracing::{debug, info, warn};
+
+/// Monotonic counter used to make temp file names unique across concurrent
+/// conversions within the same process.
+static TEMP_FILE_NONCE: AtomicU64 = AtomicU64::new(0);
 
 /// Audio formats that may need conversion before sending to transcription providers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -344,16 +349,20 @@ impl AudioConverter {
     ) -> anyhow::Result<ConversionResult> {
         let (output_format, mime_type) = self.output_format_info()?;
 
-        // Write input to a temp file so FFmpeg can seek
+        // Write input to a temp file so FFmpeg can seek.
+        // Use PID + atomic nonce to avoid collisions across concurrent calls.
         let tmp_dir = std::env::temp_dir();
+        let nonce = TEMP_FILE_NONCE.fetch_add(1, Ordering::Relaxed);
         let input_path = tmp_dir.join(format!(
-            "assistant-audio-in-{}.{}",
+            "assistant-audio-in-{}-{}.{}",
             std::process::id(),
+            nonce,
             source_format.extension()
         ));
         let output_path = tmp_dir.join(format!(
-            "assistant-audio-out-{}.{}",
+            "assistant-audio-out-{}-{}.{}",
             std::process::id(),
+            nonce,
             self.target_format.extension()
         ));
 

--- a/crates/transcription/tests/integration_tests.rs
+++ b/crates/transcription/tests/integration_tests.rs
@@ -219,3 +219,61 @@ async fn test_converter_custom_settings() {
     // without a real FFmpeg binary, but we can verify the builder pattern works
     assert_eq!(converter.check_ffmpeg().await.is_err(), true); // Invalid path
 }
+
+#[tokio::test]
+async fn test_m4a_uses_tempfile_path() {
+    // M4A/MP4 containers need seekable input (moov atom), so the converter
+    // must use a temp-file strategy rather than piping.  We can't easily
+    // fabricate a valid M4A in a unit test, but we *can* verify the code path
+    // is reached and returns a meaningful FFmpeg error rather than a
+    // "moov atom not found" crash or silent empty output.
+    skip_if_no_ffmpeg!();
+
+    let converter = AudioConverter::new().with_target_format(AudioFormat::Wav);
+
+    // Garbage data -- FFmpeg will reject it, but the important thing is that
+    // it runs the tempfile path (not pipe) and reports the error from stderr.
+    let fake_m4a = vec![0u8; 64];
+    let result = converter.convert(&fake_m4a, AudioFormat::M4a).await;
+
+    assert!(result.is_err(), "Should fail on invalid M4A data");
+    let err = result.unwrap_err().to_string();
+    // The error should come from FFmpeg stderr, not a generic "moov atom" pipe failure.
+    assert!(
+        err.contains("FFmpeg conversion failed"),
+        "Expected FFmpeg error message, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn test_convert_for_deepgram_m4a_triggers_conversion() {
+    skip_if_no_ffmpeg!();
+
+    let converter = AudioConverter::new();
+
+    // M4A should need conversion for Deepgram
+    let fake_m4a = vec![0u8; 64];
+    let result = converter
+        .convert_for_deepgram_if_needed(&fake_m4a, "audio/mp4")
+        .await;
+
+    // Will fail because data is invalid, but confirms the conversion path is taken
+    assert!(
+        result.is_err(),
+        "Should attempt conversion for audio/mp4 and fail on invalid data"
+    );
+}
+
+#[tokio::test]
+async fn test_needs_seekable_input() {
+    // M4A and MP4 need seekable input
+    assert!(AudioFormat::M4a.needs_conversion_for_deepgram());
+    assert!(AudioFormat::Mp4.needs_conversion_for_deepgram());
+
+    // Other formats that need conversion (AAC) but can be piped
+    assert!(AudioFormat::Aac.needs_conversion_for_deepgram());
+
+    // Natively supported formats don't need conversion at all
+    assert!(!AudioFormat::Wav.needs_conversion_for_deepgram());
+    assert!(!AudioFormat::Mp3.needs_conversion_for_deepgram());
+}


### PR DESCRIPTION
## Summary

- Adds an atomic counter to temp file naming to prevent collisions under concurrent voice message transcriptions.
- Adds integration tests for the M4A temp-file conversion path.

## Context

Follow-up to #174 -- the third commit (nonce fix + tests) was lost during squash merge. Without the nonce, concurrent conversions in the same process would write to identical temp file paths (`assistant-audio-in-<pid>.m4a`), causing race conditions. The fix appends a monotonically increasing counter: `assistant-audio-in-<pid>-<nonce>.m4a`.

Flagged by CodeRabbit in [#174 review](https://github.com/cedricziel/assistant/pull/174#discussion_r2873483075).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved stability during concurrent transcription operations by preventing temporary file name collisions.

* **Tests**
  * Enhanced test coverage for transcription functionality including format validation and FFmpeg behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->