### PR TITLE
fix(app): use generated CapabilitiesApi — voice buttons now visible on web/PWA

### DIFF
--- a/app/lib/api/api_client.dart
+++ b/app/lib/api/api_client.dart
@@ -5,7 +5,6 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:assistant_api/assistant_api.dart' hide ServerCapabilities;
@@ -16,9 +15,7 @@ import 'models/stream_event.dart';
 
 /// Configured client bundle: generated API instances + SSE streaming helper.
 class ApiClient {
-  ApiClient({required String baseUrl, required String token})
-    : _token = token,
-      _baseUrl = baseUrl {
+  ApiClient({required String baseUrl, required String token}) : _token = token {
     _dio = Dio(
       BaseOptions(
         baseUrl: baseUrl,
@@ -32,7 +29,6 @@ class ApiClient {
   }
 
   final String _token;
-  final String _baseUrl;
   late final Dio _dio;
   late final AssistantApi _generatedApi;
 
@@ -45,6 +41,7 @@ class ApiClient {
   AgentsApi get agents => _generatedApi.getAgentsApi();
   AnalyticsApi get analytics => _generatedApi.getAnalyticsApi();
   WorkflowsApi get workflows => _generatedApi.getWorkflowsApi();
+  CapabilitiesApi get capabilities => _generatedApi.getCapabilitiesApi();
 
   /// Stream assistant tokens for a conversation message.
   ///
@@ -79,29 +76,20 @@ class ApiClient {
   // -- Voice / capabilities ---------------------------------------------------
 
   /// Fetch server capability flags (voice_send, voice_receive, …).
-  ///
-  /// Uses dart:io HttpClient directly (no Dio interceptor chain) so no
-  /// zero-duration dart:async Timer is created during the request setup,
-  /// which keeps Flutter's fakeAsync tests clean.
   Future<ServerCapabilities> getCapabilities({CancelToken? cancelToken}) async {
-    final client = HttpClient();
-    // Disable connect timeout — no dart:async Timer created.
-    client.connectionTimeout = null;
     try {
-      final uri = Uri.parse('$_baseUrl/api/capabilities');
-      final request = await client.getUrl(uri);
-      request.headers.set('Authorization', 'Bearer $_token');
-      if (cancelToken?.isCancelled == true) return ServerCapabilities.disabled;
-      final response = await request.close();
-      if (response.statusCode == 200) {
-        final body = await response.transform(utf8.decoder).join();
-        final json = jsonDecode(body) as Map<String, dynamic>;
-        return ServerCapabilities.fromJson(json);
+      final response = await capabilities.getCapabilities(
+        cancelToken: cancelToken,
+      );
+      final data = response.data;
+      if (data != null) {
+        return ServerCapabilities(
+          voiceSend: data.voiceSend,
+          voiceReceive: data.voiceReceive,
+        );
       }
     } catch (_) {
       // Network, cancellation, or parse errors → report no capabilities.
-    } finally {
-      client.close(force: true);
     }
     return ServerCapabilities.disabled;
   }

--- a/app/test/widget/router/context_redirect_test.dart
+++ b/app/test/widget/router/context_redirect_test.dart
@@ -5,6 +5,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:assistant_app/api/capabilities_provider.dart';
+import 'package:assistant_app/api/models/server_capabilities.dart';
 import 'package:assistant_app/features/contexts/data/context_repository.dart';
 import 'package:assistant_app/features/contexts/models/context_model.dart';
 import 'package:assistant_app/features/contexts/providers/context_providers.dart';
@@ -33,7 +35,12 @@ Future<ContextRepository> makeRepo({String? activeContextId}) async {
 
 Widget buildApp(ContextRepository repo) {
   return ProviderScope(
-    overrides: [contextRepositoryProvider.overrideWithValue(repo)],
+    overrides: [
+      contextRepositoryProvider.overrideWithValue(repo),
+      capabilitiesProvider.overrideWith(
+        (ref) async => ServerCapabilities.disabled,
+      ),
+    ],
     child: Consumer(
       builder: (context, ref, child) {
         final router = ref.watch(routerProvider);


### PR DESCRIPTION
## Problem

Voice mic and audio playback buttons were never shown in the web/PWA despite the server having Deepgram transcription and TTS configured.

Root cause: `getCapabilities()` in `api_client.dart` used `dart:io HttpClient` directly. On Flutter web, `dart:io` is a stub — `HttpClient()` throws `UnsupportedError` immediately on construction. The `catch (_)` silently swallowed it and returned `ServerCapabilities.disabled`, so `capabilities.voiceSend` was always `false` and the `VoiceRecorderButton` was never rendered. No request to `/api/capabilities` ever hit the network.

## Fix

- Replace the hand-rolled `dart:io` implementation with the already-generated `CapabilitiesApi` (added in #451 alongside the voice feature itself). Auth is handled by the existing `setBearerAuth` interceptor — no manual `Authorization` header needed.
- Remove the now-unused `_baseUrl` field.
- Override `capabilitiesProvider` in router widget tests to `ServerCapabilities.disabled` — the generated Dio client's connect timeout created pending timers inside `fakeAsync`, failing those tests.

## Test plan

- [ ] All 221 Flutter tests pass (`flutter test`)
- [ ] `/api/capabilities` request is visible in browser DevTools network tab after login
- [ ] Mic button appears in the input row when server has transcription configured
- [ ] Audio play button appears on assistant messages when server has TTS configured

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the server capabilities detection process.

* **Bug Fixes**
  * Enhanced error handling when loading capabilities; system now gracefully degrades to a disabled state when issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->