### PR TITLE
fix(transcription): improve error logging for audio conversion failures

### DIFF
--- a/crates/interface-slack/src/runner.rs
+++ b/crates/interface-slack/src/runner.rs
@@ -422,7 +422,7 @@ async fn transcribe_slack_audio_files(
             Err(e) => {
                 warn!(
                     file_id = %file.id.0,
-                    error = %e,
+                    error = ?e,
                     "Audio transcription failed"
                 );
                 transcripts.push("[Voice message: transcription failed]".to_string());

--- a/crates/transcription/src/converter.rs
+++ b/crates/transcription/src/converter.rs
@@ -370,9 +370,18 @@ impl AudioConverter {
             .await
             .context("Failed to write audio to temp file")?;
 
+        // Verify the file was actually written
+        let written_meta = tokio::fs::metadata(&input_path).await.with_context(|| {
+            format!(
+                "Temp input file missing after write: {}",
+                input_path.display()
+            )
+        })?;
+
         info!(
             input_path = %input_path.display(),
             input_size = audio_data.len(),
+            written_size = written_meta.len(),
             source_format = ?source_format,
             "Using temp file for seekable MP4/M4A input"
         );
@@ -400,6 +409,11 @@ impl AudioConverter {
         if !output.status.success() {
             let _ = tokio::fs::remove_file(&output_path).await;
             let stderr = String::from_utf8_lossy(&output.stderr);
+            warn!(
+                exit_code = ?output.status.code(),
+                stderr = %stderr.trim(),
+                "FFmpeg tempfile conversion failed"
+            );
             bail!(
                 "FFmpeg conversion failed (exit code {:?}): {}",
                 output.status.code(),
@@ -407,9 +421,12 @@ impl AudioConverter {
             );
         }
 
-        let output_data = tokio::fs::read(&output_path)
-            .await
-            .context("Failed to read FFmpeg output file")?;
+        let output_data = tokio::fs::read(&output_path).await.with_context(|| {
+            format!(
+                "Failed to read FFmpeg output file at {}",
+                output_path.display()
+            )
+        })?;
         let _ = tokio::fs::remove_file(&output_path).await;
 
         if output_data.is_empty() {


### PR DESCRIPTION
## Summary

- Logs the full anyhow error chain (`?e` instead of `%e`) when voice message transcription fails, so the actual FFmpeg stderr is visible.
- Adds explicit `warn!` logging inside `convert_via_tempfile` when FFmpeg exits non-zero, including the exit code and stderr.
- Verifies the temp input file exists after writing (paranoia check).
- Includes the output file path in the error message when reading FFmpeg output fails.

## Context

Voice message transcription on schorschvm fails with `error=Failed to prepare audio for transcription` but the actual root cause (FFmpeg stderr) is hidden because the Slack runner logs with Display format (`%e`) which only shows the outermost anyhow context. This change surfaces the full error chain to diagnose why FFmpeg conversion is failing despite working correctly when run manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages and logging during audio transcription to better assist with troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->