### PR TITLE
fix(app): resolve macOS keychain -34018 error with proper signing setup

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -48,6 +48,7 @@ jobs:
           cache: true
 
       - name: Import certificates
+        if: ${{ secrets.APPLE_DEV_CERTIFICATE != '' }}
         env:
           APPLE_DEV_CERTIFICATE: ${{ secrets.APPLE_DEV_CERTIFICATE }}
         run: |

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -38,6 +38,8 @@ jobs:
   build-macos-bundle:
     name: Build macOS Bundle
     runs-on: macos-latest
+    env:
+      APPLE_DEV_CERTIFICATE: ${{ secrets.APPLE_DEV_CERTIFICATE }}
     steps:
       - uses: actions/checkout@v6
 
@@ -48,9 +50,7 @@ jobs:
           cache: true
 
       - name: Import certificates
-        if: ${{ secrets.APPLE_DEV_CERTIFICATE != '' }}
-        env:
-          APPLE_DEV_CERTIFICATE: ${{ secrets.APPLE_DEV_CERTIFICATE }}
+        if: ${{ env.APPLE_DEV_CERTIFICATE != '' }}
         run: |
           KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
           KEYCHAIN_PASSWORD=$(openssl rand -base64 20)

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -47,6 +47,21 @@ jobs:
           channel: stable
           cache: true
 
+      - name: Import certificates
+        env:
+          APPLE_DEV_CERTIFICATE: ${{ secrets.APPLE_DEV_CERTIFICATE }}
+        run: |
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          KEYCHAIN_PASSWORD=$(openssl rand -base64 20)
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          echo -n "$APPLE_DEV_CERTIFICATE" | base64 --decode -o $RUNNER_TEMP/dev-certificate.p12
+          security import "$RUNNER_TEMP/dev-certificate.p12" -P "" \
+            -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychain -d user -s "$KEYCHAIN_PATH"
+
       - name: Install Rust target
         run: rustup target add aarch64-apple-darwin
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -219,6 +219,29 @@ jobs:
           key: ${{ runner.os }}-macos-bundle-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-macos-bundle-cargo-
 
+      - name: Import certificates
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_DEV_CERTIFICATE: ${{ secrets.APPLE_DEV_CERTIFICATE }}
+        run: |
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          KEYCHAIN_PASSWORD=$(openssl rand -base64 20)
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          # Developer ID Application cert (for codesign + notarization)
+          echo -n "$APPLE_CERTIFICATE" | base64 --decode -o $RUNNER_TEMP/certificate.p12
+          security import "$RUNNER_TEMP/certificate.p12" -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          # Apple Development cert (required by flutter build macos with keychain-access-groups)
+          echo -n "$APPLE_DEV_CERTIFICATE" | base64 --decode -o $RUNNER_TEMP/dev-certificate.p12
+          security import "$RUNNER_TEMP/dev-certificate.p12" -P "" \
+            -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychain -d user -s "$KEYCHAIN_PATH"
+          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> $GITHUB_ENV
+
       - name: Build universal Rust binary for macOS bundle
         run: make build-macos-binary
 
@@ -228,23 +251,6 @@ jobs:
           VERSION="${TAG#v}"
           flutter build macos --release --build-name "${VERSION}"
         working-directory: app
-
-      - name: Import Developer ID certificate
-        env:
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-        run: |
-          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
-          KEYCHAIN_PASSWORD=$(openssl rand -base64 20)
-          echo -n "$APPLE_CERTIFICATE" | base64 --decode -o $RUNNER_TEMP/certificate.p12
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security import "$RUNNER_TEMP/certificate.p12" -P "$APPLE_CERTIFICATE_PASSWORD" \
-            -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
-          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security list-keychain -d user -s "$KEYCHAIN_PATH"
-          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> $GITHUB_ENV
 
       - name: Sign macOS app
         run: |

--- a/app/macos/Runner.xcodeproj/project.pbxproj
+++ b/app/macos/Runner.xcodeproj/project.pbxproj
@@ -592,8 +592,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = WPW3QSLZ2F;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -724,8 +726,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = WPW3QSLZ2F;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -744,8 +748,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Release.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = WPW3QSLZ2F;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/app/macos/Runner/Configs/AppInfo.xcconfig
+++ b/app/macos/Runner/Configs/AppInfo.xcconfig
@@ -12,3 +12,6 @@ PRODUCT_BUNDLE_IDENTIFIER = com.example.assistantApp
 
 // The copyright displayed in application information
 PRODUCT_COPYRIGHT = Copyright © 2026 com.example. All rights reserved.
+
+// Apple Developer Team ID — required for Keychain entitlements (flutter_secure_storage)
+DEVELOPMENT_TEAM = WPW3QSLZ2F

--- a/app/macos/Runner/DebugProfile.entitlements
+++ b/app/macos/Runner/DebugProfile.entitlements
@@ -12,5 +12,9 @@
 	<true/>
 	<key>com.apple.security.inherit</key>
 	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)$(CFBundleIdentifier)</string>
+	</array>
 </dict>
 </plist>

--- a/app/macos/Runner/Release.entitlements
+++ b/app/macos/Runner/Release.entitlements
@@ -10,5 +10,9 @@
 	<true/>
 	<key>com.apple.security.inherit</key>
 	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)$(CFBundleIdentifier)</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

- Add `keychain-access-groups` entitlement to `DebugProfile.entitlements` and `Release.entitlements` — required by `flutter_secure_storage` on macOS to access the Keychain without getting `-34018` (`errSecMissingEntitlement`)
- Set `DEVELOPMENT_TEAM = WPW3QSLZ2F` and `CODE_SIGN_IDENTITY = "Apple Development"` in the three Runner target build configs so Xcode accepts the restricted entitlement during build
- Store `DEVELOPMENT_TEAM` in `AppInfo.xcconfig` so it persists across `flutter clean`
- Import the Apple Development cert (`APPLE_DEV_CERTIFICATE` secret) in CI before `flutter build macos` in both `flutter.yml` and `release-please.yml`

## Test plan

- [ ] `flutter build macos` succeeds locally
- [ ] `flutter.yml` build-macos-bundle job passes
- [ ] `release-please.yml` build-flutter-desktop job passes (on next release)
- [ ] Launching the macOS app no longer shows `-34018` error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI to import both Developer ID and Apple Development certificates before macOS builds.
  * Adjusted macOS signing configuration to include the development team for proper app signing.
  * Added keychain access entitlements to enable secure storage access on macOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->