### PR TITLE
fix(web-ui): restore scrolling on workflow pages

### DIFF
--- a/crates/web-ui/templates/partials/default_css.html
+++ b/crates/web-ui/templates/partials/default_css.html
@@ -113,11 +113,11 @@ solid #15243b; border-radius: 8px; color: #e5e9f0; padding: 0.35rem 0.6rem;
 font-size: 0.85rem; flex: 1; } /* -- Legacy layout overrides (prevent 100vh
 inside app shell) ------------ */ .content-area .layout { min-height: 0; height:
 100%; overflow: hidden; } .content-area .layout > .main { overflow-y: auto; }
-.content-area .layout > .sidebar { overflow-y: auto; } .content-area > .page {
-overflow-y: auto; height: 100%; } @media (max-width: 900px) { .layout {
-grid-template-columns: 1fr; } .sidebar { border-right: none; border-bottom: 1px
-solid #0b1b32; } .wf-label-col { width: 150px; min-width: 150px; } .wf-time-axis
-{ margin-left: 150px; } .main { padding: 1.25rem; gap: 1rem; } .panel {
-border-radius: 14px; padding: 1rem; } } @media (max-width: 640px) {
-.wf-label-col { width: 100px; min-width: 100px; } .wf-time-axis { margin-left:
-100px; } .trace-table { min-width: 560px; } }
+.content-area .layout > .sidebar { overflow-y: auto; } .content-area > .page,
+.content-area > .wf-page { overflow-y: auto; height: 100%; } @media (max-width:
+900px) { .layout { grid-template-columns: 1fr; } .sidebar { border-right: none;
+border-bottom: 1px solid #0b1b32; } .wf-label-col { width: 150px; min-width:
+150px; } .wf-time-axis { margin-left: 150px; } .main { padding: 1.25rem; gap:
+1rem; } .panel { border-radius: 14px; padding: 1rem; } } @media (max-width:
+640px) { .wf-label-col { width: 100px; min-width: 100px; } .wf-time-axis {
+margin-left: 100px; } .trace-table { min-width: 560px; } }


### PR DESCRIPTION
## Summary
- Fix workflow page scrolling inside the app shell by adding `.wf-page` to the content-area overflow container rules.
- Resolve non-scrollable workflow detail/edit/run pages that render content beyond viewport height.
- Keep existing legacy layout behavior unchanged for `.layout` and `.page` screens.

## Validation
- Ran `make format`
- Ran `make lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scrolling behavior in main content areas to provide consistent navigation experience across different page layouts
  
* **Style**
  * Enhanced responsive design rules to maintain proper scroll functionality while preserving layout integrity across all screen sizes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->