### PR TITLE
chore(core): remove unused config fields and fix self_improvement alias

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -157,10 +157,6 @@ timeout_secs = 120
 # extra_dirs = ["~/.claude/skills", "./.claude/skills"]
 
 [mcp]
-# Enable the built-in MCP server (JSON-RPC over stdio)
-enabled = true
-# Listen address for MCP server
-listen = "127.0.0.1:3000"
 
 # ── External MCP servers (client connections) ─────────────────────────────────
 # Connect to external MCP servers and bridge their tools into the assistant.
@@ -189,8 +185,6 @@ listen = "127.0.0.1:3000"
 [self_improvement]
 # Enable passive execution trace collection
 trace_enabled = true
-# How many recent traces to include in self-analysis (per skill)
-analysis_window = 50
 # Record full message content on LLM spans (system prompt, input messages,
 # output messages, tool definitions).  Off by default — content may contain PII.
 # trace_content = false

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -111,7 +111,7 @@ pub struct AssistantConfig {
     pub skills: SkillsConfig,
     #[serde(default)]
     pub mcp: McpConfig,
-    #[serde(default)]
+    #[serde(default, alias = "self_improvement")]
     pub mirror: MirrorConfig,
     #[serde(default)]
     pub memory: MemoryConfig,
@@ -621,29 +621,14 @@ fn default_skill_extra_dirs() -> Vec<String> {
     ]
 }
 
-/// MCP configuration — covers both the built-in MCP server and external MCP
-/// client connections.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// MCP configuration — covers external MCP client connections.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct McpConfig {
-    /// Enable the built-in MCP server (JSON-RPC over stdio).
-    pub enabled: bool,
-    /// Listen address for the built-in MCP server.
-    pub listen: String,
     /// External MCP servers to connect to as a client.
     /// Each entry spawns a connection at startup and bridges the server's tools
     /// into the assistant's tool registry.
     #[serde(default)]
     pub servers: Vec<McpServerEntry>,
-}
-
-impl Default for McpConfig {
-    fn default() -> Self {
-        Self {
-            enabled: true,
-            listen: "127.0.0.1:3000".to_string(),
-            servers: Vec::new(),
-        }
-    }
 }
 
 /// An external MCP server the assistant connects to as a client.
@@ -711,11 +696,10 @@ pub enum McpTrustLevel {
     Trust,
 }
 
-/// Self-improvement config
+/// Self-improvement / tracing config
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MirrorConfig {
     pub trace_enabled: bool,
-    pub analysis_window: usize,
     /// When `true`, LLM span events include full message content
     /// (`gen_ai.input.messages`, `gen_ai.output.messages`, etc.).
     /// Off by default because content may contain PII.
@@ -727,7 +711,6 @@ impl Default for MirrorConfig {
     fn default() -> Self {
         Self {
             trace_enabled: true,
-            analysis_window: 50,
             trace_content: false,
         }
     }
@@ -980,15 +963,11 @@ mod tests {
     fn mcp_config_default_has_empty_servers() {
         let cfg = McpConfig::default();
         assert!(cfg.servers.is_empty());
-        assert!(cfg.enabled);
     }
 
     #[test]
     fn mcp_config_stdio_server() {
         let toml_str = r#"
-            enabled = true
-            listen = "127.0.0.1:3000"
-
             [[servers]]
             name = "github"
             command = ["npx", "-y", "@modelcontextprotocol/server-github"]
@@ -1017,9 +996,6 @@ mod tests {
     #[test]
     fn mcp_config_http_server() {
         let toml_str = r#"
-            enabled = true
-            listen = "127.0.0.1:3000"
-
             [[servers]]
             name = "remote-db"
             url = "https://db.example.com/mcp/sse"
@@ -1045,9 +1021,6 @@ mod tests {
     #[test]
     fn mcp_config_multiple_servers() {
         let toml_str = r#"
-            enabled = true
-            listen = "127.0.0.1:3000"
-
             [[servers]]
             name = "fs"
             command = ["mcp-server-fs", "/tmp"]
@@ -1065,10 +1038,7 @@ mod tests {
 
     #[test]
     fn mcp_config_no_servers_section_defaults_empty() {
-        let toml_str = r#"
-            enabled = true
-            listen = "127.0.0.1:3000"
-        "#;
+        let toml_str = r#""#;
         let cfg: McpConfig = toml::from_str(toml_str).unwrap();
         assert!(cfg.servers.is_empty());
     }

--- a/docs/opentelemetry.md
+++ b/docs/opentelemetry.md
@@ -29,17 +29,17 @@ OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer my-token" \
 ## Environment variables
 
 The `opentelemetry-otlp` crate reads these env vars automatically at
-exporter construction time.  Every generic variable has a per-signal
+exporter construction time. Every generic variable has a per-signal
 override that takes precedence (signal-specific > generic > default).
 
 ### Exporter configuration
 
-| Generic | Traces | Logs | Metrics | Default |
-|---------|--------|------|---------|---------|
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | `_TRACES_ENDPOINT` | `_LOGS_ENDPOINT` | `_METRICS_ENDPOINT` | `http://localhost:4317` |
-| `OTEL_EXPORTER_OTLP_HEADERS` | `_TRACES_HEADERS` | `_LOGS_HEADERS` | `_METRICS_HEADERS` | *(none)* |
-| `OTEL_EXPORTER_OTLP_TIMEOUT` | `_TRACES_TIMEOUT` | `_LOGS_TIMEOUT` | `_METRICS_TIMEOUT` | `10s` |
-| `OTEL_EXPORTER_OTLP_COMPRESSION` | `_TRACES_COMPRESSION` | `_LOGS_COMPRESSION` | `_METRICS_COMPRESSION` | `none` |
+| Generic                          | Traces                | Logs                | Metrics                | Default                 |
+| -------------------------------- | --------------------- | ------------------- | ---------------------- | ----------------------- |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`    | `_TRACES_ENDPOINT`    | `_LOGS_ENDPOINT`    | `_METRICS_ENDPOINT`    | `http://localhost:4317` |
+| `OTEL_EXPORTER_OTLP_HEADERS`     | `_TRACES_HEADERS`     | `_LOGS_HEADERS`     | `_METRICS_HEADERS`     | _(none)_                |
+| `OTEL_EXPORTER_OTLP_TIMEOUT`     | `_TRACES_TIMEOUT`     | `_LOGS_TIMEOUT`     | `_METRICS_TIMEOUT`     | `10s`                   |
+| `OTEL_EXPORTER_OTLP_COMPRESSION` | `_TRACES_COMPRESSION` | `_LOGS_COMPRESSION` | `_METRICS_COMPRESSION` | `none`                  |
 
 Headers use `key=value` pairs separated by commas:
 `OTEL_EXPORTER_OTLP_HEADERS="api-key=secret,tenant=prod"`.
@@ -48,26 +48,25 @@ Compression values: `gzip` or `none`.
 
 ### Resource / SDK configuration
 
-| Variable | Purpose | Default |
-|----------|---------|---------|
-| `OTEL_SERVICE_NAME` | `service.name` resource attribute | `assistant` |
-| `OTEL_RESOURCE_ATTRIBUTES` | Additional resource attributes (`k=v,k=v`) | *(none)* |
-| `RUST_LOG` | Console log filter (standard `tracing` EnvFilter) | `info` |
+| Variable                   | Purpose                                           | Default     |
+| -------------------------- | ------------------------------------------------- | ----------- |
+| `OTEL_SERVICE_NAME`        | `service.name` resource attribute                 | `assistant` |
+| `OTEL_RESOURCE_ATTRIBUTES` | Additional resource attributes (`k=v,k=v`)        | _(none)_    |
+| `RUST_LOG`                 | Console log filter (standard `tracing` EnvFilter) | `info`      |
 
 ### Config file
 
 In `~/.assistant/config.toml`:
 
 ```toml
-[mirror]
+[self_improvement]
 trace_enabled = true   # Enable SQLite telemetry export (default: true)
 trace_content = false  # Capture full LLM message content in spans (default: false)
-analysis_window = 50   # Number of recent traces for self-analysis
 ```
 
 `trace_content = true` records `gen_ai.input.messages`,
 `gen_ai.output.messages`, `gen_ai.system_instructions`, and
-`gen_ai.tool.definitions` on LLM spans.  Off by default for PII concerns.
+`gen_ai.tool.definitions` on LLM spans. Off by default for PII concerns.
 
 ## Traces
 
@@ -83,53 +82,53 @@ conversation                          # root span per conversation
 
 ### `conversation` span
 
-| Attribute | Type | Description |
-|-----------|------|-------------|
-| `conversation_id` | string | UUID of the conversation |
-| `interface` | string | `Cli`, `Slack`, `Mattermost`, `Signal`, `A2A` |
+| Attribute         | Type   | Description                                   |
+| ----------------- | ------ | --------------------------------------------- |
+| `conversation_id` | string | UUID of the conversation                      |
+| `interface`       | string | `Cli`, `Slack`, `Mattermost`, `Signal`, `A2A` |
 
 ### `chat {model}` span (GenAI semantic conventions)
 
-| Attribute | Type | Description |
-|-----------|------|-------------|
-| `gen_ai.system` | string | Provider name (e.g. `ollama`, `anthropic`) |
-| `gen_ai.request.model` | string | Requested model name |
-| `gen_ai.operation.name` | string | Always `chat` |
-| `server.address` | string | Provider endpoint URL |
-| `iteration` | int | ReAct loop iteration index |
-| `gen_ai.response.model` | string | Model used in response (may differ) |
-| `gen_ai.response.id` | string | Provider-assigned response ID |
-| `gen_ai.response.finish_reasons` | string | Stop reason (`stop`, `tool_use`, etc.) |
-| `gen_ai.usage.input_tokens` | int | Input token count |
-| `gen_ai.usage.output_tokens` | int | Output token count |
+| Attribute                        | Type   | Description                                |
+| -------------------------------- | ------ | ------------------------------------------ |
+| `gen_ai.system`                  | string | Provider name (e.g. `ollama`, `anthropic`) |
+| `gen_ai.request.model`           | string | Requested model name                       |
+| `gen_ai.operation.name`          | string | Always `chat`                              |
+| `server.address`                 | string | Provider endpoint URL                      |
+| `iteration`                      | int    | ReAct loop iteration index                 |
+| `gen_ai.response.model`          | string | Model used in response (may differ)        |
+| `gen_ai.response.id`             | string | Provider-assigned response ID              |
+| `gen_ai.response.finish_reasons` | string | Stop reason (`stop`, `tool_use`, etc.)     |
+| `gen_ai.usage.input_tokens`      | int    | Input token count                          |
+| `gen_ai.usage.output_tokens`     | int    | Output token count                         |
 
 When `trace_content = true`:
 
-| Attribute | Type | Description |
-|-----------|------|-------------|
-| `gen_ai.system_instructions` | string | Full system prompt |
-| `gen_ai.input.messages` | string | Serialised chat history (JSON) |
-| `gen_ai.output.messages` | string | Serialised assistant response (JSON) |
-| `gen_ai.tool.definitions` | string | Serialised tool specs (JSON) |
+| Attribute                    | Type   | Description                          |
+| ---------------------------- | ------ | ------------------------------------ |
+| `gen_ai.system_instructions` | string | Full system prompt                   |
+| `gen_ai.input.messages`      | string | Serialised chat history (JSON)       |
+| `gen_ai.output.messages`     | string | Serialised assistant response (JSON) |
+| `gen_ai.tool.definitions`    | string | Serialised tool specs (JSON)         |
 
 ### `execute_tool {name}` span
 
-| Attribute | Type | Description |
-|-----------|------|-------------|
-| `conversation_id` | string | UUID |
-| `iteration` | int | ReAct loop iteration index |
-| `turn` | int | Turn number |
-| `interface` | string | Interface name |
-| `tool_name` | string | Tool identifier (e.g. `file-read`) |
-| `tool_params` | string | Serialised parameters (JSON) |
-| `tool_status` | string | `ok`, `error`, `deferred`, `rejected`, `blocked` |
-| `tool_observation` | string | Tool output (on success) |
-| `tool_error` | string | Error message (on failure) |
+| Attribute          | Type   | Description                                      |
+| ------------------ | ------ | ------------------------------------------------ |
+| `conversation_id`  | string | UUID                                             |
+| `iteration`        | int    | ReAct loop iteration index                       |
+| `turn`             | int    | Turn number                                      |
+| `interface`        | string | Interface name                                   |
+| `tool_name`        | string | Tool identifier (e.g. `file-read`)               |
+| `tool_params`      | string | Serialised parameters (JSON)                     |
+| `tool_status`      | string | `ok`, `error`, `deferred`, `rejected`, `blocked` |
+| `tool_observation` | string | Tool output (on success)                         |
+| `tool_error`       | string | Error message (on failure)                       |
 
 ## Logs
 
 Tracing events from all `assistant_*` crates are bridged into OTel log
-records via `OpenTelemetryTracingBridge`.  Each log record carries:
+records via `OpenTelemetryTracingBridge`. Each log record carries:
 
 - Timestamp and observed timestamp
 - Severity (mapped from tracing level: TRACE=1, DEBUG=5, INFO=9, WARN=13, ERROR=17)
@@ -147,24 +146,24 @@ Meter name: `assistant-runtime`
 
 ### GenAI metrics (OTel semantic conventions)
 
-| Metric | Type | Unit | Key Attributes |
-|--------|------|------|----------------|
-| `gen_ai.client.token.usage` | Histogram | `{token}` | `gen_ai.request.model`, `gen_ai.provider.name`, `gen_ai.operation.name`, `gen_ai.token.type` (`input`/`output`) |
-| `gen_ai.client.operation.duration` | Histogram | `s` | `gen_ai.request.model`, `gen_ai.provider.name`, `gen_ai.operation.name`, `error.type` |
-| `gen_ai.server.time_to_first_token` | Histogram | `s` | `gen_ai.request.model`, `gen_ai.provider.name` |
-| `gen_ai.server.time_per_output_token` | Histogram | `s` | `gen_ai.request.model`, `gen_ai.provider.name` |
+| Metric                                | Type      | Unit      | Key Attributes                                                                                                  |
+| ------------------------------------- | --------- | --------- | --------------------------------------------------------------------------------------------------------------- |
+| `gen_ai.client.token.usage`           | Histogram | `{token}` | `gen_ai.request.model`, `gen_ai.provider.name`, `gen_ai.operation.name`, `gen_ai.token.type` (`input`/`output`) |
+| `gen_ai.client.operation.duration`    | Histogram | `s`       | `gen_ai.request.model`, `gen_ai.provider.name`, `gen_ai.operation.name`, `error.type`                           |
+| `gen_ai.server.time_to_first_token`   | Histogram | `s`       | `gen_ai.request.model`, `gen_ai.provider.name`                                                                  |
+| `gen_ai.server.time_per_output_token` | Histogram | `s`       | `gen_ai.request.model`, `gen_ai.provider.name`                                                                  |
 
 ### Operational metrics
 
-| Metric | Type | Unit | Key Attributes |
-|--------|------|------|----------------|
-| `assistant.turn.count` | Counter | `{turn}` | `skill`, `interface` |
-| `assistant.turn.duration` | Histogram | `s` | `skill`, `interface` |
-| `assistant.tool.invocations` | Counter | `{invocation}` | `tool.name` |
-| `assistant.tool.duration` | Histogram | `s` | `tool.name` |
-| `assistant.error.count` | Counter | `{error}` | `error.type`, `source` |
-| `assistant.conversation.count` | Counter | `{conversation}` | *(none)* |
-| `assistant.agent.spawn.count` | Counter | `{agent}` | *(none)* |
+| Metric                         | Type      | Unit             | Key Attributes         |
+| ------------------------------ | --------- | ---------------- | ---------------------- |
+| `assistant.turn.count`         | Counter   | `{turn}`         | `skill`, `interface`   |
+| `assistant.turn.duration`      | Histogram | `s`              | `skill`, `interface`   |
+| `assistant.tool.invocations`   | Counter   | `{invocation}`   | `tool.name`            |
+| `assistant.tool.duration`      | Histogram | `s`              | `tool.name`            |
+| `assistant.error.count`        | Counter   | `{error}`        | `error.type`, `source` |
+| `assistant.conversation.count` | Counter   | `{conversation}` | _(none)_               |
+| `assistant.agent.spawn.count`  | Counter   | `{agent}`        | _(none)_               |
 
 Metrics are exported every 60 seconds via `PeriodicReader`.
 
@@ -172,17 +171,17 @@ Metrics are exported every 60 seconds via `PeriodicReader`.
 
 Every signal carries a shared OTel `Resource`:
 
-| Attribute | Source |
-|-----------|--------|
-| `service.name` | `OTEL_SERVICE_NAME` or `"assistant"` |
-| `service.version` | Crate version from `Cargo.toml` |
-| `os.type` | Compile-time OS |
-| `host.arch` | Compile-time architecture |
-| `process.pid` | Runtime PID |
-| `process.runtime.name` | `"rust"` |
-| `telemetry.sdk.name` | `"opentelemetry"` |
-| `telemetry.sdk.language` | `"rust"` |
-| *(user-defined)* | `OTEL_RESOURCE_ATTRIBUTES` (`k=v,k=v`) |
+| Attribute                | Source                                 |
+| ------------------------ | -------------------------------------- |
+| `service.name`           | `OTEL_SERVICE_NAME` or `"assistant"`   |
+| `service.version`        | Crate version from `Cargo.toml`        |
+| `os.type`                | Compile-time OS                        |
+| `host.arch`              | Compile-time architecture              |
+| `process.pid`            | Runtime PID                            |
+| `process.runtime.name`   | `"rust"`                               |
+| `telemetry.sdk.name`     | `"opentelemetry"`                      |
+| `telemetry.sdk.language` | `"rust"`                               |
+| _(user-defined)_         | `OTEL_RESOURCE_ATTRIBUTES` (`k=v,k=v`) |
 
 ## Architecture
 
@@ -206,6 +205,6 @@ Every signal carries a shared OTel `Resource`:
        dashboard Tempo  dashboard ...  dashboard ...
 ```
 
-Both backends run side-by-side when OTLP env vars are set.  The SQLite
+Both backends run side-by-side when OTLP env vars are set. The SQLite
 exporters power the built-in web UI; the OTLP exporters send data to
 your collector of choice.


### PR DESCRIPTION
## Summary

- Remove `McpConfig.enabled` and `McpConfig.listen` — the MCP server uses stdio transport and is started via CLI subcommand, not these config fields
- Remove `MirrorConfig.analysis_window` — deserialized but never read at runtime
- Add `#[serde(alias = "self_improvement")]` to the `mirror` field so the `[self_improvement]` section in `config.toml` is actually deserialized (was silently ignored due to field name mismatch)
- Update `config.toml` and `docs/opentelemetry.md` to match

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed built-in MCP server configuration support.
  * Removed analysis_window setting from self-improvement configuration.
  * Added backward-compatible "self_improvement" alias for mirror configuration settings.

* **Documentation**
  * Updated OpenTelemetry documentation formatting and configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->