### PR TITLE
chore(web-ui): remove dead AgentStore methods

### DIFF
--- a/crates/web-ui/src/a2a/agent_store.rs
+++ b/crates/web-ui/src/a2a/agent_store.rs
@@ -93,12 +93,6 @@ impl AgentStore {
         Self::new(base.join("agents"))
     }
 
-    /// Returns the agents directory path.
-    #[allow(dead_code)]
-    pub fn dir(&self) -> &Path {
-        &self.agents_dir
-    }
-
     // -- CRUD operations --
 
     /// Registers a new agent card. Returns the assigned ID (filename slug).
@@ -258,12 +252,6 @@ impl AgentStore {
         }
 
         true
-    }
-
-    /// Returns the number of registered agents.
-    #[allow(dead_code)]
-    pub async fn count(&self) -> usize {
-        self.list().await.map(|v| v.len()).unwrap_or(0)
     }
 
     // -- Internal helpers --


### PR DESCRIPTION
## Summary

- Remove `AgentStore::dir()` and `AgentStore::count()` — both annotated `#[allow(dead_code)]` with zero callers in the codebase
- Audited all 12 `#[allow(dead_code)]` annotations; the remaining 10 are justified (serde deserialization fields, feature-gated code, or API contract placeholders)