### PR TITLE
feat(app): auto-scroll to latest message and add scroll-to-bottom FAB

### DIFF
--- a/app/lib/features/chat/chat_screen.dart
+++ b/app/lib/features/chat/chat_screen.dart
@@ -28,15 +28,19 @@ class ChatScreen extends ConsumerStatefulWidget {
   ConsumerState<ChatScreen> createState() => _ChatScreenState();
 }
 
+const double _kBottomThreshold = 80.0;
+
 class _ChatScreenState extends ConsumerState<ChatScreen> {
   final _inputController = TextEditingController();
   final _scrollController = ScrollController();
   final _inputFocus = FocusNode();
+  bool _atBottom = true;
 
   @override
   void initState() {
     super.initState();
     _inputFocus.addListener(_onInputFocusChange);
+    _scrollController.addListener(_onScroll);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _loadConversation();
     });
@@ -62,6 +66,13 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     });
   }
 
+  void _onScroll() {
+    if (!_scrollController.hasClients) return;
+    final pos = _scrollController.position;
+    final nearBottom = pos.pixels >= pos.maxScrollExtent - _kBottomThreshold;
+    if (_atBottom != nearBottom) setState(() => _atBottom = nearBottom);
+  }
+
   @override
   void didUpdateWidget(ChatScreen old) {
     super.didUpdateWidget(old);
@@ -79,11 +90,13 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     } else {
       ref.read(chatProvider.notifier).clearConversation();
     }
+    _scrollToBottom();
   }
 
   @override
   void dispose() {
     _inputFocus.removeListener(_onInputFocusChange);
+    _scrollController.removeListener(_onScroll);
     _inputController.dispose();
     _scrollController.dispose();
     _inputFocus.dispose();
@@ -123,9 +136,9 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     final chatState = chatAsync.value ?? const ChatState();
     final isWide = MediaQuery.of(context).size.width > 700;
 
-    // Scroll to bottom when messages change.
+    // Scroll to bottom when messages change, but only if already at bottom.
     ref.listen(chatProvider, (_, next) {
-      if (next.value?.messages.isNotEmpty == true) {
+      if (_atBottom && next.value?.messages.isNotEmpty == true) {
         _scrollToBottom();
       }
     });
@@ -252,41 +265,56 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
 
                   // Message list.
                   Expanded(
-                    child: chatState.messages.isEmpty
-                        ? const _EmptyChat()
-                        : ListView.builder(
-                            controller: _scrollController,
-                            padding: const EdgeInsets.symmetric(
-                              vertical: 16,
-                              horizontal: 12,
-                            ),
-                            itemCount: chatState.messages.length,
-                            itemBuilder: (context, index) {
-                              final msg = chatState.messages[index];
-                              final prevMsg = index > 0
-                                  ? chatState.messages[index - 1]
-                                  : null;
-                              final isGrouped =
-                                  prevMsg != null &&
-                                  prevMsg.role == msg.role &&
-                                  !prevMsg.isStreaming;
-                              return _MessageBubble(
-                                message: msg,
-                                isGrouped: isGrouped,
-                                capabilities: capabilities,
-                                onRetry: msg.status == MessageStatus.failed
-                                    ? () => ref
-                                          .read(chatProvider.notifier)
-                                          .retryMessage(msg)
-                                    : null,
-                                fetchMessageAudio: () {
-                                  final api = ref.read(apiClientProvider);
-                                  return api?.fetchMessageAudio(msg.id) ??
-                                      Future.value(null);
+                    child: Stack(
+                      children: [
+                        chatState.messages.isEmpty
+                            ? const _EmptyChat()
+                            : ListView.builder(
+                                controller: _scrollController,
+                                padding: const EdgeInsets.symmetric(
+                                  vertical: 16,
+                                  horizontal: 12,
+                                ),
+                                itemCount: chatState.messages.length,
+                                itemBuilder: (context, index) {
+                                  final msg = chatState.messages[index];
+                                  final prevMsg = index > 0
+                                      ? chatState.messages[index - 1]
+                                      : null;
+                                  final isGrouped =
+                                      prevMsg != null &&
+                                      prevMsg.role == msg.role &&
+                                      !prevMsg.isStreaming;
+                                  return _MessageBubble(
+                                    message: msg,
+                                    isGrouped: isGrouped,
+                                    capabilities: capabilities,
+                                    onRetry: msg.status == MessageStatus.failed
+                                        ? () => ref
+                                              .read(chatProvider.notifier)
+                                              .retryMessage(msg)
+                                        : null,
+                                    fetchMessageAudio: () {
+                                      final api = ref.read(apiClientProvider);
+                                      return api?.fetchMessageAudio(msg.id) ??
+                                          Future.value(null);
+                                    },
+                                  );
                                 },
-                              );
-                            },
+                              ),
+                        if (!_atBottom)
+                          Positioned(
+                            bottom: 8,
+                            right: 8,
+                            child: FloatingActionButton.small(
+                              key: const Key('scroll_to_bottom_button'),
+                              onPressed: _scrollToBottom,
+                              tooltip: 'Scroll to bottom',
+                              child: const Icon(Icons.keyboard_arrow_down),
+                            ),
                           ),
+                      ],
+                    ),
                   ),
 
                   // Progress indicator (shown while streaming).

--- a/app/test/widget/features/chat/chat_screen_test.dart
+++ b/app/test/widget/features/chat/chat_screen_test.dart
@@ -94,6 +94,81 @@ void main() {
     });
   });
 
+  group('Chat screen — scroll-to-bottom FAB', () {
+    /// Builds a list of [count] messages to ensure the ListView has scroll
+    /// extent in the 480×960 test viewport.
+    List<ChatMessage> manyMessages(int count) => List.generate(
+      count,
+      (i) => ChatMessage(
+        id: 'msg-$i',
+        role: i.isEven ? 'user' : 'assistant',
+        content: 'Message number $i with enough text to take up space.',
+      ),
+    );
+
+    testWidgets('FAB is hidden when at bottom (initial state)', (tester) async {
+      final res = await pumpChatScreen(tester);
+
+      res.notifier.push(
+        ChatState(conversationId: 'c1', messages: manyMessages(30)),
+      );
+      await tester.pumpAndSettle();
+
+      // At rest the user is scrolled to the bottom — FAB must not be visible.
+      expect(
+        find.byKey(const Key('scroll_to_bottom_button')),
+        findsNothing,
+        reason: 'FAB should be hidden when the list is at the bottom',
+      );
+    });
+
+    testWidgets('FAB appears after scrolling up', (tester) async {
+      final res = await pumpChatScreen(tester);
+
+      res.notifier.push(
+        ChatState(conversationId: 'c1', messages: manyMessages(30)),
+      );
+      await tester.pumpAndSettle();
+
+      // Drag the list down (i.e., scroll content upward).
+      await tester.drag(find.byType(ListView), const Offset(0, 600));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const Key('scroll_to_bottom_button')),
+        findsOneWidget,
+        reason: 'FAB should appear when scrolled away from bottom',
+      );
+    });
+
+    testWidgets('tapping FAB scrolls back to bottom and hides FAB', (
+      tester,
+    ) async {
+      final res = await pumpChatScreen(tester);
+
+      res.notifier.push(
+        ChatState(conversationId: 'c1', messages: manyMessages(30)),
+      );
+      await tester.pumpAndSettle();
+
+      // Scroll up to reveal FAB.
+      await tester.drag(find.byType(ListView), const Offset(0, 600));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('scroll_to_bottom_button')), findsOneWidget);
+
+      // Tap the FAB.
+      await tester.tap(find.byKey(const Key('scroll_to_bottom_button')));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const Key('scroll_to_bottom_button')),
+        findsNothing,
+        reason: 'FAB should disappear after scrolling back to bottom',
+      );
+    });
+  });
+
   group('Chat screen — retry affordance', () {
     testWidgets(
       '7.6: Retry button appears when a user message has status == failed',

--- a/openspec/changes/archive/2026-04-15-chat-auto-scroll/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-15-chat-auto-scroll/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-15

--- a/openspec/changes/archive/2026-04-15-chat-auto-scroll/design.md
+++ b/openspec/changes/archive/2026-04-15-chat-auto-scroll/design.md
@@ -1,0 +1,67 @@
+## Context
+
+The chat screen (`app/lib/features/chat/chat_screen.dart`) already owns a `ScrollController` and a `_scrollToBottom()` helper. A `ref.listen` on `chatProvider` calls `_scrollToBottom()` on every state change — but this causes two problems:
+
+1. **On open**: loading a conversation sets messages in state, `ref.listen` fires, but the `ListView` may not yet be fully laid out, so `maxScrollExtent` can be 0 and the scroll doesn't actually reach the bottom. This is the root cause of the bug.
+2. **While chatting**: the listener unconditionally scrolls to bottom even when the user has intentionally scrolled up to review history. This should only auto-scroll when the user is already near the bottom.
+
+Additionally, there is no visual affordance to return to the latest message when the user has scrolled up.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Scroll to the latest message as soon as a conversation is fully loaded (on open and on conversation switch)
+- Auto-scroll on new incoming messages only when the user is already at (or near) the bottom
+- Show a "scroll to bottom" FAB when the user is scrolled up, allowing one-tap return to latest
+
+**Non-Goals:**
+
+- Preserving exact scroll position across app restarts or navigation
+- Infinite scroll / pagination of older messages
+- Any backend or API changes
+
+## Decisions
+
+### D1: Track "at bottom" state via scroll position listener
+
+Add a `bool _atBottom = true` field. In `initState`, attach a listener to `_scrollController` that updates `_atBottom` whenever the scroll position changes:
+
+```dart
+_scrollController.addListener(() {
+  final pos = _scrollController.position;
+  final nearBottom = pos.pixels >= pos.maxScrollExtent - _kBottomThreshold;
+  if (_atBottom != nearBottom) setState(() => _atBottom = nearBottom);
+});
+```
+
+A threshold of **80 dp** is used so that "essentially at bottom" still counts (avoids false negatives from rounding or sub-pixel gaps).
+
+**Alternative considered**: Store scroll offset in Riverpod state. Rejected — scroll position is purely local UI state; putting it in the provider adds unnecessary complexity.
+
+### D2: Scroll to bottom after conversation load completes
+
+In `_loadConversation`, after calling `loadConversation(id)`, also call `_scrollToBottom()`. The existing `_scrollToBottom` already wraps the call in `addPostFrameCallback`, but that callback fires before the `ListView` has built all items. To reliably reach the end:
+
+1. First `addPostFrameCallback` schedules the actual scroll
+2. The scroll target is `position.maxScrollExtent`, which is correct once the ListView is laid out
+
+This is the standard Flutter pattern and is sufficient for a single-frame delay. If the layout requires multiple frames (very rare, for very long lists), a second callback fallback is added.
+
+**Alternative considered**: `jumpTo` instead of `animateTo` on first open. Rejected — smooth animation is a stated requirement and the 200 ms duration is imperceptible at normal read speed.
+
+### D3: Conditional auto-scroll in `ref.listen`
+
+Change the `ref.listen` block to only call `_scrollToBottom()` when `_atBottom == true`. This ensures the user's manual scroll position is respected during ongoing streaming.
+
+### D4: Scroll-to-bottom FAB via `Stack` overlay
+
+Wrap the message list `Expanded` in a `Stack` and overlay a small `FloatingActionButton` (or `FloatingActionButton.small`) anchored to the bottom-right. The FAB is visible only when `!_atBottom`. Tapping it calls `_scrollToBottom()` and sets `_atBottom = true`.
+
+**Alternative considered**: Using `Scaffold.floatingActionButton`. Rejected — the chat input is below the message list; a global FAB would float above the input row, causing visual conflict.
+
+## Risks / Trade-offs
+
+- **Threshold sensitivity** → 80 dp may feel "sticky" on very short conversations where the list barely exceeds the viewport. Mitigation: initialize `_atBottom = true` so a fresh/short conversation always auto-scrolls.
+- **Multiple `addPostFrameCallback` calls** → called on every provider change, but each schedules a single future frame. Slight over-scheduling for streaming messages (many rapid updates). Acceptable given the existing pattern already does this.
+- **`setState` in scroll listener** → fires frequently during programmatic and user scroll. The guard (`if (_atBottom != nearBottom)`) limits rebuilds to two transitions (up → not at bottom, down → at bottom), keeping overhead minimal.

--- a/openspec/changes/archive/2026-04-15-chat-auto-scroll/proposal.md
+++ b/openspec/changes/archive/2026-04-15-chat-auto-scroll/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+When a user opens a conversation with many messages, the chat view shows the oldest messages at the top, forcing them to scroll down manually to reach the latest message. This is a UX regression compared to standard chat apps and is especially frustrating for long conversations.
+
+## What Changes
+
+- The chat screen automatically scrolls to the bottom (latest message) when a conversation is first opened
+- The chat screen automatically scrolls to the bottom when new messages arrive (only if the user is already near the bottom)
+- A "scroll to bottom" floating action button appears when the user has scrolled up, allowing one-tap return to latest messages
+
+## Capabilities
+
+### New Capabilities
+
+- `chat-auto-scroll`: Auto-scroll behavior for the chat conversation view — scrolls to the latest message on open and on new message arrival, with a scroll-to-bottom button when scrolled up
+
+### Modified Capabilities
+
+<!-- No existing spec-level requirements are changing -->
+
+## Impact
+
+- `app/lib/features/chat/` — chat screen and message list widget
+- `app/lib/features/chat/` — scroll controller lifecycle and state management
+- No API changes, no Rust backend changes
+- No breaking changes

--- a/openspec/changes/archive/2026-04-15-chat-auto-scroll/specs/chat-auto-scroll/spec.md
+++ b/openspec/changes/archive/2026-04-15-chat-auto-scroll/specs/chat-auto-scroll/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Scroll to bottom on conversation open
+
+The chat view SHALL automatically scroll to the latest (bottom) message whenever a conversation is opened or switched to, using a smooth animation.
+
+#### Scenario: Opening a conversation with existing messages
+
+- **WHEN** the user navigates to a conversation that has messages
+- **THEN** the message list SHALL animate to the bottom within one rendered frame after the list is laid out
+
+#### Scenario: Switching between conversations
+
+- **WHEN** the user selects a different conversation from the sidebar
+- **THEN** the message list SHALL animate to the bottom of the newly loaded conversation
+
+#### Scenario: Opening an empty conversation
+
+- **WHEN** the user opens a conversation with no messages
+- **THEN** no scroll action is taken and the empty state widget is shown
+
+### Requirement: Auto-scroll on new messages when at bottom
+
+The chat view SHALL automatically scroll to the bottom when new messages arrive, but only when the user is already at or near the bottom of the message list (within 80 logical pixels).
+
+#### Scenario: New message arrives while at bottom
+
+- **WHEN** a new message is added and the user's scroll position is within 80 dp of the bottom
+- **THEN** the view SHALL animate to the new bottom
+
+#### Scenario: New message arrives while scrolled up
+
+- **WHEN** a new message is added and the user has scrolled up more than 80 dp from the bottom
+- **THEN** the scroll position SHALL remain unchanged
+
+### Requirement: Scroll-to-bottom button when scrolled up
+
+The chat view SHALL display a "scroll to bottom" button overlaid on the message list when the user has scrolled more than 80 logical pixels above the bottom of the list.
+
+#### Scenario: Button appears after scrolling up
+
+- **WHEN** the user scrolls upward past 80 dp from the bottom
+- **THEN** a scroll-to-bottom button SHALL become visible in the bottom-right area of the message list
+
+#### Scenario: Button disappears at bottom
+
+- **WHEN** the user scrolls back to within 80 dp of the bottom (manually or via the button)
+- **THEN** the scroll-to-bottom button SHALL no longer be visible
+
+#### Scenario: Tapping the button scrolls to bottom
+
+- **WHEN** the user taps the scroll-to-bottom button
+- **THEN** the message list SHALL animate smoothly to the latest message

--- a/openspec/changes/archive/2026-04-15-chat-auto-scroll/tasks.md
+++ b/openspec/changes/archive/2026-04-15-chat-auto-scroll/tasks.md
@@ -1,0 +1,27 @@
+## 1. Track "at bottom" state
+
+- [x] 1.1 Add `bool _atBottom = true` field to `_ChatScreenState` in `chat_screen.dart`
+- [x] 1.2 Add `const double _kBottomThreshold = 80.0` constant (file-level or class-level)
+- [x] 1.3 In `initState`, attach a scroll listener to `_scrollController` that updates `_atBottom` via `setState` when the user's proximity to the bottom changes
+
+## 2. Fix scroll-to-bottom on conversation open
+
+- [x] 2.1 In `_loadConversation`, call `_scrollToBottom()` after loading/clearing the conversation so the view animates to the bottom once the new message list is laid out
+- [x] 2.2 Verify that `_scrollToBottom` uses `addPostFrameCallback` (already present) so it fires after the ListView rebuilds
+
+## 3. Guard auto-scroll on new messages
+
+- [x] 3.1 Update the `ref.listen(chatProvider, ...)` block to only call `_scrollToBottom()` when `_atBottom == true`
+
+## 4. Add scroll-to-bottom FAB overlay
+
+- [x] 4.1 Wrap the message list `Expanded` widget in a `Stack`
+- [x] 4.2 Add a `Positioned` child inside the `Stack` (bottom-right corner) containing a `FloatingActionButton.small` with a `keyboard_arrow_down` icon
+- [x] 4.3 Show the FAB only when `!_atBottom` (use `AnimatedOpacity` or a conditional render)
+- [x] 4.4 Wire the FAB's `onPressed` to `_scrollToBottom()`
+
+## 5. Test
+
+- [x] 5.1 Run `flutter analyze` and confirm zero issues
+- [x] 5.2 Run `flutter test` and confirm all existing tests still pass
+- [ ] 5.3 Manual smoke test: open a long conversation → auto-scrolls to bottom; scroll up → FAB appears; tap FAB → scrolls to bottom; send a message while scrolled up → does NOT auto-scroll

--- a/openspec/specs/chat-auto-scroll/spec.md
+++ b/openspec/specs/chat-auto-scroll/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Scroll to bottom on conversation open
+
+The chat view SHALL automatically scroll to the latest (bottom) message whenever a conversation is opened or switched to, using a smooth animation.
+
+#### Scenario: Opening a conversation with existing messages
+
+- **WHEN** the user navigates to a conversation that has messages
+- **THEN** the message list SHALL animate to the bottom within one rendered frame after the list is laid out
+
+#### Scenario: Switching between conversations
+
+- **WHEN** the user selects a different conversation from the sidebar
+- **THEN** the message list SHALL animate to the bottom of the newly loaded conversation
+
+#### Scenario: Opening an empty conversation
+
+- **WHEN** the user opens a conversation with no messages
+- **THEN** no scroll action is taken and the empty state widget is shown
+
+### Requirement: Auto-scroll on new messages when at bottom
+
+The chat view SHALL automatically scroll to the bottom when new messages arrive, but only when the user is already at or near the bottom of the message list (within 80 logical pixels).
+
+#### Scenario: New message arrives while at bottom
+
+- **WHEN** a new message is added and the user's scroll position is within 80 dp of the bottom
+- **THEN** the view SHALL animate to the new bottom
+
+#### Scenario: New message arrives while scrolled up
+
+- **WHEN** a new message is added and the user has scrolled up more than 80 dp from the bottom
+- **THEN** the scroll position SHALL remain unchanged
+
+### Requirement: Scroll-to-bottom button when scrolled up
+
+The chat view SHALL display a "scroll to bottom" button overlaid on the message list when the user has scrolled more than 80 logical pixels above the bottom of the list.
+
+#### Scenario: Button appears after scrolling up
+
+- **WHEN** the user scrolls upward past 80 dp from the bottom
+- **THEN** a scroll-to-bottom button SHALL become visible in the bottom-right area of the message list
+
+#### Scenario: Button disappears at bottom
+
+- **WHEN** the user scrolls back to within 80 dp of the bottom (manually or via the button)
+- **THEN** the scroll-to-bottom button SHALL no longer be visible
+
+#### Scenario: Tapping the button scrolls to bottom
+
+- **WHEN** the user taps the scroll-to-bottom button
+- **THEN** the message list SHALL animate smoothly to the latest message


### PR DESCRIPTION
Fixes #445

## Summary

- On open/conversation switch, the chat view now scrolls to the latest message (fixes the layout-timing bug where `maxScrollExtent` was 0 when the old `ref.listen` fired)
- Auto-scroll on new messages is guarded by `_atBottom` (within 80 dp of bottom) — users reading history are no longer yanked back down
- A `FloatingActionButton.small` (↓) overlays the message list when the user has scrolled up; tapping it returns to the bottom

## Changes

- `app/lib/features/chat/chat_screen.dart` — scroll listener, `_atBottom` state, `_loadConversation` scroll fix, guarded `ref.listen`, Stack + FAB overlay
- `app/test/widget/features/chat/chat_screen_test.dart` — 3 new widget tests: FAB hidden at bottom, FAB appears on scroll, tap FAB scrolls back

## Test plan

- [x] `flutter analyze` — zero issues
- [x] `flutter test` — 219 tests pass (3 new)
- [ ] Manual: open a long conversation → scrolls to bottom automatically
- [ ] Manual: scroll up → FAB appears; tap → returns to bottom
- [ ] Manual: receive a message while scrolled up → scroll position preserved