### PR TITLE
fix(app): persist web session across hard reloads

### DIFF
--- a/app/lib/features/contexts/data/context_repository.dart
+++ b/app/lib/features/contexts/data/context_repository.dart
@@ -65,10 +65,17 @@ class ContextRepository {
           ..sort((a, b) => a.createdAt.compareTo(b.createdAt));
 
     // Re-attach tokens from secure storage.
+    // Failures are caught per-context so that a single secure-storage error
+    // (common on web when the crypto key is unavailable after a hard reload)
+    // does not prevent the contexts list from loading at all.
     final result = <AssistantContext>[];
     for (final ctx in contexts) {
-      final token = await _secureStorage.read(key: '$_kTokenPrefix${ctx.id}');
-      result.add(token != null ? ctx.copyWith(authToken: token) : ctx);
+      try {
+        final token = await _secureStorage.read(key: '$_kTokenPrefix${ctx.id}');
+        result.add(token != null ? ctx.copyWith(authToken: token) : ctx);
+      } catch (_) {
+        result.add(ctx);
+      }
     }
     return result;
   }

--- a/app/lib/features/contexts/providers/context_providers.dart
+++ b/app/lib/features/contexts/providers/context_providers.dart
@@ -69,7 +69,13 @@ class ContextsNotifier extends AsyncNotifier<List<AssistantContext>> {
     final repo = ref.read(contextRepositoryProvider);
     final saved = await repo.upsertContextByUrl(context);
     ref.invalidateSelf();
-    await future;
+    // Swallow any reload error (e.g. secure-storage failure on web) so the
+    // caller always receives `saved` and can proceed to call activate().
+    try {
+      await future;
+    } catch (_) {
+      // Context was written to storage; load failure does not block activation.
+    }
     return saved;
   }
 }

--- a/app/test/unit/contexts/context_repository_test.dart
+++ b/app/test/unit/contexts/context_repository_test.dart
@@ -20,6 +20,20 @@ class FakeSecureStorage implements SecureKeyValueStorage {
   Future<void> delete({required String key}) async => _data.remove(key);
 }
 
+/// Fake that always throws on [read] — simulates the web crypto key loss
+/// that can happen after a hard reload.
+class ThrowingSecureStorage implements SecureKeyValueStorage {
+  @override
+  Future<String?> read({required String key}) async =>
+      throw Exception('crypto key unavailable');
+
+  @override
+  Future<void> write({required String key, required String value}) async {}
+
+  @override
+  Future<void> delete({required String key}) async {}
+}
+
 void main() {
   late SharedPreferences prefs;
   late FakeSecureStorage secure;
@@ -84,6 +98,24 @@ void main() {
       await repo.saveContext(ctx);
 
       final result = await repo.loadContexts();
+      expect(result.single.authToken, isNull);
+    });
+
+    test('returns context without token when secure storage throws', () async {
+      // Simulate the web hard-reload scenario where the crypto key is
+      // unavailable and FlutterSecureStorage throws on read.
+      final ctx = makeCtx(authToken: 'secret');
+      // Write metadata via a working repo, then read via the throwing one.
+      await repo.saveContext(ctx);
+
+      final throwingRepo = ContextRepository(
+        prefs: prefs,
+        secureStorage: ThrowingSecureStorage(),
+      );
+      // Must not throw; context should be returned without its token.
+      final result = await throwingRepo.loadContexts();
+      expect(result.length, 1);
+      expect(result.single.id, ctx.id);
       expect(result.single.authToken, isNull);
     });
   });


### PR DESCRIPTION
## Summary

- `FlutterSecureStorage` can throw on web after a hard reload (Web Crypto key unavailable), causing `loadContexts()` to propagate the error → `contextsProvider` enters `AsyncError` → `activeContextProvider` appears null → router redirects to `/login` on every reload
- Secondary bug: if the post-save rebuild in `ContextsNotifier.upsertContextByUrl` threw, `activate()` was never called and the active context ID was never written to SharedPreferences — creating an infinite login loop

## Changes

- **`context_repository.dart`**: wrap each `_secureStorage.read()` in `loadContexts()` with try/catch; token read failure returns context without token instead of throwing
- **`context_providers.dart`**: wrap `await future` in `ContextsNotifier.upsertContextByUrl` with try/catch so `activate()` is always reachable even if the reload fails
- **`context_repository_test.dart`**: add `ThrowingSecureStorage` fake and regression test covering the hard-reload scenario

## Test plan

- [ ] All existing Flutter tests pass (`flutter test`)
- [ ] New regression test `returns context without token when secure storage throws` passes
- [ ] Reload the web app after logging in — should land on `/chat` without re-prompting for credentials