### PR TITLE
fix(transcription): log file magic bytes and preserve input on failure

### DIFF
--- a/crates/transcription/src/converter.rs
+++ b/crates/transcription/src/converter.rs
@@ -403,15 +403,26 @@ impl AudioConverter {
             .await
             .with_context(|| format!("Failed to spawn FFmpeg at {}", self.ffmpeg_path))?;
 
-        // Always clean up the input file
-        let _ = tokio::fs::remove_file(&input_path).await;
-
         if !output.status.success() {
+            // Keep the input file around for debugging when conversion fails
+            warn!(
+                input_path = %input_path.display(),
+                "Keeping failed conversion input file for inspection"
+            );
             let _ = tokio::fs::remove_file(&output_path).await;
             let stderr = String::from_utf8_lossy(&output.stderr);
+            // Log the first 16 bytes as hex to identify the actual file format
+            let magic = audio_data
+                .iter()
+                .take(16)
+                .map(|b| format!("{b:02x}"))
+                .collect::<Vec<_>>()
+                .join(" ");
             warn!(
                 exit_code = ?output.status.code(),
                 stderr = %stderr.trim(),
+                file_magic = %magic,
+                input_size = audio_data.len(),
                 "FFmpeg tempfile conversion failed"
             );
             bail!(
@@ -420,6 +431,9 @@ impl AudioConverter {
                 stderr.trim(),
             );
         }
+
+        // Clean up input file on success
+        let _ = tokio::fs::remove_file(&input_path).await;
 
         let output_data = tokio::fs::read(&output_path).await.with_context(|| {
             format!(


### PR DESCRIPTION
## Summary

- Logs the first 16 bytes of input audio as hex when FFmpeg conversion fails, so we can identify the actual container format.
- Preserves the temp input file on failure (instead of deleting it) so it can be inspected with `ffprobe` on the server.

## Context

Follow-up to #176. With improved error logging we now see that FFmpeg reports `moov atom not found` even when reading from a temp file (not a pipe). The file is 50KB and was written correctly, so the issue is likely that Slack's voice clips use a format that FFmpeg's mov demuxer can't parse (e.g., fragmented MP4 without a moov atom, or a different container entirely mislabeled as `audio/mp4`).

This change will let us inspect the actual file on the next failure to determine the real format and apply the correct fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during file conversion with enriched diagnostic logging that includes file size and header information.
  * Input files are now retained when conversion fails for further investigation.
  * Output files are cleaned up after conversion completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->