### PR TITLE
fix(binaries): add clap version flags to all clap programs

### DIFF
--- a/crates/interface-cli/src/main.rs
+++ b/crates/interface-cli/src/main.rs
@@ -35,7 +35,7 @@ use assistant_tool_executor::{install_skill_from_source, ToolExecutor};
 // ── Argument parsing ──────────────────────────────────────────────────────────
 
 #[derive(Parser)]
-#[command(name = "assistant", about = "Local AI assistant")]
+#[command(name = "assistant", about = "Local AI assistant", version)]
 struct Cli {
     /// Assistant agent context ID (e.g. "default", "work", "personal").
     #[arg(long, env = "ASSISTANT_AGENT")]

--- a/crates/web-ui/src/main.rs
+++ b/crates/web-ui/src/main.rs
@@ -61,6 +61,7 @@ use a2a::pages::AgentPagesState;
 use a2a::task_store::TaskStore;
 
 #[derive(Parser, Debug)]
+#[command(version)]
 struct Args {
     /// Address to listen on (e.g. 127.0.0.1:8080)
     #[arg(long, default_value = "127.0.0.1:8080")]


### PR DESCRIPTION
## Summary
- enable Clap's built-in version flag on the `assistant` CLI by adding `version` to the root `#[command(...)]` attribute
- enable Clap's built-in version flag on the `assistant-web-ui` binary by adding `#[command(version)]` to `Args`
- align all Clap-based binaries so `--version` works consistently (signal already had it)

## Testing
- make format
- make lint
- cargo check -p assistant-cli -p assistant-web-ui -p assistant-interface-signal
- cargo run -q -p assistant-cli -- --version
- cargo run -q -p assistant-web-ui -- --version
- cargo run -q -p assistant-interface-signal -- --version