### PR TITLE
feat(observability): add submit_turn lifecycle and correlation telemetry

### DIFF
--- a/crates/interface-slack/src/runner.rs
+++ b/crates/interface-slack/src/runner.rs
@@ -75,6 +75,8 @@ struct SlackIncomingEvent {
 /// orchestrator turn once the per-conversation lock is acquired.
 struct PendingMessage {
     text: String,
+    event_ts: SlackTs,
+    event_kind: String,
     user_id: String,
     channel_id: String,
     thread_ts: SlackTs,
@@ -960,6 +962,8 @@ async fn on_push_event(
             .or_default()
             .push(PendingMessage {
                 text: text.clone(),
+                event_ts: incoming.event_ts.clone(),
+                event_kind: event_kind.to_string(),
                 user_id: user_id.clone(),
                 channel_id: channel_id.clone(),
                 thread_ts: thread_ts.clone(),
@@ -1070,16 +1074,25 @@ async fn on_push_event(
         .register_extensions(conversation_id, extensions, all_attachments.clone())
         .await;
 
+    let batch_event_kind = {
+        let mut kinds = batch
+            .iter()
+            .map(|m| m.event_kind.as_str())
+            .collect::<std::collections::HashSet<_>>();
+        if kinds.len() == 1 {
+            kinds.drain().next().unwrap_or("message").to_string()
+        } else {
+            "mixed".to_string()
+        }
+    };
+
     let mut submit_metadata = HashMap::new();
     submit_metadata.insert("slack.channel_id".to_string(), channel_id.clone());
     submit_metadata.insert("slack.thread_ts".to_string(), thread_ts.0.clone());
-    submit_metadata.insert("slack.event_ts".to_string(), incoming.event_ts.0.clone());
+    submit_metadata.insert("slack.event_ts".to_string(), last.event_ts.0.clone());
     submit_metadata.insert("slack.message_ts".to_string(), last.msg_ts.0.clone());
     submit_metadata.insert("slack.batch_size".to_string(), batch_size.to_string());
-    submit_metadata.insert("slack.event_kind".to_string(), event_kind.to_string());
-    orchestrator
-        .register_submit_metadata(conversation_id, submit_metadata)
-        .await;
+    submit_metadata.insert("slack.event_kind".to_string(), batch_event_kind);
 
     let orchestrator_start = std::time::Instant::now();
     debug!(
@@ -1096,11 +1109,12 @@ async fn on_push_event(
         DateTime::from_timestamp(secs, nsecs)
     });
     let turn_result = orchestrator
-        .submit_turn(
+        .submit_turn_with_metadata(
             &contextualized_text,
             conversation_id,
             Interface::Slack,
             msg_ts,
+            submit_metadata,
         )
         .await;
     let elapsed_ms = orchestrator_start.elapsed().as_millis();
@@ -1921,6 +1935,8 @@ mod tests {
     fn make_pending(user: &str, channel: &str, text: &str, ts: &str) -> PendingMessage {
         PendingMessage {
             text: text.to_string(),
+            event_ts: SlackTs(ts.to_string()),
+            event_kind: "message".to_string(),
             user_id: user.to_string(),
             channel_id: channel.to_string(),
             thread_ts: SlackTs("1700000000.000000".to_string()),

--- a/crates/runtime/src/orchestrator/mod.rs
+++ b/crates/runtime/src/orchestrator/mod.rs
@@ -179,11 +179,6 @@ pub struct Orchestrator {
     /// Per-conversation extension tool registrations for interface-specific
     /// turns dispatched through the bus.  Consumed by the worker.
     pub(crate) extension_registrations: tokio::sync::RwLock<HashMap<Uuid, ExtensionRegistration>>,
-    /// Per-conversation submit metadata registered by interfaces.
-    ///
-    /// Consumed by `submit_turn` to enrich interface/bus telemetry with
-    /// interface-specific IDs (e.g. Slack event IDs, thread IDs).
-    pub(crate) submit_metadata: tokio::sync::RwLock<HashMap<Uuid, HashMap<String, String>>>,
     /// Cancellation tokens for running subagents, keyed by agent ID.
     pub(crate) agent_cancellations: tokio::sync::RwLock<HashMap<String, CancellationToken>>,
     /// OTel metric instruments for GenAI and operational metrics.
@@ -216,7 +211,6 @@ impl Orchestrator {
             trace_content: config.mirror.trace_content,
             token_sinks: tokio::sync::RwLock::new(HashMap::new()),
             extension_registrations: tokio::sync::RwLock::new(HashMap::new()),
-            submit_metadata: tokio::sync::RwLock::new(HashMap::new()),
             agent_cancellations: tokio::sync::RwLock::new(HashMap::new()),
             metrics: crate::MetricsRecorder::new(),
             agent_id: config.agent.id.clone(),

--- a/crates/runtime/src/orchestrator/tests.rs
+++ b/crates/runtime/src/orchestrator/tests.rs
@@ -1598,9 +1598,21 @@ async fn worker_propagates_submit_correlation_fields_to_turn_result() {
     };
 
     let result_msg = &results[0];
-    assert_eq!(result_msg.batch_id, Some(request_id));
-    assert_eq!(result_msg.correlation_id, Some(request_id));
-    assert_eq!(result_msg.causation_id, Some(request_msg_id));
+    assert_eq!(
+        result_msg.batch_id,
+        Some(request_id),
+        "TURN_RESULT should preserve the request batch_id"
+    );
+    assert_eq!(
+        result_msg.correlation_id,
+        Some(request_id),
+        "TURN_RESULT should preserve the request correlation_id"
+    );
+    assert_eq!(
+        result_msg.causation_id,
+        Some(request_msg_id),
+        "TURN_RESULT should set causation_id to the TURN_REQUEST message id"
+    );
 
     worker.abort();
 }

--- a/crates/runtime/src/orchestrator/worker.rs
+++ b/crates/runtime/src/orchestrator/worker.rs
@@ -53,21 +53,6 @@ impl Orchestrator {
         );
     }
 
-    /// Register interface-specific submit metadata for one turn.
-    ///
-    /// Call this before [`submit_turn`](Self::submit_turn). The metadata is
-    /// consumed by `submit_turn` and attached to interface/bus telemetry.
-    pub async fn register_submit_metadata(
-        &self,
-        conversation_id: Uuid,
-        attributes: HashMap<String, String>,
-    ) {
-        self.submit_metadata
-            .write()
-            .await
-            .insert(conversation_id, attributes);
-    }
-
     /// Record a deduplicated Slack event for observability.
     pub fn record_slack_duplicate_event(&self, event_kind: &str) {
         self.metrics
@@ -242,7 +227,7 @@ impl Orchestrator {
                             .with_causation_id(msg.id);
                             if let Some(bid) = msg.batch_id {
                                 pub_req = pub_req.with_batch_id(bid);
-                            } else {
+                            } else if msg.correlation_id.is_some() {
                                 self.metrics.record_submit_result_unmatched(
                                     &self.agent_id,
                                     &interface_name,
@@ -362,7 +347,7 @@ impl Orchestrator {
                             .with_causation_id(msg.id);
                             if let Some(bid) = msg.batch_id {
                                 pub_req = pub_req.with_batch_id(bid);
-                            } else {
+                            } else if msg.correlation_id.is_some() {
                                 self.metrics.record_submit_result_unmatched(
                                     &self.agent_id,
                                     &interface_name,
@@ -472,14 +457,28 @@ impl Orchestrator {
         interface: Interface,
         timestamp: Option<DateTime<Utc>>,
     ) -> Result<TurnResult> {
+        self.submit_turn_with_metadata(
+            prompt,
+            conversation_id,
+            interface,
+            timestamp,
+            HashMap::new(),
+        )
+        .await
+    }
+
+    /// Submit a turn through the message bus and wait for the result, enriched
+    /// with interface-provided metadata attributes.
+    pub async fn submit_turn_with_metadata(
+        &self,
+        prompt: &str,
+        conversation_id: Uuid,
+        interface: Interface,
+        timestamp: Option<DateTime<Utc>>,
+        submit_metadata: HashMap<String, String>,
+    ) -> Result<TurnResult> {
         let request_id = Uuid::new_v4();
         let interface_label = format!("{interface:?}");
-        let submit_metadata = self
-            .submit_metadata
-            .write()
-            .await
-            .remove(&conversation_id)
-            .unwrap_or_default();
         let interface_cx = crate::otel_spans::start_interface_root_context(
             &interface,
             "submit_turn",


### PR DESCRIPTION
## Summary
- propagate `submit_turn` correlation IDs (`request_id`/batch/correlation/causation) through bus request/result flows and attach them to relevant spans/logs
- add structured submit waiter lifecycle observability (`pending`, `matched`, `late_result`, `timeout`) plus counters for timeout, late result, unmatched correlation, and duplicate Slack events
- enrich Slack runner telemetry with event metadata (`channel/thread/event ts`, dedupe decisions) and include those attributes on submit telemetry
- add a runtime test to verify worker propagation of correlation fields on `turn.result`

## Validation
- `make format`
- `cargo test -p assistant-runtime submit_turn`
- `cargo test -p assistant-runtime worker_propagates_submit_correlation_fields_to_turn_result`
- `cargo test -p assistant-interface-slack runner::tests::incoming_from_message_event_produces_turn`
- `cargo clippy -p assistant-runtime -p assistant-interface-slack -- -D warnings`

## Notes
- repository has unrelated local `web-ui` working tree changes that are intentionally excluded from this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Slack event deduplication with structured detection and diagnostic logging for duplicate events.

* **Bug Fixes**
  * Strengthened message result matching validation to prevent processing errors when results don't match requests.
  * Improved late result detection with dedicated timeout and cutoff handling.

* **Chores**
  * Extended observability metrics to track submit operation timeouts, late-arriving results, result correlation mismatches, and duplicate Slack events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->