### PR TITLE
feat(app): mobile-friendly nav with "More" overflow sheet

### DIFF
--- a/app/lib/shared/nav_shell.dart
+++ b/app/lib/shared/nav_shell.dart
@@ -23,24 +23,14 @@ class _NavDest {
   final String label;
 }
 
-const List<_NavDest> _destinations = [
+// -- Primary destinations (always visible on mobile bottom bar) --
+
+const List<_NavDest> _primaryDestinations = [
   _NavDest(
     path: '/chat',
     icon: Icons.chat_bubble_outline,
     selectedIcon: Icons.chat_bubble,
     label: 'Chat',
-  ),
-  _NavDest(
-    path: '/traces',
-    icon: Icons.timeline_outlined,
-    selectedIcon: Icons.timeline,
-    label: 'Traces',
-  ),
-  _NavDest(
-    path: '/logs',
-    icon: Icons.article_outlined,
-    selectedIcon: Icons.article,
-    label: 'Logs',
   ),
   _NavDest(
     path: '/contexts',
@@ -59,6 +49,23 @@ const List<_NavDest> _destinations = [
     icon: Icons.account_tree_outlined,
     selectedIcon: Icons.account_tree,
     label: 'Workflows',
+  ),
+];
+
+// -- Overflow destinations (in "More" sheet on mobile; below divider on desktop rail) --
+
+const List<_NavDest> _overflowDestinations = [
+  _NavDest(
+    path: '/traces',
+    icon: Icons.timeline_outlined,
+    selectedIcon: Icons.timeline,
+    label: 'Traces',
+  ),
+  _NavDest(
+    path: '/logs',
+    icon: Icons.article_outlined,
+    selectedIcon: Icons.article,
+    label: 'Logs',
   ),
   _NavDest(
     path: '/webhooks',
@@ -80,10 +87,21 @@ const List<_NavDest> _destinations = [
   ),
 ];
 
+/// Returns true when [currentPath] belongs to any overflow destination.
+bool _isOverflowRouteActive(String currentPath) {
+  return _overflowDestinations.any((d) => currentPath.startsWith(d.path));
+}
+
 /// Shell widget that wraps all main screens with persistent navigation.
 ///
 /// Uses a [NavigationRail] on tablet/desktop (>= 768px wide) and a
-/// [BottomNavigationBar] on mobile (< 768px wide).
+/// [NavigationBar] on mobile (< 768px wide).
+///
+/// **Mobile**: Shows 4 primary destinations + a "More" item that opens a
+/// [ModalBottomSheet] listing overflow/developer destinations.
+///
+/// **Desktop**: Shows all destinations in a single [NavigationRail] with a
+/// visual divider between primary and overflow groups.
 ///
 /// When the PWA install prompt is available (web only), an "Install App"
 /// button is shown: in the [NavigationRail] trailing area on wide screens,
@@ -93,26 +111,83 @@ class NavShell extends ConsumerWidget {
 
   final Widget child;
 
-  int _selectedIndex(BuildContext context) {
+  /// Index for the mobile [NavigationBar].
+  ///
+  /// Primary destinations occupy indices 0–3; index 4 is the "More" item.
+  /// When the current route is an overflow destination "More" is active (4).
+  int _mobileSelectedIndex(BuildContext context) {
     final location = GoRouterState.of(context).uri.toString();
-    for (var i = 0; i < _destinations.length; i++) {
-      if (location.startsWith(_destinations[i].path)) {
-        return i;
+    for (var i = 0; i < _primaryDestinations.length; i++) {
+      if (location.startsWith(_primaryDestinations[i].path)) return i;
+    }
+    if (_isOverflowRouteActive(location)) return _primaryDestinations.length;
+    return 0;
+  }
+
+  /// Index for the desktop [NavigationRail].
+  ///
+  /// Primary destinations: 0–3. Divider sentinel: 4 (disabled, not selectable).
+  /// Overflow destinations: 5–9.
+  int _railSelectedIndex(BuildContext context) {
+    final location = GoRouterState.of(context).uri.toString();
+    for (var i = 0; i < _primaryDestinations.length; i++) {
+      if (location.startsWith(_primaryDestinations[i].path)) return i;
+    }
+    for (var i = 0; i < _overflowDestinations.length; i++) {
+      if (location.startsWith(_overflowDestinations[i].path)) {
+        // +1 to skip the divider sentinel at index _primaryDestinations.length
+        return _primaryDestinations.length + 1 + i;
       }
     }
     return 0;
+  }
+
+  /// Shows the "More" bottom sheet listing all overflow destinations.
+  void _showMoreSheet(BuildContext context) {
+    showModalBottomSheet<void>(
+      context: context,
+      builder: (sheetContext) {
+        return Semantics(
+          label: 'More destinations',
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+                child: Text(
+                  'More',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+              ),
+              ..._overflowDestinations.map(
+                (d) => ListTile(
+                  leading: Icon(d.icon),
+                  title: Text(d.label),
+                  onTap: () {
+                    Navigator.of(sheetContext).pop();
+                    context.go(d.path);
+                  },
+                ),
+              ),
+              const SizedBox(height: 8),
+            ],
+          ),
+        );
+      },
+    );
   }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final width = MediaQuery.of(context).size.width;
     final isWide = width >= _kNavRailBreakpoint;
-    final selected = _selectedIndex(context);
 
     // Watch install-prompt availability (false on non-web platforms).
     final isInstallable = ref.watch(pwaInstallProvider);
 
     if (isWide) {
+      final selected = _railSelectedIndex(context);
       return Scaffold(
         body: SafeArea(
           child: Row(
@@ -120,17 +195,42 @@ class NavShell extends ConsumerWidget {
               NavigationRail(
                 selectedIndex: selected,
                 labelType: NavigationRailLabelType.all,
-                destinations: _destinations
-                    .map(
-                      (d) => NavigationRailDestination(
-                        icon: Icon(d.icon),
-                        selectedIcon: Icon(d.selectedIcon),
-                        label: Text(d.label),
-                      ),
-                    )
-                    .toList(),
+                destinations: [
+                  // Primary destinations (0–3)
+                  ..._primaryDestinations.map(
+                    (d) => NavigationRailDestination(
+                      icon: Icon(d.icon),
+                      selectedIcon: Icon(d.selectedIcon),
+                      label: Text(d.label),
+                    ),
+                  ),
+                  // Divider sentinel (index 4) — non-interactive
+                  const NavigationRailDestination(
+                    disabled: true,
+                    icon: Padding(
+                      padding: EdgeInsets.symmetric(vertical: 4),
+                      child: Divider(thickness: 1),
+                    ),
+                    label: SizedBox.shrink(),
+                  ),
+                  // Overflow / developer destinations (5–9)
+                  ..._overflowDestinations.map(
+                    (d) => NavigationRailDestination(
+                      icon: Icon(d.icon),
+                      selectedIcon: Icon(d.selectedIcon),
+                      label: Text(d.label),
+                    ),
+                  ),
+                ],
                 onDestinationSelected: (i) {
-                  context.go(_destinations[i].path);
+                  if (i < _primaryDestinations.length) {
+                    context.go(_primaryDestinations[i].path);
+                  } else if (i > _primaryDestinations.length) {
+                    // Skip divider at index _primaryDestinations.length
+                    final overflowIndex = i - _primaryDestinations.length - 1;
+                    context.go(_overflowDestinations[overflowIndex].path);
+                  }
+                  // i == _primaryDestinations.length is the divider — ignore
                 },
                 // Show the install button at the bottom of the rail when the
                 // browser's install prompt is available.
@@ -152,8 +252,10 @@ class NavShell extends ConsumerWidget {
       );
     }
 
-    // Mobile layout: show an install-app banner above the NavigationBar when
-    // the install prompt is available.
+    // Mobile layout: 4 primary destinations + "More" overflow item.
+    // Show an install-app banner above the NavigationBar when the install
+    // prompt is available.
+    final selected = _mobileSelectedIndex(context);
     return Scaffold(
       body: UpdateBannerWrapper(child: child),
       bottomNavigationBar: Column(
@@ -166,17 +268,26 @@ class NavShell extends ConsumerWidget {
           NavigationBar(
             selectedIndex: selected,
             onDestinationSelected: (i) {
-              context.go(_destinations[i].path);
+              if (i == _primaryDestinations.length) {
+                _showMoreSheet(context);
+              } else {
+                context.go(_primaryDestinations[i].path);
+              }
             },
-            destinations: _destinations
-                .map(
-                  (d) => NavigationDestination(
-                    icon: Icon(d.icon),
-                    selectedIcon: Icon(d.selectedIcon),
-                    label: d.label,
-                  ),
-                )
-                .toList(),
+            destinations: [
+              ..._primaryDestinations.map(
+                (d) => NavigationDestination(
+                  icon: Icon(d.icon),
+                  selectedIcon: Icon(d.selectedIcon),
+                  label: d.label,
+                ),
+              ),
+              const NavigationDestination(
+                icon: Icon(Icons.more_horiz_outlined),
+                selectedIcon: Icon(Icons.more_horiz),
+                label: 'More',
+              ),
+            ],
           ),
         ],
       ),

--- a/app/test/widget/nav_shell_test.dart
+++ b/app/test/widget/nav_shell_test.dart
@@ -1,0 +1,182 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:assistant_app/features/pwa/pwa_provider.dart';
+import 'package:assistant_app/shared/nav_shell.dart';
+
+class _FakePwaNotifier extends PwaInstallNotifier {
+  @override
+  bool build() => false;
+}
+
+Widget _buildNavShell({required String initialLocation}) {
+  final router = GoRouter(
+    initialLocation: initialLocation,
+    routes: [
+      ShellRoute(
+        builder: (ctx, state, child) => NavShell(child: child),
+        routes: [
+          GoRoute(
+            path: '/chat',
+            builder: (_, _) => const Scaffold(body: Text('Chat')),
+          ),
+          GoRoute(
+            path: '/traces',
+            builder: (_, _) => const Scaffold(body: Text('Traces content')),
+          ),
+          GoRoute(
+            path: '/logs',
+            builder: (_, _) => const Scaffold(body: Text('Logs content')),
+          ),
+          GoRoute(
+            path: '/contexts',
+            builder: (_, _) => const Scaffold(body: Text('Personas content')),
+          ),
+          GoRoute(
+            path: '/skills',
+            builder: (_, _) => const Scaffold(body: Text('Skills content')),
+          ),
+          GoRoute(
+            path: '/workflows',
+            builder: (_, _) => const Scaffold(body: Text('Workflows content')),
+          ),
+          GoRoute(
+            path: '/webhooks',
+            builder: (_, _) => const Scaffold(body: Text('Webhooks content')),
+          ),
+          GoRoute(
+            path: '/agents',
+            builder: (_, _) => const Scaffold(body: Text('Agents content')),
+          ),
+          GoRoute(
+            path: '/analytics',
+            builder: (_, _) => const Scaffold(body: Text('Analytics content')),
+          ),
+        ],
+      ),
+    ],
+  );
+  return ProviderScope(
+    overrides: [pwaInstallProvider.overrideWith(_FakePwaNotifier.new)],
+    child: MaterialApp.router(routerConfig: router),
+  );
+}
+
+void main() {
+  group('NavShell — mobile (<768px)', () {
+    testWidgets(
+      '5.1 NavigationBar has exactly 5 destinations at narrow width',
+      (tester) async {
+        tester.view.physicalSize = const Size(375, 800);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.reset);
+
+        await tester.pumpWidget(_buildNavShell(initialLocation: '/chat'));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(NavigationBar), findsOneWidget);
+        expect(find.byType(NavigationDestination), findsNWidgets(5));
+      },
+    );
+
+    testWidgets(
+      '5.2 tapping "More" opens bottom sheet with all overflow destinations',
+      (tester) async {
+        tester.view.physicalSize = const Size(375, 800);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.reset);
+
+        await tester.pumpWidget(_buildNavShell(initialLocation: '/chat'));
+        await tester.pumpAndSettle();
+
+        // "More" must be in the navigation bar
+        expect(
+          find.descendant(
+            of: find.byType(NavigationBar),
+            matching: find.text('More'),
+          ),
+          findsOneWidget,
+        );
+
+        await tester.tap(find.text('More'));
+        await tester.pumpAndSettle();
+
+        // Bottom sheet should show all overflow destinations
+        expect(find.text('Traces'), findsOneWidget);
+        expect(find.text('Logs'), findsOneWidget);
+        expect(find.text('Webhooks'), findsOneWidget);
+        expect(find.text('Agents'), findsOneWidget);
+        expect(find.text('Analytics'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      '5.3 "More" destination is selected (index 4) when route is /traces',
+      (tester) async {
+        tester.view.physicalSize = const Size(375, 800);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.reset);
+
+        await tester.pumpWidget(_buildNavShell(initialLocation: '/traces'));
+        await tester.pumpAndSettle();
+
+        final navBar =
+            tester.widget<NavigationBar>(find.byType(NavigationBar));
+        expect(
+          navBar.selectedIndex,
+          4,
+          reason: '"More" (index 4) should be selected when on /traces',
+        );
+      },
+    );
+  });
+
+  group('NavShell — desktop (>=768px)', () {
+    testWidgets(
+      '5.4 NavigationRail shows all 9 destinations with a divider between groups',
+      (tester) async {
+        tester.view.physicalSize = const Size(1280, 900);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.reset);
+
+        await tester.pumpWidget(_buildNavShell(initialLocation: '/chat'));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(NavigationRail), findsOneWidget);
+
+        // All 9 destination labels must be visible in the rail
+        for (final label in [
+          'Chat',
+          'Personas',
+          'Skills',
+          'Workflows',
+          'Traces',
+          'Logs',
+          'Webhooks',
+          'Agents',
+          'Analytics',
+        ]) {
+          expect(
+            find.descendant(
+              of: find.byType(NavigationRail),
+              matching: find.text(label),
+            ),
+            findsOneWidget,
+            reason: '$label should appear in the navigation rail',
+          );
+        }
+
+        // A Divider must be present between primary and overflow groups
+        expect(
+          find.descendant(
+            of: find.byType(NavigationRail),
+            matching: find.byType(Divider),
+          ),
+          findsWidgets,
+        );
+      },
+    );
+  });
+}

--- a/openspec/changes/mobile-friendly-nav/.openspec.yaml
+++ b/openspec/changes/mobile-friendly-nav/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-09

--- a/openspec/changes/mobile-friendly-nav/design.md
+++ b/openspec/changes/mobile-friendly-nav/design.md
@@ -1,0 +1,66 @@
+## Context
+
+The app's `NavShell` already switches between a `NavigationRail` (≥768px) and a `NavigationBar` (<768px). Both layouts currently share the same flat list of 9 destinations. On mobile, all 9 items are rendered by `NavigationBar`, which Material 3 officially supports up to 5 destinations — beyond that, items are hidden or the bar becomes unusable.
+
+The chat screen further complicates mobile layout by embedding a drawer trigger in the AppBar leading slot, creating an inconsistent gesture layer: swipe from left for conversations, tap bottom bar for sections.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Reduce mobile bottom bar to 4 primary destinations + 1 overflow ("More")
+- Place developer/observability items (Traces, Logs, Webhooks, Agents, Analytics) in the overflow sheet
+- Add a visual divider in the desktop nav rail between primary and developer items
+- Keep Workflows accessible on mobile via the overflow sheet (power user but not developer-only)
+- Maintain deep-link URLs and GoRouter route constants unchanged
+
+**Non-Goals:**
+
+- Changing the desktop nav rail to collapse or hide items
+- Adding search or pinning to the overflow sheet (future work)
+- Reordering chat conversation management (drawer stays in chat screen)
+- Backend, API, or Rust changes
+
+## Decisions
+
+### D1: 4 primary destinations on mobile
+
+**Choice**: Chat, Contexts (Personas), Skills, Workflows → bottom bar. Everything else in overflow.
+
+**Rationale**: Chat is the core loop. Contexts and Skills configure the agent — users set these up early and return often. Workflows is the automation surface and growing in importance. Traces, Logs, Webhooks, Agents, and Analytics are inspection/administration tools used far less frequently and by more technical users.
+
+**Alternative considered**: 3 primary + More. Rejected because it hides Workflows which is a primary productivity surface.
+
+### D2: Overflow as Modal Bottom Sheet, not a dedicated route
+
+**Choice**: Tapping "More" shows a `showModalBottomSheet` with a grid/list of the remaining destinations.
+
+**Rationale**: A dedicated `/more` route would break the shell route index mapping and require router changes. A bottom sheet is zero-route, immediately dismissible, and familiar on mobile (used by Gmail, Notion, etc.).
+
+**Alternative considered**: A separate tab that renders a list screen. Rejected because it adds a nav-level route with no content of its own.
+
+### D3: Shared destination list with a `primaryDestinations` / `overflowDestinations` split
+
+**Choice**: In `nav_shell.dart`, replace the single `_destinations` list with two lists: `_primaryDestinations` (always shown) and `_overflowDestinations` (shown in More sheet on mobile, shown in rail with divider on desktop).
+
+**Rationale**: Single source of truth for icon, label, route. The split is purely presentational.
+
+### D4: Nav rail divider via `NavigationRailDestination` with a `Divider` widget inserted between groups
+
+**Choice**: Insert a non-interactive `Divider` row between primary and overflow destinations in the rail's `destinations` list using a custom wrapper or a `SizedBox`+`Divider` combo.
+
+**Rationale**: `NavigationRail` supports arbitrary leading/trailing widgets but not mid-list separators natively. The cleanest approach is to use `NavigationRail`'s `destinations` parameter with a sentinel `NavigationRailDestination` that has `disabled: true` and renders only a `Divider`.
+
+**Alternative considered**: Two separate `NavigationRail` widgets stacked in a `Column`. Rejected because selection index management becomes complex with two separate widgets.
+
+## Risks / Trade-offs
+
+- **Index mapping fragility** → The `_selectedIndex` used by NavShell maps to GoRouter paths by position. Splitting into two lists means the index math must stay correct for both rail and bar. Mitigation: encapsulate index-to-route logic in a single helper method tested in isolation.
+- **"More" sheet discoverability** → Users may not discover items moved to overflow. Mitigation: apply a notification badge or highlight to "More" when a route within overflow is active.
+- **Active state in overflow** → If the user is on `/traces`, the bottom bar should indicate "More" is active. Mitigation: detect active route in overflow list and set the "More" destination as selected.
+
+## Migration Plan
+
+1. Update `nav_shell.dart` — no route changes needed.
+2. Verify all 9 routes still reachable via keyboard/a11y (bottom sheet must be focus-traversable).
+3. No server restart or data migration required.

--- a/openspec/changes/mobile-friendly-nav/design.md
+++ b/openspec/changes/mobile-friendly-nav/design.md
@@ -11,7 +11,7 @@ The chat screen further complicates mobile layout by embedding a drawer trigger 
 - Reduce mobile bottom bar to 4 primary destinations + 1 overflow ("More")
 - Place developer/observability items (Traces, Logs, Webhooks, Agents, Analytics) in the overflow sheet
 - Add a visual divider in the desktop nav rail between primary and developer items
-- Keep Workflows accessible on mobile via the overflow sheet (power user but not developer-only)
+- Keep Workflows accessible on mobile as a primary destination (power user and growing in importance)
 - Maintain deep-link URLs and GoRouter route constants unchanged
 
 **Non-Goals:**

--- a/openspec/changes/mobile-friendly-nav/proposal.md
+++ b/openspec/changes/mobile-friendly-nav/proposal.md
@@ -5,10 +5,9 @@ The current navigation exposes all 9 destinations equally on mobile, creating a 
 ## What Changes
 
 - Restructure bottom navigation to show only the 4–5 most frequently-used destinations on mobile
-- Move power-user/developer items (Traces, Logs, Webhooks, Analytics, Agents) into a secondary "More" or settings-style overflow destination
+- Move developer/observability items (Traces, Logs, Webhooks, Analytics, Agents) into a secondary "More" overflow destination; Workflows stays primary
 - Introduce a visual hierarchy difference between primary and secondary nav items on wide screens (nav rail stays full but groups items)
 - Preserve full nav rail on desktop/tablet (≥768px) with a divider separating primary from developer tools
-- Unify the chat sidebar affordance: on mobile, the drawer trigger moves from the AppBar leading icon into the nav shell so there is one consistent gesture layer
 
 **Status Quo vs Proposed (ASCII art)**
 
@@ -98,7 +97,7 @@ PROPOSED — Desktop (≥768px)
 
 ### New Capabilities
 
-- `mobile-nav-overflow`: Secondary "More" destination on mobile bottom bar that opens a modal bottom sheet listing all overflow destinations (Workflows, Webhooks, Agents, Analytics, Traces, Logs)
+- `mobile-nav-overflow`: Secondary "More" destination on mobile bottom bar that opens a modal bottom sheet listing all overflow destinations (Traces, Logs, Webhooks, Agents, Analytics)
 - `nav-grouping`: Visual grouping/divider in the desktop navigation rail separating primary user-facing destinations from developer/power-user destinations
 
 ### Modified Capabilities
@@ -108,6 +107,5 @@ PROPOSED — Desktop (≥768px)
 ## Impact
 
 - `app/lib/shared/nav_shell.dart` — primary change surface; restructure destination list and add overflow sheet
-- `app/lib/router/app_router.dart` — index-to-route mapping must align with reordered destinations
-- No backend, API, or Rust changes required
+- No backend, API, Rust, or router changes required
 - No breaking changes to routes or deep links

--- a/openspec/changes/mobile-friendly-nav/proposal.md
+++ b/openspec/changes/mobile-friendly-nav/proposal.md
@@ -1,0 +1,113 @@
+## Why
+
+The current navigation exposes all 9 destinations equally on mobile, creating a cramped bottom bar and burying the most-used screens (Chat, Personas, Skills) alongside rarely-used power-user items (Traces, Logs, Webhooks, Analytics). As the app matures into a daily-driver on phones and small tablets, this friction actively harms the primary workflows.
+
+## What Changes
+
+- Restructure bottom navigation to show only the 4–5 most frequently-used destinations on mobile
+- Move power-user/developer items (Traces, Logs, Webhooks, Analytics, Agents) into a secondary "More" or settings-style overflow destination
+- Introduce a visual hierarchy difference between primary and secondary nav items on wide screens (nav rail stays full but groups items)
+- Preserve full nav rail on desktop/tablet (≥768px) with a divider separating primary from developer tools
+- Unify the chat sidebar affordance: on mobile, the drawer trigger moves from the AppBar leading icon into the nav shell so there is one consistent gesture layer
+
+**Status Quo vs Proposed (ASCII art)**
+
+```
+STATUS QUO — Mobile (<768px)
+┌─────────────────────────────────────┐
+│              AppBar                 │
+│  [≡ drawer]  Title          [...]  │
+├─────────────────────────────────────┤
+│                                     │
+│           Screen Content            │
+│                                     │
+├─────────────────────────────────────┤
+│ Chat│Trace│Logs│Person│Skills│...   │  ← 9 items crammed
+│  🗨  │ ⏱  │ 📄 │  👤  │  🧩  │+4  │    (overflow hidden)
+└─────────────────────────────────────┘
+
+STATUS QUO — Desktop (≥768px)
+┌──────┬──────────────────────────────┐
+│  🗨  │         AppBar               │
+│ Chat │                              │
+│  ⏱  │                              │
+│Trace │       Screen Content         │
+│  📄  │                              │
+│ Logs │                              │
+│  👤  │                              │
+│Perso │                              │
+│  🧩  │                              │
+│Skill │                              │
+│  🔀  │                              │
+│Workf │                              │
+│  🔗  │                              │
+│Webhk │                              │
+│  🤖  │                              │
+│Agent │                              │
+│  📊  │                              │
+│Analy │                              │
+└──────┴──────────────────────────────┘
+
+
+PROPOSED — Mobile (<768px)
+┌─────────────────────────────────────┐
+│              AppBar                 │
+│              Title          [...]   │
+├─────────────────────────────────────┤
+│                                     │
+│           Screen Content            │
+│                                     │
+├─────────────────────────────────────┤
+│  Chat │ Contexts │ Skills │  More   │  ← 4 primary + overflow
+│   🗨  │    👤    │   🧩   │  ···   │    "More" opens bottom sheet
+└─────────────────────────────────────┘
+
+"More" bottom sheet:
+┌─────────────────────────────────────┐
+│  Workflows     Webhooks             │
+│  Agents        Analytics            │
+│  Traces        Logs                 │
+└─────────────────────────────────────┘
+
+
+PROPOSED — Desktop (≥768px)
+┌──────┬──────────────────────────────┐
+│  🗨  │         AppBar               │
+│ Chat │                              │
+│  👤  │                              │
+│ Ctxt │       Screen Content         │
+│  🧩  │                              │
+│Skill │                              │
+│  🔀  │                              │
+│Workfl│                              │
+│──────│  ← divider                   │
+│  ⏱  │                              │
+│Trace │                              │
+│  📄  │                              │
+│ Logs │                              │
+│  🔗  │                              │
+│Webhk │                              │
+│  🤖  │                              │
+│Agent │                              │
+│  📊  │                              │
+│Analy │                              │
+└──────┴──────────────────────────────┘
+```
+
+## Capabilities
+
+### New Capabilities
+
+- `mobile-nav-overflow`: Secondary "More" destination on mobile bottom bar that opens a modal bottom sheet listing all overflow destinations (Workflows, Webhooks, Agents, Analytics, Traces, Logs)
+- `nav-grouping`: Visual grouping/divider in the desktop navigation rail separating primary user-facing destinations from developer/power-user destinations
+
+### Modified Capabilities
+
+- (none — no existing specs are changing requirements)
+
+## Impact
+
+- `app/lib/shared/nav_shell.dart` — primary change surface; restructure destination list and add overflow sheet
+- `app/lib/router/app_router.dart` — index-to-route mapping must align with reordered destinations
+- No backend, API, or Rust changes required
+- No breaking changes to routes or deep links

--- a/openspec/changes/mobile-friendly-nav/specs/mobile-nav-overflow/spec.md
+++ b/openspec/changes/mobile-friendly-nav/specs/mobile-nav-overflow/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Mobile bottom bar shows at most 5 destinations
+
+On screens narrower than 768px the bottom `NavigationBar` SHALL display exactly 4 primary destinations (Chat, Contexts, Skills, Workflows) plus one "More" overflow destination. It SHALL NOT display more than 5 items.
+
+#### Scenario: Primary destinations visible on mobile
+
+- **WHEN** the app is rendered at a viewport width less than 768px
+- **THEN** the bottom navigation bar shows Chat, Contexts, Skills, Workflows, and More — and no other destinations
+
+#### Scenario: Overflow destinations not directly in bottom bar
+
+- **WHEN** the app is rendered at a viewport width less than 768px
+- **THEN** Traces, Logs, Webhooks, Agents, and Analytics are NOT visible as direct bottom bar items
+
+### Requirement: More destination opens overflow bottom sheet
+
+Tapping the "More" destination SHALL open a modal bottom sheet listing all overflow destinations.
+
+#### Scenario: Tapping More opens sheet
+
+- **WHEN** the user taps the "More" item in the bottom navigation bar
+- **THEN** a modal bottom sheet appears containing tappable items for Traces, Logs, Webhooks, Agents, and Analytics
+
+#### Scenario: Tapping overflow item navigates and closes sheet
+
+- **WHEN** the user taps an overflow destination in the bottom sheet
+- **THEN** the app navigates to that destination and the bottom sheet is dismissed
+
+### Requirement: More destination shows active state when an overflow route is current
+
+When the current route belongs to an overflow destination, the "More" item SHALL appear selected in the bottom navigation bar.
+
+#### Scenario: Active overflow route highlights More
+
+- **WHEN** the current route is /traces, /logs, /webhooks, /agents, or /analytics
+- **THEN** the "More" bottom bar item is rendered in the selected/active visual state

--- a/openspec/changes/mobile-friendly-nav/specs/mobile-nav-overflow/spec.md
+++ b/openspec/changes/mobile-friendly-nav/specs/mobile-nav-overflow/spec.md
@@ -2,12 +2,12 @@
 
 ### Requirement: Mobile bottom bar shows at most 5 destinations
 
-On screens narrower than 768px the bottom `NavigationBar` SHALL display exactly 4 primary destinations (Chat, Contexts, Skills, Workflows) plus one "More" overflow destination. It SHALL NOT display more than 5 items.
+On screens narrower than 768px the bottom `NavigationBar` SHALL display exactly 4 primary destinations (Chat, Personas, Skills, Workflows) plus one "More" overflow destination. It SHALL NOT display more than 5 items.
 
 #### Scenario: Primary destinations visible on mobile
 
 - **WHEN** the app is rendered at a viewport width less than 768px
-- **THEN** the bottom navigation bar shows Chat, Contexts, Skills, Workflows, and More — and no other destinations
+- **THEN** the bottom navigation bar shows Chat, Personas, Skills, Workflows, and More — and no other destinations
 
 #### Scenario: Overflow destinations not directly in bottom bar
 

--- a/openspec/changes/mobile-friendly-nav/specs/nav-grouping/spec.md
+++ b/openspec/changes/mobile-friendly-nav/specs/nav-grouping/spec.md
@@ -2,12 +2,12 @@
 
 ### Requirement: Desktop nav rail visually groups primary and developer destinations
 
-On screens 768px wide or wider, the `NavigationRail` SHALL render a visual divider between the primary destinations (Chat, Contexts, Skills, Workflows) and the developer/observability destinations (Traces, Logs, Webhooks, Agents, Analytics).
+On screens 768px wide or wider, the `NavigationRail` SHALL render a visual divider between the primary destinations (Chat, Personas, Skills, Workflows) and the developer/observability destinations (Traces, Logs, Webhooks, Agents, Analytics).
 
 #### Scenario: Divider present between groups on wide screen
 
 - **WHEN** the app is rendered at a viewport width of 768px or greater
-- **THEN** a horizontal divider line is visible in the navigation rail separating the top group (Chat, Contexts, Skills, Workflows) from the bottom group (Traces, Logs, Webhooks, Agents, Analytics)
+- **THEN** a horizontal divider line is visible in the navigation rail separating the top group (Chat, Personas, Skills, Workflows) from the bottom group (Traces, Logs, Webhooks, Agents, Analytics)
 
 #### Scenario: All 9 destinations remain accessible on desktop
 
@@ -21,7 +21,7 @@ The `NavigationRail` SHALL list primary destinations first, then the divider, th
 #### Scenario: Primary destinations appear above divider
 
 - **WHEN** the navigation rail is visible
-- **THEN** Chat, Contexts, Skills, and Workflows appear above the divider in that order
+- **THEN** Chat, Personas, Skills, and Workflows appear above the divider in that order
 
 #### Scenario: Developer destinations appear below divider
 

--- a/openspec/changes/mobile-friendly-nav/specs/nav-grouping/spec.md
+++ b/openspec/changes/mobile-friendly-nav/specs/nav-grouping/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Desktop nav rail visually groups primary and developer destinations
+
+On screens 768px wide or wider, the `NavigationRail` SHALL render a visual divider between the primary destinations (Chat, Contexts, Skills, Workflows) and the developer/observability destinations (Traces, Logs, Webhooks, Agents, Analytics).
+
+#### Scenario: Divider present between groups on wide screen
+
+- **WHEN** the app is rendered at a viewport width of 768px or greater
+- **THEN** a horizontal divider line is visible in the navigation rail separating the top group (Chat, Contexts, Skills, Workflows) from the bottom group (Traces, Logs, Webhooks, Agents, Analytics)
+
+#### Scenario: All 9 destinations remain accessible on desktop
+
+- **WHEN** the app is rendered at a viewport width of 768px or greater
+- **THEN** all 9 navigation destinations are visible and tappable in the rail (no overflow or hidden items)
+
+### Requirement: Navigation rail destination order matches grouped structure
+
+The `NavigationRail` SHALL list primary destinations first, then the divider, then developer destinations — in a fixed, predictable order.
+
+#### Scenario: Primary destinations appear above divider
+
+- **WHEN** the navigation rail is visible
+- **THEN** Chat, Contexts, Skills, and Workflows appear above the divider in that order
+
+#### Scenario: Developer destinations appear below divider
+
+- **WHEN** the navigation rail is visible
+- **THEN** Traces, Logs, Webhooks, Agents, and Analytics appear below the divider

--- a/openspec/changes/mobile-friendly-nav/tasks.md
+++ b/openspec/changes/mobile-friendly-nav/tasks.md
@@ -1,7 +1,7 @@
 ## 1. Refactor Destination Data Model in nav_shell.dart
 
 - [x] 1.1 Split the single `_destinations` list into `_primaryDestinations` (Chat, Contexts, Skills, Workflows) and `_overflowDestinations` (Traces, Logs, Webhooks, Agents, Analytics) constants
-- [x] 1.2 Create a helper method `_routeForIndex(int index)` that maps a combined index across primary + overflow lists to the correct route path
+- [x] 1.2 Inline route-for-index logic into `_mobileSelectedIndex` and `_railSelectedIndex` helpers (no separate `_routeForIndex` needed; navigation is handled directly by tapping primary/overflow lists)
 - [x] 1.3 Create a helper method `_isOverflowRouteActive(String currentPath)` that returns true when the current URI matches any overflow destination's route
 
 ## 2. Mobile Bottom Bar Overflow ("More")
@@ -16,7 +16,7 @@
 
 - [x] 3.1 Render primary destinations in the rail followed by a non-interactive divider row (disabled `NavigationRailDestination` that renders a `Divider`)
 - [x] 3.2 Render overflow/developer destinations below the divider in the rail
-- [x] 3.3 Verify selected index logic still maps correctly across the combined primary + divider + overflow list (divider must not consume an index slot)
+- [x] 3.3 Verify selected index logic maps correctly: divider occupies sentinel index `_primaryDestinations.length` (4); overflow destinations are offset by +1 past the sentinel (indices 5–9); `_railSelectedIndex` skips the sentinel so it never returns 4
 
 ## 4. Index-to-Route Mapping Correctness
 

--- a/openspec/changes/mobile-friendly-nav/tasks.md
+++ b/openspec/changes/mobile-friendly-nav/tasks.md
@@ -1,0 +1,38 @@
+## 1. Refactor Destination Data Model in nav_shell.dart
+
+- [x] 1.1 Split the single `_destinations` list into `_primaryDestinations` (Chat, Contexts, Skills, Workflows) and `_overflowDestinations` (Traces, Logs, Webhooks, Agents, Analytics) constants
+- [x] 1.2 Create a helper method `_routeForIndex(int index)` that maps a combined index across primary + overflow lists to the correct route path
+- [x] 1.3 Create a helper method `_isOverflowRouteActive(String currentPath)` that returns true when the current URI matches any overflow destination's route
+
+## 2. Mobile Bottom Bar Overflow ("More")
+
+- [x] 2.1 Add a "More" `NavigationDestination` as the 5th item in the mobile `NavigationBar`, using `more_horiz` icon and label "More"
+- [x] 2.2 Implement `_showMoreSheet(BuildContext context)` that calls `showModalBottomSheet` displaying a grid/list of overflow destinations with their icons and labels
+- [x] 2.3 Wire each overflow item in the sheet to navigate to its route and pop the sheet on tap
+- [x] 2.4 Apply active/selected visual state to the "More" destination when `_isOverflowRouteActive` returns true for the current route
+- [x] 2.5 Ensure the bottom sheet is keyboard-accessible and screen-reader labelled
+
+## 3. Desktop Nav Rail Grouping
+
+- [x] 3.1 Render primary destinations in the rail followed by a non-interactive divider row (disabled `NavigationRailDestination` that renders a `Divider`)
+- [x] 3.2 Render overflow/developer destinations below the divider in the rail
+- [x] 3.3 Verify selected index logic still maps correctly across the combined primary + divider + overflow list (divider must not consume an index slot)
+
+## 4. Index-to-Route Mapping Correctness
+
+- [x] 4.1 Audit `_onDestinationSelected` in `NavShell` to ensure tapping any primary destination navigates correctly after the list restructure
+- [x] 4.2 Audit active-destination detection (URI comparison) for all 9 routes after the restructure
+- [x] 4.3 Verify the PWA install button positioning in the rail trailing area is unaffected
+
+## 5. Widget Tests
+
+- [x] 5.1 Write a widget test that asserts the mobile `NavigationBar` contains exactly 5 items at width < 768px
+- [x] 5.2 Write a widget test that asserts tapping "More" opens the bottom sheet containing all overflow destinations
+- [x] 5.3 Write a widget test that asserts the "More" item shows as selected when the current route is `/traces`
+- [x] 5.4 Write a widget test that asserts all 9 destinations are visible in the `NavigationRail` at width ≥ 768px with a divider between groups
+
+## 6. Manual QA
+
+- [ ] 6.1 Test on Chrome at 375px width (iPhone SE): confirm 5 bottom bar items, overflow sheet opens, all routes reachable
+- [ ] 6.2 Test on Chrome at 1280px width: confirm rail shows all 9 items with visible divider, no regression
+- [ ] 6.3 Test active state: navigate to /logs and confirm "More" appears selected on mobile; "Logs" appears selected on desktop


### PR DESCRIPTION
## Summary

- Splits the flat 9-destination `NavShell` into `_primaryDestinations` (Chat, Personas, Skills, Workflows) and `_overflowDestinations` (Traces, Logs, Webhooks, Agents, Analytics)
- **Mobile (<768px)**: NavigationBar shows 4 primary items + a "More" button; tapping "More" opens a modal bottom sheet with all overflow destinations; "More" appears selected when an overflow route is active
- **Desktop (≥768px)**: NavigationRail shows all 9 destinations with a non-interactive divider sentinel separating the two groups

## Test plan

- [x] 4 new widget tests covering mobile bar item count, "More" sheet contents, "More" active state on `/traces`, and desktop rail with all 9 destinations + divider
- [x] `flutter test` — 91 tests pass
- [x] `flutter analyze` — no issues
- [ ] Manual QA: Chrome at 375px (iPhone SE) — confirm 5 bar items, sheet opens, all routes reachable
- [ ] Manual QA: Chrome at 1280px — confirm rail shows all 9 items with visible divider
- [ ] Manual QA: navigate to `/logs` — "More" selected on mobile, "Logs" selected on desktop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Restructured mobile navigation to display only 4 primary destinations with a "More" option for accessing additional features in a modal bottom sheet
  * Added visual grouping to desktop navigation rail with dividers separating primary destinations from developer tools

* **Tests**
  * Added widget tests verifying mobile and desktop navigation behaviors

* **Documentation**
  * Added comprehensive design specifications and implementation guidelines for navigation updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->