### PR TITLE
fix(app): scroll chat to bottom when keyboard opens on iOS Safari

### DIFF
--- a/app/lib/features/chat/chat_screen.dart
+++ b/app/lib/features/chat/chat_screen.dart
@@ -30,8 +30,29 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   @override
   void initState() {
     super.initState();
+    _inputFocus.addListener(_onInputFocusChange);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _loadConversation();
+    });
+  }
+
+  /// Scrolls to the bottom when the input gains focus, so the latest messages
+  /// remain visible above the keyboard on mobile (especially iOS Safari).
+  /// Only scrolls if the list is already near the bottom — if the user has
+  /// scrolled up to read history we leave their position alone.
+  void _onInputFocusChange() {
+    if (!_inputFocus.hasFocus) return;
+    // Delay past the iOS keyboard animation (~300 ms) before measuring/scrolling.
+    Future.delayed(const Duration(milliseconds: 350), () {
+      if (!mounted || !_scrollController.hasClients) return;
+      final pos = _scrollController.position;
+      if (pos.maxScrollExtent - pos.pixels < 200) {
+        _scrollController.animateTo(
+          pos.maxScrollExtent,
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeOut,
+        );
+      }
     });
   }
 
@@ -56,6 +77,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
 
   @override
   void dispose() {
+    _inputFocus.removeListener(_onInputFocusChange);
     _inputController.dispose();
     _scrollController.dispose();
     _inputFocus.dispose();

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -19,6 +19,10 @@
     <meta charset="UTF-8" />
     <meta content="IE=Edge" http-equiv="X-UA-Compatible" />
     <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content"
+    />
+    <meta
       name="description"
       content="AI assistant with chat, skills, and workflow automation."
     />


### PR DESCRIPTION
## Summary

- Add `interactive-widget=resizes-content` to the viewport meta tag in `index.html` — without this, Safari treats the soft keyboard as an overlay rather than resizing the layout viewport, so Flutter's `resizeToAvoidBottomInset` never takes effect on iOS.
- Add a `FocusNode` listener on the chat input that scrolls the message list to the bottom when the field is focused. A 350 ms delay lets the keyboard animation finish before scrolling. A 200 px near-bottom guard means users who have scrolled up to read history are not yanked back down.

## Test plan

- [ ] Open `/chat` on iPhone Safari (browser or PWA)
- [ ] Send a few messages so the list is populated
- [ ] Tap the text input — keyboard appears
- [ ] Confirm the latest messages are visible above the keyboard
- [ ] Scroll up in the message list, then tap the input again — confirm scroll position is preserved (near-bottom guard)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat messages now intelligently auto-scroll to the latest content when you focus the input field, respecting your scroll position if you're reading older messages.

* **Bug Fixes**
  * Improved mobile viewport configuration for better interactive keyboard handling across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->