### PR TITLE
fix(pwa): Safari install prompt and update detection

### DIFF
--- a/app/lib/features/pwa/pwa_provider.dart
+++ b/app/lib/features/pwa/pwa_provider.dart
@@ -4,6 +4,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'pwa_service.dart';
 
+// True when running in iOS Safari outside standalone mode.
+// Safari never fires beforeinstallprompt, so we show a custom instruction
+// banner telling the user to tap Share → "Add to Home Screen".
+final safariInstallProvider = Provider<bool>(
+  (_) => PwaService.isSafariInstallable,
+);
+
 // Tracks whether the browser's PWA install prompt is currently available.
 //
 // Always false on non-web platforms. On web, becomes true once the browser

--- a/app/lib/features/pwa/pwa_service_stub.dart
+++ b/app/lib/features/pwa/pwa_service_stub.dart
@@ -4,6 +4,9 @@ abstract class PwaService {
   // Always false outside of a web browser.
   static bool get isInstallable => false;
 
+  // Always false outside of a web browser.
+  static bool get isSafariInstallable => false;
+
   // No-op on non-web platforms.
   static void setup() {}
 

--- a/app/lib/features/pwa/pwa_service_web.dart
+++ b/app/lib/features/pwa/pwa_service_web.dart
@@ -1,3 +1,5 @@
+import 'dart:js_interop';
+
 import 'package:pwa_install/pwa_install.dart';
 
 // Web implementation that delegates to the pwa_install package.
@@ -9,10 +11,29 @@ import 'package:pwa_install/pwa_install.dart';
 // The index.html JavaScript is responsible for calling hasPrompt() whenever
 // beforeinstallprompt fires (both before and after Flutter initialises), which
 // updates PWAInstall().hasPrompt so that [isInstallable] returns true.
+//
+// Safari (iOS/macOS) never fires beforeinstallprompt.  Use [isSafariInstallable]
+// to detect the "on iOS Safari and not yet installed" case and show a custom
+// instruction banner instead.
+
+@JS('isSafariInstallable')
+external bool _jsSafariInstallable();
+
 abstract class PwaService {
   // True when the browser's install prompt has been captured and the app is
   // not already running as a PWA or TWA.
   static bool get isInstallable => PWAInstall().installPromptEnabled;
+
+  // True when running in iOS Safari outside of standalone mode.
+  // Safari never fires beforeinstallprompt, so a custom "Add to Home Screen"
+  // instruction banner must be shown instead of the normal install prompt.
+  static bool get isSafariInstallable {
+    try {
+      return _jsSafariInstallable();
+    } catch (_) {
+      return false;
+    }
+  }
 
   // Registers JS-interop callbacks and determines the initial launch mode.
   // Must be called once before using [isInstallable] or [install].

--- a/app/lib/features/pwa/pwa_update_service.dart
+++ b/app/lib/features/pwa/pwa_update_service.dart
@@ -1,0 +1,4 @@
+// Conditional export: real JS-interop implementation on web, no-op stub
+// on all other platforms (macOS, etc.).
+export 'pwa_update_stub.dart'
+    if (dart.library.js_interop) 'pwa_update_web.dart';

--- a/app/lib/features/pwa/pwa_update_stub.dart
+++ b/app/lib/features/pwa/pwa_update_stub.dart
@@ -1,0 +1,8 @@
+// No-op stub for non-web platforms.
+// PWA update detection only applies in a browser context.
+
+/// No-op on non-web platforms.
+void registerPwaUpdateCallback(void Function() onUpdate) {}
+
+/// No-op on non-web platforms.
+void reloadPwa() {}

--- a/app/lib/features/pwa/pwa_update_web.dart
+++ b/app/lib/features/pwa/pwa_update_web.dart
@@ -1,0 +1,31 @@
+// Web implementation: JS-interop bindings for the PWA update detection
+// functions exposed in index.html.
+//
+// The index.html script listens for the service worker 'controllerchange'
+// event, which fires when Flutter's flutter_service_worker.js calls
+// skipWaiting() + clients.claim() after a new version is deployed.
+// This is more reliable than polling the 'waiting' state, which Flutter's
+// SW skips entirely.
+
+import 'dart:js_interop';
+
+import 'package:web/web.dart' as web;
+
+@JS('registerPwaUpdateCallback')
+external void _jsRegisterPwaUpdateCallback(JSFunction callback);
+
+/// Register [onUpdate] to be called when a new service worker version has
+/// taken control of the page (i.e. a new app version is available).
+///
+/// If the update already fired before this is called, [onUpdate] is invoked
+/// immediately.
+void registerPwaUpdateCallback(void Function() onUpdate) {
+  try {
+    _jsRegisterPwaUpdateCallback(onUpdate.toJS);
+  } catch (_) {
+    // Gracefully ignore if the JS function is not available (e.g. no SW).
+  }
+}
+
+/// Reload the page to apply the new service worker version.
+void reloadPwa() => web.window.location.reload();

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -2,11 +2,11 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_web_plugins/url_strategy.dart';
-import 'package:pwa_update_listener/pwa_update_listener.dart';
 
 import 'features/contexts/providers/context_providers.dart';
 import 'features/embedded_server/embedded_server_provider.dart';
 import 'features/notifications/notification_badge_notifier.dart';
+import 'features/pwa/pwa_update_service.dart';
 import 'router/app_router.dart';
 import 'tray/platform_init.dart';
 import 'tray/tray_platform.dart';
@@ -31,25 +31,30 @@ Future<void> main() async {
   final contextRepo = await createContextRepository();
 
   runApp(
-    // PwaUpdateListener detects when a new service worker activates (new
-    // version available) and surfaces a SnackBar prompt to reload the app.
-    PwaUpdateListener(
-      onReady: () {
-        _scaffoldMessengerKey.currentState?.showSnackBar(
-          SnackBar(
-            content: const Text('A new version is available.'),
-            action: SnackBarAction(label: 'Reload', onPressed: reloadPwa),
-            duration: const Duration(days: 1),
-          ),
-        );
-      },
-      // Riverpod ProviderScope wraps the entire widget tree.
-      child: ProviderScope(
-        overrides: [contextRepositoryProvider.overrideWithValue(contextRepo)],
-        child: const AssistantApp(),
-      ),
+    ProviderScope(
+      overrides: [contextRepositoryProvider.overrideWithValue(contextRepo)],
+      child: const AssistantApp(),
     ),
   );
+
+  // Register for PWA update notifications after the first frame so the
+  // ScaffoldMessenger key is bound and can show the SnackBar.
+  //
+  // Flutter's flutter_service_worker.js calls skipWaiting() on install, so
+  // the new SW never enters the 'waiting' state.  We listen for the
+  // 'controllerchange' event via JS instead (see index.html).  The stub
+  // implementation is a no-op on non-web platforms.
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    registerPwaUpdateCallback(() {
+      _scaffoldMessengerKey.currentState?.showSnackBar(
+        SnackBar(
+          content: const Text('A new version is available.'),
+          action: SnackBarAction(label: 'Reload', onPressed: reloadPwa),
+          duration: const Duration(days: 1),
+        ),
+      );
+    });
+  });
 }
 
 /// Root application widget.

--- a/app/lib/shared/nav_shell.dart
+++ b/app/lib/shared/nav_shell.dart
@@ -233,6 +233,8 @@ class NavShell extends ConsumerWidget {
 
     // Watch install-prompt availability (false on non-web platforms).
     final isInstallable = ref.watch(pwaInstallProvider);
+    // True when on iOS Safari and not yet installed as a PWA.
+    final isSafariInstallable = ref.watch(safariInstallProvider);
 
     if (isWide) {
       final selected = _railSelectedIndex(context);
@@ -322,6 +324,7 @@ class NavShell extends ConsumerWidget {
                       onTap: () =>
                           ref.read(pwaInstallProvider.notifier).install(),
                     ),
+                  if (isSafariInstallable) const _SafariInstallButton(),
                   const SizedBox(height: 8),
                 ],
               ),
@@ -350,6 +353,7 @@ class NavShell extends ConsumerWidget {
             _InstallBanner(
               onInstall: () => ref.read(pwaInstallProvider.notifier).install(),
             ),
+          if (isSafariInstallable) const _SafariInstallBanner(),
           NavigationBar(
             selectedIndex: selected,
             onDestinationSelected: (i) {
@@ -463,6 +467,141 @@ class _InstallBanner extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+/// Icon button shown in the [NavigationRail] trailing slot on iOS Safari.
+/// Tapping it opens a bottom sheet explaining how to add to home screen.
+class _SafariInstallButton extends StatelessWidget {
+  const _SafariInstallButton();
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton.filledTonal(
+      icon: const Icon(Icons.ios_share),
+      tooltip: 'Add to Home Screen',
+      onPressed: () => _showSafariInstructions(context),
+    );
+  }
+}
+
+/// Slim banner above the mobile [NavigationBar] on iOS Safari.
+class _SafariInstallBanner extends StatelessWidget {
+  const _SafariInstallBanner();
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Material(
+      color: colorScheme.primaryContainer,
+      child: InkWell(
+        onTap: () => _showSafariInstructions(context),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: Row(
+            children: [
+              Icon(Icons.ios_share, color: colorScheme.onPrimaryContainer),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  'Add to Home Screen',
+                  style: TextStyle(
+                    color: colorScheme.onPrimaryContainer,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ),
+              Icon(Icons.arrow_forward, color: colorScheme.onPrimaryContainer),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Shows a bottom sheet explaining iOS Safari's manual install steps.
+void _showSafariInstructions(BuildContext context) {
+  showModalBottomSheet<void>(
+    context: context,
+    builder: (sheetContext) {
+      final colorScheme = Theme.of(sheetContext).colorScheme;
+      return SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(24, 24, 24, 32),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Add to Home Screen',
+                style: Theme.of(sheetContext).textTheme.titleLarge,
+              ),
+              const SizedBox(height: 16),
+              _SafariStep(
+                number: '1',
+                icon: Icons.ios_share,
+                color: colorScheme.primary,
+                text: 'Tap the Share button in the Safari toolbar.',
+              ),
+              const SizedBox(height: 12),
+              _SafariStep(
+                number: '2',
+                icon: Icons.add_box_outlined,
+                color: colorScheme.primary,
+                text: 'Scroll down and tap "Add to Home Screen".',
+              ),
+              const SizedBox(height: 12),
+              _SafariStep(
+                number: '3',
+                icon: Icons.check_circle_outline,
+                color: colorScheme.primary,
+                text: 'Tap "Add" to confirm.',
+              ),
+            ],
+          ),
+        ),
+      );
+    },
+  );
+}
+
+class _SafariStep extends StatelessWidget {
+  const _SafariStep({
+    required this.number,
+    required this.icon,
+    required this.color,
+    required this.text,
+  });
+
+  final String number;
+  final IconData icon;
+  final Color color;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        CircleAvatar(
+          radius: 14,
+          backgroundColor: color,
+          child: Text(
+            number,
+            style: const TextStyle(
+              color: Colors.white,
+              fontWeight: FontWeight.bold,
+              fontSize: 13,
+            ),
+          ),
+        ),
+        const SizedBox(width: 12),
+        Icon(icon, color: color),
+        const SizedBox(width: 8),
+        Expanded(child: Text(text)),
+      ],
     );
   }
 }

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -647,14 +647,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.0.6"
-  pwa_update_listener:
-    dependency: "direct main"
-    description:
-      name: pwa_update_listener
-      sha256: e6d5096124ac10ae6e915d57d90d50c8025768fba78c361a118b5ad86f471887
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.0"
   quiver:
     dependency: transitive
     description:
@@ -1004,14 +996,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
-  visibility_detector:
-    dependency: transitive
-    description:
-      name: visibility_detector
-      sha256: "15c54a459ec2c17b4705450483f3d5a2858e733aee893dcee9d75fd04814940d"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.3"
   vm_service:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -23,14 +23,13 @@ dependencies:
   path_provider: ^2.1.5
   url_launcher: ^6.3.2
   package_info_plus: ^9.0.1
-  built_value: '>=8.4.0 <9.0.0'
+  built_value: ">=8.4.0 <9.0.0"
   assistant_api:
     path: packages/assistant_api
   tray_manager: ^0.5.2
   window_manager: ^0.5.1
   flutter_markdown_plus: ^1.0.0
   pwa_install: 0.0.6
-  pwa_update_listener: ^0.1.0
   flutter_local_notifications: ^21.0.0
   web: ^1.1.1
 dev_dependencies:

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -77,6 +77,57 @@
             appLaunchedInBrowser();
         }
       }
+
+      // -- Safari install detection ------------------------------------------
+      // Safari (iOS/macOS) never fires beforeinstallprompt.  We detect the
+      // "installable but not yet installed" state ourselves and let Dart show
+      // a custom instruction banner (Share → Add to Home Screen on iOS).
+      window.isSafariInstallable = function () {
+        const ua = navigator.userAgent;
+        const isIOS = /iP(ad|hone|od)/.test(ua);
+        const isSafariBrowser =
+          /Safari/.test(ua) && !/CriOS|FxiOS|OPiOS|EdgiOS/.test(ua);
+        const isStandalone =
+          navigator.standalone === true ||
+          window.matchMedia("(display-mode: standalone)").matches;
+        return isIOS && isSafariBrowser && !isStandalone;
+      };
+
+      // -- PWA update detection ----------------------------------------------
+      // Flutter's generated flutter_service_worker.js calls self.skipWaiting()
+      // on install, so the new SW goes straight from 'installing' → 'activated'
+      // without ever entering the 'waiting' state.  Packages that poll for the
+      // 'waiting' state (e.g. pwa_update_listener) therefore never fire.
+      //
+      // We listen for 'controllerchange' instead, which fires the moment the
+      // new SW calls clients.claim() after skipWaiting().  The first
+      // controllerchange on a fresh install (no previous controller) is
+      // ignored; only replacements trigger the update callback.
+      (function () {
+        if (!("serviceWorker" in navigator)) return;
+        let initialController = navigator.serviceWorker.controller;
+        let updateReady = false;
+        const updateCallbacks = [];
+
+        window.registerPwaUpdateCallback = function (cb) {
+          if (updateReady) {
+            cb();
+            return;
+          }
+          updateCallbacks.push(cb);
+        };
+
+        navigator.serviceWorker.addEventListener("controllerchange", () => {
+          if (initialController !== null) {
+            // A replacement SW has taken control — new version is ready.
+            updateReady = true;
+            updateCallbacks.forEach((cb) => cb());
+          } else {
+            // First activation (no prior controller) — not an update.
+            initialController = navigator.serviceWorker.controller;
+          }
+        });
+      })();
     </script>
 
     <!--


### PR DESCRIPTION
## Summary

- **Safari install prompt**: Safari never fires `beforeinstallprompt` (Chrome/Android only), so the install button was permanently hidden. Detect iOS Safari + not-standalone via JS and show a custom "Add to Home Screen" instruction banner/sheet with step-by-step Share menu guidance.
- **PWA update detection**: `pwa_update_listener` polls the service worker `waiting` state, but Flutter's `flutter_service_worker.js` calls `skipWaiting()` on install so the SW goes straight from `installing → activated`, skipping `waiting` entirely — `onReady` never fired. Replace with a `controllerchange` listener (ignoring initial activation). Remove `pwa_update_listener` dependency.

## Changes

- `app/web/index.html` — add `isSafariInstallable()` JS helper and `registerPwaUpdateCallback()` via `controllerchange` listener
- `app/lib/features/pwa/pwa_service_web.dart` — expose `isSafariInstallable` via `@JS` interop
- `app/lib/features/pwa/pwa_service_stub.dart` — add no-op `isSafariInstallable` for non-web
- `app/lib/features/pwa/pwa_provider.dart` — add `safariInstallProvider`
- `app/lib/features/pwa/pwa_update_{web,stub,service}.dart` — new conditional-export update service replacing `pwa_update_listener`
- `app/lib/main.dart` — remove `PwaUpdateListener` wrapper, register `controllerchange` callback post-first-frame
- `app/lib/shared/nav_shell.dart` — Safari install button (rail) and banner (mobile) with instruction bottom sheet
- `app/pubspec.yaml` — remove `pwa_update_listener`

## Test plan

- [ ] Open `assistant.58lab.org` in iOS Safari (not installed) — "Add to Home Screen" banner appears at bottom
- [ ] Tap banner → bottom sheet with 3-step instructions appears
- [ ] Open in Chrome/Android — existing `beforeinstallprompt` install button still works, Safari banner does not appear
- [ ] Deploy a new version → `controllerchange` fires → "A new version is available — Reload" SnackBar appears

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added iOS Safari installation support with guided "Add to Home Screen" instructions for users on compatible devices.

* **Bug Fixes**
  * Improved PWA update detection for more reliable service worker refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->