### PR TITLE
ci(openapi): add Redocly lint job to validate OpenAPI spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -432,6 +432,21 @@ jobs:
               core.info(`No branch visual-diffs/pr-${prNumber} to clean up`);
             }
 
+  validate-openapi:
+    name: Validate OpenAPI spec
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Lint OpenAPI spec with Redocly
+        run: npx --yes @redocly/cli lint openapi.json
+
   integration:
     name: Integration (smoke)
     if: github.event.action != 'closed'

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,10 @@ dump-openapi:
 	cargo run -p assistant-cli -- webui serve --print-openapi 2>/dev/null \
 	  | python3 -m json.tool --no-ensure-ascii --indent 2 > openapi.json
 
+# Validate the OpenAPI spec with Redocly CLI (requires Node.js / npx).
+validate-openapi: openapi.json
+	npx --yes @redocly/cli lint openapi.json
+
 # Generate the Dart/Flutter API client from openapi.json.
 # Requires: openapi-generator (brew install openapi-generator)
 generate-flutter-client: openapi.json

--- a/crates/a2a-json-schema/src/requests.rs
+++ b/crates/a2a-json-schema/src/requests.rs
@@ -34,7 +34,7 @@ pub struct SendMessageRequest {
 
 /// Request for the `GetTask` method.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema, utoipa::IntoParams))]
 #[serde(rename_all = "camelCase")]
 pub struct GetTaskRequest {
     /// Optional tenant ID.
@@ -51,7 +51,7 @@ pub struct GetTaskRequest {
 
 /// Request for the `ListTasks` method.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema, utoipa::IntoParams))]
 #[serde(rename_all = "camelCase")]
 pub struct ListTasksRequest {
     /// Tenant ID.

--- a/crates/web-ui/src/a2a/handlers.rs
+++ b/crates/web-ui/src/a2a/handlers.rs
@@ -22,6 +22,7 @@ use assistant_a2a_json_schema::responses::*;
 use assistant_a2a_json_schema::types::*;
 
 use super::task_store::TaskStore;
+use crate::openapi::ApiErrorResponse;
 
 // -- Shared state --
 
@@ -67,7 +68,8 @@ fn bad_request(msg: impl Into<String>) -> Response {
     path = "/.well-known/agent.json",
     responses(
         (status = 200, description = "Public agent card", body = AgentCard,
-         content_type = "application/json")
+         content_type = "application/json"),
+        (status = 404, description = "Agent card not found")
     ),
     tag = "agent-card",
     security()
@@ -102,10 +104,12 @@ pub async fn get_extended_agent_card(State(state): State<A2AState>) -> Json<Agen
 #[utoipa::path(
     post,
     path = "/message/send",
+    operation_id = "a2a_send_message",
     request_body(content = SendMessageRequest, content_type = "application/json"),
     responses(
         (status = 200, description = "Task created and completed", body = SendMessageResponse,
          content_type = "application/json"),
+        (status = 400, description = "Bad request"),
         (status = 401, description = "Unauthorized")
     ),
     tag = "messages",
@@ -180,10 +184,12 @@ pub async fn send_message(
 #[utoipa::path(
     post,
     path = "/message/stream",
+    operation_id = "a2a_send_message_streaming",
     request_body(content = SendMessageRequest, content_type = "application/json"),
     responses(
         (status = 200, description = "Streaming SSE response; each event is a JSON-encoded StreamResponse",
-         content_type = "text/event-stream"),
+         content_type = "text/event-stream", body = StreamResponse),
+        (status = 400, description = "Bad request"),
         (status = 401, description = "Unauthorized")
     ),
     tag = "messages",
@@ -288,38 +294,45 @@ pub async fn send_message_streaming(
     get,
     path = "/tasks/{id}",
     params(
-        ("id" = String, Path, description = "Task ID")
+        ("id" = String, Path, description = "Task ID"),
+        GetTaskQuery
     ),
     responses(
         (status = 200, description = "Task details", body = Task,
          content_type = "application/json"),
-        (status = 404, description = "Task not found"),
+        (status = 404, description = "Task not found", body = ApiErrorResponse,
+         content_type = "application/json"),
         (status = 401, description = "Unauthorized")
     ),
     tag = "tasks",
     security(("bearer_token" = []))
 )]
-pub async fn get_task(State(state): State<A2AState>, Path(id): Path<String>) -> Response {
+pub async fn get_task(
+    State(state): State<A2AState>,
+    Path(id): Path<String>,
+    Query(_query): Query<GetTaskQuery>,
+) -> Response {
     match state.task_store.get_task(&id).await {
         Some(task) => Json(task).into_response(),
         None => not_found(format!("Task '{id}' not found")),
     }
 }
 
-/// Query parameters for `GET /tasks`.
+/// Query parameters for `GET /tasks/{id}`.
 #[derive(Debug, Default, serde::Deserialize, utoipa::IntoParams)]
 #[serde(rename_all = "camelCase")]
-pub struct ListTasksQuery {
-    pub context_id: Option<String>,
-    pub status: Option<TaskState>,
-    pub page_size: Option<i32>,
+pub struct GetTaskQuery {
+    /// Max number of recent messages to include in history.
+    pub history_length: Option<i32>,
+    /// Optional tenant ID.
+    pub tenant: Option<String>,
 }
 
 /// `GET /tasks` -- Lists tasks matching optional filters.
 #[utoipa::path(
     get,
     path = "/tasks",
-    params(ListTasksQuery),
+    params(ListTasksRequest),
     responses(
         (status = 200, description = "Paginated task list", body = ListTasksResponse,
          content_type = "application/json"),
@@ -330,7 +343,7 @@ pub struct ListTasksQuery {
 )]
 pub async fn list_tasks(
     State(state): State<A2AState>,
-    Query(query): Query<ListTasksQuery>,
+    Query(query): Query<ListTasksRequest>,
 ) -> Json<ListTasksResponse> {
     let limit = query.page_size.unwrap_or(50).clamp(1, 100) as usize;
 
@@ -355,16 +368,24 @@ pub async fn list_tasks(
     params(
         ("id" = String, Path, description = "Task ID to cancel")
     ),
+    request_body(content = CancelTaskRequest, content_type = "application/json",
+                 description = "Optional cancellation metadata"),
     responses(
         (status = 200, description = "Cancelled task", body = Task,
          content_type = "application/json"),
-        (status = 404, description = "Task not found"),
+        (status = 404, description = "Task not found", body = ApiErrorResponse,
+         content_type = "application/json"),
         (status = 401, description = "Unauthorized")
     ),
     tag = "tasks",
     security(("bearer_token" = []))
 )]
-pub async fn cancel_task(State(state): State<A2AState>, Path(id): Path<String>) -> Response {
+pub async fn cancel_task(
+    State(state): State<A2AState>,
+    Path(id): Path<String>,
+    body: Option<axum::Json<CancelTaskRequest>>,
+) -> Response {
+    let _ = body; // body fields are available for future use (e.g. metadata)
     match state.task_store.cancel_task(&id).await {
         Some(task) => Json(task).into_response(),
         None => not_found(format!("Task '{id}' not found")),
@@ -380,9 +401,11 @@ pub async fn cancel_task(State(state): State<A2AState>, Path(id): Path<String>) 
     ),
     responses(
         (status = 200, description = "SSE stream of StreamResponse events",
-         content_type = "text/event-stream"),
-        (status = 400, description = "Task already in terminal state"),
-        (status = 404, description = "Task not found"),
+         content_type = "text/event-stream", body = StreamResponse),
+        (status = 400, description = "Task already in terminal state", body = ApiErrorResponse,
+         content_type = "application/json"),
+        (status = 404, description = "Task not found", body = ApiErrorResponse,
+         content_type = "application/json"),
         (status = 401, description = "Unauthorized")
     ),
     tag = "tasks",
@@ -446,7 +469,8 @@ pub async fn subscribe_to_task(State(state): State<A2AState>, Path(id): Path<Str
     responses(
         (status = 201, description = "Push notification config created", body = TaskPushNotificationConfig,
          content_type = "application/json"),
-        (status = 404, description = "Task not found"),
+        (status = 404, description = "Task not found", body = ApiErrorResponse,
+         content_type = "application/json"),
         (status = 401, description = "Unauthorized")
     ),
     tag = "push-notifications",
@@ -478,7 +502,8 @@ pub async fn create_push_notification_config(
     responses(
         (status = 200, description = "Push notification config", body = TaskPushNotificationConfig,
          content_type = "application/json"),
-        (status = 404, description = "Config not found"),
+        (status = 404, description = "Config not found", body = ApiErrorResponse,
+         content_type = "application/json"),
         (status = 401, description = "Unauthorized")
     ),
     tag = "push-notifications",
@@ -544,7 +569,8 @@ pub async fn list_push_notification_configs(
     ),
     responses(
         (status = 204, description = "Config deleted"),
-        (status = 404, description = "Config not found"),
+        (status = 404, description = "Config not found", body = ApiErrorResponse,
+         content_type = "application/json"),
         (status = 401, description = "Unauthorized")
     ),
     tag = "push-notifications",

--- a/crates/web-ui/src/openapi.rs
+++ b/crates/web-ui/src/openapi.rs
@@ -9,12 +9,7 @@ use assistant_a2a_json_schema::{
         AgentCapabilities, AgentCard, AgentCardSignature, AgentExtension, AgentInterface,
         AgentProvider, AgentSkill,
     },
-    requests::{
-        CancelTaskRequest, CreateTaskPushNotificationConfigRequest, GetExtendedAgentCardRequest,
-        GetTaskPushNotificationConfigRequest, GetTaskRequest,
-        ListTaskPushNotificationConfigsRequest, ListTasksRequest, SendMessageRequest,
-        SubscribeToTaskRequest,
-    },
+    requests::{CancelTaskRequest, CreateTaskPushNotificationConfigRequest, SendMessageRequest},
     responses::{
         ListTaskPushNotificationConfigsResponse, ListTasksResponse, SendMessageResponse,
         StreamResponse,
@@ -41,8 +36,7 @@ use crate::api::push::{SubscribeRequest, UnsubscribeRequest, VapidKeyResponse};
 use crate::api::{
     agents::{AgentDetail, AgentSummary, RegisterAgentRequest, UpdateAgentRequest},
     analytics::{
-        AnalyticsQueryParams, AnalyticsSummaryResponse, ModelUsageResponse, TimeSeriesResponse,
-        ToolUsageResponse,
+        AnalyticsSummaryResponse, ModelUsageResponse, TimeSeriesResponse, ToolUsageResponse,
     },
     logs::LogEntryResponse,
     personas::{
@@ -63,15 +57,6 @@ use crate::api::{
     ConversationDetail, ConversationSummary, CreateConversationRequest, MessageSummary,
     SendMessageRequest as ApiSendMessageRequest, ServerCapabilities, UpdateConversationRequest,
 };
-
-/// API error response body (JSON-RPC style used by A2A handlers).
-#[derive(serde::Serialize, utoipa::ToSchema)]
-pub struct ApiErrorResponse {
-    /// Numeric error code.
-    pub code: i32,
-    /// Human-readable error message.
-    pub message: String,
-}
 
 /// Adds the Bearer token security scheme to the OpenAPI components.
 struct BearerTokenSecurityAddon;
@@ -96,6 +81,15 @@ impl Modify for BearerTokenSecurityAddon {
     }
 }
 
+/// API error response body returned for 4xx and 5xx errors.
+#[derive(serde::Serialize, utoipa::ToSchema)]
+pub struct ApiErrorResponse {
+    /// Numeric error code.
+    pub code: i32,
+    /// Human-readable error message.
+    pub message: String,
+}
+
 /// Assembled OpenAPI document for the Assistant web-UI.
 ///
 /// Covers the machine-readable APIs:
@@ -112,7 +106,7 @@ impl Modify for BearerTokenSecurityAddon {
         description = "AI assistant API — A2A protocol (Agent-to-Agent), chat, and workflow management.\n\n\
                        **Authentication**: protected endpoints require `Authorization: Bearer <token>`.\n\
                        The token is set via `--auth-token` / `ASSISTANT_WEB_TOKEN` on the server.",
-        license(name = "MIT"),
+        license(name = "MIT", identifier = "MIT"),
     ),
     modifiers(&BearerTokenSecurityAddon),
     paths(
@@ -214,14 +208,8 @@ impl Modify for BearerTokenSecurityAddon {
             StringList,
             // A2A request types
             SendMessageRequest,
-            ListTasksRequest,
-            GetTaskRequest,
             CancelTaskRequest,
-            SubscribeToTaskRequest,
             CreateTaskPushNotificationConfigRequest,
-            GetTaskPushNotificationConfigRequest,
-            ListTaskPushNotificationConfigsRequest,
-            GetExtendedAgentCardRequest,
             // A2A response types
             SendMessageResponse,
             StreamResponse,
@@ -285,7 +273,6 @@ impl Modify for BearerTokenSecurityAddon {
             ModelUsageResponse,
             ToolUsageResponse,
             TimeSeriesResponse,
-            AnalyticsQueryParams,
             // Workflow API types
             WorkflowSummary,
             WorkflowDetail,
@@ -299,7 +286,7 @@ impl Modify for BearerTokenSecurityAddon {
             VapidKeyResponse,
             SubscribeRequest,
             UnsubscribeRequest,
-            // Local handler types
+            // Common error response
             ApiErrorResponse,
         )
     ),

--- a/openapi.json
+++ b/openapi.json
@@ -4,9 +4,10 @@
     "title": "Assistant API",
     "description": "AI assistant API — A2A protocol (Agent-to-Agent), chat, and workflow management.\n\n**Authentication**: protected endpoints require `Authorization: Bearer <token>`.\nThe token is set via `--auth-token` / `ASSISTANT_WEB_TOKEN` on the server.",
     "license": {
-      "name": "MIT"
+      "name": "MIT",
+      "identifier": "MIT"
     },
-    "version": "0.1.97"
+    "version": "0.1.98"
   },
   "servers": [
     {
@@ -32,6 +33,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Agent card not found"
           }
         },
         "security": []
@@ -2779,7 +2783,7 @@
         ],
         "summary": "`POST /message/send` -- Sends a message to the agent (unary).",
         "description": "Creates a task, records the user message, transitions to Working, produces\nan agent reply, and returns the final task state.",
-        "operationId": "send_message",
+        "operationId": "a2a_send_message",
         "requestBody": {
           "content": {
             "application/json": {
@@ -2801,6 +2805,9 @@
               }
             }
           },
+          "400": {
+            "description": "Bad request"
+          },
           "401": {
             "description": "Unauthorized"
           }
@@ -2818,7 +2825,7 @@
           "messages"
         ],
         "summary": "`POST /message/stream` -- Sends a message with streaming response (SSE).",
-        "operationId": "send_message_streaming",
+        "operationId": "a2a_send_message_streaming",
         "requestBody": {
           "content": {
             "application/json": {
@@ -2833,8 +2840,15 @@
           "200": {
             "description": "Streaming SSE response; each event is a JSON-encoded StreamResponse",
             "content": {
-              "text/event-stream": {}
+              "text/event-stream": {
+                "schema": {
+                  "$ref": "#/components/schemas/StreamResponse"
+                }
+              }
             }
+          },
+          "400": {
+            "description": "Bad request"
           },
           "401": {
             "description": "Unauthorized"
@@ -2856,8 +2870,21 @@
         "operationId": "list_tasks",
         "parameters": [
           {
+            "name": "tenant",
+            "in": "query",
+            "description": "Tenant ID.",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          {
             "name": "contextId",
             "in": "query",
+            "description": "Filter tasks by context ID.",
             "required": false,
             "schema": {
               "type": [
@@ -2869,6 +2896,7 @@
           {
             "name": "status",
             "in": "query",
+            "description": "Filter tasks by current status state.",
             "required": false,
             "schema": {
               "oneOf": [
@@ -2884,6 +2912,7 @@
           {
             "name": "pageSize",
             "in": "query",
+            "description": "Max number of tasks to return (1..=100, default 50).",
             "required": false,
             "schema": {
               "type": [
@@ -2891,6 +2920,56 @@
                 "null"
               ],
               "format": "int32"
+            }
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "description": "Page token from a previous `ListTasks` call.",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          {
+            "name": "historyLength",
+            "in": "query",
+            "description": "Max number of messages to include in each task's history.",
+            "required": false,
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "statusTimestampAfter",
+            "in": "query",
+            "description": "Filter tasks with status updated after this timestamp.",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "includeArtifacts",
+            "in": "query",
+            "description": "Whether to include artifacts in returned tasks.",
+            "required": false,
+            "schema": {
+              "type": [
+                "boolean",
+                "null"
+              ]
             }
           }
         ],
@@ -2932,6 +3011,31 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "historyLength",
+            "in": "query",
+            "description": "Max number of recent messages to include in history.",
+            "required": false,
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "tenant",
+            "in": "query",
+            "description": "Optional tenant ID.",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
           }
         ],
         "responses": {
@@ -2949,7 +3053,14 @@
             "description": "Unauthorized"
           },
           "404": {
-            "description": "Task not found"
+            "description": "Task not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -2977,6 +3088,17 @@
             }
           }
         ],
+        "requestBody": {
+          "description": "Optional cancellation metadata",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CancelTaskRequest"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "200": {
             "description": "Cancelled task",
@@ -2992,7 +3114,14 @@
             "description": "Unauthorized"
           },
           "404": {
-            "description": "Task not found"
+            "description": "Task not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -3024,17 +3153,35 @@
           "200": {
             "description": "SSE stream of StreamResponse events",
             "content": {
-              "text/event-stream": {}
+              "text/event-stream": {
+                "schema": {
+                  "$ref": "#/components/schemas/StreamResponse"
+                }
+              }
             }
           },
           "400": {
-            "description": "Task already in terminal state"
+            "description": "Task already in terminal state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized"
           },
           "404": {
-            "description": "Task not found"
+            "description": "Task not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -3148,7 +3295,14 @@
             "description": "Unauthorized"
           },
           "404": {
-            "description": "Task not found"
+            "description": "Task not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -3200,7 +3354,14 @@
             "description": "Unauthorized"
           },
           "404": {
-            "description": "Config not found"
+            "description": "Config not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -3243,7 +3404,14 @@
             "description": "Unauthorized"
           },
           "404": {
-            "description": "Config not found"
+            "description": "Config not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -3634,20 +3802,6 @@
           }
         }
       },
-      "AnalyticsQueryParams": {
-        "type": "object",
-        "description": "Query parameters for the analytics endpoint.",
-        "properties": {
-          "window": {
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "int64",
-            "description": "Window in hours. Valid values: 1, 6, 24, 72, 168. Defaults to 24."
-          }
-        }
-      },
       "AnalyticsSummaryResponse": {
         "type": "object",
         "description": "Aggregated analytics summary for a time window.",
@@ -3729,7 +3883,7 @@
       },
       "ApiErrorResponse": {
         "type": "object",
-        "description": "API error response body (JSON-RPC style used by A2A handlers).",
+        "description": "API error response body returned for 4xx and 5xx errors.",
         "required": [
           "code",
           "message"
@@ -4154,72 +4308,6 @@
           }
         }
       },
-      "GetExtendedAgentCardRequest": {
-        "type": "object",
-        "description": "Request for the `GetExtendedAgentCard` method.",
-        "properties": {
-          "tenant": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "Optional tenant ID."
-          }
-        }
-      },
-      "GetTaskPushNotificationConfigRequest": {
-        "type": "object",
-        "description": "Request for the `GetTaskPushNotificationConfig` method.",
-        "required": [
-          "taskId",
-          "id"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The resource ID of the configuration to retrieve."
-          },
-          "taskId": {
-            "type": "string",
-            "description": "The parent task resource ID."
-          },
-          "tenant": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "Optional tenant ID."
-          }
-        }
-      },
-      "GetTaskRequest": {
-        "type": "object",
-        "description": "Request for the `GetTask` method.",
-        "required": [
-          "id"
-        ],
-        "properties": {
-          "historyLength": {
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "int32",
-            "description": "Max number of recent messages to include in history."
-          },
-          "id": {
-            "type": "string",
-            "description": "The resource ID of the task to retrieve."
-          },
-          "tenant": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "Optional tenant ID."
-          }
-        }
-      },
       "HttpAuthSecurityScheme": {
         "type": "object",
         "description": "Defines a security scheme using HTTP authentication.",
@@ -4277,41 +4365,6 @@
           }
         }
       },
-      "ListTaskPushNotificationConfigsRequest": {
-        "type": "object",
-        "description": "Request for the `ListTaskPushNotificationConfigs` method.",
-        "required": [
-          "taskId"
-        ],
-        "properties": {
-          "pageSize": {
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "int32",
-            "description": "Max number of configurations to return."
-          },
-          "pageToken": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "Page token from a previous call."
-          },
-          "taskId": {
-            "type": "string",
-            "description": "The parent task resource ID."
-          },
-          "tenant": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "Optional tenant ID."
-          }
-        }
-      },
       "ListTaskPushNotificationConfigsResponse": {
         "type": "object",
         "description": "Response for the `ListTaskPushNotificationConfigs` method.",
@@ -4332,75 +4385,6 @@
               "null"
             ],
             "description": "A token to retrieve the next page of results."
-          }
-        }
-      },
-      "ListTasksRequest": {
-        "type": "object",
-        "description": "Request for the `ListTasks` method.",
-        "properties": {
-          "contextId": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "Filter tasks by context ID."
-          },
-          "historyLength": {
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "int32",
-            "description": "Max number of messages to include in each task's history."
-          },
-          "includeArtifacts": {
-            "type": [
-              "boolean",
-              "null"
-            ],
-            "description": "Whether to include artifacts in returned tasks."
-          },
-          "pageSize": {
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "int32",
-            "description": "Max number of tasks to return (1..=100, default 50)."
-          },
-          "pageToken": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "Page token from a previous `ListTasks` call."
-          },
-          "status": {
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
-                "$ref": "#/components/schemas/TaskState",
-                "description": "Filter tasks by current status state."
-              }
-            ]
-          },
-          "statusTimestampAfter": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "format": "date-time",
-            "description": "Filter tasks with status updated after this timestamp."
-          },
-          "tenant": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "Tenant ID."
           }
         }
       },
@@ -5416,26 +5400,6 @@
           "p256dh": {
             "type": "string",
             "description": "Base64url-encoded P-256 ECDH public key from the browser subscription."
-          }
-        }
-      },
-      "SubscribeToTaskRequest": {
-        "type": "object",
-        "description": "Request for the `SubscribeToTask` method.",
-        "required": [
-          "id"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The resource ID of the task to subscribe to."
-          },
-          "tenant": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "Optional tenant ID."
           }
         }
       },


### PR DESCRIPTION
## Summary

- Adds a `validate-openapi` CI job using `@redocly/cli lint` to catch spec warnings/errors on every push and PR
- Adds a `make validate-openapi` target for local use

## Test plan

- [ ] CI job appears in the Actions run
- [ ] `make validate-openapi` runs locally and reports any warnings
- [ ] Intentionally broken spec causes the job to fail