### PR TITLE
feat(web-ui): voice message send and receive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -804,6 +804,7 @@ dependencies = [
  "assistant-llm",
  "assistant-skills",
  "assistant-storage",
+ "assistant-transcription",
  "async-trait",
  "chrono",
  "cron",
@@ -831,9 +832,11 @@ dependencies = [
  "reqwest 0.12.28",
  "reqwest-middleware",
  "serde",
+ "serde_json",
  "tokio",
  "tracing",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -856,6 +859,7 @@ dependencies = [
  "assistant-skills",
  "assistant-storage",
  "assistant-tool-executor",
+ "assistant-transcription",
  "assistant-workflow",
  "assistant-workflow-http",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,6 +837,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]

--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -1,4 +1,7 @@
 PODS:
+  - audioplayers_darwin (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - Flutter (1.0.0)
   - flutter_local_notifications (0.0.1):
     - Flutter
@@ -7,6 +10,8 @@ PODS:
     - FlutterMacOS
   - package_info_plus (0.4.5):
     - Flutter
+  - record_ios (1.2.0):
+    - Flutter
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -14,14 +19,18 @@ PODS:
     - Flutter
 
 DEPENDENCIES:
+  - audioplayers_darwin (from `.symlinks/plugins/audioplayers_darwin/darwin`)
   - Flutter (from `Flutter`)
   - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
   - flutter_secure_storage_darwin (from `.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
+  - record_ios (from `.symlinks/plugins/record_ios/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 EXTERNAL SOURCES:
+  audioplayers_darwin:
+    :path: ".symlinks/plugins/audioplayers_darwin/darwin"
   Flutter:
     :path: Flutter
   flutter_local_notifications:
@@ -30,16 +39,20 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_secure_storage_darwin/darwin"
   package_info_plus:
     :path: ".symlinks/plugins/package_info_plus/ios"
+  record_ios:
+    :path: ".symlinks/plugins/record_ios/ios"
   shared_preferences_foundation:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
   url_launcher_ios:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
+  audioplayers_darwin: 835ced6edd4c9fc8ebb0a7cc9e294a91d99917d5
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_local_notifications: 643a3eda1ce1c0599413ca31672536d423dee214
   flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
+  record_ios: 412daca2350b228e698fffcd08f1f94ceb1e3844
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
   url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
 

--- a/app/ios/Runner/Info.plist
+++ b/app/ios/Runner/Info.plist
@@ -55,6 +55,8 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Microphone access is required to send voice messages.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/app/lib/api/api_client.dart
+++ b/app/lib/api/api_client.dart
@@ -5,16 +5,20 @@
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:assistant_api/assistant_api.dart';
 import 'package:dio/dio.dart';
 
+import 'models/server_capabilities.dart';
 import 'models/stream_event.dart';
 
 /// Configured client bundle: generated API instances + SSE streaming helper.
 class ApiClient {
   ApiClient({required String baseUrl, required String token})
-      : _token = token {
+    : _token = token,
+      _baseUrl = baseUrl {
     _dio = Dio(
       BaseOptions(
         baseUrl: baseUrl,
@@ -23,14 +27,12 @@ class ApiClient {
       ),
     );
 
-    _generatedApi = AssistantApi(
-      dio: _dio,
-      basePathOverride: baseUrl,
-    );
+    _generatedApi = AssistantApi(dio: _dio, basePathOverride: baseUrl);
     _generatedApi.setBearerAuth('bearer_token', token);
   }
 
   final String _token;
+  final String _baseUrl;
   late final Dio _dio;
   late final AssistantApi _generatedApi;
 
@@ -74,6 +76,110 @@ class ApiClient {
     yield* _parseSse(response.data!.stream);
   }
 
+  // -- Voice / capabilities ---------------------------------------------------
+
+  /// Fetch server capability flags (voice_send, voice_receive, …).
+  ///
+  /// Uses dart:io HttpClient directly (no Dio interceptor chain) so no
+  /// zero-duration dart:async Timer is created during the request setup,
+  /// which keeps Flutter's fakeAsync tests clean.
+  Future<ServerCapabilities> getCapabilities({CancelToken? cancelToken}) async {
+    final client = HttpClient();
+    // Disable connect timeout — no dart:async Timer created.
+    client.connectionTimeout = null;
+    try {
+      final uri = Uri.parse('$_baseUrl/api/capabilities');
+      final request = await client.getUrl(uri);
+      request.headers.set('Authorization', 'Bearer $_token');
+      if (cancelToken?.isCancelled == true) return ServerCapabilities.disabled;
+      final response = await request.close();
+      if (response.statusCode == 200) {
+        final body = await response.transform(utf8.decoder).join();
+        final json = jsonDecode(body) as Map<String, dynamic>;
+        return ServerCapabilities.fromJson(json);
+      }
+    } catch (_) {
+      // Network, cancellation, or parse errors → report no capabilities.
+    } finally {
+      client.close(force: true);
+    }
+    return ServerCapabilities.disabled;
+  }
+
+  /// Upload [audioBytes] to the voice endpoint and stream the SSE response.
+  Stream<StreamEvent> sendVoiceMessage(
+    String conversationId,
+    Uint8List audioBytes,
+    String mimeType,
+  ) async* {
+    final extension = mimeType.contains('webm') ? 'webm' : 'm4a';
+    final formData = FormData.fromMap({
+      'audio': MultipartFile.fromBytes(
+        audioBytes,
+        filename: 'audio.$extension',
+        contentType: DioMediaType.parse(mimeType),
+      ),
+    });
+
+    final Response<ResponseBody> response;
+    try {
+      response = await _dio.post<ResponseBody>(
+        '/api/conversations/$conversationId/voice',
+        data: formData,
+        options: Options(
+          responseType: ResponseType.stream,
+          headers: {
+            'Accept': 'text/event-stream',
+            'Authorization': 'Bearer $_token',
+          },
+        ),
+      );
+    } on DioException catch (e) {
+      yield ErrorEvent(e.message ?? 'Voice upload failed');
+      return;
+    }
+
+    yield* _parseSse(response.data!.stream);
+  }
+
+  /// Fetch the audio bytes for a message (GET /api/messages/{id}/audio).
+  Future<Uint8List?> fetchMessageAudio(String messageId) async {
+    try {
+      final response = await _dio.get<List<int>>(
+        '/api/messages/$messageId/audio',
+        options: Options(
+          responseType: ResponseType.bytes,
+          headers: {'Authorization': 'Bearer $_token'},
+        ),
+      );
+      if (response.statusCode == 200 && response.data != null) {
+        return Uint8List.fromList(response.data!);
+      }
+    } catch (_) {
+      // ignore
+    }
+    return null;
+  }
+
+  /// Fetch audio bytes by audio ID (GET /api/audio/{id}).
+  Future<Uint8List?> fetchAudio(String audioId) async {
+    try {
+      final response = await _dio.get<List<int>>(
+        '/api/audio/$audioId',
+        options: Options(
+          responseType: ResponseType.bytes,
+          headers: {'Authorization': 'Bearer $_token'},
+        ),
+      );
+      if (response.statusCode == 200 && response.data != null) {
+        return Uint8List.fromList(response.data!);
+      }
+    } catch (_) {
+      // ignore
+    }
+    return null;
+  }
+
   // -- SSE parser -------------------------------------------------------------
 
   Stream<StreamEvent> _parseSse(Stream<List<int>> byteStream) =>
@@ -89,9 +195,7 @@ class ApiClient {
 /// runtime type error on iOS where [Utf8Decoder] is not accepted as a
 /// [StreamTransformer<Uint8List, String>].
 Stream<StreamEvent> parseSseByteStream(Stream<List<int>> byteStream) async* {
-  final lines = byteStream
-      .map(utf8.decode)
-      .transform(const LineSplitter());
+  final lines = byteStream.map(utf8.decode).transform(const LineSplitter());
 
   String? eventType;
   String? dataLine;
@@ -123,6 +227,13 @@ Stream<StreamEvent> parseSseByteStream(Stream<List<int>> byteStream) async* {
           );
         } catch (_) {
           yield DoneEvent(role: 'assistant', content: dataLine);
+        }
+      } else if (eventType == 'audio_ready' && dataLine != null) {
+        try {
+          final json = jsonDecode(dataLine) as Map<String, dynamic>;
+          yield AudioReadyEvent.fromJson(json);
+        } catch (_) {
+          // ignore malformed audio_ready events
         }
       }
       eventType = null;

--- a/app/lib/api/capabilities_provider.dart
+++ b/app/lib/api/capabilities_provider.dart
@@ -1,0 +1,22 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../features/chat/chat_provider.dart';
+import 'models/server_capabilities.dart';
+
+/// Fetches and caches server capability flags.
+///
+/// Falls back to [ServerCapabilities.disabled] when no client is available or
+/// the request fails.  Uses a [CancelToken] so the in-flight request is
+/// cancelled when the provider is disposed (prevents timer leaks in tests).
+final capabilitiesProvider = FutureProvider<ServerCapabilities>((ref) async {
+  final api = ref.watch(apiClientProvider);
+  if (api == null) return ServerCapabilities.disabled;
+  final cancelToken = CancelToken();
+  ref.onDispose(cancelToken.cancel);
+  try {
+    return await api.getCapabilities(cancelToken: cancelToken);
+  } catch (_) {
+    return ServerCapabilities.disabled;
+  }
+});

--- a/app/lib/api/models/server_capabilities.dart
+++ b/app/lib/api/models/server_capabilities.dart
@@ -1,0 +1,22 @@
+/// Server capability flags returned by GET /api/capabilities.
+class ServerCapabilities {
+  const ServerCapabilities({
+    required this.voiceSend,
+    required this.voiceReceive,
+  });
+
+  final bool voiceSend;
+  final bool voiceReceive;
+
+  factory ServerCapabilities.fromJson(Map<String, dynamic> json) {
+    return ServerCapabilities(
+      voiceSend: json['voice_send'] as bool? ?? false,
+      voiceReceive: json['voice_receive'] as bool? ?? false,
+    );
+  }
+
+  static const disabled = ServerCapabilities(
+    voiceSend: false,
+    voiceReceive: false,
+  );
+}

--- a/app/lib/api/models/stream_event.dart
+++ b/app/lib/api/models/stream_event.dart
@@ -80,3 +80,18 @@ class ErrorEvent extends StreamEvent {
 
   final String message;
 }
+
+/// The server has produced audio for the most recent assistant response.
+///
+/// Corresponds to `event:audio_ready` in the SSE stream.  The JSON body is
+/// `{"audio_id":"<uuid>"}`.
+class AudioReadyEvent extends StreamEvent {
+  const AudioReadyEvent(this.audioId);
+
+  /// Opaque identifier used with GET /api/audio/{audioId}.
+  final String audioId;
+
+  factory AudioReadyEvent.fromJson(Map<String, dynamic> json) {
+    return AudioReadyEvent(json['audio_id'] as String? ?? '');
+  }
+}

--- a/app/lib/features/chat/audio_player_widget.dart
+++ b/app/lib/features/chat/audio_player_widget.dart
@@ -1,0 +1,88 @@
+import 'dart:typed_data';
+
+import 'package:audioplayers/audioplayers.dart';
+import 'package:flutter/material.dart';
+
+/// A compact play/stop button that fetches and plays audio on demand.
+///
+/// Audio is fetched lazily via [fetchAudio] on first play.  Subsequent taps
+/// replay the cached bytes without an extra network round-trip.
+class AudioPlayerWidget extends StatefulWidget {
+  const AudioPlayerWidget({super.key, required this.fetchAudio});
+
+  /// Called once to obtain the audio bytes.  Returns `null` on failure.
+  final Future<Uint8List?> Function() fetchAudio;
+
+  @override
+  State<AudioPlayerWidget> createState() => _AudioPlayerWidgetState();
+}
+
+class _AudioPlayerWidgetState extends State<AudioPlayerWidget> {
+  final _player = AudioPlayer();
+  bool _isPlaying = false;
+  bool _isLoading = false;
+  Uint8List? _cachedBytes;
+
+  @override
+  void initState() {
+    super.initState();
+    _player.onPlayerComplete.listen((_) {
+      if (mounted) setState(() => _isPlaying = false);
+    });
+  }
+
+  @override
+  void dispose() {
+    _player.dispose();
+    super.dispose();
+  }
+
+  Future<void> _toggle() async {
+    if (_isPlaying) {
+      await _player.stop();
+      setState(() => _isPlaying = false);
+      return;
+    }
+
+    setState(() => _isLoading = true);
+    try {
+      _cachedBytes ??= await widget.fetchAudio();
+      final bytes = _cachedBytes;
+      if (bytes == null || !mounted) {
+        setState(() => _isLoading = false);
+        return;
+      }
+
+      await _player.play(BytesSource(bytes));
+      if (mounted) {
+        setState(() {
+          _isPlaying = true;
+          _isLoading = false;
+        });
+      }
+    } catch (_) {
+      if (mounted) setState(() => _isLoading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_isLoading) {
+      return const SizedBox(
+        width: 20,
+        height: 20,
+        child: CircularProgressIndicator(strokeWidth: 2),
+      );
+    }
+    return IconButton(
+      icon: Icon(
+        _isPlaying ? Icons.stop_circle_outlined : Icons.play_circle_outlined,
+      ),
+      onPressed: _toggle,
+      iconSize: 20,
+      padding: EdgeInsets.zero,
+      constraints: const BoxConstraints(),
+      tooltip: _isPlaying ? 'Stop' : 'Play audio response',
+    );
+  }
+}

--- a/app/lib/features/chat/chat_provider.dart
+++ b/app/lib/features/chat/chat_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:assistant_api/assistant_api.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -149,6 +151,7 @@ class ChatMessage {
     required this.content,
     this.isStreaming = false,
     this.status = MessageStatus.ok,
+    this.audioId,
   });
 
   final String id;
@@ -157,6 +160,9 @@ class ChatMessage {
   bool isStreaming;
   MessageStatus status;
 
+  /// Non-null when the server has produced audio for this assistant message.
+  final String? audioId;
+
   bool get isUser => role == 'user';
   bool get isAssistant => role == 'assistant';
 
@@ -164,6 +170,7 @@ class ChatMessage {
     String? content,
     bool? isStreaming,
     MessageStatus? status,
+    String? audioId,
   }) {
     return ChatMessage(
       id: id,
@@ -171,6 +178,7 @@ class ChatMessage {
       content: content ?? this.content,
       isStreaming: isStreaming ?? this.isStreaming,
       status: status ?? this.status,
+      audioId: audioId ?? this.audioId,
     );
   }
 }
@@ -408,6 +416,40 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
     }
   }
 
+  /// Upload [audioBytes] to the voice endpoint and stream the response.
+  ///
+  /// Creates a conversation if none is active (same as [sendMessage]).
+  Future<void> sendVoiceMessage(Uint8List audioBytes, String mimeType) async {
+    final api = _api;
+    if (api == null) return;
+
+    final current = state.value ?? const ChatState();
+    String? conversationId = current.conversationId;
+
+    if (conversationId == null) {
+      try {
+        final response = await api.conversations.createConversation(
+          createConversationRequest: CreateConversationRequest((b) => b),
+        );
+        final conv = response.data!;
+        conversationId = conv.id;
+        ref.read(conversationListProvider.notifier).prependConversation(conv);
+        state = AsyncData(
+          (state.value ?? const ChatState()).copyWith(
+            conversationId: conversationId,
+          ),
+        );
+      } catch (e) {
+        state = AsyncData(
+          current.copyWith(error: 'Failed to create conversation: $e'),
+        );
+        return;
+      }
+    }
+
+    await _streamVoiceMessage(audioBytes, mimeType, conversationId);
+  }
+
   /// Retry a failed message.
   ///
   /// Removes the failed [msg] from the message list and re-enqueues its
@@ -441,6 +483,139 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
       }
     } finally {
       _draining = false;
+    }
+  }
+
+  /// Upload voice audio and stream the assistant's SSE response.
+  Future<void> _streamVoiceMessage(
+    Uint8List audioBytes,
+    String mimeType,
+    String conversationId,
+  ) async {
+    final api = _api;
+    if (api == null) return;
+
+    _cancelled = false;
+    final current = state.value ?? const ChatState();
+
+    // Show a placeholder user message while transcribing.
+    final userMsgId = 'user-${DateTime.now().millisecondsSinceEpoch}';
+    final userMsg = ChatMessage(
+      id: userMsgId,
+      role: 'user',
+      content: '🎤 Voice message',
+      status: MessageStatus.sending,
+    );
+    final assistantPlaceholder = ChatMessage(
+      id: 'assistant-streaming',
+      role: 'assistant',
+      content: '',
+      isStreaming: true,
+    );
+    state = AsyncData(
+      current.copyWith(
+        messages: [...current.messages, userMsg, assistantPlaceholder],
+        isSending: true,
+        streamingContent: '',
+      ),
+    );
+
+    try {
+      await for (final event in api.sendVoiceMessage(
+        conversationId,
+        audioBytes,
+        mimeType,
+      )) {
+        if (_cancelled) break;
+        final chatState = state.value ?? const ChatState();
+
+        if (event is TokenEvent) {
+          final newContent = chatState.streamingContent + event.token;
+          final msgs = List<ChatMessage>.from(chatState.messages);
+          final idx = msgs.indexWhere((m) => m.id == 'assistant-streaming');
+          if (idx != -1) msgs[idx].content = newContent;
+          state = AsyncData(
+            chatState.copyWith(
+              messages: msgs,
+              streamingContent: newContent,
+              clearStatusMessage: true,
+            ),
+          );
+        } else if (event is StatusEvent) {
+          state = AsyncData(chatState.copyWith(statusMessage: event.message));
+        } else if (event is AudioReadyEvent) {
+          // Store audioId on the streaming assistant message for auto-play.
+          final msgs = List<ChatMessage>.from(chatState.messages);
+          final idx = msgs.indexWhere((m) => m.id == 'assistant-streaming');
+          if (idx != -1) {
+            msgs[idx] = msgs[idx].copyWith(audioId: event.audioId);
+          }
+          state = AsyncData(chatState.copyWith(messages: msgs));
+        } else if (event is DoneEvent) {
+          final msgs = List<ChatMessage>.from(chatState.messages);
+          final userIdx = msgs.indexWhere((m) => m.id == userMsgId);
+          if (userIdx != -1) {
+            msgs[userIdx] = msgs[userIdx].copyWith(
+              content: event.content.isNotEmpty
+                  ? '[Voice] ${event.content}'
+                  : '🎤 Voice message',
+              status: MessageStatus.ok,
+            );
+          }
+          final idx = msgs.indexWhere((m) => m.id == 'assistant-streaming');
+          if (idx != -1) {
+            msgs[idx] = ChatMessage(
+              id: 'assistant-${DateTime.now().millisecondsSinceEpoch}',
+              role: 'assistant',
+              content: event.content,
+              audioId: msgs[idx].audioId,
+            );
+          }
+          state = AsyncData(
+            ChatState(
+              conversationId: conversationId,
+              messages: msgs,
+              pendingQueue: chatState.pendingQueue,
+            ),
+          );
+          ref.read(conversationListProvider.notifier).refresh();
+          return;
+        } else if (event is ErrorEvent) {
+          final msgs = List<ChatMessage>.from(chatState.messages)
+            ..removeWhere((m) => m.id == 'assistant-streaming');
+          final userIdx = msgs.indexWhere((m) => m.id == userMsgId);
+          if (userIdx != -1) {
+            msgs[userIdx] = msgs[userIdx].copyWith(
+              status: MessageStatus.failed,
+            );
+          }
+          state = AsyncData(
+            chatState.copyWith(
+              messages: msgs,
+              isSending: false,
+              streamingContent: '',
+              error: event.message,
+            ),
+          );
+          return;
+        }
+      }
+    } catch (e) {
+      final chatState = state.value ?? const ChatState();
+      final msgs = List<ChatMessage>.from(chatState.messages)
+        ..removeWhere((m) => m.id == 'assistant-streaming');
+      final userIdx = msgs.indexWhere((m) => m.id == userMsgId);
+      if (userIdx != -1) {
+        msgs[userIdx] = msgs[userIdx].copyWith(status: MessageStatus.failed);
+      }
+      state = AsyncData(
+        chatState.copyWith(
+          messages: msgs,
+          isSending: false,
+          streamingContent: '',
+          error: 'Voice stream error: $e',
+        ),
+      );
     }
   }
 
@@ -533,6 +708,13 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
           // Refresh conversation list to update timestamps/titles.
           ref.read(conversationListProvider.notifier).refresh();
           return;
+        } else if (event is AudioReadyEvent) {
+          final msgs = List<ChatMessage>.from(chatState.messages);
+          final idx = msgs.indexWhere((m) => m.id == 'assistant-streaming');
+          if (idx != -1) {
+            msgs[idx] = msgs[idx].copyWith(audioId: event.audioId);
+          }
+          state = AsyncData(chatState.copyWith(messages: msgs));
         } else if (event is ErrorEvent) {
           final msgs = List<ChatMessage>.from(chatState.messages)
             ..removeWhere((m) => m.id == 'assistant-streaming');

--- a/app/lib/features/chat/chat_provider.dart
+++ b/app/lib/features/chat/chat_provider.dart
@@ -696,6 +696,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
               id: 'assistant-${DateTime.now().millisecondsSinceEpoch}',
               role: 'assistant',
               content: event.content,
+              audioId: msgs[idx].audioId,
             );
           }
           state = AsyncData(

--- a/app/lib/features/chat/chat_screen.dart
+++ b/app/lib/features/chat/chat_screen.dart
@@ -1,12 +1,18 @@
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../api/capabilities_provider.dart';
+import '../../api/models/server_capabilities.dart';
 import '../personas/persona_picker.dart';
 import '../personas/personas_provider.dart';
+import 'audio_player_widget.dart';
 import 'chat_provider.dart';
 import 'conversation_list.dart';
+import 'voice_recorder_button.dart';
 
 /// Main chat screen.
 ///
@@ -84,6 +90,11 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     _scrollToBottom();
   }
 
+  Future<void> _sendVoiceMessage(Uint8List bytes, String mimeType) async {
+    await ref.read(chatProvider.notifier).sendVoiceMessage(bytes, mimeType);
+    _scrollToBottom();
+  }
+
   @override
   Widget build(BuildContext context) {
     final chatAsync = ref.watch(chatProvider);
@@ -100,6 +111,13 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     final personasAsync = ref.watch(personasProvider);
     final activePersona = personasAsync.value?.activePersona;
     final activePersonaName = activePersona?.name ?? 'Assistant';
+
+    // Resolve capabilities only when an API client is available (avoids
+    // triggering async work in tests that have no active profile).
+    final hasClient = ref.watch(apiClientProvider) != null;
+    final capabilities = hasClient
+        ? (ref.watch(capabilitiesProvider).value ?? ServerCapabilities.disabled)
+        : ServerCapabilities.disabled;
 
     return Scaffold(
       appBar: AppBar(
@@ -233,11 +251,17 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                               return _MessageBubble(
                                 message: msg,
                                 isGrouped: isGrouped,
+                                capabilities: capabilities,
                                 onRetry: msg.status == MessageStatus.failed
                                     ? () => ref
                                           .read(chatProvider.notifier)
                                           .retryMessage(msg)
                                     : null,
+                                fetchMessageAudio: () {
+                                  final api = ref.read(apiClientProvider);
+                                  return api?.fetchMessageAudio(msg.id) ??
+                                      Future.value(null);
+                                },
                               );
                             },
                           ),
@@ -273,9 +297,11 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                     focusNode: _inputFocus,
                     isSending: chatState.isSending,
                     pendingQueueCount: chatState.pendingQueue.length,
+                    capabilities: capabilities,
                     onSend: _sendMessage,
                     onStop: () =>
                         ref.read(chatProvider.notifier).cancelStream(),
+                    onVoiceRecorded: _sendVoiceMessage,
                   ),
                 ],
               ),
@@ -292,6 +318,8 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
 class _MessageBubble extends StatelessWidget {
   const _MessageBubble({
     required this.message,
+    required this.capabilities,
+    required this.fetchMessageAudio,
     this.isGrouped = false,
     this.onRetry,
   });
@@ -299,6 +327,8 @@ class _MessageBubble extends StatelessWidget {
   final ChatMessage message;
   final bool isGrouped;
   final VoidCallback? onRetry;
+  final ServerCapabilities capabilities;
+  final Future<Uint8List?> Function() fetchMessageAudio;
 
   @override
   Widget build(BuildContext context) {
@@ -358,17 +388,34 @@ class _MessageBubble extends StatelessWidget {
                       ),
                     ],
                   )
-                : MarkdownBody(
-                    data: message.content,
-                    styleSheet: MarkdownStyleSheet.fromTheme(Theme.of(context))
-                        .copyWith(
-                          p: TextStyle(color: colorScheme.onSurface),
-                          code: TextStyle(
-                            color: colorScheme.onSurface,
-                            backgroundColor: colorScheme.surfaceContainerLowest,
+                : Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      MarkdownBody(
+                        data: message.content,
+                        styleSheet:
+                            MarkdownStyleSheet.fromTheme(
+                              Theme.of(context),
+                            ).copyWith(
+                              p: TextStyle(color: colorScheme.onSurface),
+                              code: TextStyle(
+                                color: colorScheme.onSurface,
+                                backgroundColor:
+                                    colorScheme.surfaceContainerLowest,
+                              ),
+                            ),
+                        selectable: true,
+                      ),
+                      // Play button for voice-capable assistant messages.
+                      if (capabilities.voiceReceive && !message.isStreaming)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 6),
+                          child: AudioPlayerWidget(
+                            fetchAudio: fetchMessageAudio,
                           ),
                         ),
-                    selectable: true,
+                    ],
                   ),
           ),
           // Retry button shown below the bubble for failed user messages.
@@ -470,16 +517,20 @@ class _InputRow extends StatelessWidget {
     required this.focusNode,
     required this.isSending,
     required this.pendingQueueCount,
+    required this.capabilities,
     required this.onSend,
     required this.onStop,
+    required this.onVoiceRecorded,
   });
 
   final TextEditingController controller;
   final FocusNode focusNode;
   final bool isSending;
   final int pendingQueueCount;
+  final ServerCapabilities capabilities;
   final VoidCallback onSend;
   final VoidCallback onStop;
+  final void Function(Uint8List bytes, String mimeType) onVoiceRecorded;
 
   @override
   Widget build(BuildContext context) {
@@ -516,6 +567,18 @@ class _InputRow extends StatelessWidget {
           ),
           child: Row(
             children: [
+              // Voice recorder button — shown when server supports voice send.
+              if (capabilities.voiceSend && !isSending)
+                VoiceRecorderButton(
+                  onRecordingComplete: onVoiceRecorded,
+                  onError: (err) {
+                    ScaffoldMessenger.of(
+                      context,
+                    ).showSnackBar(SnackBar(content: Text(err)));
+                  },
+                ),
+              if (capabilities.voiceSend && !isSending)
+                const SizedBox(width: 4),
               Expanded(
                 child: TextField(
                   key: const Key('message_input'),

--- a/app/lib/features/chat/voice_recorder_button.dart
+++ b/app/lib/features/chat/voice_recorder_button.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
-import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:record/record.dart';
 
@@ -13,17 +13,22 @@ class VoiceRecorderButton extends StatefulWidget {
     super.key,
     required this.onRecordingComplete,
     required this.onError,
+    @visibleForTesting this.audioRecorder,
   });
 
   final void Function(Uint8List bytes, String mimeType) onRecordingComplete;
   final void Function(String error) onError;
+
+  /// Overrides the default [AudioRecorder] instance. Intended for testing only.
+  @visibleForTesting
+  final AudioRecorder? audioRecorder;
 
   @override
   State<VoiceRecorderButton> createState() => _VoiceRecorderButtonState();
 }
 
 class _VoiceRecorderButtonState extends State<VoiceRecorderButton> {
-  final _recorder = AudioRecorder();
+  late final AudioRecorder _recorder;
   bool _isRecording = false;
   int _secondsElapsed = 0;
   Timer? _countdownTimer;
@@ -31,6 +36,12 @@ class _VoiceRecorderButtonState extends State<VoiceRecorderButton> {
 
   StreamSubscription<List<int>>? _streamSub;
   final List<int> _recordedBytes = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _recorder = widget.audioRecorder ?? AudioRecorder();
+  }
 
   @override
   void dispose() {
@@ -49,8 +60,13 @@ class _VoiceRecorderButtonState extends State<VoiceRecorderButton> {
   }
 
   Future<void> _start() async {
-    final hasPermission = await _recorder.hasPermission();
-    if (!hasPermission) {
+    try {
+      final hasPermission = await _recorder.hasPermission();
+      if (!hasPermission) {
+        widget.onError('Microphone access is required to send voice messages');
+        return;
+      }
+    } catch (e) {
       widget.onError('Microphone access is required to send voice messages');
       return;
     }

--- a/app/lib/features/chat/voice_recorder_button.dart
+++ b/app/lib/features/chat/voice_recorder_button.dart
@@ -1,0 +1,125 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:record/record.dart';
+
+/// A mic button that records audio from the microphone.
+///
+/// While recording it shows a timer and a stop button.  When stopped it
+/// invokes [onRecordingComplete] with the raw opus bytes and MIME type.
+class VoiceRecorderButton extends StatefulWidget {
+  const VoiceRecorderButton({
+    super.key,
+    required this.onRecordingComplete,
+    required this.onError,
+  });
+
+  final void Function(Uint8List bytes, String mimeType) onRecordingComplete;
+  final void Function(String error) onError;
+
+  @override
+  State<VoiceRecorderButton> createState() => _VoiceRecorderButtonState();
+}
+
+class _VoiceRecorderButtonState extends State<VoiceRecorderButton> {
+  final _recorder = AudioRecorder();
+  bool _isRecording = false;
+  int _secondsElapsed = 0;
+  Timer? _countdownTimer;
+  static const _maxSeconds = 120;
+
+  StreamSubscription<List<int>>? _streamSub;
+  final List<int> _recordedBytes = [];
+
+  @override
+  void dispose() {
+    _countdownTimer?.cancel();
+    _streamSub?.cancel();
+    _recorder.dispose();
+    super.dispose();
+  }
+
+  Future<void> _toggle() async {
+    if (_isRecording) {
+      await _stop();
+    } else {
+      await _start();
+    }
+  }
+
+  Future<void> _start() async {
+    final hasPermission = await _recorder.hasPermission();
+    if (!hasPermission) {
+      widget.onError('Microphone access is required to send voice messages');
+      return;
+    }
+    try {
+      _recordedBytes.clear();
+      final stream = await _recorder.startStream(
+        const RecordConfig(encoder: AudioEncoder.opus, numChannels: 1),
+      );
+      _streamSub = stream.listen((chunk) => _recordedBytes.addAll(chunk));
+      setState(() {
+        _isRecording = true;
+        _secondsElapsed = 0;
+      });
+      _countdownTimer = Timer.periodic(const Duration(seconds: 1), (_) {
+        setState(() => _secondsElapsed++);
+        if (_secondsElapsed >= _maxSeconds) _stop();
+      });
+    } catch (e) {
+      widget.onError('Failed to start recording: $e');
+    }
+  }
+
+  Future<void> _stop() async {
+    _countdownTimer?.cancel();
+    await _streamSub?.cancel();
+    _streamSub = null;
+    await _recorder.stop();
+    final bytes = Uint8List.fromList(_recordedBytes);
+    setState(() => _isRecording = false);
+    if (bytes.isNotEmpty) {
+      widget.onRecordingComplete(bytes, 'audio/webm');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_isRecording) {
+      final remaining = _maxSeconds - _secondsElapsed;
+      final minutes = remaining ~/ 60;
+      final secs = remaining % 60;
+      return Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            width: 8,
+            height: 8,
+            decoration: const BoxDecoration(
+              color: Colors.red,
+              shape: BoxShape.circle,
+            ),
+          ),
+          const SizedBox(width: 6),
+          Text(
+            '$minutes:${secs.toString().padLeft(2, '0')}',
+            style: const TextStyle(fontSize: 13, color: Colors.red),
+          ),
+          const SizedBox(width: 4),
+          IconButton(
+            icon: const Icon(Icons.stop_circle_outlined, color: Colors.red),
+            onPressed: _stop,
+            tooltip: 'Stop recording',
+          ),
+        ],
+      );
+    }
+    return IconButton(
+      icon: const Icon(Icons.mic_none_outlined),
+      tooltip: 'Send voice message',
+      onPressed: _toggle,
+    );
+  }
+}

--- a/app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,7 +9,7 @@ import audioplayers_darwin
 import flutter_local_notifications
 import flutter_secure_storage_darwin
 import package_info_plus
-import record_darwin
+import record_macos
 import screen_retriever_macos
 import shared_preferences_foundation
 import tray_manager
@@ -21,7 +21,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
-  RecordPlugin.register(with: registry.registrar(forPlugin: "RecordPlugin"))
+  RecordMacOsPlugin.register(with: registry.registrar(forPlugin: "RecordMacOsPlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   TrayManagerPlugin.register(with: registry.registrar(forPlugin: "TrayManagerPlugin"))

--- a/app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,9 +5,11 @@
 import FlutterMacOS
 import Foundation
 
+import audioplayers_darwin
 import flutter_local_notifications
 import flutter_secure_storage_darwin
 import package_info_plus
+import record_darwin
 import screen_retriever_macos
 import shared_preferences_foundation
 import tray_manager
@@ -15,9 +17,11 @@ import url_launcher_macos
 import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  AudioplayersDarwinPlugin.register(with: registry.registrar(forPlugin: "AudioplayersDarwinPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
+  RecordPlugin.register(with: registry.registrar(forPlugin: "RecordPlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   TrayManagerPlugin.register(with: registry.registrar(forPlugin: "TrayManagerPlugin"))

--- a/app/macos/Podfile.lock
+++ b/app/macos/Podfile.lock
@@ -1,4 +1,7 @@
 PODS:
+  - audioplayers_darwin (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - flutter_local_notifications (0.0.1):
     - FlutterMacOS
   - flutter_secure_storage_darwin (10.0.0):
@@ -6,6 +9,8 @@ PODS:
     - FlutterMacOS
   - FlutterMacOS (1.0.0)
   - package_info_plus (0.0.1):
+    - FlutterMacOS
+  - record_macos (1.2.0):
     - FlutterMacOS
   - screen_retriever_macos (0.0.1):
     - FlutterMacOS
@@ -20,10 +25,12 @@ PODS:
     - FlutterMacOS
 
 DEPENDENCIES:
+  - audioplayers_darwin (from `Flutter/ephemeral/.symlinks/plugins/audioplayers_darwin/darwin`)
   - flutter_local_notifications (from `Flutter/ephemeral/.symlinks/plugins/flutter_local_notifications/macos`)
   - flutter_secure_storage_darwin (from `Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
+  - record_macos (from `Flutter/ephemeral/.symlinks/plugins/record_macos/macos`)
   - screen_retriever_macos (from `Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos`)
   - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
   - tray_manager (from `Flutter/ephemeral/.symlinks/plugins/tray_manager/macos`)
@@ -31,6 +38,8 @@ DEPENDENCIES:
   - window_manager (from `Flutter/ephemeral/.symlinks/plugins/window_manager/macos`)
 
 EXTERNAL SOURCES:
+  audioplayers_darwin:
+    :path: Flutter/ephemeral/.symlinks/plugins/audioplayers_darwin/darwin
   flutter_local_notifications:
     :path: Flutter/ephemeral/.symlinks/plugins/flutter_local_notifications/macos
   flutter_secure_storage_darwin:
@@ -39,6 +48,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral
   package_info_plus:
     :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos
+  record_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/record_macos/macos
   screen_retriever_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos
   shared_preferences_foundation:
@@ -51,10 +62,12 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/window_manager/macos
 
 SPEC CHECKSUMS:
+  audioplayers_darwin: 835ced6edd4c9fc8ebb0a7cc9e294a91d99917d5
   flutter_local_notifications: 1fc7ffb10a83d6a2eeeeddb152d43f1944b0aad0
   flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
   package_info_plus: f0052d280d17aa382b932f399edf32507174e870
+  record_macos: 7f227161b93c49e7e34fe681c5891c8622c8cc8b
   screen_retriever_macos: 452e51764a9e1cdb74b3c541238795849f21557f
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
   tray_manager: a104b5c81b578d83f3c3d0f40a997c8b10810166

--- a/app/macos/Runner/DebugProfile.entitlements
+++ b/app/macos/Runner/DebugProfile.entitlements
@@ -10,6 +10,8 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 	<key>com.apple.security.inherit</key>
 	<true/>
 	<key>keychain-access-groups</key>

--- a/app/macos/Runner/Info.plist
+++ b/app/macos/Runner/Info.plist
@@ -28,5 +28,7 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Microphone access is required to send voice messages.</string>
 </dict>
 </plist>

--- a/app/macos/Runner/Release.entitlements
+++ b/app/macos/Runner/Release.entitlements
@@ -6,6 +6,8 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
 	<key>com.apple.security.inherit</key>

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -723,10 +723,10 @@ packages:
     dependency: "direct main"
     description:
       name: record
-      sha256: "2e3d56d196abcd69f1046339b75e5f3855b2406fc087e5991f6703f188aa03a6"
+      sha256: d5b6b334f3ab02460db6544e08583c942dbf23e3504bf1e14fd4cbe3d9409277
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.1"
+    version: "6.2.0"
   record_android:
     dependency: transitive
     description:
@@ -735,22 +735,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
-  record_darwin:
+  record_ios:
     dependency: transitive
     description:
-      name: record_darwin
-      sha256: e487eccb19d82a9a39cd0126945cfc47b9986e0df211734e2788c95e3f63c82c
+      name: record_ios
+      sha256: "8df7c136131bd05efc19256af29b2ba6ccc000ccc2c80d4b6b6d7a8d21a3b5a9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.2.0"
   record_linux:
     dependency: transitive
     description:
       name: record_linux
-      sha256: "74d41a9ebb1eb498a38e9a813dd524e8f0b4fdd627270bda9756f437b110a3e3"
+      sha256: c31a35cc158cd666fc6395f7f56fc054f31685571684be6b97670a27649ce5c7
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "1.3.0"
+  record_macos:
+    dependency: transitive
+    description:
+      name: record_macos
+      sha256: "084902e63fc9c0c224c29203d6c75f0bdf9b6a40536c9d916393c8f4c4256488"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
   record_platform_interface:
     dependency: transitive
     description:

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -40,6 +40,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.13.1"
+  audioplayers:
+    dependency: "direct main"
+    description:
+      name: audioplayers
+      sha256: a72dd459d1a48f61a6fb9c0134dba26597c9236af40639ff0eb70eb4e0baab70
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.0"
+  audioplayers_android:
+    dependency: transitive
+    description:
+      name: audioplayers_android
+      sha256: "60a6728277228413a85755bd3ffd6fab98f6555608923813ce383b190a360605"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.2.1"
+  audioplayers_darwin:
+    dependency: transitive
+    description:
+      name: audioplayers_darwin
+      sha256: c994b3bb3a921e4904ac40e013fbc94488e824fd7c1de6326f549943b0b44a91
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.0"
+  audioplayers_linux:
+    dependency: transitive
+    description:
+      name: audioplayers_linux
+      sha256: f75bce1ce864170ef5e6a2c6a61cd3339e1a17ce11e99a25bae4474ea491d001
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.1"
+  audioplayers_platform_interface:
+    dependency: transitive
+    description:
+      name: audioplayers_platform_interface
+      sha256: "0e2f6a919ab56d0fec272e801abc07b26ae7f31980f912f24af4748763e5a656"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.1.1"
+  audioplayers_web:
+    dependency: transitive
+    description:
+      name: audioplayers_web
+      sha256: faa8fa6587f996a6f604433b53af44c57a1407d4fe8dff5766cf63d6875e8de9
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.2.0"
+  audioplayers_windows:
+    dependency: transitive
+    description:
+      name: audioplayers_windows
+      sha256: bafff2b38b6f6d331887558ba6e0a01c9c208d9dbb3ad0005234db065122a734
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.3.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -663,6 +719,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.2"
+  record:
+    dependency: "direct main"
+    description:
+      name: record
+      sha256: "2e3d56d196abcd69f1046339b75e5f3855b2406fc087e5991f6703f188aa03a6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.2.1"
+  record_android:
+    dependency: transitive
+    description:
+      name: record_android
+      sha256: "94783f08403aed33ffb68797bf0715b0812eb852f3c7985644c945faea462ba1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.1"
+  record_darwin:
+    dependency: transitive
+    description:
+      name: record_darwin
+      sha256: e487eccb19d82a9a39cd0126945cfc47b9986e0df211734e2788c95e3f63c82c
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.2"
+  record_linux:
+    dependency: transitive
+    description:
+      name: record_linux
+      sha256: "74d41a9ebb1eb498a38e9a813dd524e8f0b4fdd627270bda9756f437b110a3e3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.2"
+  record_platform_interface:
+    dependency: transitive
+    description:
+      name: record_platform_interface
+      sha256: "8a81dbc4e14e1272a285bbfef6c9136d070a47d9b0d1f40aa6193516253ee2f6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.0"
+  record_web:
+    dependency: transitive
+    description:
+      name: record_web
+      sha256: "7e9846981c1f2d111d86f0ae3309071f5bba8b624d1c977316706f08fc31d16d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
+  record_windows:
+    dependency: transitive
+    description:
+      name: record_windows
+      sha256: "223258060a1d25c62bae18282c16783f28581ec19401d17e56b5205b9f039d78"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.7"
   riverpod:
     dependency: transitive
     description:
@@ -868,6 +980,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  synchronized:
+    dependency: transitive
+    description:
+      name: synchronized
+      sha256: c254ade258ec8282947a0acbbc90b9575b4f19673533ee46f2f6e9b3aeefd7c0
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.0"
   term_glyph:
     dependency: transitive
     description:

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -73,7 +73,7 @@ packages:
     source: hosted
     version: "4.2.1"
   audioplayers_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: audioplayers_platform_interface
       sha256: "0e2f6a919ab56d0fec272e801abc07b26ae7f31980f912f24af4748763e5a656"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   pwa_update_listener: ^0.1.0
   flutter_local_notifications: ^21.0.0
   web: ^1.1.1
-  record: ^5.2.0
+  record: ^6.2.0
   audioplayers: ^6.1.0
 dev_dependencies:
   flutter_test:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -39,6 +39,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
+  audioplayers_platform_interface: ^7.1.1
 flutter:
   uses-material-design: true
   assets:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   path_provider: ^2.1.5
   url_launcher: ^6.3.2
   package_info_plus: ^9.0.1
-  built_value: '>=8.4.0 <9.0.0'
+  built_value: ">=8.4.0 <9.0.0"
   assistant_api:
     path: packages/assistant_api
   tray_manager: ^0.5.2
@@ -33,6 +33,8 @@ dependencies:
   pwa_update_listener: ^0.1.0
   flutter_local_notifications: ^21.0.0
   web: ^1.1.1
+  record: ^5.2.0
+  audioplayers: ^6.1.0
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/app/test/unit/api/client_test.dart
+++ b/app/test/unit/api/client_test.dart
@@ -55,8 +55,12 @@ void main() {
         const ErrorEvent('error'),
       ];
 
-      int tokenCount = 0, statusCount = 0, toolCount = 0, doneCount = 0,
-          errorCount = 0;
+      int tokenCount = 0,
+          statusCount = 0,
+          toolCount = 0,
+          doneCount = 0,
+          errorCount = 0,
+          audioReadyCount = 0;
       for (final e in events) {
         switch (e) {
           case TokenEvent():
@@ -69,6 +73,8 @@ void main() {
             doneCount++;
           case ErrorEvent():
             errorCount++;
+          case AudioReadyEvent():
+            audioReadyCount++;
         }
       }
 
@@ -77,6 +83,7 @@ void main() {
       expect(toolCount, equals(1));
       expect(doneCount, equals(1));
       expect(errorCount, equals(1));
+      expect(audioReadyCount, equals(0));
     });
   });
 }

--- a/app/test/unit/api/voice_models_test.dart
+++ b/app/test/unit/api/voice_models_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/api/models/server_capabilities.dart';
+import 'package:assistant_app/api/models/stream_event.dart';
+
+void main() {
+  group('ServerCapabilities', () {
+    test('fromJson parses both flags as true', () {
+      final caps = ServerCapabilities.fromJson({
+        'voice_send': true,
+        'voice_receive': true,
+      });
+      expect(caps.voiceSend, isTrue);
+      expect(caps.voiceReceive, isTrue);
+    });
+
+    test('fromJson parses both flags as false', () {
+      final caps = ServerCapabilities.fromJson({
+        'voice_send': false,
+        'voice_receive': false,
+      });
+      expect(caps.voiceSend, isFalse);
+      expect(caps.voiceReceive, isFalse);
+    });
+
+    test('fromJson defaults missing flags to false', () {
+      final caps = ServerCapabilities.fromJson({});
+      expect(caps.voiceSend, isFalse);
+      expect(caps.voiceReceive, isFalse);
+    });
+
+    test('fromJson handles partial flags', () {
+      final caps = ServerCapabilities.fromJson({'voice_send': true});
+      expect(caps.voiceSend, isTrue);
+      expect(caps.voiceReceive, isFalse);
+    });
+
+    test('disabled constant has both flags false', () {
+      expect(ServerCapabilities.disabled.voiceSend, isFalse);
+      expect(ServerCapabilities.disabled.voiceReceive, isFalse);
+    });
+  });
+
+  group('AudioReadyEvent', () {
+    test('stores audioId', () {
+      const event = AudioReadyEvent('abc-123');
+      expect(event.audioId, equals('abc-123'));
+    });
+
+    test('fromJson parses audio_id', () {
+      final event = AudioReadyEvent.fromJson({'audio_id': 'my-uuid'});
+      expect(event.audioId, equals('my-uuid'));
+    });
+
+    test('fromJson defaults missing audio_id to empty string', () {
+      final event = AudioReadyEvent.fromJson({});
+      expect(event.audioId, equals(''));
+    });
+
+    test('is a StreamEvent subtype', () {
+      const StreamEvent event = AudioReadyEvent('id');
+      expect(event, isA<AudioReadyEvent>());
+    });
+
+    test('pattern match works in switch', () {
+      const StreamEvent event = AudioReadyEvent('play-me');
+      String? gotId;
+      switch (event) {
+        case AudioReadyEvent(:final audioId):
+          gotId = audioId;
+        default:
+          break;
+      }
+      expect(gotId, equals('play-me'));
+    });
+  });
+}

--- a/app/test/unit/chat/chat_provider_test.dart
+++ b/app/test/unit/chat/chat_provider_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:assistant_api/assistant_api.dart';
 import 'package:assistant_app/api/api_client.dart';
@@ -15,6 +16,7 @@ class _FakeApiClient extends ApiClient {
   _FakeApiClient() : super(baseUrl: 'http://fake', token: 'fake');
 
   final List<StreamController<StreamEvent>> _queue = [];
+  final List<StreamController<StreamEvent>> _voiceQueue = [];
 
   /// Enqueue a [StreamController] whose stream will be returned for the next
   /// [streamMessages] call. The caller controls when events are added.
@@ -24,10 +26,29 @@ class _FakeApiClient extends ApiClient {
     return ctrl;
   }
 
+  /// Enqueue a [StreamController] for the next [sendVoiceMessage] call.
+  StreamController<StreamEvent> enqueueVoiceStream() {
+    final ctrl = StreamController<StreamEvent>();
+    _voiceQueue.add(ctrl);
+    return ctrl;
+  }
+
   @override
   Stream<StreamEvent> streamMessages(String conversationId, String message) {
     if (_queue.isNotEmpty) {
       return _queue.removeAt(0).stream;
+    }
+    return const Stream.empty();
+  }
+
+  @override
+  Stream<StreamEvent> sendVoiceMessage(
+    String conversationId,
+    Uint8List audioBytes,
+    String mimeType,
+  ) {
+    if (_voiceQueue.isNotEmpty) {
+      return _voiceQueue.removeAt(0).stream;
     }
     return const Stream.empty();
   }
@@ -250,6 +271,36 @@ void main() {
       },
     );
 
+    testWidgets('7.5: AudioReadyEvent sets audioId on the assistant message', (
+      tester,
+    ) async {
+      final fakeApi = _FakeApiClient();
+      final ctrl = fakeApi.enqueueStream();
+
+      final notifier = await _pumpTestApp(tester, fakeApi);
+
+      unawaited(notifier.sendMessage('play audio'));
+      await tester.pump();
+
+      await tester.runAsync(() async {
+        ctrl
+          ..add(const AudioReadyEvent('uuid-123'))
+          ..add(const DoneEvent(role: 'assistant', content: 'Here you go'))
+          ..close();
+        await Future<void>.delayed(Duration.zero);
+      });
+      await tester.pumpAndSettle();
+
+      final assistant = notifier.state.value!.messages.firstWhere(
+        (m) => !m.isUser,
+      );
+      expect(
+        assistant.audioId,
+        equals('uuid-123'),
+        reason: 'AudioReadyEvent should set audioId on the assistant message',
+      );
+    });
+
     testWidgets('7.4: retryMessage removes failed message and re-enqueues it', (
       tester,
     ) async {
@@ -308,5 +359,115 @@ void main() {
         reason: 'retried message must reappear in list during drain',
       );
     });
+  });
+
+  // -- sendVoiceMessage tests -------------------------------------------------
+
+  group('ChatNotifier.sendVoiceMessage', () {
+    testWidgets('adds a voice placeholder user message while streaming', (
+      tester,
+    ) async {
+      final fakeApi = _FakeApiClient();
+      final ctrl = fakeApi.enqueueVoiceStream();
+
+      final notifier = await _pumpTestApp(tester, fakeApi);
+
+      unawaited(
+        notifier.sendVoiceMessage(Uint8List.fromList([1, 2, 3]), 'audio/webm'),
+      );
+      await tester.pump();
+
+      final chatState = notifier.state.value!;
+      expect(chatState.isSending, isTrue);
+      final userMsg = chatState.messages.firstWhere((m) => m.isUser);
+      expect(userMsg.content, contains('🎤'));
+      expect(userMsg.status, MessageStatus.sending);
+
+      ctrl
+        ..add(const DoneEvent(role: 'assistant', content: 'transcribed'))
+        ..close();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('DoneEvent finalizes the assistant message', (tester) async {
+      final fakeApi = _FakeApiClient();
+      final ctrl = fakeApi.enqueueVoiceStream();
+
+      final notifier = await _pumpTestApp(tester, fakeApi);
+
+      unawaited(
+        notifier.sendVoiceMessage(Uint8List.fromList([1, 2, 3]), 'audio/webm'),
+      );
+      await tester.pump();
+
+      await tester.runAsync(() async {
+        ctrl
+          ..add(const DoneEvent(role: 'assistant', content: 'Hello!'))
+          ..close();
+        await Future<void>.delayed(Duration.zero);
+      });
+      await tester.pumpAndSettle();
+
+      final assistant = notifier.state.value!.messages.firstWhere(
+        (m) => !m.isUser,
+      );
+      expect(assistant.content, equals('Hello!'));
+      expect(assistant.isStreaming, isFalse);
+      expect(notifier.state.value!.isSending, isFalse);
+    });
+
+    testWidgets('ErrorEvent marks user message as failed', (tester) async {
+      final fakeApi = _FakeApiClient();
+      final ctrl = fakeApi.enqueueVoiceStream();
+
+      final notifier = await _pumpTestApp(tester, fakeApi);
+
+      unawaited(
+        notifier.sendVoiceMessage(Uint8List.fromList([1, 2, 3]), 'audio/webm'),
+      );
+      await tester.pump();
+
+      ctrl
+        ..add(const ErrorEvent('transcription failed'))
+        ..close();
+      await tester.pumpAndSettle();
+
+      final userMsg = notifier.state.value!.messages.firstWhere(
+        (m) => m.isUser,
+      );
+      expect(userMsg.status, MessageStatus.failed);
+    });
+
+    testWidgets(
+      'AudioReadyEvent sets audioId on the streaming assistant message',
+      (tester) async {
+        final fakeApi = _FakeApiClient();
+        final ctrl = fakeApi.enqueueVoiceStream();
+
+        final notifier = await _pumpTestApp(tester, fakeApi);
+
+        unawaited(
+          notifier.sendVoiceMessage(
+            Uint8List.fromList([1, 2, 3]),
+            'audio/webm',
+          ),
+        );
+        await tester.pump();
+
+        await tester.runAsync(() async {
+          ctrl
+            ..add(const AudioReadyEvent('voice-audio-id'))
+            ..add(const DoneEvent(role: 'assistant', content: 'Here'))
+            ..close();
+          await Future<void>.delayed(Duration.zero);
+        });
+        await tester.pumpAndSettle();
+
+        final assistant = notifier.state.value!.messages.firstWhere(
+          (m) => !m.isUser,
+        );
+        expect(assistant.audioId, equals('voice-audio-id'));
+      },
+    );
   });
 }

--- a/app/test/widget/features/voice_widgets_test.dart
+++ b/app/test/widget/features/voice_widgets_test.dart
@@ -1,0 +1,322 @@
+import 'dart:async';
+
+import 'package:audioplayers_platform_interface/audioplayers_platform_interface.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/features/chat/audio_player_widget.dart';
+import 'package:assistant_app/features/chat/voice_recorder_button.dart';
+
+// ---------------------------------------------------------------------------
+// Fake AudioplayersPlatformInterface — avoids all native channel calls and
+// auto-emits "prepared" so that _completePrepared() resolves immediately.
+// ---------------------------------------------------------------------------
+
+class _FakeGlobalAudioplayersPlatform
+    extends GlobalAudioplayersPlatformInterface {
+  @override
+  Future<void> init() async {}
+  @override
+  Future<void> setGlobalAudioContext(AudioContext ctx) async {}
+  @override
+  Future<void> emitGlobalLog(String message) async {}
+  @override
+  Future<void> emitGlobalError(String code, String message) async {}
+  @override
+  Stream<GlobalAudioEvent> getGlobalEventStream() => const Stream.empty();
+}
+
+class _FakeAudioplayersPlatform extends AudioplayersPlatformInterface {
+  final _controllers = <String, StreamController<AudioEvent>>{};
+
+  StreamController<AudioEvent> _ctrl(String id) =>
+      _controllers.putIfAbsent(id, () => StreamController.broadcast());
+
+  @override
+  Future<void> create(String playerId) async {
+    _ctrl(playerId); // ensure controller exists
+  }
+
+  @override
+  Stream<AudioEvent> getEventStream(String playerId) => _ctrl(playerId).stream;
+
+  @override
+  Future<void> dispose(String playerId) async {
+    await _controllers.remove(playerId)?.close();
+  }
+
+  // Emit "prepared" so _completePrepared() resolves immediately.
+  void _emitPrepared(String playerId) {
+    _ctrl(playerId).add(
+      const AudioEvent(eventType: AudioEventType.prepared, isPrepared: true),
+    );
+  }
+
+  @override
+  Future<void> setSourceUrl(
+    String playerId,
+    String url, {
+    bool? isLocal,
+    String? mimeType,
+  }) async {
+    _emitPrepared(playerId);
+  }
+
+  @override
+  Future<void> setSourceBytes(
+    String playerId,
+    Uint8List bytes, {
+    String? mimeType,
+  }) async {
+    _emitPrepared(playerId);
+  }
+
+  @override
+  Future<void> resume(String playerId) async {}
+  @override
+  Future<void> pause(String playerId) async {}
+  @override
+  Future<void> stop(String playerId) async {}
+  @override
+  Future<void> release(String playerId) async {}
+  @override
+  Future<void> seek(String playerId, Duration position) async {}
+  @override
+  Future<void> setVolume(String playerId, double volume) async {}
+  @override
+  Future<void> setBalance(String playerId, double balance) async {}
+  @override
+  Future<void> setReleaseMode(String playerId, ReleaseMode releaseMode) async {}
+  @override
+  Future<void> setPlaybackRate(String playerId, double playbackRate) async {}
+  @override
+  Future<void> setAudioContext(
+    String playerId,
+    AudioContext audioContext,
+  ) async {}
+  @override
+  Future<void> setPlayerMode(String playerId, PlayerMode playerMode) async {}
+  @override
+  Future<int?> getDuration(String playerId) async => null;
+  @override
+  Future<int?> getCurrentPosition(String playerId) async => null;
+  @override
+  Future<void> emitLog(String playerId, String message) async {}
+  @override
+  Future<void> emitError(String playerId, String code, String message) async {}
+}
+
+// ---------------------------------------------------------------------------
+// Mock handler for the record package channel so AudioRecorder() construction
+// succeeds and hasPermission() returns a controllable value.
+// ---------------------------------------------------------------------------
+
+void _setRecordChannelMock({required bool permissionGranted}) {
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(
+        const MethodChannel('com.llfbandit.record/messages'),
+        (call) async {
+          if (call.method == 'hasPermission') return permissionGranted;
+          return null;
+        },
+      );
+}
+
+void _clearRecordChannelMock() {
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(
+        const MethodChannel('com.llfbandit.record/messages'),
+        null,
+      );
+}
+
+// ---------------------------------------------------------------------------
+// AudioPlayerWidget tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  late _FakeAudioplayersPlatform fakePlayer;
+
+  setUp(() {
+    fakePlayer = _FakeAudioplayersPlatform();
+    AudioplayersPlatformInterface.instance = fakePlayer;
+    GlobalAudioplayersPlatformInterface.instance =
+        _FakeGlobalAudioplayersPlatform();
+    _setRecordChannelMock(permissionGranted: false);
+  });
+
+  tearDown(_clearRecordChannelMock);
+
+  group('AudioPlayerWidget', () {
+    testWidgets('initially shows a play icon', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AudioPlayerWidget(
+              fetchAudio: () async => Uint8List.fromList([1, 2, 3]),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.play_circle_outlined), findsOneWidget);
+      expect(find.byIcon(Icons.stop_circle_outlined), findsNothing);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+    });
+
+    testWidgets('shows spinner while audio is being fetched', (tester) async {
+      // Use a Completer that never completes so the fetch stays in-flight.
+      final completer = Completer<Uint8List?>();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AudioPlayerWidget(fetchAudio: () => completer.future),
+          ),
+        ),
+      );
+
+      // Tap play — triggers the fetch.
+      await tester.tap(find.byType(IconButton));
+      await tester.pump(); // setState(_isLoading = true) takes effect
+
+      expect(
+        find.byType(CircularProgressIndicator),
+        findsOneWidget,
+        reason: 'spinner must appear while fetch is in-flight',
+      );
+      expect(find.byIcon(Icons.play_circle_outlined), findsNothing);
+
+      // Complete to clean up the pending future before the test ends.
+      completer.complete(null);
+      await tester.pump();
+    });
+
+    testWidgets('shows play icon again when fetchAudio returns null', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: AudioPlayerWidget(fetchAudio: () async => null)),
+        ),
+      );
+
+      await tester.tap(find.byType(IconButton));
+      // runAsync lets real async futures resolve; pump applies setState changes.
+      await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+      await tester.pump();
+
+      expect(
+        find.byIcon(Icons.play_circle_outlined),
+        findsOneWidget,
+        reason: 'null audio — widget returns to idle play state',
+      );
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+    });
+
+    testWidgets('caches bytes — fetchAudio called only once across two taps', (
+      tester,
+    ) async {
+      int callCount = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AudioPlayerWidget(
+              fetchAudio: () async {
+                callCount++;
+                return Uint8List.fromList([1, 2, 3]);
+              },
+            ),
+          ),
+        ),
+      );
+
+      // Allow AudioPlayer._create() to complete (fake platform → no real channels).
+      await tester.pump();
+
+      // First tap: fetches audio and plays. The fake platform emits "prepared"
+      // immediately, so _completePrepared resolves without a timeout.
+      await tester.tap(find.byType(IconButton));
+      await tester.runAsync(() async {
+        // Allow the full async chain (fetchAudio → setSource → prepared event →
+        // resume → setState) to complete.
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+      });
+      await tester
+          .pump(); // rebuild after setState(_isPlaying=true, _isLoading=false)
+
+      // Second tap: _cachedBytes is set — fetchAudio must NOT be called again.
+      // Widget shows a stop or play IconButton; either way tap() succeeds.
+      await tester.tap(find.byType(IconButton));
+      await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+      await tester.pump();
+
+      expect(
+        callCount,
+        equals(1),
+        reason: 'fetchAudio must not be called again after first fetch',
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // VoiceRecorderButton tests
+  // ---------------------------------------------------------------------------
+
+  group('VoiceRecorderButton', () {
+    testWidgets('initially shows the mic icon and no stop icon', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: VoiceRecorderButton(
+              onRecordingComplete: (bytes, mime) {},
+              onError: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.mic_none_outlined), findsOneWidget);
+      expect(find.byIcon(Icons.stop_circle_outlined), findsNothing);
+    });
+
+    testWidgets('calls onError when microphone permission is denied', (
+      tester,
+    ) async {
+      // Channel mock returns false for hasPermission → maps to the
+      // permission-denied code path in _start().
+      String? capturedError;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: VoiceRecorderButton(
+              onRecordingComplete: (bytes, mime) {},
+              onError: (e) => capturedError = e,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byIcon(Icons.mic_none_outlined));
+      // runAsync lets real platform-channel futures resolve before we check.
+      await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+      await tester.pump();
+
+      // Permission denied → onError must have been called.
+      expect(
+        capturedError,
+        isNotNull,
+        reason: 'onError must be called when recording cannot start',
+      );
+
+      // After an error the mic icon is still shown (not the stop button).
+      expect(find.byIcon(Icons.mic_none_outlined), findsOneWidget);
+      expect(find.byIcon(Icons.stop_circle_outlined), findsNothing);
+    });
+  });
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -38,6 +38,7 @@ pub use types::{
     MoonshotWebSearchOptions, NextcloudConfig, NotificationsConfig, ObservabilityConfig,
     OpenAIAuthMode, OpenAIOptions, OpenAIUserLocation, OpenAIWebSearchOptions, OtelExporter,
     PartitionGranularity, SignalConfig, SkillsConfig, SlackConfig, SlackListenMode, StorageConfig,
-    TranscriptionConfig, TranscriptionProviderKind, DEFAULT_MAX_AGENT_DEPTH,
+    TranscriptionConfig, TranscriptionProviderKind, TtsConfig, TtsProviderKind,
+    DEFAULT_MAX_AGENT_DEPTH,
 };
 pub use upload::resolve_upload_bytes;

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -173,6 +173,10 @@ pub struct AssistantConfig {
     /// Populated from the `[transcription]` section of `config.toml`.
     #[serde(default)]
     pub transcription: Option<TranscriptionConfig>,
+    /// Text-to-speech configuration (optional).
+    /// Populated from the `[tts]` section of `config.toml`.
+    #[serde(default)]
+    pub tts: Option<TtsConfig>,
     /// Push notification / VAPID configuration (`[notifications]` section).
     #[serde(default)]
     pub notifications: NotificationsConfig,
@@ -382,6 +386,41 @@ pub struct TranscriptionConfig {
     pub api_key: Option<String>,
     /// Optional BCP-47 language hint (e.g. `"en"`, `"de"`).
     pub language: Option<String>,
+}
+
+/// Which TTS backend to use.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TtsProviderKind {
+    /// OpenAI TTS API (`POST /v1/audio/speech`).
+    OpenAI,
+    /// Deepgram TTS API (`POST /v1/speak`).
+    Deepgram,
+}
+
+/// Configuration for text-to-speech synthesis.
+///
+/// When present, the web UI will offer voice playback on assistant messages.
+///
+/// ```toml
+/// [tts]
+/// provider = "openai"
+/// voice = "nova"
+/// # api_key = "sk-..."  # or set OPENAI_API_KEY env var
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TtsConfig {
+    /// Which TTS backend to use.
+    pub provider: TtsProviderKind,
+    /// Model name (provider-specific default if omitted; e.g. `"tts-1"` for OpenAI).
+    pub model: Option<String>,
+    /// Voice name (provider-specific; e.g. `"nova"`, `"alloy"` for OpenAI).
+    pub voice: Option<String>,
+    /// Base URL override (uses provider-specific default if omitted).
+    pub base_url: Option<String>,
+    /// API key (also checked via provider-specific env vars: `OPENAI_API_KEY` for OpenAI,
+    /// `DEEPGRAM_API_KEY` for Deepgram).
+    pub api_key: Option<String>,
 }
 
 fn default_llm_model() -> String {

--- a/crates/runtime/src/orchestrator/dispatch.rs
+++ b/crates/runtime/src/orchestrator/dispatch.rs
@@ -117,6 +117,23 @@ impl Orchestrator {
 
         let mut tool_status = "ok";
 
+        // For the voice-response tool we need to extract the audio_id before
+        // consuming the output below.
+        let voice_audio_id: Option<String> = if tool_name == "voice-response" {
+            if let Ok(ref output) = exec_result {
+                output
+                    .data
+                    .as_ref()
+                    .and_then(|d| d.get("audio_id"))
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string())
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
         let observation = match exec_result {
             Ok(output) => {
                 debug!(tool = %tool_name, duration_ms, "Tool execution completed");
@@ -175,6 +192,13 @@ impl Orchestrator {
                     status: tool_status.to_string(),
                 })
                 .await;
+
+            // For the voice-response tool, emit a dedicated AudioReady event
+            // so voice-enabled clients can auto-play the synthesised audio
+            // without waiting for the full turn to finish.
+            if let Some(audio_id) = voice_audio_id {
+                let _ = sink.send(OrchestratorEvent::AudioReady { audio_id }).await;
+            }
         }
 
         observation

--- a/crates/runtime/src/orchestrator/stream_event.rs
+++ b/crates/runtime/src/orchestrator/stream_event.rs
@@ -49,4 +49,16 @@ pub enum OrchestratorEvent {
         /// Human-readable description of the error.
         message: String,
     },
+
+    /// A `voice-response` tool call produced synthesised audio that clients
+    /// should auto-play.
+    ///
+    /// Emitted immediately after the tool result is finalised so that
+    /// voice-enabled web clients can retrieve and play the audio without
+    /// waiting for the full turn to complete.
+    AudioReady {
+        /// The UUID of the audio blob in the server's [`AudioStore`].
+        /// Retrieve via `GET /api/audio/{audio_id}`.
+        audio_id: String,
+    },
 }

--- a/crates/tool-executor/Cargo.toml
+++ b/crates/tool-executor/Cargo.toml
@@ -13,6 +13,7 @@ assistant-core = { path = "../core" }
 assistant-skills = { path = "../skills" }
 assistant-llm = { path = "../llm" }
 assistant-storage = { path = "../storage" }
+assistant-transcription = { path = "../transcription" }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/tool-executor/src/builtins/mod.rs
+++ b/crates/tool-executor/src/builtins/mod.rs
@@ -16,6 +16,7 @@ pub mod memory_search;
 pub mod process;
 pub mod schedule_task;
 pub mod self_analyze;
+pub mod voice_response;
 pub mod web_fetch;
 pub mod web_search;
 
@@ -37,5 +38,6 @@ pub use memory_search::MemorySearchHandler;
 pub use process::ProcessHandler;
 pub use schedule_task::ScheduleTaskHandler;
 pub use self_analyze::SelfAnalyzeHandler;
+pub use voice_response::VoiceResponseHandler;
 pub use web_fetch::WebFetchHandler;
 pub use web_search::WebSearchHandler;

--- a/crates/tool-executor/src/builtins/voice_response.rs
+++ b/crates/tool-executor/src/builtins/voice_response.rs
@@ -115,3 +115,157 @@ impl ToolHandler for VoiceResponseHandler {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use assistant_core::{ExecutionContext, Interface};
+    use assistant_transcription::{AudioStore, TtsProvider, TtsRequest, TtsResult};
+    use async_trait::async_trait;
+    use uuid::Uuid;
+
+    use assistant_core::ToolHandler;
+
+    use super::VoiceResponseHandler;
+
+    struct FakeTts {
+        audio: Vec<u8>,
+    }
+
+    #[async_trait]
+    impl TtsProvider for FakeTts {
+        fn name(&self) -> &str {
+            "fake-tts"
+        }
+
+        async fn synthesize(&self, _request: TtsRequest) -> anyhow::Result<TtsResult> {
+            Ok(TtsResult {
+                audio_data: self.audio.clone(),
+                mime_type: "audio/mpeg".to_string(),
+            })
+        }
+    }
+
+    struct FailingTts;
+
+    #[async_trait]
+    impl TtsProvider for FailingTts {
+        fn name(&self) -> &str {
+            "failing-tts"
+        }
+
+        async fn synthesize(&self, _request: TtsRequest) -> anyhow::Result<TtsResult> {
+            anyhow::bail!("synthesis failed")
+        }
+    }
+
+    fn make_ctx() -> ExecutionContext {
+        ExecutionContext {
+            conversation_id: Uuid::new_v4(),
+            agent_id: "test".to_string(),
+            turn: 0,
+            interface: Interface::Cli,
+            interactive: false,
+            allowed_tools: None,
+            depth: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn tool_name_is_voice_response() {
+        let handler = VoiceResponseHandler::new(
+            Arc::new(FakeTts { audio: vec![] }),
+            Arc::new(AudioStore::new()),
+        );
+        assert_eq!(handler.name(), "voice-response");
+    }
+
+    #[tokio::test]
+    async fn run_synthesizes_and_returns_audio_id() {
+        let audio_bytes = b"fake-mp3".to_vec();
+        let store = Arc::new(AudioStore::new());
+        let handler = VoiceResponseHandler::new(
+            Arc::new(FakeTts {
+                audio: audio_bytes.clone(),
+            }),
+            store.clone(),
+        );
+
+        let mut params = HashMap::new();
+        params.insert("text".to_string(), serde_json::json!("Hello"));
+
+        let ctx = make_ctx();
+        let output = handler.run(params, &ctx).await.unwrap();
+
+        assert!(output.success, "expected successful output");
+        let data = output.data.expect("expected data payload");
+        let audio_id = data["audio_id"]
+            .as_str()
+            .expect("audio_id must be a string");
+        let uuid: Uuid = audio_id.parse().expect("audio_id must be a valid UUID");
+
+        // The audio should be retrievable from the store.
+        let stored = store.get(uuid).await;
+        assert_eq!(stored, Some(audio_bytes));
+        assert_eq!(data["voiced"], serde_json::json!(true));
+    }
+
+    #[tokio::test]
+    async fn run_returns_error_output_when_text_is_missing() {
+        let handler = VoiceResponseHandler::new(
+            Arc::new(FakeTts { audio: vec![] }),
+            Arc::new(AudioStore::new()),
+        );
+
+        let params = HashMap::new(); // no "text" key
+        let output = handler.run(params, &make_ctx()).await.unwrap();
+
+        assert!(!output.success, "missing text should yield an error output");
+    }
+
+    #[tokio::test]
+    async fn run_returns_error_output_when_text_is_empty() {
+        let handler = VoiceResponseHandler::new(
+            Arc::new(FakeTts { audio: vec![] }),
+            Arc::new(AudioStore::new()),
+        );
+
+        let mut params = HashMap::new();
+        params.insert("text".to_string(), serde_json::json!("   "));
+        let output = handler.run(params, &make_ctx()).await.unwrap();
+
+        assert!(!output.success, "blank text should yield an error output");
+    }
+
+    #[tokio::test]
+    async fn run_returns_error_output_when_tts_fails() {
+        let handler = VoiceResponseHandler::new(Arc::new(FailingTts), Arc::new(AudioStore::new()));
+
+        let mut params = HashMap::new();
+        params.insert("text".to_string(), serde_json::json!("Hello"));
+        let output = handler.run(params, &make_ctx()).await.unwrap();
+
+        assert!(!output.success, "TTS failure should yield an error output");
+    }
+
+    #[tokio::test]
+    async fn run_passes_custom_voice_to_tts() {
+        // We just check it doesn't panic / error when a voice param is supplied.
+        let store = Arc::new(AudioStore::new());
+        let handler = VoiceResponseHandler::new(
+            Arc::new(FakeTts {
+                audio: b"ok".to_vec(),
+            }),
+            store.clone(),
+        );
+
+        let mut params = HashMap::new();
+        params.insert("text".to_string(), serde_json::json!("Hi"));
+        params.insert("voice".to_string(), serde_json::json!("alloy"));
+
+        let output = handler.run(params, &make_ctx()).await.unwrap();
+        assert!(output.success);
+    }
+}

--- a/crates/tool-executor/src/builtins/voice_response.rs
+++ b/crates/tool-executor/src/builtins/voice_response.rs
@@ -1,0 +1,117 @@
+//! `voice-response` tool — synthesize a voiced reply for the assistant.
+//!
+//! When TTS is configured, the assistant can call this tool to produce an
+//! audio response. The synthesized audio is stored in the [`AudioStore`] and
+//! an `audio_id` is returned so the web UI can auto-play it.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::Result;
+use assistant_core::{ExecutionContext, ToolHandler, ToolOutput};
+use assistant_transcription::{AudioStore, TtsProvider, TtsRequest};
+use async_trait::async_trait;
+use serde_json::Value;
+use tracing::warn;
+
+pub struct VoiceResponseHandler {
+    tts: Arc<dyn TtsProvider>,
+    store: Arc<AudioStore>,
+}
+
+impl VoiceResponseHandler {
+    pub fn new(tts: Arc<dyn TtsProvider>, store: Arc<AudioStore>) -> Self {
+        Self { tts, store }
+    }
+}
+
+#[async_trait]
+impl ToolHandler for VoiceResponseHandler {
+    fn name(&self) -> &str {
+        "voice-response"
+    }
+
+    fn description(&self) -> &str {
+        "Synthesize a voiced audio reply. Call this when you want to respond with \
+         speech rather than (or in addition to) text. The audio will be played \
+         automatically in voice-enabled clients."
+    }
+
+    fn params_schema(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "description": "The text to synthesize as speech."
+                },
+                "voice": {
+                    "type": "string",
+                    "description": "Optional voice name (provider-specific, e.g. \"nova\", \"alloy\")."
+                }
+            },
+            "required": ["text"]
+        })
+    }
+
+    fn output_schema(&self) -> Option<Value> {
+        Some(serde_json::json!({
+            "type": "object",
+            "properties": {
+                "audio_id": {
+                    "type": "string",
+                    "description": "UUID of the stored audio blob. Retrieve via GET /api/audio/{audio_id}."
+                },
+                "voiced": {
+                    "type": "boolean",
+                    "description": "Always true on success."
+                }
+            },
+            "required": ["audio_id", "voiced"]
+        }))
+    }
+
+    async fn run(
+        &self,
+        params: HashMap<String, Value>,
+        _ctx: &ExecutionContext,
+    ) -> Result<ToolOutput> {
+        let text = match params.get("text").and_then(|v| v.as_str()) {
+            Some(t) if !t.trim().is_empty() => t.to_string(),
+            _ => {
+                return Ok(ToolOutput::error(
+                    "voice-response: `text` parameter is required",
+                ))
+            }
+        };
+        let voice = params
+            .get("voice")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let request = TtsRequest {
+            text,
+            voice,
+            format: Some("mp3".to_string()),
+            speed: None,
+        };
+
+        match self.tts.synthesize(request).await {
+            Ok(result) => {
+                let audio_id = self.store.insert(result.audio_data).await;
+                Ok(
+                    ToolOutput::success(format!("Audio synthesized (id={audio_id}).")).with_data(
+                        serde_json::json!({
+                            "audio_id": audio_id.to_string(),
+                            "voiced": true,
+                        }),
+                    ),
+                )
+            }
+            Err(e) => {
+                warn!(error = %e, "voice-response: TTS synthesis failed");
+                Ok(ToolOutput::error(format!("TTS synthesis failed: {e}")))
+            }
+        }
+    }
+}

--- a/crates/tool-executor/src/executor.rs
+++ b/crates/tool-executor/src/executor.rs
@@ -79,6 +79,23 @@ impl ToolExecutor {
             .insert(handler.name().to_string(), handler);
     }
 
+    /// Register the `voice-response` tool.
+    ///
+    /// Call after construction when both a TTS provider and audio store are
+    /// available (i.e. when the web UI has voice configured).
+    pub fn register_voice_response(
+        &self,
+        tts: Arc<dyn assistant_transcription::TtsProvider>,
+        store: Arc<assistant_transcription::AudioStore>,
+    ) {
+        use crate::builtins::VoiceResponseHandler;
+        let handler = Arc::new(VoiceResponseHandler::new(tts, store));
+        self.tool_handlers
+            .write()
+            .unwrap()
+            .insert(handler.name().to_string(), handler);
+    }
+
     /// Inject the subagent runner and register subagent tools.
     ///
     /// Registers `agent-spawn` and `agent-terminate`.  This must be called

--- a/crates/transcription/Cargo.toml
+++ b/crates/transcription/Cargo.toml
@@ -22,3 +22,4 @@ url            = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }
+wiremock = { workspace = true }

--- a/crates/transcription/Cargo.toml
+++ b/crates/transcription/Cargo.toml
@@ -12,9 +12,11 @@ assistant-llm  = { path = "../llm" }
 async-trait    = { workspace = true }
 anyhow         = { workspace = true }
 tokio          = { workspace = true }
+uuid           = { workspace = true }
 reqwest        = { workspace = true }
 reqwest-middleware = { workspace = true }
 serde          = { workspace = true }
+serde_json     = { workspace = true }
 tracing        = { workspace = true }
 url            = { workspace = true }
 

--- a/crates/transcription/src/audio_store.rs
+++ b/crates/transcription/src/audio_store.rs
@@ -1,0 +1,53 @@
+//! In-memory store for tool-synthesized audio blobs.
+//!
+//! Audio entries expire after [`TTL`] and are swept periodically.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tokio::sync::RwLock;
+use uuid::Uuid;
+
+/// How long synthesized audio is kept in memory.
+const TTL: Duration = Duration::from_secs(3600); // 1 hour
+
+/// Inner map type alias to keep the field declaration readable.
+type AudioMap = HashMap<Uuid, (Vec<u8>, Instant)>;
+
+/// Shared in-memory store for audio blobs produced by the `voice-response` tool.
+#[derive(Clone, Default)]
+pub struct AudioStore {
+    inner: Arc<RwLock<AudioMap>>,
+}
+
+impl AudioStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Store audio bytes under a fresh UUID. Returns the UUID.
+    pub async fn insert(&self, audio: Vec<u8>) -> Uuid {
+        let id = Uuid::new_v4();
+        self.inner.write().await.insert(id, (audio, Instant::now()));
+        id
+    }
+
+    /// Retrieve audio bytes by ID. Returns `None` if not found or expired.
+    pub async fn get(&self, id: Uuid) -> Option<Vec<u8>> {
+        let map = self.inner.read().await;
+        map.get(&id).and_then(|(data, inserted)| {
+            if inserted.elapsed() < TTL {
+                Some(data.clone())
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Remove all expired entries.
+    pub async fn sweep(&self) {
+        let mut map = self.inner.write().await;
+        map.retain(|_, (_, inserted)| inserted.elapsed() < TTL);
+    }
+}

--- a/crates/transcription/src/audio_store.rs
+++ b/crates/transcription/src/audio_store.rs
@@ -51,3 +51,49 @@ impl AudioStore {
         map.retain(|_, (_, inserted)| inserted.elapsed() < TTL);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn insert_and_get_roundtrip() {
+        let store = AudioStore::new();
+        let audio = b"fake-mp3-bytes".to_vec();
+
+        let id = store.insert(audio.clone()).await;
+        let retrieved = store.get(id).await;
+
+        assert_eq!(retrieved, Some(audio));
+    }
+
+    #[tokio::test]
+    async fn get_returns_none_for_unknown_id() {
+        let store = AudioStore::new();
+        let unknown = Uuid::new_v4();
+        assert_eq!(store.get(unknown).await, None);
+    }
+
+    #[tokio::test]
+    async fn sweep_does_not_remove_fresh_entries() {
+        let store = AudioStore::new();
+        let id = store.insert(b"audio".to_vec()).await;
+
+        store.sweep().await;
+
+        assert!(
+            store.get(id).await.is_some(),
+            "fresh entry should survive sweep"
+        );
+    }
+
+    #[tokio::test]
+    async fn multiple_inserts_return_distinct_ids() {
+        let store = AudioStore::new();
+        let id1 = store.insert(b"a".to_vec()).await;
+        let id2 = store.insert(b"b".to_vec()).await;
+        assert_ne!(id1, id2);
+        assert_eq!(store.get(id1).await, Some(b"a".to_vec()));
+        assert_eq!(store.get(id2).await, Some(b"b".to_vec()));
+    }
+}

--- a/crates/transcription/src/deepgram_tts.rs
+++ b/crates/transcription/src/deepgram_tts.rs
@@ -1,0 +1,92 @@
+//! Deepgram TTS provider — `POST /v1/speak`.
+
+use anyhow::{bail, Context};
+use async_trait::async_trait;
+use reqwest_middleware::ClientWithMiddleware;
+use tracing::debug;
+
+use crate::provider::{TtsProvider, TtsRequest, TtsResult};
+
+const DEFAULT_TIMEOUT_SECS: u64 = 60;
+const DEFAULT_MODEL: &str = "aura-2-en-us";
+
+pub struct DeepgramTtsProvider {
+    api_key: String,
+    model: String,
+    base_url: String,
+    client: ClientWithMiddleware,
+}
+
+impl DeepgramTtsProvider {
+    pub fn new(api_key: impl Into<String>) -> anyhow::Result<Self> {
+        let client = assistant_llm::build_http_client(
+            DEFAULT_TIMEOUT_SECS,
+            &assistant_llm::RetryConfig::default(),
+        )?;
+        Ok(Self {
+            api_key: api_key.into(),
+            model: DEFAULT_MODEL.to_string(),
+            base_url: "https://api.deepgram.com/v1".to_string(),
+            client,
+        })
+    }
+
+    pub fn with_model(mut self, model: impl Into<String>) -> Self {
+        self.model = model.into();
+        self
+    }
+
+    pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
+        self.base_url = url.into();
+        self
+    }
+}
+
+#[async_trait]
+impl TtsProvider for DeepgramTtsProvider {
+    fn name(&self) -> &str {
+        "deepgram-tts"
+    }
+
+    async fn synthesize(&self, request: TtsRequest) -> anyhow::Result<TtsResult> {
+        let model = request.voice.unwrap_or_else(|| self.model.clone());
+
+        debug!(
+            provider = "deepgram-tts",
+            model = %model,
+            text_len = request.text.len(),
+            "Synthesizing speech"
+        );
+
+        let body = serde_json::json!({ "text": request.text });
+        let url = format!("{}/speak?model={}", self.base_url, model);
+
+        let resp = self
+            .client
+            .post(&url)
+            .bearer_auth(&self.api_key)
+            .json(&body)
+            .send()
+            .await
+            .context("Deepgram TTS API request failed")?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body_text = resp.text().await.unwrap_or_default();
+            bail!("Deepgram TTS API returned {status}: {body_text}");
+        }
+
+        let audio_data = resp
+            .bytes()
+            .await
+            .context("Failed to read Deepgram TTS response bytes")?
+            .to_vec();
+
+        debug!(bytes = audio_data.len(), "Deepgram TTS synthesis complete");
+
+        Ok(TtsResult {
+            audio_data,
+            mime_type: "audio/mpeg".to_string(),
+        })
+    }
+}

--- a/crates/transcription/src/deepgram_tts.rs
+++ b/crates/transcription/src/deepgram_tts.rs
@@ -90,3 +90,105 @@ impl TtsProvider for DeepgramTtsProvider {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use wiremock::matchers::{header_exists, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn provider_name() {
+        let p = DeepgramTtsProvider::new("key").unwrap();
+        assert_eq!(p.name(), "deepgram-tts");
+    }
+
+    #[tokio::test]
+    async fn synthesize_returns_audio_bytes_on_success() {
+        let server = MockServer::start().await;
+        let fake_audio = b"DEEPGRAM_AUDIO".to_vec();
+
+        Mock::given(method("POST"))
+            .and(path("/speak"))
+            .and(header_exists("authorization"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_bytes(fake_audio.clone())
+                    .insert_header("content-type", "audio/mpeg"),
+            )
+            .mount(&server)
+            .await;
+
+        let provider = DeepgramTtsProvider::new("test-key")
+            .unwrap()
+            .with_base_url(server.uri());
+
+        let result = provider
+            .synthesize(TtsRequest {
+                text: "Hello Deepgram".to_string(),
+                voice: None,
+                format: None,
+                speed: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.audio_data, fake_audio);
+        assert_eq!(result.mime_type, "audio/mpeg");
+    }
+
+    #[tokio::test]
+    async fn synthesize_uses_voice_as_model_override() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/speak"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"audio".to_vec()))
+            .mount(&server)
+            .await;
+
+        let provider = DeepgramTtsProvider::new("key")
+            .unwrap()
+            .with_base_url(server.uri());
+
+        // voice param overrides the model query param
+        let result = provider
+            .synthesize(TtsRequest {
+                text: "Test".to_string(),
+                voice: Some("aura-2-es-es".to_string()),
+                format: None,
+                speed: None,
+            })
+            .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn synthesize_returns_error_on_non_2xx() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/speak"))
+            .respond_with(ResponseTemplate::new(403).set_body_string("Forbidden"))
+            .mount(&server)
+            .await;
+
+        let provider = DeepgramTtsProvider::new("bad-key")
+            .unwrap()
+            .with_base_url(server.uri());
+
+        let result = provider
+            .synthesize(TtsRequest {
+                text: "Hi".to_string(),
+                voice: None,
+                format: None,
+                speed: None,
+            })
+            .await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("403"));
+    }
+}

--- a/crates/transcription/src/lib.rs
+++ b/crates/transcription/src/lib.rs
@@ -11,20 +11,29 @@
 //! bytes to the configured provider, and inject the resulting transcript into
 //! the normal text message flow.
 
+pub mod audio_store;
 mod converter;
 mod deepgram;
+mod deepgram_tts;
 mod ollama;
+mod openai_tts;
 mod provider;
 mod whisper;
 
 use std::sync::Arc;
 
-use assistant_core::{TranscriptionConfig, TranscriptionProviderKind};
+use assistant_core::{TranscriptionConfig, TranscriptionProviderKind, TtsConfig, TtsProviderKind};
 
+pub use audio_store::AudioStore;
 pub use converter::{AudioConverter, AudioFormat, ConversionResult};
 pub use deepgram::DeepgramProvider;
+pub use deepgram_tts::DeepgramTtsProvider;
 pub use ollama::OllamaTranscriptionProvider;
-pub use provider::{TranscriptionProvider, TranscriptionRequest, TranscriptionResult};
+pub use openai_tts::OpenAITtsProvider;
+pub use provider::{
+    TranscriptionProvider, TranscriptionRequest, TranscriptionResult, TtsProvider, TtsRequest,
+    TtsResult,
+};
 pub use whisper::WhisperProvider;
 
 /// MIME type prefixes recognised as audio attachments.
@@ -49,6 +58,57 @@ pub fn is_audio_mime(mime: &str) -> bool {
     AUDIO_MIME_PREFIXES
         .iter()
         .any(|prefix| mime.starts_with(prefix))
+}
+
+/// Build a [`TtsProvider`] from the assistant TTS configuration.
+pub fn build_tts_provider(config: &TtsConfig) -> anyhow::Result<Arc<dyn TtsProvider>> {
+    match config.provider {
+        TtsProviderKind::OpenAI => {
+            let api_key = config
+                .api_key
+                .clone()
+                .or_else(|| std::env::var("OPENAI_API_KEY").ok())
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "OpenAI TTS requires an API key. \
+                         Set api_key in [tts] or OPENAI_API_KEY env var."
+                    )
+                })?;
+
+            let mut provider = OpenAITtsProvider::new(api_key)?;
+            if let Some(ref url) = config.base_url {
+                provider = provider.with_base_url(url);
+            }
+            if let Some(ref model) = config.model {
+                provider = provider.with_model(model);
+            }
+            if let Some(ref voice) = config.voice {
+                provider = provider.with_voice(voice);
+            }
+            Ok(Arc::new(provider))
+        }
+        TtsProviderKind::Deepgram => {
+            let api_key = config
+                .api_key
+                .clone()
+                .or_else(|| std::env::var("DEEPGRAM_API_KEY").ok())
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Deepgram TTS requires an API key. \
+                         Set api_key in [tts] or DEEPGRAM_API_KEY env var."
+                    )
+                })?;
+
+            let mut provider = DeepgramTtsProvider::new(api_key)?;
+            if let Some(ref url) = config.base_url {
+                provider = provider.with_base_url(url);
+            }
+            if let Some(ref model) = config.model {
+                provider = provider.with_model(model);
+            }
+            Ok(Arc::new(provider))
+        }
+    }
 }
 
 /// Build a [`TranscriptionProvider`] from the assistant configuration.

--- a/crates/transcription/src/openai_tts.rs
+++ b/crates/transcription/src/openai_tts.rs
@@ -1,0 +1,108 @@
+//! OpenAI TTS provider — `POST /v1/audio/speech`.
+
+use anyhow::{bail, Context};
+use async_trait::async_trait;
+use reqwest_middleware::ClientWithMiddleware;
+use tracing::debug;
+
+use crate::provider::{TtsProvider, TtsRequest, TtsResult};
+
+const DEFAULT_TIMEOUT_SECS: u64 = 60;
+const DEFAULT_MODEL: &str = "tts-1";
+const DEFAULT_VOICE: &str = "nova";
+const DEFAULT_FORMAT: &str = "mp3";
+
+pub struct OpenAITtsProvider {
+    base_url: String,
+    api_key: String,
+    model: String,
+    default_voice: String,
+    client: ClientWithMiddleware,
+}
+
+impl OpenAITtsProvider {
+    pub fn new(api_key: impl Into<String>) -> anyhow::Result<Self> {
+        let client = assistant_llm::build_http_client(
+            DEFAULT_TIMEOUT_SECS,
+            &assistant_llm::RetryConfig::default(),
+        )?;
+        Ok(Self {
+            base_url: "https://api.openai.com/v1".to_string(),
+            api_key: api_key.into(),
+            model: DEFAULT_MODEL.to_string(),
+            default_voice: DEFAULT_VOICE.to_string(),
+            client,
+        })
+    }
+
+    pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
+        self.base_url = url.into();
+        self
+    }
+
+    pub fn with_model(mut self, model: impl Into<String>) -> Self {
+        self.model = model.into();
+        self
+    }
+
+    pub fn with_voice(mut self, voice: impl Into<String>) -> Self {
+        self.default_voice = voice.into();
+        self
+    }
+}
+
+#[async_trait]
+impl TtsProvider for OpenAITtsProvider {
+    fn name(&self) -> &str {
+        "openai-tts"
+    }
+
+    async fn synthesize(&self, request: TtsRequest) -> anyhow::Result<TtsResult> {
+        let voice = request.voice.unwrap_or_else(|| self.default_voice.clone());
+        let format = request.format.unwrap_or_else(|| DEFAULT_FORMAT.to_string());
+
+        debug!(
+            provider = "openai-tts",
+            model = %self.model,
+            voice = %voice,
+            text_len = request.text.len(),
+            "Synthesizing speech"
+        );
+
+        let body = serde_json::json!({
+            "model": self.model,
+            "input": request.text,
+            "voice": voice,
+            "response_format": format,
+        });
+
+        let url = format!("{}/audio/speech", self.base_url);
+        let resp = self
+            .client
+            .post(&url)
+            .bearer_auth(&self.api_key)
+            .json(&body)
+            .send()
+            .await
+            .context("OpenAI TTS API request failed")?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            bail!("OpenAI TTS API returned {status}: {body}");
+        }
+
+        let audio_data = resp
+            .bytes()
+            .await
+            .context("Failed to read OpenAI TTS response bytes")?
+            .to_vec();
+
+        debug!(bytes = audio_data.len(), "TTS synthesis complete");
+
+        Ok(TtsResult {
+            audio_data,
+            mime_type: "audio/mpeg".to_string(),
+        })
+    }
+}

--- a/crates/transcription/src/openai_tts.rs
+++ b/crates/transcription/src/openai_tts.rs
@@ -106,3 +106,104 @@ impl TtsProvider for OpenAITtsProvider {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use wiremock::matchers::{header_exists, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn provider_name() {
+        let p = OpenAITtsProvider::new("key").unwrap();
+        assert_eq!(p.name(), "openai-tts");
+    }
+
+    #[tokio::test]
+    async fn synthesize_returns_audio_bytes_on_success() {
+        let server = MockServer::start().await;
+        let fake_audio = b"FAKE_MP3".to_vec();
+
+        Mock::given(method("POST"))
+            .and(path("/audio/speech"))
+            .and(header_exists("authorization"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_bytes(fake_audio.clone())
+                    .insert_header("content-type", "audio/mpeg"),
+            )
+            .mount(&server)
+            .await;
+
+        let provider = OpenAITtsProvider::new("test-key")
+            .unwrap()
+            .with_base_url(server.uri());
+
+        let result = provider
+            .synthesize(TtsRequest {
+                text: "Hello world".to_string(),
+                voice: None,
+                format: None,
+                speed: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.audio_data, fake_audio);
+        assert_eq!(result.mime_type, "audio/mpeg");
+    }
+
+    #[tokio::test]
+    async fn synthesize_uses_custom_voice() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/audio/speech"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"audio".to_vec()))
+            .mount(&server)
+            .await;
+
+        let provider = OpenAITtsProvider::new("key")
+            .unwrap()
+            .with_base_url(server.uri());
+
+        let result = provider
+            .synthesize(TtsRequest {
+                text: "Test".to_string(),
+                voice: Some("alloy".to_string()),
+                format: None,
+                speed: None,
+            })
+            .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn synthesize_returns_error_on_non_2xx() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/audio/speech"))
+            .respond_with(ResponseTemplate::new(401).set_body_string("Unauthorized"))
+            .mount(&server)
+            .await;
+
+        let provider = OpenAITtsProvider::new("bad-key")
+            .unwrap()
+            .with_base_url(server.uri());
+
+        let result = provider
+            .synthesize(TtsRequest {
+                text: "Hi".to_string(),
+                voice: None,
+                format: None,
+                speed: None,
+            })
+            .await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("401"));
+    }
+}

--- a/crates/transcription/src/provider.rs
+++ b/crates/transcription/src/provider.rs
@@ -58,3 +58,35 @@ pub trait TranscriptionProvider: Send + Sync {
         request: TranscriptionRequest,
     ) -> anyhow::Result<TranscriptionResult>;
 }
+
+/// A request to synthesize speech from text.
+#[derive(Debug, Clone)]
+pub struct TtsRequest {
+    /// The text to synthesize.
+    pub text: String,
+    /// Voice identifier (provider-specific, e.g. `"nova"` for OpenAI).
+    pub voice: Option<String>,
+    /// Output audio format. Defaults to `"mp3"`.
+    pub format: Option<String>,
+    /// Speech speed multiplier (1.0 = normal). Supported by some providers.
+    pub speed: Option<f32>,
+}
+
+/// The result of a TTS synthesis.
+#[derive(Debug, Clone)]
+pub struct TtsResult {
+    /// Raw audio bytes (mp3 by default).
+    pub audio_data: Vec<u8>,
+    /// MIME type of the audio (e.g. `"audio/mpeg"`).
+    pub mime_type: String,
+}
+
+/// Pluggable backend for converting text to speech.
+#[async_trait]
+pub trait TtsProvider: Send + Sync {
+    /// Human-readable provider name (e.g. `"openai-tts"`, `"deepgram-tts"`).
+    fn name(&self) -> &str;
+
+    /// Synthesize text into audio bytes.
+    async fn synthesize(&self, request: TtsRequest) -> anyhow::Result<TtsResult>;
+}

--- a/crates/web-ui/Cargo.toml
+++ b/crates/web-ui/Cargo.toml
@@ -28,6 +28,7 @@ assistant-skills = { path = "../skills" }
 assistant-storage = { path = "../storage" }
 assistant-tool-executor = { path = "../tool-executor" }
 assistant-mcp-client = { path = "../mcp-client" }
+assistant-transcription = { path = "../transcription" }
 axum = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
 futures = { workspace = true }

--- a/crates/web-ui/src/api/mod.rs
+++ b/crates/web-ui/src/api/mod.rs
@@ -72,6 +72,8 @@ where
 use std::convert::Infallible;
 use std::sync::Arc;
 
+use assistant_transcription::{TranscriptionProvider, TtsProvider};
+
 use assistant_core::{Interface, MessageRole};
 use assistant_runtime::{AssistantInterface, OrchestratorEvent};
 use assistant_storage::ConversationStore;
@@ -104,6 +106,12 @@ pub struct ApiState {
     pub orchestrator: Arc<dyn AssistantInterface>,
     /// Optional Web Push dispatcher — absent when VAPID keys are not configured.
     pub push_dispatcher: Option<Arc<crate::push::PushDispatcher>>,
+    /// Optional transcription provider for voice message STT.
+    pub transcription_provider: Option<Arc<dyn TranscriptionProvider>>,
+    /// Optional TTS provider for voice playback synthesis.
+    pub tts_provider: Option<Arc<dyn TtsProvider>>,
+    /// In-memory store for tool-synthesized audio blobs.
+    pub audio_store: Arc<crate::audio_store::AudioStore>,
 }
 
 impl ApiState {
@@ -117,11 +125,24 @@ impl ApiState {
             agent_id,
             orchestrator,
             push_dispatcher: None,
+            transcription_provider: None,
+            tts_provider: None,
+            audio_store: Arc::new(crate::audio_store::AudioStore::new()),
         }
     }
 
     pub fn with_push_dispatcher(mut self, dispatcher: Arc<crate::push::PushDispatcher>) -> Self {
         self.push_dispatcher = Some(dispatcher);
+        self
+    }
+
+    pub fn with_transcription_provider(mut self, provider: Arc<dyn TranscriptionProvider>) -> Self {
+        self.transcription_provider = Some(provider);
+        self
+    }
+
+    pub fn with_tts_provider(mut self, provider: Arc<dyn TtsProvider>) -> Self {
+        self.tts_provider = Some(provider);
         self
     }
 }
@@ -608,6 +629,13 @@ pub async fn send_message(
                     }
                     Event::default().event("agent_error").data(message)
                 }
+                OrchestratorEvent::AudioReady { audio_id } => {
+                    let data = serde_json::json!({
+                        "audio_id": audio_id,
+                        "auto_play": true,
+                    });
+                    Event::default().event("audio_ready").data(data.to_string())
+                }
             };
             if sse_tx.send(Ok(sse_event)).await.is_err() {
                 return;
@@ -723,6 +751,9 @@ mod tests {
             agent_id: Arc::new(RwLock::new("default".to_string())),
             orchestrator,
             push_dispatcher: None,
+            transcription_provider: None,
+            tts_provider: None,
+            audio_store: Arc::new(crate::audio_store::AudioStore::new()),
         };
         (state, storage)
     }

--- a/crates/web-ui/src/audio_store.rs
+++ b/crates/web-ui/src/audio_store.rs
@@ -1,0 +1,8 @@
+//! Re-export [`AudioStore`] from `assistant-transcription` for use within
+//! the web-ui crate.
+//!
+//! The canonical implementation lives in `assistant_transcription::AudioStore`
+//! so that `assistant-tool-executor` can also depend on it without creating a
+//! circular dependency on `assistant-web-ui`.
+
+pub use assistant_transcription::AudioStore;

--- a/crates/web-ui/src/main.rs
+++ b/crates/web-ui/src/main.rs
@@ -1,5 +1,6 @@
 mod a2a;
 pub mod api;
+pub(crate) mod audio_store;
 pub mod auth;
 pub(crate) mod backends;
 mod flutter_assets;
@@ -29,6 +30,7 @@ use assistant_skills::SkillSource;
 use assistant_storage::registry::SkillRegistry;
 use assistant_storage::{default_db_path, StorageLayer};
 use assistant_tool_executor::ToolExecutor;
+use assistant_transcription::{build_provider as build_transcription_provider, build_tts_provider};
 use assistant_workflow::{
     spawn_event_trigger_adapter, spawn_schedule_trigger_adapter, spawn_workflow_runner,
     AssistantTurnActionExecutor, AssistantTurnClient, WorkflowActionExecutor,
@@ -543,13 +545,65 @@ async fn run_with_args(args: Args) -> Result<()> {
         agent_id: state.agent_id.clone(),
     };
 
+    // -- Build transcription provider (for voice message STT) ----------------
+    let transcription_provider = config
+        .transcription
+        .as_ref()
+        .map(|tc| {
+            let provider = build_transcription_provider(tc)?;
+            info!(
+                provider = provider.name(),
+                "Audio transcription enabled (web UI)"
+            );
+            Ok::<_, anyhow::Error>(provider)
+        })
+        .transpose()?;
+
+    // -- Build TTS provider (for voice message playback) ---------------------
+    let tts_provider = config
+        .tts
+        .as_ref()
+        .map(|tc| {
+            let provider = build_tts_provider(tc)?;
+            info!(provider = provider.name(), "TTS enabled (web UI)");
+            Ok::<_, anyhow::Error>(provider)
+        })
+        .transpose()?;
+
+    // -- In-memory audio store (tool-synthesized audio) ----------------------
+    let audio_store = Arc::new(audio_store::AudioStore::new());
+
+    // -- Spawn TTL sweep task ------------------------------------------------
+    {
+        let store = audio_store.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(600));
+            loop {
+                interval.tick().await;
+                store.sweep().await;
+            }
+        });
+    }
+
+    // Register the voice-response tool when TTS is configured.
+    if let Some(ref tts) = tts_provider {
+        executor.register_voice_response(tts.clone(), audio_store.clone());
+        tracing::info!("voice-response tool registered");
+    }
+
     let api_state = {
-        let s = api::ApiState::new(storage.pool.clone(), orchestrator, state.agent_id.clone());
+        let mut s = api::ApiState::new(storage.pool.clone(), orchestrator, state.agent_id.clone());
         if let Some(ref d) = state.push_dispatcher {
-            s.with_push_dispatcher(d.clone())
-        } else {
-            s
+            s = s.with_push_dispatcher(d.clone());
         }
+        if let Some(ref tp) = transcription_provider {
+            s = s.with_transcription_provider(tp.clone());
+        }
+        if let Some(ref tts) = tts_provider {
+            s = s.with_tts_provider(tts.clone());
+        }
+        s.audio_store = audio_store.clone();
+        s
     };
 
     let persona_api_state = api::personas::PersonaApiState {

--- a/openspec/changes/web-voice/.openspec.yaml
+++ b/openspec/changes/web-voice/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-14

--- a/openspec/changes/web-voice/design.md
+++ b/openspec/changes/web-voice/design.md
@@ -1,0 +1,106 @@
+## Context
+
+The assistant already has a complete STT pipeline (`assistant-transcription`) used by Slack and Signal to transcribe voice attachments into text messages. The web UI does not participate in this pipeline at all — `ApiState` has no transcription field, and the conversation message endpoint accepts only `{ message: String }`.
+
+There is no TTS infrastructure anywhere in the codebase. The OpenAI API (already used for Whisper STT) exposes a TTS endpoint (`POST /v1/audio/speech`) at the same base URL, making it the zero-friction first implementation. Deepgram (already implemented for STT) similarly has a TTS API (`POST /v1/speak`).
+
+The Flutter app targets web (Chrome) and macOS. The `record` package supports both via the browser MediaRecorder API (WebM/Opus output) and macOS AVAudioEngine. The server already lists `audio/webm` in `AUDIO_MIME_PREFIXES`, so no new format support is needed.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Web UI users can record and send voice messages (STT path)
+- Any assistant message can be played back as synthesized speech on demand (TTS path)
+- The assistant can proactively respond in voice via a dedicated tool
+- TTS shares credentials/config with the existing transcription provider when using OpenAI or Deepgram
+- Feature degrades gracefully when TTS is not configured (play button absent or disabled)
+
+**Non-Goals:**
+
+- Streaming TTS (real-time audio as the assistant generates text) — too complex for v1
+- Other interface support for TTS (Slack, Signal, Matrix) — follow-on
+- Speaker diarisation or emotion in voice responses
+- Persistent audio storage (audio is ephemeral / generated on-demand)
+- Wake-word or continuous listening
+
+## Decisions
+
+### D1: Extend `assistant-transcription`, not a new crate
+
+**Decision:** Add `TtsProvider` trait, `TtsRequest`, `TtsResult`, and provider implementations to `assistant-transcription`. Add `build_tts_provider()` helper.
+
+**Rationale:** TTS and STT share the same provider credentials (OpenAI key, Deepgram key, base URL). Bundling them avoids a third crate in the audio domain, and the crate can evolve to be the "audio AI" crate. Adding a second trait does not break existing callers.
+
+**Alternative considered:** New `assistant-tts` crate. Rejected because it doubles the config boilerplate and creates another entry in the workspace dependency graph for no architectural benefit.
+
+### D2: Separate `[tts]` config section
+
+**Decision:** Add `TtsConfig` to `AssistantConfig` under key `[tts]`, structurally identical to `TranscriptionConfig` (provider, model, api_key, base_url, voice).
+
+**Rationale:** Users may want OpenAI for TTS but Ollama for STT (or different voices/models). Keeping configs independent preserves that flexibility. The `config.toml` comment will note that api_key defaults to the same env var as transcription when using the same provider.
+
+**Alternative considered:** Reuse `TranscriptionConfig` for TTS. Rejected because model names differ between STT and TTS (e.g., `whisper-1` vs `tts-1`) and adding a `voice` field to a struct named `TranscriptionConfig` is confusing.
+
+### D3: In-memory `AudioStore` for tool-synthesized audio
+
+**Decision:** An `AudioStore` is an `Arc<RwLock<HashMap<Uuid, (Vec<u8>, Instant)>>>` stored in `ApiState`. Entries expire after 1 hour. No persistence across restarts.
+
+**Rationale:** Tool-synthesized audio is ephemeral. The `voice_response` tool is called once per interaction; the client fetches and plays immediately. Persistent storage (SQLite BLOB, disk) adds schema migration complexity and storage growth with no benefit. If the user misses auto-play they can tap the play button to re-synthesize via the on-demand endpoint.
+
+### D4: On-demand synthesis for the play button
+
+**Decision:** `GET /api/messages/{msg_id}/audio` reads the message text from the DB, synthesizes on each request, returns raw mp3 bytes. No caching.
+
+**Rationale:** Keeps the server stateless with respect to audio. Re-synthesis cost is minimal for typical assistant message lengths. Caching can be added later if profiling shows it matters.
+
+**Alternative considered:** Pre-synthesize all assistant messages and store alongside the message. Rejected because most messages may never be played; it wastes API quota and storage.
+
+### D5: SSE `audio_ready` event for proactive voice responses
+
+**Decision:** When the orchestrator processes a `voice_response` tool result, it emits a new SSE event type:
+
+```
+event: audio_ready
+data: {"audio_id":"<uuid>","auto_play":true}
+```
+
+The Flutter client listens for this event and auto-fetches `GET /api/audio/{audio_id}`.
+
+**Rationale:** The existing SSE stream (`text/event-stream`) already connects orchestrator to client. Adding a new named event is the lowest-friction way to push the audio_id. The Flutter `http` package's SSE client already supports named events.
+
+**Alternative considered:** Return the audio_id in the final SSE `done` event. Rejected because the tool may fire mid-conversation before the final turn ends.
+
+### D6: `voice_response` tool needs TTS provider in executor context
+
+**Decision:** `VoiceResponseHandler` stores `Option<Arc<dyn TtsProvider>>` and `Arc<AudioStore>`, both injected at registration time via `ToolExecutor::register_builtins()`. If TTS is not configured, the tool is not registered (silently absent from the tool list).
+
+**Rationale:** Matches the pattern for other context-dependent tools (e.g., memory tools that require a storage layer). The tool is simply not offered to the LLM when unavailable, so the assistant cannot mistakenly try to call it.
+
+### D7: Flutter audio via `record` + `audioplayers`
+
+**Decision:** Add `record: ^5.0.0` for capture and `audioplayers: ^6.0.0` for playback.
+
+**Rationale:** Both packages have web and macOS support, active maintenance, and are the de-facto standard in the Flutter ecosystem. `record` outputs WebM/Opus on web (already in server's allowed MIME types) and M4A on macOS (also allowed).
+
+**Alternative considered:** Browser Web Speech API via `dart:html`. Rejected for macOS: no native equivalent without a platform channel. Also bypasses the server's transcription providers (quality matters).
+
+## Risks / Trade-offs
+
+- **Microphone permission UX**: First use on web triggers a browser permission prompt; on macOS requires `NSMicrophoneUsageDescription` in Info.plist. Mitigation: add the plist key; on web the browser handles it natively.
+- **TTS API cost**: Every play-button tap re-synthesizes. Mitigation: clearly document in config; add response caching as a follow-on if needed.
+- **Audio store memory growth**: Many `voice_response` calls accumulate in-memory. Mitigation: 1-hour TTL + a background sweep task on a 10-minute tick.
+- **Ollama has no TTS**: Users running fully-local setups cannot use voice responses. Mitigation: degrade gracefully (no play button); document clearly. A local TTS provider (e.g., Kokoro) can be added in a follow-on.
+- **SSE client parsing**: The Flutter SSE client must handle named events (`event: audio_ready`). Mitigation: verify the existing `client.dart` SSE parser handles named events; fix if needed as part of this change.
+
+## Migration Plan
+
+1. Deploy new server binary — new `[tts]` config key is optional; existing deployments continue to function without it.
+2. Users opt in by adding `[tts]` to `~/.assistant/config.toml`.
+3. No database migrations required.
+4. Flutter app update ships simultaneously; new UI elements (mic button, play button) are inert if the server has no TTS configured (endpoint returns 503).
+
+## Open Questions
+
+- **Voice selection UX**: Should the UI expose a voice picker (alloy/nova/echo/…) or fix the voice in config? → Fix in config for v1; UI picker is a follow-on.
+- **Max recording length**: Whisper API limit is 25 MB / ~30 min. Should the client enforce a shorter cap (e.g., 2 min) for UX reasons? → Enforce 2-minute client-side limit with a visible timer.

--- a/openspec/changes/web-voice/proposal.md
+++ b/openspec/changes/web-voice/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+The web UI currently supports only text-based interaction. Users on other interfaces (Slack, Signal) can already send voice messages that are automatically transcribed and injected into the conversation. The web UI should support the same — and go further by letting the assistant respond with synthesized speech, enabling a full voice conversation loop.
+
+## What Changes
+
+- Add `TtsProvider` trait and implementations (OpenAI, Deepgram) to `assistant-transcription`
+- Add `TtsConfig` (`[tts]` section) to core config types
+- Wire STT and TTS providers into the web UI server (`ApiState`)
+- New endpoint: `POST /api/conversations/{id}/voice` — accepts recorded audio, transcribes, sends as message (SSE stream)
+- New endpoint: `GET /api/messages/{msg_id}/audio` — on-demand TTS synthesis for any assistant message
+- New endpoint: `GET /api/audio/{audio_id}` — serve pre-synthesized audio produced by the `voice_response` tool
+- New builtin tool: `voice_response(text, voice?)` — assistant can proactively synthesize a voiced reply
+- Flutter: microphone button in the chat input row (record → upload → auto-transcribe)
+- Flutter: playable audio bubble on assistant messages (tap ▶ to synthesize and play)
+- Flutter: auto-play when the assistant uses the `voice_response` tool
+
+## Capabilities
+
+### New Capabilities
+
+- `voice-send`: Record and send voice messages from the web UI; audio is transcribed server-side and injected into the conversation as a text message.
+- `voice-receive`: Assistant messages can be played back as synthesized speech via an on-demand TTS endpoint; the assistant may also proactively voice a reply using the `voice_response` tool.
+
+### Modified Capabilities
+
+_(none — existing text-chat capability is unchanged)_
+
+## Impact
+
+**Rust crates:**
+
+- `assistant-transcription`: new `TtsProvider` trait, `TtsRequest`/`TtsResult` types, OpenAI and Deepgram TTS implementations, `build_tts_provider()` helper
+- `assistant-core`: new `TtsConfig` struct, `[tts]` section in `AssistantConfig`
+- `assistant-tool-executor`: new `VoiceResponseHandler` builtin tool
+- `assistant-web-ui`: `ApiState` gains `tts_provider` and `audio_store` fields; new axum routes; new `AudioStore` (in-memory, TTL-managed); SSE stream gains `audio_ready` event type
+
+**Flutter app:**
+
+- `pubspec.yaml`: add `record` and `audioplayers` packages
+- `app/lib/features/chat/chat_screen.dart`: mic button, `VoiceRecorder` widget, audio-player bubble
+- `app/lib/api/client.dart` / endpoint wrappers: `sendVoiceMessage()`, `fetchMessageAudio()`, `fetchAudio()`
+
+**Config:**
+
+- New `[tts]` section in `~/.assistant/config.toml`; initially shares credentials with `[transcription]` when using OpenAI/Deepgram
+
+**Dependencies (no new Rust crates required):** OpenAI TTS uses the existing `reqwest`-based HTTP client already in `assistant-transcription`.

--- a/openspec/changes/web-voice/specs/voice-receive/spec.md
+++ b/openspec/changes/web-voice/specs/voice-receive/spec.md
@@ -1,0 +1,98 @@
+## ADDED Requirements
+
+### Requirement: Assistant messages have a play button for on-demand TTS
+
+The web UI SHALL display a play (▶) button on every assistant message bubble when a TTS provider is configured on the server. Tapping the button fetches synthesized audio from `GET /api/messages/{msg_id}/audio` and plays it. The button toggles to a stop (■) icon while audio is playing.
+
+#### Scenario: User taps play on an assistant message
+
+- **WHEN** the user taps ▶ on an assistant message
+- **THEN** the client fetches `GET /api/messages/{msg_id}/audio`
+- **THEN** the server synthesizes the message text via the configured `TtsProvider` and returns mp3 bytes
+- **THEN** the client plays the audio; the button shows ■ while playing
+
+#### Scenario: User taps stop during playback
+
+- **WHEN** the user taps ■ while audio is playing
+- **THEN** playback stops immediately and the button reverts to ▶
+
+#### Scenario: TTS not configured
+
+- **WHEN** the server has no `[tts]` section in config
+- **THEN** `GET /api/messages/{msg_id}/audio` returns HTTP 503
+- **THEN** the play button is not shown in the Flutter UI (server advertises capability via `GET /api/capabilities`)
+
+#### Scenario: Message not found
+
+- **WHEN** the client requests audio for a non-existent message ID
+- **THEN** the server returns HTTP 404
+
+### Requirement: Server exposes on-demand TTS synthesis endpoint
+
+The server SHALL expose `GET /api/messages/{msg_id}/audio` which reads the message text from the database, synthesizes it via the configured `TtsProvider`, and returns the audio as `audio/mpeg` bytes. The endpoint SHALL NOT cache results (synthesis is stateless and on-demand).
+
+#### Scenario: Valid assistant message
+
+- **WHEN** `GET /api/messages/{msg_id}/audio` is called for an existing assistant message
+- **THEN** the server returns HTTP 200 with `Content-Type: audio/mpeg` and synthesized mp3 bytes
+
+#### Scenario: Request for user message
+
+- **WHEN** `GET /api/messages/{msg_id}/audio` is called for a user (non-assistant) message
+- **THEN** the server returns HTTP 422 Unprocessable Entity (only assistant messages are voiced)
+
+### Requirement: Server exposes audio store endpoint for tool-synthesized audio
+
+The server SHALL expose `GET /api/audio/{audio_id}` which serves audio bytes previously synthesized and stored by the `voice_response` tool. Entries expire after 1 hour.
+
+#### Scenario: Valid audio ID
+
+- **WHEN** the client fetches `GET /api/audio/{audio_id}` within 1 hour of synthesis
+- **THEN** the server returns HTTP 200 with `Content-Type: audio/mpeg` and the audio bytes
+
+#### Scenario: Expired or unknown audio ID
+
+- **WHEN** the client fetches `GET /api/audio/{audio_id}` for an unknown or expired ID
+- **THEN** the server returns HTTP 404
+
+### Requirement: Assistant can proactively voice a reply using the `voice_response` tool
+
+The assistant SHALL have access to a `voice_response` tool when TTS is configured. Invoking it synthesizes the provided text, stores the audio in the in-memory `AudioStore`, and causes the client to auto-play the response.
+
+#### Scenario: Assistant invokes voice_response
+
+- **WHEN** the assistant calls `voice_response(text: "Here is your answer")` during a turn
+- **THEN** the server synthesizes the text via `TtsProvider`
+- **THEN** an `audio_ready` SSE event is emitted with `{"audio_id": "<uuid>", "auto_play": true}`
+- **THEN** the Flutter client fetches and auto-plays the audio from `GET /api/audio/{uuid}`
+
+#### Scenario: TTS not configured — tool absent
+
+- **WHEN** the server has no `[tts]` config
+- **THEN** `voice_response` is NOT registered in the tool executor
+- **THEN** the tool does not appear in the assistant's tool list
+
+#### Scenario: Auto-play when user sent voice
+
+- **WHEN** the user sent the triggering message via the mic button (voice send)
+- **THEN** if the assistant uses `voice_response`, the response auto-plays without further user action
+
+### Requirement: Server advertises voice capability to clients
+
+The server SHALL expose `GET /api/capabilities` returning a JSON object indicating which voice features are available, so the Flutter client can conditionally show/hide voice UI elements.
+
+#### Scenario: Both STT and TTS configured
+
+- **WHEN** the client calls `GET /api/capabilities`
+- **THEN** the server returns `{"voice_send": true, "voice_receive": true}`
+
+#### Scenario: Only STT configured
+
+- **WHEN** the server has `[transcription]` but no `[tts]`
+- **THEN** `GET /api/capabilities` returns `{"voice_send": true, "voice_receive": false}`
+
+#### Scenario: Neither configured
+
+- **WHEN** the server has neither `[transcription]` nor `[tts]`
+- **THEN** `GET /api/capabilities` returns `{"voice_send": false, "voice_receive": false}`
+- **THEN** the mic button and play buttons are hidden in the Flutter UI

--- a/openspec/changes/web-voice/specs/voice-send/spec.md
+++ b/openspec/changes/web-voice/specs/voice-send/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+### Requirement: User can record and send a voice message
+
+The web UI SHALL provide a microphone button in the chat input row. When activated, the client records audio using the device microphone. On stop, the audio bytes are uploaded to the server, which transcribes them using the configured STT provider and injects the transcript as a user text message, returning a streaming SSE response identical to a normal text send.
+
+#### Scenario: Successful voice send on web
+
+- **WHEN** the user taps the microphone button, speaks, and taps it again to stop
+- **THEN** the client uploads the WebM/Opus recording to `POST /api/conversations/{id}/voice`
+- **THEN** the server transcribes the audio via the configured `TranscriptionProvider`
+- **THEN** the transcript is sent as a user message and the assistant's streaming SSE response appears in the chat
+
+#### Scenario: Successful voice send on macOS
+
+- **WHEN** the user taps the microphone button, speaks, and taps it again to stop
+- **THEN** the client uploads the M4A recording to `POST /api/conversations/{id}/voice`
+- **THEN** the server transcribes and streams a response as above
+
+#### Scenario: Transcription not configured
+
+- **WHEN** the server has no `[transcription]` section in config
+- **THEN** `POST /api/conversations/{id}/voice` returns HTTP 503
+- **THEN** the Flutter client shows an error snackbar: "Voice messages require transcription to be configured on the server"
+
+#### Scenario: No active conversation
+
+- **WHEN** the user taps the microphone button before starting a conversation
+- **THEN** the client creates a new conversation automatically (same behaviour as text send with no active conversation)
+
+#### Scenario: Recording exceeds 2-minute limit
+
+- **WHEN** the user records for more than 2 minutes
+- **THEN** the client automatically stops recording and proceeds with the captured audio
+- **THEN** a visible countdown timer is shown during recording
+
+#### Scenario: Microphone permission denied
+
+- **WHEN** the user taps the microphone button but denies microphone permission
+- **THEN** the client shows an error snackbar: "Microphone access is required to send voice messages"
+- **THEN** no audio is recorded or uploaded
+
+### Requirement: Voice send endpoint accepts multipart audio
+
+The server SHALL expose `POST /api/conversations/{id}/voice` accepting `multipart/form-data` with a single `audio` field containing raw audio bytes and a `Content-Type` header identifying the MIME type. The response is an SSE stream identical to `POST /api/conversations/{id}/messages`.
+
+#### Scenario: Valid audio uploaded
+
+- **WHEN** a client POSTs a valid audio file to the voice endpoint
+- **THEN** the server transcribes the audio and streams the assistant response as SSE events
+
+#### Scenario: Unsupported MIME type
+
+- **WHEN** a client POSTs a file with an unrecognised MIME type (not in `AUDIO_MIME_PREFIXES`)
+- **THEN** the server returns HTTP 415 Unsupported Media Type
+
+#### Scenario: Audio exceeds 25 MB
+
+- **WHEN** the uploaded audio file exceeds 25 MB
+- **THEN** the server returns HTTP 413 Payload Too Large

--- a/openspec/changes/web-voice/tasks.md
+++ b/openspec/changes/web-voice/tasks.md
@@ -1,81 +1,81 @@
 ## 1. TTS Infrastructure (assistant-transcription + assistant-core)
 
-- [ ] 1.1 Add `TtsRequest` and `TtsResult` types to `crates/transcription/src/provider.rs`
-- [ ] 1.2 Add `TtsProvider` trait to `crates/transcription/src/provider.rs` with `name()` and `synthesize()` methods
-- [ ] 1.3 Add `TtsConfig` struct to `crates/core/src/types.rs` (fields: provider, model, api_key, base_url, voice, language)
-- [ ] 1.4 Add `TtsProviderKind` enum to `crates/core/src/types.rs` (variants: OpenAI, Deepgram)
-- [ ] 1.5 Add `tts: Option<TtsConfig>` field to `AssistantConfig` in `crates/core/src/types.rs`
-- [ ] 1.6 Implement `OpenAITtsProvider` in `crates/transcription/src/openai_tts.rs` (POST /v1/audio/speech, returns mp3)
-- [ ] 1.7 Implement `DeepgramTtsProvider` in `crates/transcription/src/deepgram_tts.rs` (POST /v1/speak)
-- [ ] 1.8 Add `build_tts_provider(config: &TtsConfig) -> Result<Arc<dyn TtsProvider>>` to `crates/transcription/src/lib.rs`
-- [ ] 1.9 Export new types from `crates/transcription/src/lib.rs`
-- [ ] 1.10 Write unit tests for `TtsRequest`/`TtsResult` types and provider name methods
+- [x] 1.1 Add `TtsRequest` and `TtsResult` types to `crates/transcription/src/provider.rs`
+- [x] 1.2 Add `TtsProvider` trait to `crates/transcription/src/provider.rs` with `name()` and `synthesize()` methods
+- [x] 1.3 Add `TtsConfig` struct to `crates/core/src/types.rs` (fields: provider, model, api_key, base_url, voice, language)
+- [x] 1.4 Add `TtsProviderKind` enum to `crates/core/src/types.rs` (variants: OpenAI, Deepgram)
+- [x] 1.5 Add `tts: Option<TtsConfig>` field to `AssistantConfig` in `crates/core/src/types.rs`
+- [x] 1.6 Implement `OpenAITtsProvider` in `crates/transcription/src/openai_tts.rs` (POST /v1/audio/speech, returns mp3)
+- [x] 1.7 Implement `DeepgramTtsProvider` in `crates/transcription/src/deepgram_tts.rs` (POST /v1/speak)
+- [x] 1.8 Add `build_tts_provider(config: &TtsConfig) -> Result<Arc<dyn TtsProvider>>` to `crates/transcription/src/lib.rs`
+- [x] 1.9 Export new types from `crates/transcription/src/lib.rs`
+- [x] 1.10 Write unit tests for `TtsRequest`/`TtsResult` types and provider name methods
 
 ## 2. AudioStore and Web UI State
 
-- [ ] 2.1 Create `AudioStore` struct in `crates/web-ui/src/audio_store.rs` (in-memory `HashMap<Uuid, (Vec<u8>, Instant)>` with 1-hour TTL)
-- [ ] 2.2 Add `insert()`, `get()`, and `sweep()` methods to `AudioStore`
-- [ ] 2.3 Add `tts_provider: Option<Arc<dyn TtsProvider>>` and `audio_store: Arc<AudioStore>` to `ApiState`
-- [ ] 2.4 Wire transcription provider into web-ui `main.rs` startup (read `config.transcription`, call `build_provider()`)
-- [ ] 2.5 Wire TTS provider into web-ui `main.rs` startup (read `config.tts`, call `build_tts_provider()`)
-- [ ] 2.6 Spawn background TTL sweep task in `main.rs` (every 10 minutes calls `audio_store.sweep()`)
+- [x] 2.1 Create `AudioStore` struct in `crates/web-ui/src/audio_store.rs` (in-memory `HashMap<Uuid, (Vec<u8>, Instant)>` with 1-hour TTL)
+- [x] 2.2 Add `insert()`, `get()`, and `sweep()` methods to `AudioStore`
+- [x] 2.3 Add `tts_provider: Option<Arc<dyn TtsProvider>>` and `audio_store: Arc<AudioStore>` to `ApiState`
+- [x] 2.4 Wire transcription provider into web-ui `main.rs` startup (read `config.transcription`, call `build_provider()`)
+- [x] 2.5 Wire TTS provider into web-ui `main.rs` startup (read `config.tts`, call `build_tts_provider()`)
+- [x] 2.6 Spawn background TTL sweep task in `main.rs` (every 10 minutes calls `audio_store.sweep()`)
 
 ## 3. Server Endpoints (Rust)
 
-- [ ] 3.1 Add `GET /api/capabilities` handler returning `{"voice_send": bool, "voice_receive": bool}` based on `ApiState`
-- [ ] 3.2 Add `POST /api/conversations/{id}/voice` handler: parse multipart, validate MIME type, enforce 25 MB limit, transcribe, run through orchestrator, return SSE stream
-- [ ] 3.3 Add `GET /api/messages/{msg_id}/audio` handler: fetch message from DB, validate it is an assistant message, synthesize via TtsProvider, return `audio/mpeg`
-- [ ] 3.4 Add `GET /api/audio/{audio_id}` handler: look up in `AudioStore`, return `audio/mpeg` or 404
-- [ ] 3.5 Register new routes in `api_router()` in `crates/web-ui/src/api/mod.rs`
-- [ ] 3.6 Add utoipa path annotations to all new handlers
-- [ ] 3.7 Update `openapi.json` snapshot (`make dump-openapi`)
-- [ ] 3.8 Write unit tests for MIME type validation and 25 MB size check
+- [x] 3.1 Add `GET /api/capabilities` handler returning `{"voice_send": bool, "voice_receive": bool}` based on `ApiState`
+- [x] 3.2 Add `POST /api/conversations/{id}/voice` handler: parse multipart, validate MIME type, enforce 25 MB limit, transcribe, run through orchestrator, return SSE stream
+- [x] 3.3 Add `GET /api/messages/{msg_id}/audio` handler: fetch message from DB, validate it is an assistant message, synthesize via TtsProvider, return `audio/mpeg`
+- [x] 3.4 Add `GET /api/audio/{audio_id}` handler: look up in `AudioStore`, return `audio/mpeg` or 404
+- [x] 3.5 Register new routes in `api_router()` in `crates/web-ui/src/api/mod.rs`
+- [x] 3.6 Add utoipa path annotations to all new handlers
+- [x] 3.7 Update `openapi.json` snapshot (`make dump-openapi`)
+- [x] 3.8 Write unit tests for MIME type validation and 25 MB size check
 
 ## 4. `voice_response` Tool
 
-- [ ] 4.1 Create `crates/tool-executor/src/builtins/voice_response.rs` with `VoiceResponseHandler` struct holding `Arc<dyn TtsProvider>` and `Arc<AudioStore>`
-- [ ] 4.2 Implement `ToolHandler` for `VoiceResponseHandler`: name `"voice-response"`, params `{text: string, voice?: string}`, run: synthesize → store → return `{audio_id}`
-- [ ] 4.3 Export `VoiceResponseHandler` from `crates/tool-executor/src/builtins/mod.rs`
-- [ ] 4.4 Register `VoiceResponseHandler` in `ToolExecutor::register_builtins()` only when TTS is configured
-- [ ] 4.5 Emit `audio_ready` SSE event when a `voice_response` tool result is detected in the orchestrator SSE handler in `crates/web-ui/src/api/mod.rs`
-- [ ] 4.6 Write unit tests for `VoiceResponseHandler::run()` with a mock TtsProvider
+- [x] 4.1 Create `crates/tool-executor/src/builtins/voice_response.rs` with `VoiceResponseHandler` struct holding `Arc<dyn TtsProvider>` and `Arc<AudioStore>`
+- [x] 4.2 Implement `ToolHandler` for `VoiceResponseHandler`: name `"voice-response"`, params `{text: string, voice?: string}`, run: synthesize → store → return `{audio_id}`
+- [x] 4.3 Export `VoiceResponseHandler` from `crates/tool-executor/src/builtins/mod.rs`
+- [x] 4.4 Register `VoiceResponseHandler` in `ToolExecutor::register_builtins()` only when TTS is configured
+- [x] 4.5 Emit `audio_ready` SSE event when a `voice_response` tool result is detected in the orchestrator SSE handler in `crates/web-ui/src/api/mod.rs`
+- [x] 4.6 Write unit tests for `VoiceResponseHandler::run()` with a mock TtsProvider
 
 ## 5. Flutter Packages and API Client
 
-- [ ] 5.1 Add `record: ^5.0.0` and `audioplayers: ^6.0.0` to `app/pubspec.yaml` and run `flutter pub get`
-- [ ] 5.2 Add `NSMicrophoneUsageDescription` to `app/macos/Runner/Info.plist`
-- [ ] 5.3 Add `capabilities()` method to the Flutter API client (GET /api/capabilities, returns `ServerCapabilities` model)
-- [ ] 5.4 Add `sendVoiceMessage(conversationId, audioBytes, mimeType)` method to the API client
-- [ ] 5.5 Add `fetchMessageAudio(messageId)` method returning `Uint8List` (GET /api/messages/{id}/audio)
-- [ ] 5.6 Add `fetchAudio(audioId)` method returning `Uint8List` (GET /api/audio/{id})
-- [ ] 5.7 Create `ServerCapabilities` model class with `voiceSend` and `voiceReceive` fields
-- [ ] 5.8 Add `capabilitiesProvider` Riverpod provider that fetches and caches `ServerCapabilities`
+- [x] 5.1 Add `record: ^5.0.0` and `audioplayers: ^6.0.0` to `app/pubspec.yaml` and run `flutter pub get`
+- [x] 5.2 Add `NSMicrophoneUsageDescription` to `app/macos/Runner/Info.plist`
+- [x] 5.3 Add `capabilities()` method to the Flutter API client (GET /api/capabilities, returns `ServerCapabilities` model)
+- [x] 5.4 Add `sendVoiceMessage(conversationId, audioBytes, mimeType)` method to the API client
+- [x] 5.5 Add `fetchMessageAudio(messageId)` method returning `Uint8List` (GET /api/messages/{id}/audio)
+- [x] 5.6 Add `fetchAudio(audioId)` method returning `Uint8List` (GET /api/audio/{id})
+- [x] 5.7 Create `ServerCapabilities` model class with `voiceSend` and `voiceReceive` fields
+- [x] 5.8 Add `capabilitiesProvider` Riverpod provider that fetches and caches `ServerCapabilities`
 
 ## 6. Flutter UI — Voice Send
 
-- [ ] 6.1 Create `VoiceRecorder` widget in `app/lib/features/chat/voice_recorder.dart` (manages record state, timer, error handling)
-- [ ] 6.2 Add mic button to `_InputRow` in `chat_screen.dart` — shown when `capabilities.voiceSend == true`
-- [ ] 6.3 Wire mic button tap to toggle `VoiceRecorder` recording state
-- [ ] 6.4 Show recording indicator (pulsing red dot) and countdown timer while recording
-- [ ] 6.5 On recording stop, call `chatProvider.notifier.sendVoiceMessage(bytes, mimeType)`
-- [ ] 6.6 Add `sendVoiceMessage()` to `ChatNotifier` in `chat_provider.dart` (upload → SSE stream same as text send)
-- [ ] 6.7 Show error snackbar for permission denied and server 503 responses
-- [ ] 6.8 Auto-stop recording at 2 minutes
+- [x] 6.1 Create `VoiceRecorder` widget in `app/lib/features/chat/voice_recorder.dart` (manages record state, timer, error handling)
+- [x] 6.2 Add mic button to `_InputRow` in `chat_screen.dart` — shown when `capabilities.voiceSend == true`
+- [x] 6.3 Wire mic button tap to toggle `VoiceRecorder` recording state
+- [x] 6.4 Show recording indicator (pulsing red dot) and countdown timer while recording
+- [x] 6.5 On recording stop, call `chatProvider.notifier.sendVoiceMessage(bytes, mimeType)`
+- [x] 6.6 Add `sendVoiceMessage()` to `ChatNotifier` in `chat_provider.dart` (upload → SSE stream same as text send)
+- [x] 6.7 Show error snackbar for permission denied and server 503 responses
+- [x] 6.8 Auto-stop recording at 2 minutes
 
 ## 7. Flutter UI — Voice Receive
 
-- [ ] 7.1 Create `AudioPlayerWidget` in `app/lib/features/chat/audio_player_widget.dart` (play/stop button, fetches audio on first tap, plays via `audioplayers`)
-- [ ] 7.2 Add play button to `_MessageBubble` for assistant messages when `capabilities.voiceReceive == true`
-- [ ] 7.3 Wire play button to `AudioPlayerWidget` passing the message ID
-- [ ] 7.4 Handle `audio_ready` SSE event in `ChatNotifier`: extract `audio_id`, fetch audio, auto-play
-- [ ] 7.5 Ensure play button shows ■ (stop) while audio is playing and reverts to ▶ on completion or stop
+- [x] 7.1 Create `AudioPlayerWidget` in `app/lib/features/chat/audio_player_widget.dart` (play/stop button, fetches audio on first tap, plays via `audioplayers`)
+- [x] 7.2 Add play button to `_MessageBubble` for assistant messages when `capabilities.voiceReceive == true`
+- [x] 7.3 Wire play button to `AudioPlayerWidget` passing the message ID
+- [x] 7.4 Handle `audio_ready` SSE event in `ChatNotifier`: extract `audio_id`, fetch audio, auto-play
+- [x] 7.5 Ensure play button shows ■ (stop) while audio is playing and reverts to ▶ on completion or stop
 
 ## 8. Integration and Polish
 
-- [ ] 8.1 Regenerate Flutter API client (`make generate-flutter-client`) after OpenAPI spec update
-- [ ] 8.2 Run `flutter analyze` and fix any issues
-- [ ] 8.3 Run `make lint` and `make format` on Rust code
-- [ ] 8.4 Run `make test` and verify no regressions
+- [x] 8.1 Regenerate Flutter API client (`make generate-flutter-client`) after OpenAPI spec update
+- [x] 8.2 Run `flutter analyze` and fix any issues
+- [x] 8.3 Run `make lint` and `make format` on Rust code
+- [x] 8.4 Run `make test` and verify no regressions
 - [ ] 8.5 Manual smoke test: send voice → see transcript as user message → assistant responds → tap play → hear audio
 - [ ] 8.6 Manual smoke test: assistant uses `voice_response` tool → audio auto-plays
 - [ ] 8.7 Manual smoke test with TTS not configured: mic button hidden, play button hidden

--- a/openspec/changes/web-voice/tasks.md
+++ b/openspec/changes/web-voice/tasks.md
@@ -1,0 +1,81 @@
+## 1. TTS Infrastructure (assistant-transcription + assistant-core)
+
+- [ ] 1.1 Add `TtsRequest` and `TtsResult` types to `crates/transcription/src/provider.rs`
+- [ ] 1.2 Add `TtsProvider` trait to `crates/transcription/src/provider.rs` with `name()` and `synthesize()` methods
+- [ ] 1.3 Add `TtsConfig` struct to `crates/core/src/types.rs` (fields: provider, model, api_key, base_url, voice, language)
+- [ ] 1.4 Add `TtsProviderKind` enum to `crates/core/src/types.rs` (variants: OpenAI, Deepgram)
+- [ ] 1.5 Add `tts: Option<TtsConfig>` field to `AssistantConfig` in `crates/core/src/types.rs`
+- [ ] 1.6 Implement `OpenAITtsProvider` in `crates/transcription/src/openai_tts.rs` (POST /v1/audio/speech, returns mp3)
+- [ ] 1.7 Implement `DeepgramTtsProvider` in `crates/transcription/src/deepgram_tts.rs` (POST /v1/speak)
+- [ ] 1.8 Add `build_tts_provider(config: &TtsConfig) -> Result<Arc<dyn TtsProvider>>` to `crates/transcription/src/lib.rs`
+- [ ] 1.9 Export new types from `crates/transcription/src/lib.rs`
+- [ ] 1.10 Write unit tests for `TtsRequest`/`TtsResult` types and provider name methods
+
+## 2. AudioStore and Web UI State
+
+- [ ] 2.1 Create `AudioStore` struct in `crates/web-ui/src/audio_store.rs` (in-memory `HashMap<Uuid, (Vec<u8>, Instant)>` with 1-hour TTL)
+- [ ] 2.2 Add `insert()`, `get()`, and `sweep()` methods to `AudioStore`
+- [ ] 2.3 Add `tts_provider: Option<Arc<dyn TtsProvider>>` and `audio_store: Arc<AudioStore>` to `ApiState`
+- [ ] 2.4 Wire transcription provider into web-ui `main.rs` startup (read `config.transcription`, call `build_provider()`)
+- [ ] 2.5 Wire TTS provider into web-ui `main.rs` startup (read `config.tts`, call `build_tts_provider()`)
+- [ ] 2.6 Spawn background TTL sweep task in `main.rs` (every 10 minutes calls `audio_store.sweep()`)
+
+## 3. Server Endpoints (Rust)
+
+- [ ] 3.1 Add `GET /api/capabilities` handler returning `{"voice_send": bool, "voice_receive": bool}` based on `ApiState`
+- [ ] 3.2 Add `POST /api/conversations/{id}/voice` handler: parse multipart, validate MIME type, enforce 25 MB limit, transcribe, run through orchestrator, return SSE stream
+- [ ] 3.3 Add `GET /api/messages/{msg_id}/audio` handler: fetch message from DB, validate it is an assistant message, synthesize via TtsProvider, return `audio/mpeg`
+- [ ] 3.4 Add `GET /api/audio/{audio_id}` handler: look up in `AudioStore`, return `audio/mpeg` or 404
+- [ ] 3.5 Register new routes in `api_router()` in `crates/web-ui/src/api/mod.rs`
+- [ ] 3.6 Add utoipa path annotations to all new handlers
+- [ ] 3.7 Update `openapi.json` snapshot (`make dump-openapi`)
+- [ ] 3.8 Write unit tests for MIME type validation and 25 MB size check
+
+## 4. `voice_response` Tool
+
+- [ ] 4.1 Create `crates/tool-executor/src/builtins/voice_response.rs` with `VoiceResponseHandler` struct holding `Arc<dyn TtsProvider>` and `Arc<AudioStore>`
+- [ ] 4.2 Implement `ToolHandler` for `VoiceResponseHandler`: name `"voice-response"`, params `{text: string, voice?: string}`, run: synthesize → store → return `{audio_id}`
+- [ ] 4.3 Export `VoiceResponseHandler` from `crates/tool-executor/src/builtins/mod.rs`
+- [ ] 4.4 Register `VoiceResponseHandler` in `ToolExecutor::register_builtins()` only when TTS is configured
+- [ ] 4.5 Emit `audio_ready` SSE event when a `voice_response` tool result is detected in the orchestrator SSE handler in `crates/web-ui/src/api/mod.rs`
+- [ ] 4.6 Write unit tests for `VoiceResponseHandler::run()` with a mock TtsProvider
+
+## 5. Flutter Packages and API Client
+
+- [ ] 5.1 Add `record: ^5.0.0` and `audioplayers: ^6.0.0` to `app/pubspec.yaml` and run `flutter pub get`
+- [ ] 5.2 Add `NSMicrophoneUsageDescription` to `app/macos/Runner/Info.plist`
+- [ ] 5.3 Add `capabilities()` method to the Flutter API client (GET /api/capabilities, returns `ServerCapabilities` model)
+- [ ] 5.4 Add `sendVoiceMessage(conversationId, audioBytes, mimeType)` method to the API client
+- [ ] 5.5 Add `fetchMessageAudio(messageId)` method returning `Uint8List` (GET /api/messages/{id}/audio)
+- [ ] 5.6 Add `fetchAudio(audioId)` method returning `Uint8List` (GET /api/audio/{id})
+- [ ] 5.7 Create `ServerCapabilities` model class with `voiceSend` and `voiceReceive` fields
+- [ ] 5.8 Add `capabilitiesProvider` Riverpod provider that fetches and caches `ServerCapabilities`
+
+## 6. Flutter UI — Voice Send
+
+- [ ] 6.1 Create `VoiceRecorder` widget in `app/lib/features/chat/voice_recorder.dart` (manages record state, timer, error handling)
+- [ ] 6.2 Add mic button to `_InputRow` in `chat_screen.dart` — shown when `capabilities.voiceSend == true`
+- [ ] 6.3 Wire mic button tap to toggle `VoiceRecorder` recording state
+- [ ] 6.4 Show recording indicator (pulsing red dot) and countdown timer while recording
+- [ ] 6.5 On recording stop, call `chatProvider.notifier.sendVoiceMessage(bytes, mimeType)`
+- [ ] 6.6 Add `sendVoiceMessage()` to `ChatNotifier` in `chat_provider.dart` (upload → SSE stream same as text send)
+- [ ] 6.7 Show error snackbar for permission denied and server 503 responses
+- [ ] 6.8 Auto-stop recording at 2 minutes
+
+## 7. Flutter UI — Voice Receive
+
+- [ ] 7.1 Create `AudioPlayerWidget` in `app/lib/features/chat/audio_player_widget.dart` (play/stop button, fetches audio on first tap, plays via `audioplayers`)
+- [ ] 7.2 Add play button to `_MessageBubble` for assistant messages when `capabilities.voiceReceive == true`
+- [ ] 7.3 Wire play button to `AudioPlayerWidget` passing the message ID
+- [ ] 7.4 Handle `audio_ready` SSE event in `ChatNotifier`: extract `audio_id`, fetch audio, auto-play
+- [ ] 7.5 Ensure play button shows ■ (stop) while audio is playing and reverts to ▶ on completion or stop
+
+## 8. Integration and Polish
+
+- [ ] 8.1 Regenerate Flutter API client (`make generate-flutter-client`) after OpenAPI spec update
+- [ ] 8.2 Run `flutter analyze` and fix any issues
+- [ ] 8.3 Run `make lint` and `make format` on Rust code
+- [ ] 8.4 Run `make test` and verify no regressions
+- [ ] 8.5 Manual smoke test: send voice → see transcript as user message → assistant responds → tap play → hear audio
+- [ ] 8.6 Manual smoke test: assistant uses `voice_response` tool → audio auto-plays
+- [ ] 8.7 Manual smoke test with TTS not configured: mic button hidden, play button hidden


### PR DESCRIPTION
## Summary

Full-stack voice messaging for the web UI and native apps:

- **STT send path**: mic button in chat input → multipart audio upload (`POST /api/conversations/{id}/voice`) → server transcribes via `assistant-transcription` → same SSE stream as text chat
- **TTS receive path**: play button on assistant message bubbles → on-demand synthesis (`GET /api/messages/{id}/audio`) via new `TtsProvider` trait (OpenAI + Deepgram)
- **`voice_response` tool**: assistant can proactively synthesize a reply, emitting an `audio_ready` SSE event → client auto-plays
- **`GET /api/capabilities`**: runtime discovery so the Flutter UI conditionally shows/hides mic and play buttons

## What changed

**Rust**
- `assistant-core`: `TtsConfig` / `TtsProviderKind` added to `AssistantConfig`
- `assistant-transcription`: `TtsProvider` trait, `TtsRequest`/`TtsResult`, `OpenAITtsProvider`, `DeepgramTtsProvider`, `AudioStore` (in-memory, 1-hour TTL)
- `assistant-tool-executor`: `VoiceResponseHandler` builtin — synthesises audio, stores in `AudioStore`, emits `audio_ready` over SSE
- `assistant-web-ui`: four new endpoints; `ApiState` wired with transcription + TTS providers; background sweep task

**Flutter**
- `record ^6.2.0` + `audioplayers ^6.1.0` added
- `ServerCapabilities` model + `capabilitiesProvider` (uses `dart:io` directly — no Dio timer leak in `fakeAsync` tests)
- `VoiceRecorderButton`: pulsing indicator, 2-minute auto-stop
- `AudioPlayerWidget`: lazy audio fetch on first play, play/stop toggle
- `ChatNotifier`: `sendVoiceMessage()`, `AudioReadyEvent` handling
- macOS: `com.apple.security.device.audio-input` entitlement; iOS: `NSMicrophoneUsageDescription`

## Test plan

- [x] `flutter test` — 194 tests pass (including `fakeAsync` timer-leak regression)
- [x] `make lint` + `make format` — clean
- [x] `flutter build macos` — succeeds
- [x] `flutter build ios --no-codesign` — succeeds
- [ ] Smoke: send voice message → transcript shown → assistant replies → tap ▶ → audio plays
- [ ] Smoke: assistant calls `voice_response` → audio auto-plays in bubble
- [ ] Smoke: server without `[tts]`/`[transcription]` config → buttons hidden