### PR TITLE
fix(ci): use force-with-lease for gh-pages deploy safety

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -339,4 +339,4 @@ jobs:
           git checkout --orphan tmp-pages
           git add -A
           git commit -m "chore: update package repo for ${{ needs.release-please.outputs.tag_name }}"
-          git push --force origin tmp-pages:gh-pages
+          git push --force-with-lease origin tmp-pages:gh-pages


### PR DESCRIPTION
## Summary

- Switch `--force` to `--force-with-lease` for the gh-pages orphan push, preventing accidental overwrites if the branch was updated concurrently
- Triggers release-please (follow-up to #180 which merged as `chore`)