### PR TITLE
ci: pre-build Flutter web once and share as artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,35 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  build-flutter-web:
+    name: Build Flutter web
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Flutter SDK
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.x"
+          channel: stable
+          cache: true
+
+      - name: Install Flutter dependencies
+        run: flutter pub get
+        working-directory: app
+
+      - name: Build Flutter web
+        run: flutter build web --release
+        working-directory: app
+
+      - name: Upload Flutter web artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: flutter-web-build
+          path: app/build/web/
+          retention-days: 1
+
   check:
     name: Check
     if: github.event.action != 'closed'
@@ -129,6 +158,7 @@ jobs:
     name: Visual Regression
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
+    needs: [build-flutter-web]
     continue-on-error: true
     permissions:
       contents: write
@@ -142,16 +172,11 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get update -y && sudo apt-get install -y protobuf-compiler ffmpeg
 
-      - name: Install Flutter SDK
-        uses: subosito/flutter-action@v2
+      - name: Download Flutter web build
+        uses: actions/download-artifact@v8
         with:
-          flutter-version: "3.x"
-          channel: stable
-          cache: true
-
-      - name: Install Flutter dependencies
-        working-directory: app
-        run: flutter pub get
+          name: flutter-web-build
+          path: app/build/web/
 
       - name: Cache cargo
         uses: actions/cache@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', 'app/pubspec.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Build unified assistant binary (embeds Flutter web)

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,10 +25,40 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+  build-flutter-web:
+    name: Build Flutter web
+    runs-on: ubuntu-latest
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Flutter SDK
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.x"
+          channel: stable
+          cache: true
+
+      - name: Install Flutter dependencies
+        run: flutter pub get
+        working-directory: app
+
+      - name: Build Flutter web
+        run: flutter build web --release
+        working-directory: app
+
+      - name: Upload Flutter web artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: flutter-web-build
+          path: app/build/web/
+          retention-days: 1
+
   build-binaries:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
-    needs: release-please
+    needs: [release-please, build-flutter-web]
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     strategy:
       fail-fast: false
@@ -58,16 +88,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install Flutter SDK
-        uses: subosito/flutter-action@v2
+      - name: Download Flutter web build
+        uses: actions/download-artifact@v8
         with:
-          flutter-version: "3.x"
-          channel: stable
-          cache: true
-
-      - name: Install Flutter dependencies
-        run: flutter pub get
-        working-directory: app
+          name: flutter-web-build
+          path: app/build/web/
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -82,7 +107,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock', 'app/pubspec.lock') }}
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-${{ matrix.target }}-cargo-
 
       - name: Install protoc (Linux)
@@ -96,10 +121,6 @@ jobs:
       - name: Install cross
         if: matrix.use_cross
         run: cargo install cross --git https://github.com/cross-rs/cross
-
-      - name: Pre-build Flutter web
-        run: flutter build web --release
-        working-directory: app
 
       - name: Preflight check assistant-cli bin
         if: matrix.target == 'x86_64-unknown-linux-gnu'


### PR DESCRIPTION
## Summary

- Adds a dedicated `build-flutter-web` job to both `ci.yml` and `release-please.yml` that builds the Flutter web app once on `ubuntu-latest` (x86_64) and uploads it as a GitHub Actions artifact
- `build-binaries` (release) and `visual-regression` (CI) download the artifact instead of installing Flutter themselves
- Fixes the `aarch64-unknown-linux-gnu` release build failure caused by `subosito/flutter-action` being unable to resolve `flutter-version: 3.x` on arm64 Linux runners ([upstream issue subosito/flutter-action#345](https://github.com/subosito/flutter-action/issues/345), blocked by [flutter/flutter#164431](https://github.com/flutter/flutter/issues/164431))

`build.rs` already handles this path: when Flutter is not installed but `app/build/web/index.html` exists, it reuses the pre-built output silently. No changes to Rust code needed.

`build-flutter-desktop` is unchanged — it still needs Flutter installed locally to run `flutter build macos`.

## Test plan

- [ ] Verify `build-flutter-web` job succeeds and uploads artifact
- [ ] Verify `build-binaries` matrix (including `aarch64-unknown-linux-gnu`) completes without Flutter installed
- [ ] Verify `visual-regression` job in CI still produces a working binary with embedded Flutter web UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD pipeline architecture for faster and more efficient build execution.
  * Enhanced artifact caching and reuse across build jobs to streamline release workflows.
  * Improved dependency cache management for more reliable and faster deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->