### PR TITLE
feat(app): replace flutter_markdown with flutter_markdown_plus

### DIFF
--- a/app/lib/features/chat/chat_screen.dart
+++ b/app/lib/features/chat/chat_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -237,14 +237,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
-  flutter_markdown:
+  flutter_markdown_plus:
     dependency: "direct main"
     description:
-      name: flutter_markdown
-      sha256: "08fb8315236099ff8e90cb87bb2b935e0a724a3af1623000a9cec930468e0f27"
+      name: flutter_markdown_plus
+      sha256: "039177906850278e8fb1cd364115ee0a46281135932fa8ecea8455522166d2de"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7+1"
+    version: "1.0.7"
   flutter_riverpod:
     dependency: "direct main"
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -23,12 +23,12 @@ dependencies:
   path_provider: ^2.1.5
   url_launcher: ^6.3.2
   package_info_plus: ^9.0.1
-  built_value: '>=8.4.0 <9.0.0'
+  built_value: ">=8.4.0 <9.0.0"
   assistant_api:
     path: packages/assistant_api
   tray_manager: ^0.2.3
   window_manager: ^0.4.3
-  flutter_markdown: ^0.7.6
+  flutter_markdown_plus: ^1.0.0
   pwa_install: 0.0.6
   pwa_update_listener: ^0.1.0
   flutter_local_notifications: ^21.0.0


### PR DESCRIPTION
## Summary
- Replaces `flutter_markdown ^0.7.6` with `flutter_markdown_plus ^1.0.0` in `pubspec.yaml`
- Updates the import in `chat_screen.dart` from `flutter_markdown` to `flutter_markdown_plus`
- Runs `flutter pub get` to update `pubspec.lock`

## Test plan
- [ ] `flutter analyze` passes (no issues)
- [ ] Chat screen renders markdown correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependencies**
  * Updated markdown rendering library for improved chat message display.

* **Chores**
  * Optimized CI/CD build pipeline with artifact caching for faster deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->