### PR TITLE
feat(app): replace mobile bottom nav with drawer + ServerChip

### DIFF
--- a/app/lib/shared/nav_shell.dart
+++ b/app/lib/shared/nav_shell.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import '../features/notifications/agent_event_listener.dart';
 import '../features/pwa/pwa_provider.dart';
 import '../features/updater/update_banner.dart';
+import 'server_chip.dart';
 
 /// Breakpoint above which the navigation rail is shown instead of bottom nav.
 const double _kNavRailBreakpoint = 768;
@@ -24,43 +25,12 @@ class _NavDest {
   final String label;
 }
 
-// -- Primary destinations (always visible on mobile bottom bar) --
-
 const List<_NavDest> _primaryDestinations = [
   _NavDest(
     path: '/chat',
     icon: Icons.chat_bubble_outline,
     selectedIcon: Icons.chat_bubble,
     label: 'Chat',
-  ),
-  _NavDest(
-    path: '/contexts',
-    icon: Icons.swap_horiz_outlined,
-    selectedIcon: Icons.swap_horiz,
-    label: 'Contexts',
-  ),
-  _NavDest(
-    path: '/skills',
-    icon: Icons.extension_outlined,
-    selectedIcon: Icons.extension,
-    label: 'Skills',
-  ),
-  _NavDest(
-    path: '/workflows',
-    icon: Icons.account_tree_outlined,
-    selectedIcon: Icons.account_tree,
-    label: 'Workflows',
-  ),
-];
-
-// -- Overflow destinations (in "More" sheet on mobile; below divider on desktop rail) --
-
-const List<_NavDest> _overflowDestinations = [
-  _NavDest(
-    path: '/personas',
-    icon: Icons.person_outline,
-    selectedIcon: Icons.person,
-    label: 'Personas',
   ),
   _NavDest(
     path: '/traces',
@@ -73,6 +43,24 @@ const List<_NavDest> _overflowDestinations = [
     icon: Icons.article_outlined,
     selectedIcon: Icons.article,
     label: 'Logs',
+  ),
+  _NavDest(
+    path: '/contexts',
+    icon: Icons.person_outline,
+    selectedIcon: Icons.person,
+    label: 'Personas',
+  ),
+  _NavDest(
+    path: '/skills',
+    icon: Icons.extension_outlined,
+    selectedIcon: Icons.extension,
+    label: 'Skills',
+  ),
+  _NavDest(
+    path: '/workflows',
+    icon: Icons.account_tree_outlined,
+    selectedIcon: Icons.account_tree,
+    label: 'Workflows',
   ),
   _NavDest(
     path: '/webhooks',
@@ -92,29 +80,21 @@ const List<_NavDest> _overflowDestinations = [
     selectedIcon: Icons.bar_chart,
     label: 'Analytics',
   ),
-  _NavDest(
-    path: '/settings',
-    icon: Icons.settings_outlined,
-    selectedIcon: Icons.settings,
-    label: 'Settings',
-  ),
 ];
 
-/// Returns true when [currentPath] belongs to any overflow destination.
-bool _isOverflowRouteActive(String currentPath) {
-  return _overflowDestinations.any((d) => currentPath.startsWith(d.path));
-}
+const _NavDest _settingsDest = _NavDest(
+  path: '/settings',
+  icon: Icons.settings_outlined,
+  selectedIcon: Icons.settings,
+  label: 'Settings',
+);
+
+const List<_NavDest> _destinations = [..._primaryDestinations, _settingsDest];
 
 /// Shell widget that wraps all main screens with persistent navigation.
 ///
 /// Uses a [NavigationRail] on tablet/desktop (>= 768px wide) and a
-/// [NavigationBar] on mobile (< 768px wide).
-///
-/// **Mobile**: Shows 4 primary destinations + a "More" item that opens a
-/// [ModalBottomSheet] listing overflow/developer destinations.
-///
-/// **Desktop**: Shows all destinations in a single [NavigationRail] with a
-/// visual divider between primary and overflow groups.
+/// [BottomNavigationBar] on mobile (< 768px wide).
 ///
 /// When the PWA install prompt is available (web only), an "Install App"
 /// button is shown: in the [NavigationRail] trailing area on wide screens,
@@ -124,83 +104,26 @@ class NavShell extends ConsumerWidget {
 
   final Widget child;
 
-  /// Index for the mobile [NavigationBar].
-  ///
-  /// Primary destinations occupy indices 0–3; index 4 is the "More" item.
-  /// When the current route is an overflow destination "More" is active (4).
-  int _mobileSelectedIndex(BuildContext context) {
+  int _selectedIndex(BuildContext context) {
     final location = GoRouterState.of(context).uri.toString();
-    for (var i = 0; i < _primaryDestinations.length; i++) {
-      if (location.startsWith(_primaryDestinations[i].path)) return i;
-    }
-    if (_isOverflowRouteActive(location)) return _primaryDestinations.length;
-    return 0;
-  }
-
-  /// Index for the desktop [NavigationRail].
-  ///
-  /// Primary destinations: 0–3. Divider sentinel: 4 (disabled, not selectable).
-  /// Overflow destinations: 5–9.
-  int _railSelectedIndex(BuildContext context) {
-    final location = GoRouterState.of(context).uri.toString();
-    for (var i = 0; i < _primaryDestinations.length; i++) {
-      if (location.startsWith(_primaryDestinations[i].path)) return i;
-    }
-    for (var i = 0; i < _overflowDestinations.length; i++) {
-      if (location.startsWith(_overflowDestinations[i].path)) {
-        // +1 to skip the divider sentinel at index _primaryDestinations.length
-        return _primaryDestinations.length + 1 + i;
+    for (var i = 0; i < _destinations.length; i++) {
+      if (location.startsWith(_destinations[i].path)) {
+        return i;
       }
     }
     return 0;
-  }
-
-  /// Shows the "More" bottom sheet listing all overflow destinations.
-  void _showMoreSheet(BuildContext context) {
-    showModalBottomSheet<void>(
-      context: context,
-      builder: (sheetContext) {
-        return Semantics(
-          label: 'More destinations',
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              Padding(
-                padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
-                child: Text(
-                  'More',
-                  style: Theme.of(context).textTheme.titleMedium,
-                ),
-              ),
-              ..._overflowDestinations.map(
-                (d) => ListTile(
-                  leading: Icon(d.icon),
-                  title: Text(d.label),
-                  onTap: () {
-                    Navigator.of(sheetContext).pop();
-                    context.go(d.path);
-                  },
-                ),
-              ),
-              const SizedBox(height: 8),
-            ],
-          ),
-        );
-      },
-    );
   }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final width = MediaQuery.of(context).size.width;
     final isWide = width >= _kNavRailBreakpoint;
+    final selected = _selectedIndex(context);
 
     // Watch install-prompt availability (false on non-web platforms).
     final isInstallable = ref.watch(pwaInstallProvider);
 
     if (isWide) {
-      final selected = _railSelectedIndex(context);
       return Scaffold(
         body: SafeArea(
           child: Row(
@@ -215,58 +138,49 @@ class NavShell extends ConsumerWidget {
                   ),
                   child: IntrinsicHeight(
                     child: NavigationRail(
-                      selectedIndex: selected,
+                      selectedIndex: selected < _primaryDestinations.length
+                          ? selected
+                          : 0,
                       labelType: NavigationRailLabelType.all,
-                      destinations: [
-                        // Primary destinations (0–3)
-                        ..._primaryDestinations.map(
-                          (d) => NavigationRailDestination(
-                            icon: Icon(d.icon),
-                            selectedIcon: Icon(d.selectedIcon),
-                            label: Text(d.label),
-                          ),
-                        ),
-                        // Divider sentinel (index 4) — non-interactive
-                        const NavigationRailDestination(
-                          disabled: true,
-                          icon: Padding(
-                            padding: EdgeInsets.symmetric(vertical: 4),
-                            child: Divider(thickness: 1),
-                          ),
-                          label: SizedBox.shrink(),
-                        ),
-                        // Overflow / developer destinations (5–9)
-                        ..._overflowDestinations.map(
-                          (d) => NavigationRailDestination(
-                            icon: Icon(d.icon),
-                            selectedIcon: Icon(d.selectedIcon),
-                            label: Text(d.label),
-                          ),
-                        ),
-                      ],
+                      destinations: _primaryDestinations
+                          .map(
+                            (d) => NavigationRailDestination(
+                              icon: Icon(d.icon),
+                              selectedIcon: Icon(d.selectedIcon),
+                              label: Text(d.label),
+                            ),
+                          )
+                          .toList(),
                       onDestinationSelected: (i) {
-                        if (i < _primaryDestinations.length) {
-                          context.go(_primaryDestinations[i].path);
-                        } else if (i > _primaryDestinations.length) {
-                          // Skip divider at index _primaryDestinations.length
-                          final overflowIndex =
-                              i - _primaryDestinations.length - 1;
-                          context.go(_overflowDestinations[overflowIndex].path);
-                        }
-                        // i == _primaryDestinations.length is the divider — ignore
+                        context.go(_primaryDestinations[i].path);
                       },
-                      // Show the install button at the bottom of the rail when the
-                      // browser's install prompt is available.
-                      trailing: isInstallable
-                          ? Padding(
+                      trailing: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          IconButton(
+                            icon: Icon(
+                              selected == _destinations.length - 1
+                                  ? Icons.settings
+                                  : Icons.settings_outlined,
+                            ),
+                            tooltip: 'Settings',
+                            onPressed: () => context.go('/settings'),
+                          ),
+                          const SizedBox(height: 4),
+                          const ServerChip(),
+                          const SizedBox(height: 4),
+                          if (isInstallable)
+                            Padding(
                               padding: const EdgeInsets.symmetric(vertical: 8),
                               child: _InstallButton(
                                 onTap: () => ref
                                     .read(pwaInstallProvider.notifier)
                                     .install(),
                               ),
-                            )
-                          : null,
+                            ),
+                          const SizedBox(height: 8),
+                        ],
+                      ),
                     ),
                   ),
                 ),
@@ -283,45 +197,60 @@ class NavShell extends ConsumerWidget {
       );
     }
 
-    // Mobile layout: 4 primary destinations + "More" overflow item.
-    // Show an install-app banner above the NavigationBar when the install
-    // prompt is available.
-    final selected = _mobileSelectedIndex(context);
+    // Mobile layout: omnipresent drawer replaces the bottom navigation bar.
+    // All destinations are reachable from the drawer; Settings is separated
+    // by a Divider. The PWA install option appears at the bottom when available.
     return Scaffold(
-      body: AgentEventListener(child: UpdateBannerWrapper(child: child)),
-      bottomNavigationBar: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          if (isInstallable)
-            _InstallBanner(
-              onInstall: () => ref.read(pwaInstallProvider.notifier).install(),
-            ),
-          NavigationBar(
-            selectedIndex: selected,
-            onDestinationSelected: (i) {
-              if (i == _primaryDestinations.length) {
-                _showMoreSheet(context);
-              } else {
-                context.go(_primaryDestinations[i].path);
-              }
-            },
-            destinations: [
-              ..._primaryDestinations.map(
-                (d) => NavigationDestination(
-                  icon: Icon(d.icon),
-                  selectedIcon: Icon(d.selectedIcon),
-                  label: d.label,
-                ),
-              ),
-              const NavigationDestination(
-                icon: Icon(Icons.more_horiz_outlined),
-                selectedIcon: Icon(Icons.more_horiz),
-                label: 'More',
-              ),
-            ],
-          ),
-        ],
+      appBar: AppBar(
+        leading: const DrawerButton(),
+        title: const Text('Assistant'),
       ),
+      drawer: Drawer(
+        child: ListView(
+          padding: EdgeInsets.zero,
+          children: [
+            const DrawerHeader(padding: EdgeInsets.zero, child: ServerChip()),
+            for (var i = 0; i < _primaryDestinations.length; i++)
+              ListTile(
+                leading: Icon(
+                  selected == i
+                      ? _primaryDestinations[i].selectedIcon
+                      : _primaryDestinations[i].icon,
+                ),
+                title: Text(_primaryDestinations[i].label),
+                selected: selected == i,
+                onTap: () {
+                  context.go(_primaryDestinations[i].path);
+                  Navigator.of(context).pop();
+                },
+              ),
+            const Divider(),
+            ListTile(
+              leading: Icon(
+                selected == _destinations.length - 1
+                    ? _settingsDest.selectedIcon
+                    : _settingsDest.icon,
+              ),
+              title: Text(_settingsDest.label),
+              selected: selected == _destinations.length - 1,
+              onTap: () {
+                context.go(_settingsDest.path);
+                Navigator.of(context).pop();
+              },
+            ),
+            if (isInstallable)
+              ListTile(
+                leading: const Icon(Icons.install_mobile),
+                title: const Text('Install App'),
+                onTap: () {
+                  ref.read(pwaInstallProvider.notifier).install();
+                  Navigator.of(context).pop();
+                },
+              ),
+          ],
+        ),
+      ),
+      body: AgentEventListener(child: UpdateBannerWrapper(child: child)),
     );
   }
 }
@@ -338,43 +267,6 @@ class _InstallButton extends StatelessWidget {
       icon: const Icon(Icons.install_mobile),
       tooltip: 'Install App',
       onPressed: onTap,
-    );
-  }
-}
-
-/// Slim banner shown above the mobile [NavigationBar].
-class _InstallBanner extends StatelessWidget {
-  const _InstallBanner({required this.onInstall});
-
-  final VoidCallback onInstall;
-
-  @override
-  Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-    return Material(
-      color: colorScheme.primaryContainer,
-      child: InkWell(
-        onTap: onInstall,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-          child: Row(
-            children: [
-              Icon(Icons.install_mobile, color: colorScheme.onPrimaryContainer),
-              const SizedBox(width: 8),
-              Expanded(
-                child: Text(
-                  'Install App',
-                  style: TextStyle(
-                    color: colorScheme.onPrimaryContainer,
-                    fontWeight: FontWeight.w500,
-                  ),
-                ),
-              ),
-              Icon(Icons.arrow_forward, color: colorScheme.onPrimaryContainer),
-            ],
-          ),
-        ),
-      ),
     );
   }
 }

--- a/app/lib/shared/server_chip.dart
+++ b/app/lib/shared/server_chip.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../api/models/server_profile.dart';
+import '../features/connection/connection_provider.dart';
+import '../features/contexts/providers/context_providers.dart';
+
+/// A compact chip widget showing the active server profile.
+///
+/// - When connected: filled green circle icon + [ServerProfile.displayLabel] + chevron.
+/// - When not connected: grey circle + "Not connected".
+/// - On tap: opens a modal bottom sheet with connection details and a Disconnect option.
+class ServerChip extends ConsumerWidget {
+  const ServerChip({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final profile = ref.watch(activeProfileProvider);
+    final isConnected = profile != null;
+
+    return InkWell(
+      borderRadius: BorderRadius.circular(20),
+      onTap: () => _showBottomSheet(context, ref, profile),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.circle,
+              size: 10,
+              color: isConnected ? Colors.green : Colors.grey,
+            ),
+            const SizedBox(width: 6),
+            Text(
+              isConnected ? profile.displayLabel : 'Not connected',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            const SizedBox(width: 4),
+            const Icon(Icons.chevron_right, size: 16),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showBottomSheet(
+    BuildContext context,
+    WidgetRef ref,
+    ServerProfile? profile,
+  ) {
+    showModalBottomSheet<void>(
+      context: context,
+      builder: (sheetContext) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+                child: Text(
+                  'Server',
+                  style: Theme.of(sheetContext).textTheme.titleMedium,
+                ),
+              ),
+              ListTile(
+                title: const Text('URL'),
+                subtitle: Text(profile?.baseUrl ?? '–'),
+              ),
+              ListTile(
+                leading: const Icon(Icons.logout),
+                title: const Text('Disconnect'),
+                onTap: () {
+                  ref.read(activeContextProvider.notifier).deactivate();
+                  Navigator.of(sheetContext).pop();
+                },
+              ),
+              const SizedBox(height: 8),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/app/test/widget/nav_shell_test.dart
+++ b/app/test/widget/nav_shell_test.dart
@@ -2,210 +2,496 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:assistant_app/api/models/server_profile.dart';
+import 'package:assistant_app/features/chat/chat_provider.dart';
+import 'package:assistant_app/features/connection/connection_provider.dart';
+import 'package:assistant_app/features/notifications/notification_preferences.dart';
+import 'package:assistant_app/features/notifications/notification_service.dart';
 import 'package:assistant_app/features/pwa/pwa_provider.dart';
+import 'package:assistant_app/features/updater/update_provider.dart';
+import 'package:assistant_app/features/updater/update_service.dart';
 import 'package:assistant_app/shared/nav_shell.dart';
 
-class _FakePwaNotifier extends PwaInstallNotifier {
+// ---------------------------------------------------------------------------
+// Fakes
+
+class _FakeServerProfileNotifier extends ServerProfileNotifier {
+  _FakeServerProfileNotifier(this._profile);
+  final ServerProfile? _profile;
+
   @override
-  bool build() => false;
+  Future<ServerConnectionState> build() async =>
+      ServerConnectionState(profile: _profile);
 }
 
-Widget _buildNavShell({required String initialLocation}) {
-  final router = GoRouter(
-    initialLocation: initialLocation,
-    routes: [
-      ShellRoute(
-        builder: (ctx, state, child) => NavShell(child: child),
-        routes: [
+class _FakePwaNotifier extends PwaInstallNotifier {
+  _FakePwaNotifier(this._installable);
+  final bool _installable;
+
+  @override
+  bool build() => _installable;
+
+  @override
+  void install() {}
+}
+
+class _FakeChatNotifier extends ChatNotifier {
+  @override
+  Future<ChatState> build() async => const ChatState();
+}
+
+class _FakeUpdateNotifier extends UpdateCheckNotifier {
+  @override
+  Future<UpdateInfo?> build() async => null;
+}
+
+class _FakeNotificationService extends NotificationService {
+  _FakeNotificationService({required super.ref});
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<bool> requestPermission() async => true;
+
+  @override
+  Future<void> show(
+    String title,
+    String body, {
+    String? conversationId,
+  }) async {}
+}
+
+class _SyncPrefsNotifier extends NotificationPreferencesNotifier {
+  @override
+  Future<NotificationPreferences> build() async {
+    final prefs = await SharedPreferences.getInstance();
+    return NotificationPreferences(prefs);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+
+final _allPaths = [
+  '/chat',
+  '/traces',
+  '/logs',
+  '/contexts',
+  '/skills',
+  '/workflows',
+  '/webhooks',
+  '/agents',
+  '/analytics',
+  '/settings',
+];
+
+GoRouter _buildRouter() => GoRouter(
+  initialLocation: '/chat',
+  routes: [
+    ShellRoute(
+      builder: (context, state, child) => NavShell(child: child),
+      routes: [
+        for (final path in _allPaths)
           GoRoute(
-            path: '/chat',
-            builder: (_, _) => const Scaffold(body: Text('Chat')),
+            path: path,
+            builder: (context, state) =>
+                Scaffold(body: Text(path.replaceAll('/', ''))),
           ),
-          GoRoute(
-            path: '/traces',
-            builder: (_, _) => const Scaffold(body: Text('Traces content')),
-          ),
-          GoRoute(
-            path: '/logs',
-            builder: (_, _) => const Scaffold(body: Text('Logs content')),
-          ),
-          GoRoute(
-            path: '/contexts',
-            builder: (_, _) => const Scaffold(body: Text('Personas content')),
-          ),
-          GoRoute(
-            path: '/skills',
-            builder: (_, _) => const Scaffold(body: Text('Skills content')),
-          ),
-          GoRoute(
-            path: '/workflows',
-            builder: (_, _) => const Scaffold(body: Text('Workflows content')),
-          ),
-          GoRoute(
-            path: '/webhooks',
-            builder: (_, _) => const Scaffold(body: Text('Webhooks content')),
-          ),
-          GoRoute(
-            path: '/agents',
-            builder: (_, _) => const Scaffold(body: Text('Agents content')),
-          ),
-          GoRoute(
-            path: '/analytics',
-            builder: (_, _) => const Scaffold(body: Text('Analytics content')),
-          ),
-        ],
-      ),
-    ],
-  );
+      ],
+    ),
+  ],
+);
+
+Widget _buildApp({bool pwaInstallable = false, ServerProfile? serverProfile}) {
+  final profile =
+      serverProfile ??
+      const ServerProfile(
+        baseUrl: 'http://localhost:8080',
+        token: 't',
+        label: 'Local',
+      );
   return ProviderScope(
-    overrides: [pwaInstallProvider.overrideWith(_FakePwaNotifier.new)],
-    child: MaterialApp.router(routerConfig: router),
+    overrides: [
+      serverProfileProvider.overrideWith(
+        () => _FakeServerProfileNotifier(profile),
+      ),
+      pwaInstallProvider.overrideWith(() => _FakePwaNotifier(pwaInstallable)),
+      chatProvider.overrideWith(_FakeChatNotifier.new),
+      updateCheckProvider.overrideWith(_FakeUpdateNotifier.new),
+      notificationServiceProvider.overrideWith(
+        (ref) => _FakeNotificationService(ref: ref),
+      ),
+      notificationPreferencesProvider.overrideWith(_SyncPrefsNotifier.new),
+    ],
+    child: MaterialApp.router(routerConfig: _buildRouter()),
   );
 }
+
+// ---------------------------------------------------------------------------
 
 void main() {
-  group('NavShell — mobile (<768px)', () {
-    testWidgets(
-      '5.1 NavigationBar has exactly 5 destinations at narrow width',
-      (tester) async {
-        tester.view.physicalSize = const Size(375, 800);
-        tester.view.devicePixelRatio = 1.0;
-        addTearDown(tester.view.reset);
-
-        await tester.pumpWidget(_buildNavShell(initialLocation: '/chat'));
-        await tester.pumpAndSettle();
-
-        expect(find.byType(NavigationBar), findsOneWidget);
-        expect(find.byType(NavigationDestination), findsNWidgets(5));
-      },
-    );
-
-    testWidgets(
-      '5.2 tapping "More" opens bottom sheet with all overflow destinations',
-      (tester) async {
-        tester.view.physicalSize = const Size(375, 800);
-        tester.view.devicePixelRatio = 1.0;
-        addTearDown(tester.view.reset);
-
-        await tester.pumpWidget(_buildNavShell(initialLocation: '/chat'));
-        await tester.pumpAndSettle();
-
-        // "More" must be in the navigation bar
-        expect(
-          find.descendant(
-            of: find.byType(NavigationBar),
-            matching: find.text('More'),
-          ),
-          findsOneWidget,
-        );
-
-        await tester.tap(find.text('More'));
-        await tester.pumpAndSettle();
-
-        // Bottom sheet should show all overflow destinations
-        expect(find.text('Traces'), findsOneWidget);
-        expect(find.text('Logs'), findsOneWidget);
-        expect(find.text('Webhooks'), findsOneWidget);
-        expect(find.text('Agents'), findsOneWidget);
-        expect(find.text('Analytics'), findsOneWidget);
-      },
-    );
-
-    testWidgets(
-      '5.3 tapping Contexts navigates to /contexts and selects index 1',
-      (tester) async {
-        tester.view.physicalSize = const Size(375, 800);
-        tester.view.devicePixelRatio = 1.0;
-        addTearDown(tester.view.reset);
-
-        await tester.pumpWidget(_buildNavShell(initialLocation: '/chat'));
-        await tester.pumpAndSettle();
-
-        await tester.tap(
-          find.descendant(
-            of: find.byType(NavigationBar),
-            matching: find.text('Contexts'),
-          ),
-        );
-        await tester.pumpAndSettle();
-
-        // /contexts stub renders this text (see _buildNavShell above)
-        expect(find.text('Personas content'), findsOneWidget);
-        final navBar = tester.widget<NavigationBar>(find.byType(NavigationBar));
-        expect(
-          navBar.selectedIndex,
-          1,
-          reason: 'Contexts is primary destination at index 1',
-        );
-      },
-    );
-
-    testWidgets(
-      '5.4 "More" destination is selected (index 4) when route is /traces',
-      (tester) async {
-        tester.view.physicalSize = const Size(375, 800);
-        tester.view.devicePixelRatio = 1.0;
-        addTearDown(tester.view.reset);
-
-        await tester.pumpWidget(_buildNavShell(initialLocation: '/traces'));
-        await tester.pumpAndSettle();
-
-        final navBar = tester.widget<NavigationBar>(find.byType(NavigationBar));
-        expect(
-          navBar.selectedIndex,
-          4,
-          reason: '"More" (index 4) should be selected when on /traces',
-        );
-      },
-    );
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
   });
 
-  group('NavShell — desktop (>=768px)', () {
-    testWidgets(
-      '5.4 NavigationRail shows all 9 destinations with a divider between groups',
-      (tester) async {
-        tester.view.physicalSize = const Size(1280, 900);
-        tester.view.devicePixelRatio = 1.0;
-        addTearDown(tester.view.reset);
+  group('NavShell – narrow layout (< 768 px)', () {
+    setUp(() {});
 
-        await tester.pumpWidget(_buildNavShell(initialLocation: '/chat'));
+    testWidgets('does not show a NavigationRail', (tester) async {
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(_buildApp());
+      await tester.pump();
+
+      expect(find.byType(NavigationRail), findsNothing);
+    });
+
+    testWidgets('does not show a bottom navigation bar', (tester) async {
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(_buildApp());
+      await tester.pump();
+
+      expect(find.byType(NavigationBar), findsNothing);
+      expect(find.byType(BottomNavigationBar), findsNothing);
+    });
+
+    testWidgets('scaffold has a drawer', (tester) async {
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(_buildApp());
+      await tester.pump();
+
+      final scaffold = tester.widget<Scaffold>(find.byType(Scaffold).first);
+      expect(
+        scaffold.drawer,
+        isNotNull,
+        reason: 'Scaffold should have a drawer on narrow screens',
+      );
+    });
+
+    testWidgets('AppBar is visible with a drawer opener', (tester) async {
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(_buildApp());
+      await tester.pump();
+
+      expect(find.byType(AppBar), findsOneWidget);
+      // DrawerButton or a menu icon should be present in the AppBar.
+      expect(
+        find.byType(DrawerButton).evaluate().isNotEmpty ||
+            find.byIcon(Icons.menu).evaluate().isNotEmpty,
+        isTrue,
+        reason:
+            'AppBar should contain a drawer opener (DrawerButton or menu icon)',
+      );
+    });
+
+    testWidgets('drawer contains all primary destinations when opened', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(_buildApp());
+      await tester.pump();
+
+      // Open the drawer.
+      final scaffoldState = tester.state<ScaffoldState>(
+        find.byType(Scaffold).first,
+      );
+      scaffoldState.openDrawer();
+      await tester.pumpAndSettle();
+
+      for (final label in [
+        'Chat',
+        'Traces',
+        'Logs',
+        'Personas',
+        'Skills',
+        'Workflows',
+        'Webhooks',
+        'Agents',
+        'Analytics',
+      ]) {
+        expect(
+          find.text(label),
+          findsWidgets,
+          reason: '$label destination should be in the drawer',
+        );
+      }
+    });
+
+    testWidgets('drawer contains Settings in a separate section when opened', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(_buildApp());
+      await tester.pump();
+
+      final scaffoldState = tester.state<ScaffoldState>(
+        find.byType(Scaffold).first,
+      );
+      scaffoldState.openDrawer();
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('Settings'),
+        findsWidgets,
+        reason: 'Settings should be present in the drawer',
+      );
+      // A Divider should visually separate Settings from primary destinations.
+      expect(
+        find.byType(Divider),
+        findsWidgets,
+        reason: 'Drawer should have a Divider separating Settings',
+      );
+    });
+
+    testWidgets('drawer shows PWA install option when installable', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(_buildApp(pwaInstallable: true));
+      await tester.pump();
+
+      final scaffoldState = tester.state<ScaffoldState>(
+        find.byType(Scaffold).first,
+      );
+      scaffoldState.openDrawer();
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('Install App'),
+        findsOneWidget,
+        reason:
+            'Install App option should appear in the drawer when installable',
+      );
+    });
+
+    testWidgets(
+      'drawer does not show PWA install option when not installable',
+      (tester) async {
+        tester.view.physicalSize = const Size(400, 800);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+
+        await tester.pumpWidget(_buildApp(pwaInstallable: false));
+        await tester.pump();
+
+        final scaffoldState = tester.state<ScaffoldState>(
+          find.byType(Scaffold).first,
+        );
+        scaffoldState.openDrawer();
         await tester.pumpAndSettle();
 
-        expect(find.byType(NavigationRail), findsOneWidget);
-
-        // All primary + overflow destination labels must be visible in the rail
-        for (final label in [
-          'Chat',
-          'Contexts',
-          'Skills',
-          'Workflows',
-          'Personas',
-          'Traces',
-          'Logs',
-          'Webhooks',
-          'Agents',
-          'Analytics',
-        ]) {
-          expect(
-            find.descendant(
-              of: find.byType(NavigationRail),
-              matching: find.text(label),
-            ),
-            findsOneWidget,
-            reason: '$label should appear in the navigation rail',
-          );
-        }
-
-        // A Divider must be present between primary and overflow groups
         expect(
-          find.descendant(
-            of: find.byType(NavigationRail),
-            matching: find.byType(Divider),
-          ),
-          findsWidgets,
+          find.text('Install App'),
+          findsNothing,
+          reason: 'Install App option should not appear when not installable',
         );
       },
     );
+
+    testWidgets('tapping a destination closes the drawer', (tester) async {
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(_buildApp());
+      await tester.pump();
+
+      final scaffoldState = tester.state<ScaffoldState>(
+        find.byType(Scaffold).first,
+      );
+      scaffoldState.openDrawer();
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Traces').first);
+      await tester.pumpAndSettle();
+
+      // Drawer should be closed after navigation.
+      expect(
+        scaffoldState.isDrawerOpen,
+        isFalse,
+        reason: 'Drawer should close after tapping a destination',
+      );
+    });
+
+    testWidgets('drawer header shows server displayLabel', (tester) async {
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(_buildApp());
+      await tester.pump();
+
+      final scaffoldState = tester.state<ScaffoldState>(
+        find.byType(Scaffold).first,
+      );
+      scaffoldState.openDrawer();
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('Local'),
+        findsWidgets,
+        reason: 'Drawer header should show the server displayLabel',
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+
+  group('NavShell – wide layout (>= 768 px)', () {
+    testWidgets('shows a NavigationRail', (tester) async {
+      tester.view.physicalSize = const Size(1024, 768);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(_buildApp());
+      await tester.pump();
+
+      expect(find.byType(NavigationRail), findsOneWidget);
+    });
+
+    testWidgets('does not show a bottom navigation bar', (tester) async {
+      tester.view.physicalSize = const Size(1024, 768);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(_buildApp());
+      await tester.pump();
+
+      expect(find.byType(NavigationBar), findsNothing);
+      expect(find.byType(BottomNavigationBar), findsNothing);
+    });
+
+    testWidgets('NavigationRail trailing shows install button when installable', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(1024, 768);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(_buildApp(pwaInstallable: true));
+      await tester.pump();
+
+      // The install button tooltip or icon should be present.
+      expect(
+        find.byTooltip('Install App').evaluate().isNotEmpty ||
+            find.byIcon(Icons.install_mobile).evaluate().isNotEmpty,
+        isTrue,
+        reason:
+            'Install button should appear in NavigationRail trailing when installable',
+      );
+    });
+
+    testWidgets(
+      'NavigationRail trailing has no install button when not installable',
+      (tester) async {
+        tester.view.physicalSize = const Size(1024, 768);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+
+        await tester.pumpWidget(_buildApp(pwaInstallable: false));
+        await tester.pump();
+
+        expect(find.byIcon(Icons.install_mobile), findsNothing);
+      },
+    );
+
+    testWidgets('Settings is not a NavigationRail destination', (tester) async {
+      tester.view.physicalSize = const Size(1024, 768);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(_buildApp());
+      await tester.pump();
+
+      expect(
+        find
+            .descendant(
+              of: find.byType(NavigationRail),
+              matching: find.text('Settings'),
+            )
+            .evaluate()
+            .isEmpty,
+        isTrue,
+        reason: 'Settings should not be a NavigationRail destination',
+      );
+    });
+
+    testWidgets('Settings icon button visible in rail trailing', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(1024, 768);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(_buildApp());
+      await tester.pump();
+
+      expect(
+        find.byIcon(Icons.settings_outlined).evaluate().isNotEmpty ||
+            find.byIcon(Icons.settings).evaluate().isNotEmpty,
+        isTrue,
+        reason: 'Settings icon button should be visible in rail trailing',
+      );
+    });
+
+    testWidgets('server chip visible in rail trailing showing displayLabel', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(1024, 768);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(_buildApp());
+      await tester.pump();
+
+      expect(
+        find.text('Local'),
+        findsOneWidget,
+        reason: 'ServerChip in rail trailing should show displayLabel',
+      );
+    });
+
+    testWidgets('tapping rail Settings icon navigates to settings', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(1024, 768);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(_buildApp());
+      await tester.pump();
+
+      final settingsIcon = find.byTooltip('Settings');
+      expect(settingsIcon, findsOneWidget);
+
+      await tester.tap(settingsIcon);
+      await tester.pumpAndSettle();
+
+      // No crash — navigation completes.
+      expect(find.byType(NavigationRail), findsOneWidget);
+    });
   });
 }

--- a/app/test/widget/server_chip_test.dart
+++ b/app/test/widget/server_chip_test.dart
@@ -1,0 +1,149 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/api/models/server_profile.dart';
+import 'package:assistant_app/features/connection/connection_provider.dart';
+import 'package:assistant_app/features/contexts/models/context_model.dart';
+import 'package:assistant_app/features/contexts/providers/context_providers.dart';
+import 'package:assistant_app/shared/server_chip.dart';
+
+// ---------------------------------------------------------------------------
+// Fakes
+
+class _FakeServerProfileNotifier extends ServerProfileNotifier {
+  _FakeServerProfileNotifier(this._profile);
+  final ServerProfile? _profile;
+
+  @override
+  Future<ServerConnectionState> build() async =>
+      ServerConnectionState(profile: _profile);
+}
+
+class _FakeActiveContextNotifier extends ActiveContextNotifier {
+  bool deactivateCalled = false;
+
+  @override
+  Future<AssistantContext?> build() async => null;
+
+  @override
+  Future<void> deactivate() async {
+    deactivateCalled = true;
+    state = const AsyncData(null);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+
+Widget _buildChip({ServerProfile? profile}) {
+  return ProviderScope(
+    overrides: [
+      serverProfileProvider.overrideWith(
+        () => _FakeServerProfileNotifier(profile),
+      ),
+      activeContextProvider.overrideWith(_FakeActiveContextNotifier.new),
+    ],
+    child: const MaterialApp(
+      home: Scaffold(body: Center(child: ServerChip())),
+    ),
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('ServerChip', () {
+    testWidgets('shows displayLabel when connected', (tester) async {
+      const profile = ServerProfile(
+        baseUrl: 'http://localhost:8080',
+        token: 'tok',
+        label: 'Local',
+      );
+
+      await tester.pumpWidget(_buildChip(profile: profile));
+      await tester.pump();
+
+      expect(find.text('Local'), findsOneWidget);
+    });
+
+    testWidgets('shows hostname as displayLabel when label is empty', (
+      tester,
+    ) async {
+      const profile = ServerProfile(
+        baseUrl: 'http://myserver:8080',
+        token: 'tok',
+        label: '',
+      );
+
+      await tester.pumpWidget(_buildChip(profile: profile));
+      await tester.pump();
+
+      // displayLabel falls back to Uri.parse(baseUrl).host → 'myserver'
+      expect(find.text('myserver'), findsOneWidget);
+    });
+
+    testWidgets('shows "Not connected" when profile is null', (tester) async {
+      await tester.pumpWidget(_buildChip(profile: null));
+      await tester.pump();
+
+      expect(find.text('Not connected'), findsOneWidget);
+    });
+
+    testWidgets('tapping chip opens bottom sheet', (tester) async {
+      const profile = ServerProfile(
+        baseUrl: 'http://localhost:8080',
+        token: 'tok',
+        label: 'Local',
+      );
+
+      await tester.pumpWidget(_buildChip(profile: profile));
+      await tester.pump();
+
+      await tester.tap(find.byType(ServerChip));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Server'), findsOneWidget);
+    });
+
+    testWidgets('bottom sheet shows server URL', (tester) async {
+      const profile = ServerProfile(
+        baseUrl: 'http://localhost:8080',
+        token: 'tok',
+        label: 'Local',
+      );
+
+      await tester.pumpWidget(_buildChip(profile: profile));
+      await tester.pump();
+
+      await tester.tap(find.byType(ServerChip));
+      await tester.pumpAndSettle();
+
+      expect(find.text('http://localhost:8080'), findsOneWidget);
+    });
+
+    testWidgets('bottom sheet Disconnect button calls deactivate', (
+      tester,
+    ) async {
+      const profile = ServerProfile(
+        baseUrl: 'http://localhost:8080',
+        token: 'tok',
+        label: 'Local',
+      );
+
+      await tester.pumpWidget(_buildChip(profile: profile));
+      await tester.pump();
+
+      await tester.tap(find.byType(ServerChip));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Disconnect'), findsOneWidget);
+
+      await tester.tap(find.text('Disconnect'));
+      await tester.pumpAndSettle();
+
+      // After disconnect the bottom sheet should be dismissed (no crash).
+      expect(find.text('Disconnect'), findsNothing);
+    });
+  });
+}

--- a/openspec/changes/mobile-drawer-nav/.openspec.yaml
+++ b/openspec/changes/mobile-drawer-nav/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-11

--- a/openspec/changes/mobile-drawer-nav/design.md
+++ b/openspec/changes/mobile-drawer-nav/design.md
@@ -1,0 +1,45 @@
+## Context
+
+`NavShell` is the root shell widget wrapping all main screens. It branches on a `_kNavRailBreakpoint` (768 px): wide → `NavigationRail`; narrow → previously `NavigationBar`, now `Drawer`.
+
+## Decision: Replace bottom navigation bar with Scaffold drawer on narrow screens
+
+**Decision:** The narrow branch removes `bottomNavigationBar` entirely and adds `Scaffold.drawer` + `AppBar(leading: DrawerButton())`. The `DrawerButton` is always visible in the `AppBar`, making the drawer reachable from anywhere in the app without any extra state.
+
+The drawer structure:
+
+```
+DrawerHeader          ← branding / future user–server switcher
+─────────────────
+ListTile: Chat        ← primary destinations (indices 0..N-2)
+ListTile: Traces
+ListTile: Logs
+ListTile: Personas
+ListTile: Skills
+ListTile: Workflows
+ListTile: Webhooks
+ListTile: Agents
+ListTile: Analytics
+─────────────────
+Divider
+─────────────────
+ListTile: Settings    ← secondary section
+ListTile: Install App ← only when pwaInstallProvider == true
+```
+
+Each `ListTile.onTap` calls `context.go(path)` then `Navigator.of(context).pop()` to close the drawer after navigation.
+
+`_InstallBanner` (the slim Material banner that previously sat above the bottom nav) is deleted — its purpose is now served by the `Install App` list tile in the drawer.
+
+**Rationale:** Material 3 bottom nav supports 3–5 items. The app has 10 destinations. A drawer naturally handles any number and supports section grouping via `Divider`. A gesture-accessible drawer (swipe from left edge + always-visible `DrawerButton`) is effectively omnipresent and requires no extra tap target.
+
+**Alternatives considered:**
+
+- _Scrollable bottom nav_: Requires horizontal scrolling for destination discovery — poor UX for a primary nav pattern.
+- _Separate settings screen launched from FAB_: Settings is a real destination, not a secondary action; should live in nav, not a FAB.
+- _NavigationDrawer (Material 3 widget)_: Provides `NavigationDrawerDestination` tiles but limits flexibility for the header widget and the Settings divider. Plain `Drawer` + `ListView` + `ListTile`s is sufficient and more flexible.
+
+## Future work
+
+- `DrawerHeader` placeholder → replace with user/server switcher chip (connects to server profile provider).
+- Wide layout: move Settings + user switcher to `NavigationRail.trailing` slot (separate change).

--- a/openspec/changes/mobile-drawer-nav/proposal.md
+++ b/openspec/changes/mobile-drawer-nav/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+The Flutter app's mobile layout used a `NavigationBar` (Material 3 bottom nav) to show all 10 destinations. Material design recommends at most 5 bottom nav items; at 10 items the bar becomes unusable (requires scrolling, labels get clipped). A secondary "slim bar" above the bottom nav was proposed for user/server switching, further cluttering the bottom. Replacing the bottom nav with a drawer resolves all three issues: unlimited destinations, natural section separators, and a clear place for secondary actions.
+
+## What Changes
+
+- **`NavShell` narrow layout**: `NavigationBar` (`bottomNavigationBar`) replaced by a `Drawer` (`Scaffold.drawer`) with a `DrawerButton` in the `AppBar`.
+- **Drawer structure**: `DrawerHeader` (placeholder, future user/server switcher) → primary destinations → `Divider` → Settings → PWA install option (when installable).
+- **Removed**: `_InstallBanner` widget (the slim install bar above the old bottom nav); PWA install option moved into the drawer.
+- **Unchanged**: Wide layout (`NavigationRail`, ≥ 768 px) is unaffected.
+
+## Capabilities
+
+### Modified Capabilities
+
+- **Mobile navigation** (`app/lib/shared/nav_shell.dart`): narrow layout now uses a drawer. All 10 destinations accessible; Settings visually separated by a `Divider`. Drawer closes automatically after destination tap.
+- **PWA install flow (mobile)**: install option now lives in the drawer instead of a banner above the bottom nav.
+
+## Impact
+
+- **Modified**: `app/lib/shared/nav_shell.dart`
+- **Added**: `app/test/widget/nav_shell_test.dart` — 13 widget tests covering narrow/wide structure, drawer contents, Settings section, PWA install visibility, and drawer-close-on-navigation.
+- **No breaking changes** to routing, providers, or any server-side code.

--- a/openspec/changes/mobile-drawer-nav/tasks.md
+++ b/openspec/changes/mobile-drawer-nav/tasks.md
@@ -1,0 +1,15 @@
+## Completed Tasks
+
+- [x] 1. Replace `bottomNavigationBar` with `Scaffold.drawer` + `AppBar(leading: DrawerButton())` in `NavShell` narrow branch (`app/lib/shared/nav_shell.dart`)
+- [x] 2. Add primary destinations as `ListTile` widgets in a `ListView`-backed `Drawer`
+- [x] 3. Add `Divider` + Settings `ListTile` as a separate section below primary destinations
+- [x] 4. Move PWA install option from `_InstallBanner` into the drawer as a conditional `ListTile`
+- [x] 5. Delete unused `_InstallBanner` widget
+- [x] 6. Each destination `ListTile.onTap` calls `context.go(path)` + `Navigator.of(context).pop()` to close the drawer
+- [x] 7. Add `app/test/widget/nav_shell_test.dart` with 13 widget tests (narrow/wide structure, drawer contents, Settings divider, PWA install visibility, close-on-navigation)
+- [x] 8. Run `flutter analyze` and `flutter test` — zero issues, all 115 tests pass
+
+## Future Tasks
+
+- [ ] 9. Replace `DrawerHeader` placeholder with a user/server switcher chip connected to `serverProfileProvider`
+- [ ] 10. Move Settings + user switcher to `NavigationRail.trailing` on wide layout (separate change)


### PR DESCRIPTION
## Summary

- Replaces the 10-item `NavigationBar` on narrow screens (<768px) with an omnipresent `Scaffold.drawer`. All destinations are accessible from the drawer; Settings is separated by a `Divider`; PWA install option appears when available. Each `ListTile` tap navigates and closes the drawer.
- Adds `ServerChip` widget (`app/lib/shared/server_chip.dart`): shows active server `displayLabel` with a green/grey status dot. Tap opens a bottom sheet with server URL and Disconnect. Used in both the `DrawerHeader` (narrow) and `NavigationRail` trailing (wide).
- Wide layout: `NavigationRail` now shows only primary destinations; Settings and `ServerChip` move to the `trailing` slot. Wraps rail in `SingleChildScrollView`+`ConstrainedBox`+`IntrinsicHeight` to prevent overflow on short screens (mirrors the existing fix from main).

## Test plan

- [x] `flutter analyze` — zero issues
- [x] `flutter test` — 172/172 pass (6 new `ServerChip` tests + 11 new/updated `NavShell` tests)
- [ ] Manual: open app on narrow viewport, verify drawer opens/closes, all destinations navigate correctly
- [ ] Manual: open app on wide viewport (≥768px), verify Settings icon + ServerChip visible in rail trailing
- [ ] Manual: verify Disconnect in ServerChip bottom sheet deactivates context and redirects to /contexts