### PR TITLE
fix(release): install protoc in aarch64 cross pre-build

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,5 +1,5 @@
 [target.aarch64-unknown-linux-gnu]
 pre-build = [
     "dpkg --add-architecture arm64",
-    "apt-get update && apt-get install -y libssl-dev:arm64 pkg-config",
+    "apt-get update && apt-get install -y libssl-dev:arm64 pkg-config protobuf-compiler",
 ]


### PR DESCRIPTION
## Summary
- update `Cross.toml` for `aarch64-unknown-linux-gnu` cross builds to install `protobuf-compiler` in the container pre-build step
- ensures `protoc` is available for transitive crates (e.g. signal/spqr) that run protobuf codegen in build scripts

## Why
- release job `Build assistant-signal (non-fatal)` on aarch64 cross currently reports `Could not find protoc`
- this keeps the signal build path healthy instead of relying on failure-tolerant behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system dependencies for Linux ARM64 target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->