### PR TITLE
chore(ci): keep gh-pages branch small by pruning old packages

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -236,7 +236,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install repo tools
@@ -271,16 +271,19 @@ jobs:
       - name: Add .deb packages and regenerate APT index
         run: |
           mkdir -p repo/apt
+          rm -f repo/apt/*.deb
           cp new-packages/*.deb repo/apt/
           cd repo/apt
-          dpkg-scanpackages --multiversion . > Packages
+          dpkg-scanpackages . > Packages
           gzip -k -f Packages
 
       - name: Add .rpm packages and regenerate YUM index
         run: |
           mkdir -p repo/rpm
+          rm -f repo/rpm/*.rpm
           cp new-packages/*.rpm repo/rpm/
-          createrepo_c --update repo/rpm/
+          rm -rf repo/rpm/repodata
+          createrepo_c repo/rpm/
 
       - name: Ensure .nojekyll
         run: touch repo/.nojekyll
@@ -328,12 +331,12 @@ jobs:
           HTMLDOC
           sed -i "s/TAG_PLACEHOLDER/${TAG}/" repo/index.html
 
-      - name: Commit and push
+      - name: Commit and force-push (single orphan commit keeps branch small)
         run: |
           cd repo
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout --orphan tmp-pages
           git add -A
-          git diff --cached --quiet || \
-            git commit -m "chore: update package repo for ${{ needs.release-please.outputs.tag_name }}"
-          git push origin gh-pages
+          git commit -m "chore: update package repo for ${{ needs.release-please.outputs.tag_name }}"
+          git push --force origin tmp-pages:gh-pages


### PR DESCRIPTION
## Summary

- Remove old `.deb`/`.rpm` blobs before copying new ones so only the latest release is served
- Force-push a single orphan commit to `gh-pages` instead of appending, preventing unbounded history growth
- Switch to `fetch-depth: 1` (deep clone was unnecessary) and drop `--multiversion`/`--update` flags

This should significantly speed up Pages deployments by keeping the `gh-pages` branch small regardless of how many releases have been made.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized continuous integration workflow fetch operations to reduce build time and improve performance
  * Enhanced Debian and RPM package index generation with improved cleanup procedures for cleaner releases
  * Streamlined release process using optimized branch management strategy to maintain repository efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->