### PR TITLE
fix(interface-slack): align websocket TLS dependency versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ dependencies = [
  "serde_json",
  "slack-morphism",
  "tokio",
- "tokio-tungstenite 0.29.0",
+ "tokio-tungstenite",
  "toml",
  "tracing",
  "url",
@@ -5928,7 +5928,7 @@ dependencies = [
  "subtle",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite 0.28.0",
+ "tokio-tungstenite",
  "tracing",
  "url",
 ]
@@ -6619,25 +6619,12 @@ checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
- "rustls-native-certs 0.8.3",
- "tokio",
- "tungstenite 0.28.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
-dependencies = [
- "futures-util",
- "log",
  "rustls",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite 0.29.0",
+ "tungstenite 0.28.0",
 ]
 
 [[package]]
@@ -6965,27 +6952,11 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.2",
- "sha1",
- "thiserror 2.0.18",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
-dependencies = [
- "bytes",
- "data-encoding",
- "http 1.4.0",
- "httparse",
- "log",
- "rand 0.9.2",
  "rustls",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
+ "utf-8",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,9 +133,9 @@ wiremock = "0.6"
 lru = "0.16"
 # Slack / Mattermost interfaces
 slack-morphism = { version = "2", features = ["hyper"] }
-# Force rustls TLS on the tokio-tungstenite transitive dep (slack-morphism only
-# enables the cert-store feature, not the actual TLS impl, causing wss:// to fail)
-tokio-tungstenite = { version = "0.29", features = ["rustls-tls-native-roots"] }
+# Force rustls TLS on the same tokio-tungstenite major/minor used by
+# slack-morphism so wss:// support is actually enabled in the Slack client.
+tokio-tungstenite = { version = "0.28", features = ["rustls-tls-native-roots"] }
 mattermost_api = "0.8"
 # Internal crates
 opentelemetry-exporter-sqlite = { path = "crates/opentelemetry-exporter-sqlite" }


### PR DESCRIPTION
## Summary
- pin workspace `tokio-tungstenite` to `0.28` so it matches `slack-morphism`'s transitive websocket stack
- keep rustls TLS enabled on that exact shared version (`rustls-tls-native-roots`)
- remove duplicate 0.29 websocket dependencies from `Cargo.lock` so the TLS feature override applies to the runtime Slack socket path

## Why
- Slack Socket Mode was running but failed every `wss://` connect with `Url(TlsFeatureNotEnabled)` because TLS features were enabled on `tokio-tungstenite 0.29`, while Slack used `0.28`

## Testing
- cargo check -p assistant-cli --all-features
- cargo tree -p assistant-interface-slack -e features | rg "tokio-tungstenite v0.29|tokio-tungstenite v0.28|rustls-native-certs|rustls-tls-native-roots"