### PR TITLE
feat(web-ui): introduce Stimulus controller for workflow secrets

### DIFF
--- a/crates/web-ui/src/common.rs
+++ b/crates/web-ui/src/common.rs
@@ -35,6 +35,21 @@ pub trait StaticUrls {
         crate::static_assets::app_js_url()
     }
 
+    /// Fingerprinted URL for the vendored Stimulus runtime.
+    fn stimulus_url(&self) -> &'static str {
+        crate::static_assets::stimulus_url()
+    }
+
+    /// Fingerprinted URL for Stimulus app bootstrap JS.
+    fn stimulus_boot_js_url(&self) -> &'static str {
+        crate::static_assets::stimulus_boot_js_url()
+    }
+
+    /// Fingerprinted URL for workflow secrets Stimulus controller JS.
+    fn workflow_secrets_controller_js_url(&self) -> &'static str {
+        crate::static_assets::workflow_secrets_controller_js_url()
+    }
+
     /// Fingerprinted URL for chat-specific JS.
     fn chat_js_url(&self) -> &'static str {
         crate::static_assets::chat_js_url()

--- a/crates/web-ui/src/static_assets/app.js
+++ b/crates/web-ui/src/static_assets/app.js
@@ -68,15 +68,6 @@ function trapDrawerFocus(event) {
   }
 }
 
-function setWebhookRevealStatus(revealBtn, message, isError) {
-  var statusTargetId = revealBtn.getAttribute("data-status-target");
-  if (!statusTargetId) return;
-  var statusTarget = document.getElementById(statusTargetId);
-  if (!statusTarget) return;
-  statusTarget.textContent = message || "";
-  statusTarget.style.color = isError ? "#ff9b9b" : "#8aa5d8";
-}
-
 document.addEventListener("click", function (e) {
   if (e.target.closest(".hamburger")) {
     toggleDrawer();
@@ -94,80 +85,6 @@ document.addEventListener("click", function (e) {
     closeDrawer(false);
     return;
   }
-
-  var revealBtn = e.target.closest("[data-reveal-webhook-secrets]");
-  if (!revealBtn) return;
-  var tokenTarget = document.getElementById(
-    revealBtn.getAttribute("data-token-target"),
-  );
-  var urlTarget = document.getElementById(
-    revealBtn.getAttribute("data-url-target"),
-  );
-  if (!tokenTarget || !urlTarget) return;
-
-  var isRevealed = revealBtn.getAttribute("data-revealed") === "true";
-  if (isRevealed) {
-    tokenTarget.textContent = revealBtn.getAttribute("data-token-masked") || "";
-    urlTarget.textContent = revealBtn.getAttribute("data-url-masked") || "";
-    revealBtn.textContent = "Reveal";
-    revealBtn.setAttribute("data-revealed", "false");
-    revealBtn.setAttribute("aria-pressed", "false");
-    setWebhookRevealStatus(revealBtn, "", false);
-    return;
-  }
-
-  var cachedToken = revealBtn.getAttribute("data-token") || "";
-  var cachedUrl = revealBtn.getAttribute("data-url") || "";
-  if (cachedToken && cachedUrl) {
-    tokenTarget.textContent = cachedToken;
-    urlTarget.textContent = cachedUrl;
-    revealBtn.textContent = "Hide";
-    revealBtn.setAttribute("data-revealed", "true");
-    revealBtn.setAttribute("aria-pressed", "true");
-    setWebhookRevealStatus(revealBtn, "Secrets revealed", false);
-    return;
-  }
-
-  var endpoint = revealBtn.getAttribute("data-secrets-endpoint");
-  if (!endpoint) return;
-
-  revealBtn.disabled = true;
-  revealBtn.textContent = "Loading...";
-  setWebhookRevealStatus(revealBtn, "Loading secrets...", false);
-
-  fetch(endpoint, {
-    method: "GET",
-    credentials: "same-origin",
-    headers: {
-      Accept: "application/json",
-    },
-  })
-    .then(function (res) {
-      if (!res.ok) {
-        throw new Error("Failed to load webhook secrets");
-      }
-      return res.json();
-    })
-    .then(function (payload) {
-      if (!payload || !payload.webhook_token || !payload.webhook_url) {
-        throw new Error("Webhook secret payload is incomplete");
-      }
-      revealBtn.setAttribute("data-token", payload.webhook_token);
-      revealBtn.setAttribute("data-url", payload.webhook_url);
-      tokenTarget.textContent = payload.webhook_token;
-      urlTarget.textContent = payload.webhook_url;
-      revealBtn.textContent = "Hide";
-      revealBtn.setAttribute("data-revealed", "true");
-      revealBtn.setAttribute("aria-pressed", "true");
-      setWebhookRevealStatus(revealBtn, "Secrets revealed", false);
-    })
-    .catch(function () {
-      revealBtn.textContent = "Reveal";
-      setWebhookRevealStatus(revealBtn, "Unable to reveal secrets", true);
-    })
-    .finally(function () {
-      revealBtn.disabled = false;
-    });
 });
 
 // -- Clickable table rows ([data-href]) -------------------------------------

--- a/crates/web-ui/src/static_assets/controllers/workflow-secrets.js
+++ b/crates/web-ui/src/static_assets/controllers/workflow-secrets.js
@@ -1,0 +1,87 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static values = {
+    endpoint: String,
+    tokenMasked: String,
+    urlMasked: String,
+  };
+
+  static targets = ["button", "token", "url", "status"];
+
+  connect() {
+    this.revealed = false;
+    this.token = null;
+    this.url = null;
+  }
+
+  toggle() {
+    if (this.revealed) {
+      this.hideSecrets();
+      return;
+    }
+
+    if (this.token && this.url) {
+      this.showSecrets(this.token, this.url);
+      return;
+    }
+
+    this.fetchSecrets();
+  }
+
+  hideSecrets() {
+    this.tokenTarget.textContent = this.tokenMaskedValue;
+    this.urlTarget.textContent = this.urlMaskedValue;
+    this.buttonTarget.textContent = "Reveal";
+    this.buttonTarget.setAttribute("aria-pressed", "false");
+    this.statusTarget.textContent = "";
+    this.statusTarget.style.color = "#8aa5d8";
+    this.revealed = false;
+  }
+
+  showSecrets(token, url) {
+    this.tokenTarget.textContent = token;
+    this.urlTarget.textContent = url;
+    this.buttonTarget.textContent = "Hide";
+    this.buttonTarget.setAttribute("aria-pressed", "true");
+    this.statusTarget.textContent = "Secrets revealed";
+    this.statusTarget.style.color = "#8aa5d8";
+    this.revealed = true;
+  }
+
+  fetchSecrets() {
+    this.buttonTarget.disabled = true;
+    this.buttonTarget.textContent = "Loading...";
+    this.statusTarget.textContent = "Loading secrets...";
+    this.statusTarget.style.color = "#8aa5d8";
+
+    fetch(this.endpointValue, {
+      method: "GET",
+      credentials: "same-origin",
+      headers: { Accept: "application/json" },
+    })
+      .then(function (res) {
+        if (!res.ok) {
+          throw new Error("failed to load workflow webhook secrets");
+        }
+        return res.json();
+      })
+      .then((payload) => {
+        if (!payload || !payload.webhook_token || !payload.webhook_url) {
+          throw new Error("workflow webhook secret payload is incomplete");
+        }
+        this.token = payload.webhook_token;
+        this.url = payload.webhook_url;
+        this.showSecrets(this.token, this.url);
+      })
+      .catch(() => {
+        this.buttonTarget.textContent = "Reveal";
+        this.buttonTarget.setAttribute("aria-pressed", "false");
+        this.statusTarget.textContent = "Unable to reveal secrets";
+        this.statusTarget.style.color = "#ff9b9b";
+      })
+      .finally(() => {
+        this.buttonTarget.disabled = false;
+      });
+  }
+}

--- a/crates/web-ui/src/static_assets/mod.rs
+++ b/crates/web-ui/src/static_assets/mod.rs
@@ -25,6 +25,8 @@ const WORKFLOW_CSS: &str = include_str!("../../templates/partials/workflow_css.h
 
 // First-party JS modules.
 const APP_JS: &str = include_str!("app.js");
+const STIMULUS_BOOT_JS: &str = include_str!("stimulus-boot.js");
+const WORKFLOW_SECRETS_CONTROLLER_JS: &str = include_str!("controllers/workflow-secrets.js");
 const CHAT_JS: &str = include_str!("chat.js");
 const TRACE_DETAIL_JS: &str = include_str!("trace-detail.js");
 const AGENT_FORM_JS: &str = include_str!("agent-form.js");
@@ -33,6 +35,7 @@ const WORKFLOW_EDITOR_JS: &str = include_str!("workflow-editor.js");
 // Vendored third-party JS (committed to repo, no CDN fetch at runtime).
 const HTMX_JS: &str = include_str!("vendor/htmx.min.js");
 const HTMX_SSE_JS: &str = include_str!("vendor/sse.js");
+const STIMULUS_JS: &str = include_str!("vendor/stimulus.js");
 
 // -- Fingerprinted asset -----------------------------------------------------
 
@@ -94,6 +97,17 @@ static SSE_ASSET: LazyLock<Asset> =
 
 static APP_JS_ASSET: LazyLock<Asset> = LazyLock::new(|| fingerprint_static("app", "js", APP_JS));
 
+static STIMULUS_BOOT_JS_ASSET: LazyLock<Asset> =
+    LazyLock::new(|| fingerprint_static("stimulus-boot", "js", STIMULUS_BOOT_JS));
+
+static WORKFLOW_SECRETS_CONTROLLER_JS_ASSET: LazyLock<Asset> = LazyLock::new(|| {
+    fingerprint_static(
+        "workflow-secrets-controller",
+        "js",
+        WORKFLOW_SECRETS_CONTROLLER_JS,
+    )
+});
+
 static CHAT_JS_ASSET: LazyLock<Asset> = LazyLock::new(|| fingerprint_static("chat", "js", CHAT_JS));
 
 static TRACE_DETAIL_JS_ASSET: LazyLock<Asset> =
@@ -104,6 +118,9 @@ static AGENT_FORM_JS_ASSET: LazyLock<Asset> =
 
 static WORKFLOW_EDITOR_JS_ASSET: LazyLock<Asset> =
     LazyLock::new(|| fingerprint_static("workflow-editor", "js", WORKFLOW_EDITOR_JS));
+
+static STIMULUS_ASSET: LazyLock<Asset> =
+    LazyLock::new(|| fingerprint_static("stimulus", "js", STIMULUS_JS));
 
 // -- Public API --------------------------------------------------------------
 
@@ -125,6 +142,21 @@ pub fn htmx_sse_url() -> &'static str {
 /// Fingerprinted URL for the app shell JS.
 pub fn app_js_url() -> &'static str {
     &APP_JS_ASSET.url
+}
+
+/// Fingerprinted URL for the vendored Stimulus runtime.
+pub fn stimulus_url() -> &'static str {
+    &STIMULUS_ASSET.url
+}
+
+/// Fingerprinted URL for Stimulus app bootstrapping.
+pub fn stimulus_boot_js_url() -> &'static str {
+    &STIMULUS_BOOT_JS_ASSET.url
+}
+
+/// Fingerprinted URL for the workflow secrets Stimulus controller.
+pub fn workflow_secrets_controller_js_url() -> &'static str {
+    &WORKFLOW_SECRETS_CONTROLLER_JS_ASSET.url
 }
 
 /// Fingerprinted URL for chat-specific JS.
@@ -187,6 +219,18 @@ async fn serve_app_js() -> Response {
     serve_js_immutable(APP_JS_ASSET.content)
 }
 
+async fn serve_stimulus_js() -> Response {
+    serve_js_immutable(STIMULUS_ASSET.content)
+}
+
+async fn serve_stimulus_boot_js() -> Response {
+    serve_js_immutable(STIMULUS_BOOT_JS_ASSET.content)
+}
+
+async fn serve_workflow_secrets_controller_js() -> Response {
+    serve_js_immutable(WORKFLOW_SECRETS_CONTROLLER_JS_ASSET.content)
+}
+
 async fn serve_chat_js() -> Response {
     serve_js_immutable(CHAT_JS_ASSET.content)
 }
@@ -227,8 +271,14 @@ pub fn static_router() -> Router {
         // Vendored JS
         .route(&HTMX_ASSET.url, get(serve_htmx))
         .route(&SSE_ASSET.url, get(serve_sse))
+        .route(&STIMULUS_ASSET.url, get(serve_stimulus_js))
         // First-party JS
         .route(&APP_JS_ASSET.url, get(serve_app_js))
+        .route(&STIMULUS_BOOT_JS_ASSET.url, get(serve_stimulus_boot_js))
+        .route(
+            &WORKFLOW_SECRETS_CONTROLLER_JS_ASSET.url,
+            get(serve_workflow_secrets_controller_js),
+        )
         .route(&CHAT_JS_ASSET.url, get(serve_chat_js))
         .route(&TRACE_DETAIL_JS_ASSET.url, get(serve_trace_detail_js))
         .route(&AGENT_FORM_JS_ASSET.url, get(serve_agent_form_js))

--- a/crates/web-ui/src/static_assets/stimulus-boot.js
+++ b/crates/web-ui/src/static_assets/stimulus-boot.js
@@ -1,0 +1,9 @@
+import { Application } from "@hotwired/stimulus";
+
+import WorkflowSecretsController from "controllers/workflow-secrets";
+
+var application = Application.start();
+
+application.register("workflow-secrets", WorkflowSecretsController);
+
+window.Stimulus = application;

--- a/crates/web-ui/templates/base.html
+++ b/crates/web-ui/templates/base.html
@@ -16,9 +16,10 @@
   <meta name="apple-mobile-web-app-title" content="Assistant">
   <link rel="apple-touch-icon" href="/pwa/icon.svg">
 
-  <script type="importmap">{"imports":{"htmx.org":"{{ self.htmx_url() }}","htmx-ext-sse":"{{ self.htmx_sse_url() }}"}}</script>
+  <script type="importmap">{"imports":{"htmx.org":"{{ self.htmx_url() }}","htmx-ext-sse":"{{ self.htmx_sse_url() }}","@hotwired/stimulus":"{{ self.stimulus_url() }}","controllers/workflow-secrets":"{{ self.workflow_secrets_controller_js_url() }}"}}</script>
   <script src="{{ self.htmx_url() }}"></script>
   <script src="{{ self.htmx_sse_url() }}"></script>
+  <script type="module" src="{{ self.stimulus_boot_js_url() }}"></script>
   <link rel="stylesheet" href="{{ self.app_css_url() }}">
   <style>{% block extra_css %}{% endblock %}</style>
 </head>

--- a/crates/web-ui/templates/workflows/detail.html
+++ b/crates/web-ui/templates/workflows/detail.html
@@ -84,33 +84,36 @@ breadcrumb %}
       <h3 style="margin-top: 1rem; margin-bottom: 0.5rem">
         Inbound Webhook Trigger
       </h3>
-      <div class="wf-card">
+      <div
+        class="wf-card"
+        data-controller="workflow-secrets"
+        data-workflow-secrets-endpoint-value="/api/workflows/{{ id }}/webhook-secrets"
+        data-workflow-secrets-token-masked-value="{{ webhook_token_masked }}"
+        data-workflow-secrets-url-masked-value="{{ webhook_url_masked }}"
+      >
         <div class="wf-k">Endpoint</div>
-        <div class="wf-v workflow-mono" id="webhookEndpointMasked">
+        <div class="wf-v workflow-mono" data-workflow-secrets-target="url">
           {{ webhook_url_masked }}
         </div>
         <div class="wf-k" style="margin-top: 0.55rem">Token</div>
-        <div class="wf-v workflow-mono" id="webhookTokenMasked">
+        <div class="wf-v workflow-mono" data-workflow-secrets-target="token">
           {{ webhook_token_masked }}
         </div>
         <button
           type="button"
           class="ghost-btn"
-          id="revealWebhookSecretsBtn"
-          data-reveal-webhook-secrets="true"
-          data-secrets-endpoint="/api/workflows/{{ id }}/webhook-secrets"
-          data-token-target="webhookTokenMasked"
-          data-url-target="webhookEndpointMasked"
-          data-token-masked="{{ webhook_token_masked }}"
-          data-url-masked="{{ webhook_url_masked }}"
-          data-status-target="webhookSecretsStatus"
-          data-revealed="false"
+          data-workflow-secrets-target="button"
+          data-action="workflow-secrets#toggle"
           aria-pressed="false"
           style="margin-top: 0.6rem"
         >
           Reveal
         </button>
-        <div id="webhookSecretsStatus" class="wf-k" aria-live="polite"></div>
+        <div
+          class="wf-k"
+          data-workflow-secrets-target="status"
+          aria-live="polite"
+        ></div>
         <div class="wf-k" style="margin-top: 0.55rem">Last Rotated</div>
         <div class="wf-v">{{ webhook_updated_at }}</div>
         <form

--- a/crates/web-ui/vendor.lock
+++ b/crates/web-ui/vendor.lock
@@ -14,6 +14,13 @@
       "file": "sse.js",
       "url": "https://unpkg.com/htmx-ext-sse@2.2.2/sse.js",
       "sha256": "83eca6fa0611fe2b0bf1700b424b88b5eced38ef448ef9760a2ea08fbc875611"
+    },
+    {
+      "name": "@hotwired/stimulus",
+      "version": "3.2.2",
+      "file": "stimulus.js",
+      "url": "https://cdn.jsdelivr.net/npm/@hotwired/stimulus@3.2.2/dist/stimulus.js",
+      "sha256": "23deecdac6f36c08e8f39fbed6b27f60c850cacad3a34eb71194462b7b1647f3"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Introduce Stimulus as a vendored frontend dependency and bootstrap it via importmap/static assets (no CDN at runtime).
- Add a feature-scoped `workflow-secrets` Stimulus controller that owns reveal/hide state, fetches secrets on demand, and updates accessibility state (`aria-pressed` + live status).
- Migrate workflow secret reveal behavior out of global `app.js` into the controller, reducing global event coupling and providing a clear pattern for future stateful interactions.

## Validation
- `make vendor`
- `make format`
- `make lint`
- `cargo test -p assistant-web-ui`