### PR TITLE
refactor(llm): extract shared build_reqwest_client to assistant-llm

### DIFF
--- a/crates/llm/src/http.rs
+++ b/crates/llm/src/http.rs
@@ -15,6 +15,17 @@ use reqwest_tracing::TracingMiddleware;
 
 use crate::retry::RetryConfig;
 
+/// Build a plain `reqwest::Client` with the given timeout.
+///
+/// Use this for libraries like `async-openai` that require a bare
+/// `reqwest::Client` rather than `ClientWithMiddleware`.
+pub fn build_reqwest_client(timeout_secs: u64) -> anyhow::Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(timeout_secs))
+        .build()
+        .map_err(|e| anyhow::anyhow!("Failed to build HTTP client: {e}"))
+}
+
 /// Build an instrumented HTTP client with the given timeout and retry config.
 ///
 /// The returned [`ClientWithMiddleware`] wraps a standard `reqwest::Client`

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -11,7 +11,7 @@ pub use client::{
     LlmResponseMeta, ToolCallItem,
 };
 pub use embedding::{EmbeddingProvider, LlmEmbedder, WithEmbeddingOverride};
-pub use http::build_http_client;
+pub use http::{build_http_client, build_reqwest_client};
 pub use provider::{Capabilities, HostedTool, LlmProvider, ToolSupport};
 pub use retry::{is_transient_error_message, is_transient_status, with_retry, RetryConfig};
 pub use tool_spec::ToolSpec;

--- a/crates/provider-moonshot/src/provider.rs
+++ b/crates/provider-moonshot/src/provider.rs
@@ -6,8 +6,6 @@
 //! because it uses the non-standard `"type": "builtin_function"` tool spec
 //! and requires an echo-back loop.
 
-use std::time::Duration;
-
 use async_openai::config::OpenAIConfig as AsyncOpenAIConfig;
 use async_openai::types::chat::{
     ChatCompletionMessageToolCall, ChatCompletionMessageToolCalls,
@@ -25,9 +23,9 @@ use tracing::{debug, warn};
 
 use assistant_core::LlmConfig;
 use assistant_llm::{
-    is_transient_error_message, with_retry, Capabilities, ChatHistoryMessage, ChatRole,
-    ContentBlock, HostedTool, LlmProvider, LlmResponse, LlmResponseMeta, RetryConfig, ToolCallItem,
-    ToolSpec, ToolSupport,
+    build_reqwest_client, is_transient_error_message, with_retry, Capabilities, ChatHistoryMessage,
+    ChatRole, ContentBlock, HostedTool, LlmProvider, LlmResponse, LlmResponseMeta, RetryConfig,
+    ToolCallItem, ToolSpec, ToolSupport,
 };
 
 // ── Defaults ──────────────────────────────────────────────────────────────────
@@ -585,14 +583,6 @@ impl LlmProvider for MoonshotProvider {
 }
 
 // ── HTTP client helper ────────────────────────────────────────────────────────
-
-/// Build a `reqwest::Client` with the configured timeout for `async-openai`.
-fn build_reqwest_client(timeout_secs: u64) -> anyhow::Result<reqwest::Client> {
-    reqwest::Client::builder()
-        .timeout(Duration::from_secs(timeout_secs))
-        .build()
-        .map_err(|e| anyhow::anyhow!("Failed to build HTTP client: {e}"))
-}
 
 // ── Chat Completions message conversion ───────────────────────────────────────
 

--- a/crates/provider-openai/src/provider.rs
+++ b/crates/provider-openai/src/provider.rs
@@ -9,7 +9,6 @@
 //! - **OAuth PKCE** — Codex subscription via ChatGPT sign-in.
 
 use std::sync::Arc;
-use std::time::Duration;
 
 use async_openai::config::OpenAIConfig as AsyncOpenAIConfig;
 use async_openai::types::embeddings::CreateEmbeddingRequestArgs;
@@ -30,9 +29,9 @@ use tracing::{debug, warn};
 use assistant_core::types::OpenAIUserLocation;
 use assistant_core::LlmConfig;
 use assistant_llm::{
-    is_transient_error_message, with_retry, Capabilities, ChatHistoryMessage, ChatRole,
-    ContentBlock, HostedTool, LlmProvider, LlmResponse, LlmResponseMeta, RetryConfig, ToolCallItem,
-    ToolSpec, ToolSupport,
+    build_reqwest_client, is_transient_error_message, with_retry, Capabilities, ChatHistoryMessage,
+    ChatRole, ContentBlock, HostedTool, LlmProvider, LlmResponse, LlmResponseMeta, RetryConfig,
+    ToolCallItem, ToolSpec, ToolSupport,
 };
 
 use crate::oauth::OAuthManager;
@@ -688,20 +687,6 @@ fn extract_response_meta(response: &Response) -> LlmResponseMeta {
         output_tokens: response.usage.as_ref().map(|u| u.output_tokens as u64),
         finish_reason: Some(status),
     }
-}
-
-// ── HTTP client ───────────────────────────────────────────────────────────────
-
-/// Build a `reqwest::Client` with the configured timeout.
-///
-/// `async-openai` does not support `reqwest-middleware`, so we cannot inject the
-/// tracing middleware.  We do however set the request timeout so that it matches
-/// the provider configuration rather than relying on async-openai's defaults.
-fn build_reqwest_client(timeout_secs: u64) -> anyhow::Result<reqwest::Client> {
-    reqwest::Client::builder()
-        .timeout(Duration::from_secs(timeout_secs))
-        .build()
-        .map_err(|e| anyhow::anyhow!("Failed to build HTTP client: {e}"))
 }
 
 // ── URL normalisation ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Deduplicate the identical `build_reqwest_client` function from `provider-openai` and `provider-moonshot` into `assistant_llm::http`
- Sits alongside the existing `build_http_client` (which adds tracing + retry middleware)
- The plain variant is needed for `async-openai` which requires a bare `reqwest::Client`
- Net -14 lines