### PR TITLE
fix(cli): start turn worker in Slack and Mattermost only modes

### DIFF
--- a/crates/interface-cli/src/main.rs
+++ b/crates/interface-cli/src/main.rs
@@ -770,7 +770,7 @@ async fn main() -> Result<()> {
         let slack_cfg = bs.config.slack.clone().context(
             "Slack is not configured. Add a [slack] section to ~/.assistant/config.toml",
         )?;
-        let mut iface = SlackInterface::new(slack_cfg, bs.orchestrator, bs.storage);
+        let mut iface = SlackInterface::new(slack_cfg, bs.orchestrator.clone(), bs.storage.clone());
         if let Some(ref tp) = transcription_provider {
             iface = iface.with_transcription(tp.clone(), transcription_language.clone());
         }
@@ -783,6 +783,14 @@ async fn main() -> Result<()> {
             info!("Registered ambient tool: {tool_name}");
         }
 
+        // Spawn the turn worker — required for submit_turn to process bus
+        // messages.  Without this the interface would timeout waiting for
+        // a turn result.
+        let worker_orch = bs.orchestrator.clone();
+        let _worker = tokio::spawn(async move {
+            worker_orch.run_worker("slack-worker").await;
+        });
+
         info!("Starting Slack-only mode");
         return iface.run().await;
     }
@@ -794,7 +802,16 @@ async fn main() -> Result<()> {
         let mm_cfg = bs.config.mattermost.clone().context(
             "Mattermost is not configured. Add a [mattermost] section to ~/.assistant/config.toml",
         )?;
-        let iface = MattermostInterface::new(mm_cfg, bs.orchestrator);
+        let iface = MattermostInterface::new(mm_cfg, bs.orchestrator.clone());
+
+        // Spawn the turn worker — required for submit_turn to process bus
+        // messages.  Without this the interface would timeout waiting for
+        // a turn result.
+        let worker_orch = bs.orchestrator.clone();
+        let _worker = tokio::spawn(async move {
+            worker_orch.run_worker("mattermost-worker").await;
+        });
+
         info!("Starting Mattermost-only mode");
         return iface.run().await;
     }
@@ -806,7 +823,16 @@ async fn main() -> Result<()> {
         let nc_cfg = bs.config.nextcloud.clone().context(
             "Nextcloud is not configured. Add a [nextcloud] section to ~/.assistant/config.toml",
         )?;
-        let iface = NextcloudInterface::new(nc_cfg, bs.orchestrator);
+        let iface = NextcloudInterface::new(nc_cfg, bs.orchestrator.clone());
+
+        // Spawn the turn worker — required for submit_turn to process bus
+        // messages.  Without this the interface would timeout waiting for
+        // a turn result.
+        let worker_orch = bs.orchestrator.clone();
+        let _worker = tokio::spawn(async move {
+            worker_orch.run_worker("nextcloud-worker").await;
+        });
+
         info!("Starting Nextcloud Talk-only mode");
         return iface.run().await;
     }

--- a/crates/runtime/src/orchestrator/tests.rs
+++ b/crates/runtime/src/orchestrator/tests.rs
@@ -1950,3 +1950,59 @@ async fn subagent_max_iterations_returns_failed_status() {
         report.content
     );
 }
+
+// ── Worker integration tests ────────────────────────────────────────────────
+
+/// Test that submit_turn works correctly when the worker is running.
+/// This reproduces the bug where Slack/Mattermost-only modes didn't spawn
+/// the worker, causing submit_turn to timeout waiting for a result.
+#[tokio::test]
+async fn submit_turn_with_worker_returns_result() {
+    let server = MockServer::start().await;
+    mount_answer(&server, "hello from worker").await;
+
+    let (orch, _) = build(&server.uri()).await;
+    let conv_id = Uuid::new_v4();
+
+    // Spawn the worker in the background (as the CLI would do).
+    let worker_orch = orch.clone();
+    let _worker = tokio::spawn(async move {
+        worker_orch.run_worker("test-worker").await;
+    });
+
+    // Give the worker a moment to start.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let result = orch
+        .submit_turn("test message", conv_id, Interface::Slack, None)
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "submit_turn should succeed when worker is running"
+    );
+    assert_eq!(result.unwrap().answer, "hello from worker");
+}
+
+/// Test that submit_turn times out when no worker is running.
+/// This verifies the bug condition that was fixed.
+#[tokio::test]
+async fn submit_turn_without_worker_times_out() {
+    let server = MockServer::start().await;
+    mount_answer(&server, "this should not be received").await;
+
+    let (orch, _) = build(&server.uri()).await;
+    let conv_id = Uuid::new_v4();
+
+    // No worker spawned — simulates the bug condition.
+    let result = tokio::time::timeout(
+        Duration::from_secs(2),
+        orch.submit_turn("test message", conv_id, Interface::Slack, None),
+    )
+    .await;
+
+    assert!(
+        result.is_err() || result.unwrap().is_err(),
+        "submit_turn should fail/timeout when worker is not running"
+    );
+}


### PR DESCRIPTION
## Problem

The `assistant-slack` and `assistant-mattermost` commands were not starting the turn worker, causing all `submit_turn()` calls to timeout after 10 minutes.

### Root Cause

In the Slack-only and Mattermost-only modes, the turn worker was never spawned. The worker is responsible for:
1. Claiming `turn.request` messages from the message bus
2. Processing them through the orchestrator
3. Publishing `turn.result` messages back to the bus

Without the worker, the Slack/Mattermost interfaces would:
1. Publish a `turn.request` message
2. Wait indefinitely for a matching `turn.result` (by `batch_id`)
3. Timeout after 10 minutes

### The Fix

Spawn the turn worker in both:
- Slack-only mode (`assistant slack`)
- Mattermost-only mode (`assistant mattermost`)

The default mode (CLI + background interfaces) already had the worker spawn correctly, which is why the issue only affected the standalone modes.

### Changes

- Added worker spawn in Slack-only mode
- Added worker spawn in Mattermost-only mode
- Added `.clone()` call for orchestrator in Mattermost mode (needed for the spawn)

Fixes the `submit_turn timed out waiting for result` error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added background workers for Slack, Mattermost, and Nextcloud interfaces to improve message processing and reliability.

* **Tests**
  * Added integration tests to verify background worker functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->