### PR TITLE
chore(deps): bump reedline from 0.46.0 to 0.47.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,8 +171,8 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "strum 0.27.2",
- "strum_macros 0.27.2",
+ "strum",
+ "strum_macros",
  "thiserror 2.0.18",
  "uuid",
  "zstd",
@@ -3100,7 +3100,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_with",
- "strum 0.27.2",
+ "strum",
  "tokio",
  "typed-builder",
  "typetag",
@@ -4713,9 +4713,9 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9e7c532bfc2759bc8a28902c04e8b993fc13ebd085ee4292eb1b230fa9beef"
+checksum = "2066729dce9fecd28d1c6850a159ee68719130f149b22467c362353e16994e90"
 dependencies = [
  "chrono",
  "crossterm",
@@ -4724,8 +4724,7 @@ dependencies = [
  "nu-ansi-term",
  "serde",
  "strip-ansi-escapes",
- "strum 0.26.3",
- "strum_macros 0.26.4",
+ "strum",
  "thiserror 2.0.18",
  "unicase",
  "unicode-segmentation",
@@ -5965,30 +5964,11 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-
-[[package]]
-name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros 0.27.2",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
+ "strum_macros",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ axum = { version = "0.8", features = ["macros"] }
 # Async streams
 futures = "0.3"
 # Terminal line editor
-reedline = "0.46"
+reedline = "0.47"
 # YAML frontmatter parser
 gray_matter = "0.3"
 # YAML serialization (for writing agent card frontmatter)

--- a/crates/interface-cli/src/main.rs
+++ b/crates/interface-cli/src/main.rs
@@ -1958,6 +1958,8 @@ async fn main() -> Result<()> {
                 break;
             }
 
+            Ok(_) => {}
+
             Err(e) => {
                 eprintln!("Read error: {e}");
                 break;


### PR DESCRIPTION
## Summary

- Bumps `reedline` from 0.46.0 to 0.47.0
- Adds `Ok(_) => {}` wildcard arm to the REPL `Signal` match — required because `Signal` is now `#[non_exhaustive]` in 0.47.0
- Also drops the `strum 0.26` duplicate in `Cargo.lock` (reedline now uses `strum 0.27` like the rest of the workspace)

Closes #454