### PR TITLE
fix(release): fix macOS build signing and sandbox for CI

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -256,7 +256,8 @@ jobs:
           find "$APP/Contents/Frameworks" \( -name "*.framework" -o -name "*.dylib" \) 2>/dev/null | while read f; do
             codesign --force --sign "$IDENTITY" --options runtime --timestamp "$f"
           done
-          codesign --force --sign "$IDENTITY" --options runtime --timestamp "$APP"
+          codesign --force --sign "$IDENTITY" --options runtime --timestamp \
+            --entitlements app/macos/Runner/Release.entitlements "$APP"
 
       - name: Notarize macOS app
         run: |

--- a/app/macos/Runner.xcodeproj/project.pbxproj
+++ b/app/macos/Runner.xcodeproj/project.pbxproj
@@ -748,8 +748,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Release.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = WPW3QSLZ2F;
 				INFOPLIST_FILE = Runner/Info.plist;

--- a/app/macos/Runner/Release.entitlements
+++ b/app/macos/Runner/Release.entitlements
@@ -3,12 +3,10 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<true/>
+	<false/>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.network.server</key>
-	<true/>
-	<key>com.apple.security.inherit</key>
 	<true/>
 	<key>keychain-access-groups</key>
 	<array>


### PR DESCRIPTION
## Summary

- **Provisioning profile error**: Runner Release config was using `CODE_SIGN_STYLE=Automatic` + `CODE_SIGN_IDENTITY="Apple Development"`, which requires Xcode to find/create a Mac App Development provisioning profile. Developer ID distribution doesn't need one, and CI has no mechanism to create it. Switched to `CODE_SIGN_STYLE=Manual` + `CODE_SIGN_IDENTITY="-"` (ad-hoc) so the build completes without a profile; the existing `codesign` step re-signs with the Developer ID Application cert afterwards.
- **Entitlements safety**: Updated the `codesign` step to pass `--entitlements app/macos/Runner/Release.entitlements` explicitly so sandbox/network/keychain entitlements are guaranteed to be applied correctly at final sign time.
- **Sandbox disabled**: The embedded Rust binary needs to execute arbitrary commands, spawn processes, and access arbitrary file paths. `app-sandbox=true` blocks all of that. Removed for Release (Developer ID distribution does not require sandboxing).
- **`com.apple.security.inherit` removed**: Sandbox-only entitlement (lets child processes inherit the sandbox container); meaningless and potentially problematic without sandbox.
- **`keychain-access-groups` kept**: Required by `flutter_secure_storage` — it uses `kSecAttrAccessGroup` to scope keychain items, which requires this entitlement even for non-sandboxed Developer ID apps.

## Test plan

- [ ] Trigger a release or manually run the `build-flutter-desktop` job and confirm the macOS build completes
- [ ] Verify the notarization step succeeds (app signed with hardened runtime + timestamp + correct entitlements)
- [ ] Smoke-test the resulting `.app`: launch, connect to a server, verify stored credentials survive restart (keychain), verify tool execution works (sandbox disabled)