### PR TITLE
fix(otel-exporter-sqlite): provide Tokio context for batch processor threads

### DIFF
--- a/crates/opentelemetry-exporter-sqlite/Cargo.toml
+++ b/crates/opentelemetry-exporter-sqlite/Cargo.toml
@@ -15,5 +15,8 @@ sqlx = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 
+[dependencies.tokio]
+workspace = true
+
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/opentelemetry-exporter-sqlite/src/log.rs
+++ b/crates/opentelemetry-exporter-sqlite/src/log.rs
@@ -7,18 +7,58 @@ use opentelemetry_sdk::logs::{LogBatch, LogExporter, SdkLogRecord};
 use opentelemetry_sdk::Resource;
 use serde_json::{Map, Number};
 use sqlx::{SqliteConnection, SqlitePool};
+use tokio::runtime::Handle;
 use uuid::Uuid;
 
 /// OpenTelemetry log exporter that persists log records into the `logs`
 /// SQLite table.
+///
+/// The OTel SDK's `BatchLogProcessor` runs its export loop on a plain OS
+/// thread (not a Tokio task), so `sqlx` operations would panic with
+/// *"this functionality requires a Tokio context"*.  We capture the Tokio
+/// [`Handle`] at construction time and use [`Handle::block_on`] when no
+/// Tokio context is available (batch processor thread), falling back to
+/// direct async execution when one already exists (e.g. unit tests).
 #[derive(Clone, Debug)]
 pub struct SqliteLogExporter {
     pool: SqlitePool,
+    rt_handle: Handle,
 }
 
 impl SqliteLogExporter {
+    /// Create a new exporter.
+    ///
+    /// # Panics
+    /// Panics if called outside a Tokio runtime (the handle is captured
+    /// via [`Handle::current()`]).
     pub fn new(pool: SqlitePool) -> Self {
-        Self { pool }
+        Self {
+            pool,
+            rt_handle: Handle::current(),
+        }
+    }
+
+    /// Inner export logic, always called with a Tokio context available.
+    async fn export_inner(&self, batch: LogBatch<'_>) -> OTelSdkResult {
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| OTelSdkError::InternalFailure(format!("SQLite begin failed: {e}")))?;
+
+        for (record, _scope) in batch.iter() {
+            if let Err(err) = Self::persist_log(&mut tx, record).await {
+                return Err(OTelSdkError::InternalFailure(format!(
+                    "SQLite log export failed: {err}"
+                )));
+            }
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| OTelSdkError::InternalFailure(format!("SQLite commit failed: {e}")))?;
+
+        Ok(())
     }
 
     async fn persist_log(
@@ -76,25 +116,14 @@ impl SqliteLogExporter {
 
 impl LogExporter for SqliteLogExporter {
     async fn export(&self, batch: LogBatch<'_>) -> OTelSdkResult {
-        let mut tx = self
-            .pool
-            .begin()
-            .await
-            .map_err(|e| OTelSdkError::InternalFailure(format!("SQLite begin failed: {e}")))?;
-
-        for (record, _scope) in batch.iter() {
-            if let Err(err) = Self::persist_log(&mut tx, record).await {
-                return Err(OTelSdkError::InternalFailure(format!(
-                    "SQLite log export failed: {err}"
-                )));
-            }
+        // The BatchLogProcessor calls us from a plain OS thread with no
+        // Tokio runtime.  When a Tokio context already exists (tests), we
+        // await directly; otherwise we block on the captured Handle.
+        if Handle::try_current().is_ok() {
+            self.export_inner(batch).await
+        } else {
+            self.rt_handle.block_on(self.export_inner(batch))
         }
-
-        tx.commit()
-            .await
-            .map_err(|e| OTelSdkError::InternalFailure(format!("SQLite commit failed: {e}")))?;
-
-        Ok(())
     }
 
     fn set_resource(&mut self, _resource: &Resource) {

--- a/crates/opentelemetry-exporter-sqlite/src/metric.rs
+++ b/crates/opentelemetry-exporter-sqlite/src/metric.rs
@@ -18,19 +18,92 @@ use opentelemetry_sdk::Resource;
 use serde_json::{Map, Number};
 use sha2::{Digest, Sha256};
 use sqlx::{SqliteConnection, SqlitePool};
+use tokio::runtime::Handle;
 use tracing::warn;
 
 /// OpenTelemetry metric exporter that persists data points into the
 /// `metric_points` SQLite table, with resources and scopes normalized
 /// into join tables.
+///
+/// See [`SqliteLogExporter`](crate::SqliteLogExporter) for details on why
+/// we capture a Tokio [`Handle`].
 #[derive(Clone, Debug)]
 pub struct SqliteMetricExporter {
     pool: SqlitePool,
+    rt_handle: Handle,
 }
 
 impl SqliteMetricExporter {
+    /// Create a new exporter.
+    ///
+    /// # Panics
+    /// Panics if called outside a Tokio runtime.
     pub fn new(pool: SqlitePool) -> Self {
-        Self { pool }
+        Self {
+            pool,
+            rt_handle: Handle::current(),
+        }
+    }
+
+    /// Inner export logic, always called with a Tokio context available.
+    async fn export_inner(&self, metrics: &ResourceMetrics) -> OTelSdkResult {
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| OTelSdkError::InternalFailure(format!("SQLite begin failed: {e}")))?;
+
+        let resource_id = Self::ensure_resource(&mut tx, metrics.resource())
+            .await
+            .map_err(|e| OTelSdkError::InternalFailure(e.to_string()))?;
+
+        for scope_metrics in metrics.scope_metrics() {
+            let scope_id = Self::ensure_scope(&mut tx, scope_metrics.scope())
+                .await
+                .map_err(|e| OTelSdkError::InternalFailure(e.to_string()))?;
+
+            for metric in scope_metrics.metrics() {
+                let name = metric.name();
+                let unit = metric.unit();
+                let desc = metric.description();
+
+                match metric.data() {
+                    AggregatedMetrics::F64(data) => {
+                        Self::process_f64_metric(
+                            &mut tx,
+                            resource_id,
+                            scope_id,
+                            name,
+                            unit,
+                            desc,
+                            data,
+                        )
+                        .await;
+                    }
+                    AggregatedMetrics::I64(data) => {
+                        Self::process_i64_metric(
+                            &mut tx,
+                            resource_id,
+                            scope_id,
+                            name,
+                            unit,
+                            desc,
+                            data,
+                        )
+                        .await;
+                    }
+                    AggregatedMetrics::U64(_) => {
+                        warn!(metric = name, "u64 metrics not yet supported, skipping");
+                    }
+                }
+            }
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| OTelSdkError::InternalFailure(format!("SQLite commit failed: {e}")))?;
+
+        Ok(())
     }
 
     /// Upsert the resource and return its row id.
@@ -456,63 +529,11 @@ impl SqliteMetricExporter {
 
 impl PushMetricExporter for SqliteMetricExporter {
     async fn export(&self, metrics: &ResourceMetrics) -> OTelSdkResult {
-        let mut tx = self
-            .pool
-            .begin()
-            .await
-            .map_err(|e| OTelSdkError::InternalFailure(format!("SQLite begin failed: {e}")))?;
-
-        let resource_id = Self::ensure_resource(&mut tx, metrics.resource())
-            .await
-            .map_err(|e| OTelSdkError::InternalFailure(e.to_string()))?;
-
-        for scope_metrics in metrics.scope_metrics() {
-            let scope_id = Self::ensure_scope(&mut tx, scope_metrics.scope())
-                .await
-                .map_err(|e| OTelSdkError::InternalFailure(e.to_string()))?;
-
-            for metric in scope_metrics.metrics() {
-                let name = metric.name();
-                let unit = metric.unit();
-                let desc = metric.description();
-
-                match metric.data() {
-                    AggregatedMetrics::F64(data) => {
-                        Self::process_f64_metric(
-                            &mut tx,
-                            resource_id,
-                            scope_id,
-                            name,
-                            unit,
-                            desc,
-                            data,
-                        )
-                        .await;
-                    }
-                    AggregatedMetrics::I64(data) => {
-                        Self::process_i64_metric(
-                            &mut tx,
-                            resource_id,
-                            scope_id,
-                            name,
-                            unit,
-                            desc,
-                            data,
-                        )
-                        .await;
-                    }
-                    AggregatedMetrics::U64(_) => {
-                        warn!(metric = name, "u64 metrics not yet supported, skipping");
-                    }
-                }
-            }
+        if Handle::try_current().is_ok() {
+            self.export_inner(metrics).await
+        } else {
+            self.rt_handle.block_on(self.export_inner(metrics))
         }
-
-        tx.commit()
-            .await
-            .map_err(|e| OTelSdkError::InternalFailure(format!("SQLite commit failed: {e}")))?;
-
-        Ok(())
     }
 
     fn force_flush(&self) -> OTelSdkResult {

--- a/crates/opentelemetry-exporter-sqlite/src/span.rs
+++ b/crates/opentelemetry-exporter-sqlite/src/span.rs
@@ -5,18 +5,53 @@ use opentelemetry_sdk::error::{OTelSdkError, OTelSdkResult};
 use opentelemetry_sdk::trace::{SpanData, SpanExporter};
 use serde_json::{Map, Number};
 use sqlx::{SqliteConnection, SqlitePool};
+use tokio::runtime::Handle;
 use uuid::Uuid;
 
 /// OpenTelemetry span exporter that persists spans into the `distributed_traces`
 /// SQLite table.
+///
+/// See [`SqliteLogExporter`](crate::SqliteLogExporter) for details on why
+/// we capture a Tokio [`Handle`].
 #[derive(Clone, Debug)]
 pub struct SqliteSpanExporter {
     pool: SqlitePool,
+    rt_handle: Handle,
 }
 
 impl SqliteSpanExporter {
+    /// Create a new exporter.
+    ///
+    /// # Panics
+    /// Panics if called outside a Tokio runtime.
     pub fn new(pool: SqlitePool) -> Self {
-        Self { pool }
+        Self {
+            pool,
+            rt_handle: Handle::current(),
+        }
+    }
+
+    /// Inner export logic, always called with a Tokio context available.
+    async fn export_inner(&self, batch: Vec<SpanData>) -> OTelSdkResult {
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| OTelSdkError::InternalFailure(format!("SQLite begin failed: {e}")))?;
+
+        for span in batch {
+            if let Err(err) = SqliteSpanExporter::persist_span(&mut tx, span).await {
+                return Err(OTelSdkError::InternalFailure(format!(
+                    "SQLite span export failed: {err}"
+                )));
+            }
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| OTelSdkError::InternalFailure(format!("SQLite commit failed: {e}")))?;
+
+        Ok(())
     }
 
     async fn persist_span(conn: &mut SqliteConnection, span: SpanData) -> Result<(), sqlx::Error> {
@@ -117,25 +152,11 @@ impl SqliteSpanExporter {
 
 impl SpanExporter for SqliteSpanExporter {
     async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
-        let mut tx = self
-            .pool
-            .begin()
-            .await
-            .map_err(|e| OTelSdkError::InternalFailure(format!("SQLite begin failed: {e}")))?;
-
-        for span in batch {
-            if let Err(err) = SqliteSpanExporter::persist_span(&mut tx, span).await {
-                return Err(OTelSdkError::InternalFailure(format!(
-                    "SQLite span export failed: {err}"
-                )));
-            }
+        if Handle::try_current().is_ok() {
+            self.export_inner(batch).await
+        } else {
+            self.rt_handle.block_on(self.export_inner(batch))
         }
-
-        tx.commit()
-            .await
-            .map_err(|e| OTelSdkError::InternalFailure(format!("SQLite commit failed: {e}")))?;
-
-        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary

- **Root cause**: The OTel SDK's `BatchLogProcessor`, `BatchSpanProcessor`, and `PeriodicReader` run their export loops on plain OS threads without a Tokio runtime. Our SQLite exporters use `sqlx` which requires a Tokio context, causing the batch processor thread to panic on first flush (`"this functionality requires a Tokio context"`).
- **Symptom**: After the panic the processor is marked as shut down, and every subsequent tracing event produces `BatchLogProcessor.Emit.AfterShutdown` warnings — flooding the journal with noise and silently dropping **all** telemetry data (spans, logs, metrics).
- **Fix**: Capture `tokio::runtime::Handle::current()` at exporter construction. In `export()`, check `Handle::try_current()` — if a Tokio context already exists (unit tests), await directly; otherwise `block_on` the captured handle (batch processor thread). Applied to all three exporters (`SqliteLogExporter`, `SqliteSpanExporter`, `SqliteMetricExporter`).

## Observed on schorschvm

```
thread 'OpenTelemetry.Logs.BatchProcessor' panicked at sqlx-core/src/rt/mod.rs:42:
this functionality requires a Tokio context
```

Followed by hundreds of:
```
WARN opentelemetry_sdk: name="BatchLogProcessor.Emit.AfterShutdown"
WARN opentelemetry_sdk: name="BatchSpanProcessor.OnEnd.AfterShutdown"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced async runtime compatibility for SQLite exporters (log, metric, and span). Exporters now intelligently handle both inside and outside Tokio runtime contexts, improving flexibility and reliability in various deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->