### PR TITLE
docs(skills): add Stimulus playbook and component criteria

### DIFF
--- a/.claude/skills/stimulus-playbook/SKILL.md
+++ b/.claude/skills/stimulus-playbook/SKILL.md
@@ -77,7 +77,7 @@ Use this decision gate before creating a Stimulus controller:
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["query", "list"];
+  static targets = ["root", "query", "list"];
 
   apply() {
     const q = this.queryTarget.value.trim().toLowerCase();

--- a/.claude/skills/ux-principles/SKILL.md
+++ b/.claude/skills/ux-principles/SKILL.md
@@ -179,13 +179,8 @@ export default class extends Controller {
 }
 ```
 
-**Rules:**
-
-- Keep controllers small and feature-scoped (one concern per controller)
-- Prefer declarative `data-action`/`data-target` wiring over manual DOM queries
-- Keep server-rendered HTML as source of truth; use Stimulus for glue/state only
-- Use events (`dispatch`) for cross-controller communication before direct lookup
-- If behavior can be done with native HTML or htmx alone, do not introduce Stimulus
+For detailed Stimulus implementation rules and htmx interop patterns, see
+[`stimulus-playbook`](../stimulus-playbook/SKILL.md).
 
 ### Component Creation Criteria
 


### PR DESCRIPTION
## Summary
- add a new `stimulus-playbook` skill with practical guidance for when to use Stimulus versus native HTML/htmx
- update `ux-principles` with a Stimulus progressive-enhancement hint and explicit component creation criteria
- document a shared decision gate so reviewers have consistent rules for introducing Stimulus controllers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance for implementing interactive client-side behaviors in the UI framework
  * Enhanced UX principles documentation with decision frameworks and best practices for component creation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->