### PR TITLE
fix(app): fix provider race condition on page open + widget tests

### DIFF
--- a/app/lib/api/capabilities_provider.dart
+++ b/app/lib/api/capabilities_provider.dart
@@ -1,7 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../features/chat/chat_provider.dart';
+import '../features/connection/connection_provider.dart';
 import 'models/server_capabilities.dart';
 
 /// Fetches and caches server capability flags.

--- a/app/lib/features/agents/agents_provider.dart
+++ b/app/lib/features/agents/agents_provider.dart
@@ -21,14 +21,12 @@ class AgentsState {
 class AgentsNotifier extends AsyncNotifier<AgentsState> {
   @override
   Future<AgentsState> build() async {
+    final api = ref.watch(apiClientProvider);
+    if (api == null) return const AgentsState();
     return _fetchAgents();
   }
 
-  ApiClient? get _api {
-    final profile = ref.read(activeProfileProvider);
-    if (profile == null) return null;
-    return ApiClient(baseUrl: profile.baseUrl, token: profile.token);
-  }
+  ApiClient? get _api => ref.read(apiClientProvider);
 
   Future<AgentsState> _fetchAgents() async {
     final api = _api;
@@ -52,19 +50,15 @@ class AgentsNotifier extends AsyncNotifier<AgentsState> {
 /// Provider for [AgentsNotifier].
 final agentsProvider =
     AsyncNotifierProvider.autoDispose<AgentsNotifier, AgentsState>(
-  AgentsNotifier.new,
-);
+      AgentsNotifier.new,
+    );
 
 // ---------------------------------------------------------------------------
 // Agent detail
 
 /// State for a single agent detail screen.
 class AgentDetailState {
-  const AgentDetailState({
-    this.agent,
-    this.isLoading = false,
-    this.error,
-  });
+  const AgentDetailState({this.agent, this.isLoading = false, this.error});
 
   final AgentDetail? agent;
   final bool isLoading;
@@ -79,14 +73,12 @@ class AgentDetailNotifier extends AsyncNotifier<AgentDetailState> {
 
   @override
   Future<AgentDetailState> build() async {
+    final api = ref.watch(apiClientProvider);
+    if (api == null) return const AgentDetailState();
     return _fetchDetail(_agentId);
   }
 
-  ApiClient? get _api {
-    final profile = ref.read(activeProfileProvider);
-    if (profile == null) return null;
-    return ApiClient(baseUrl: profile.baseUrl, token: profile.token);
-  }
+  ApiClient? get _api => ref.read(apiClientProvider);
 
   Future<AgentDetailState> _fetchDetail(String agentId) async {
     final api = _api;
@@ -109,5 +101,5 @@ class AgentDetailNotifier extends AsyncNotifier<AgentDetailState> {
 /// Family provider for [AgentDetailNotifier].
 final agentDetailProvider = AsyncNotifierProvider.autoDispose
     .family<AgentDetailNotifier, AgentDetailState, String>(
-  (arg) => AgentDetailNotifier(arg),
-);
+      (arg) => AgentDetailNotifier(arg),
+    );

--- a/app/lib/features/analytics/analytics_provider.dart
+++ b/app/lib/features/analytics/analytics_provider.dart
@@ -38,31 +38,22 @@ class AnalyticsState {
 class AnalyticsNotifier extends AsyncNotifier<AnalyticsState> {
   @override
   Future<AnalyticsState> build() async {
+    final api = ref.watch(apiClientProvider);
+    if (api == null) return const AnalyticsState();
     return _fetchAnalytics(24);
   }
 
-  ApiClient? get _api {
-    final profile = ref.read(activeProfileProvider);
-    if (profile == null) return null;
-    return ApiClient(baseUrl: profile.baseUrl, token: profile.token);
-  }
+  ApiClient? get _api => ref.read(apiClientProvider);
 
   Future<AnalyticsState> _fetchAnalytics(int windowHours) async {
     final api = _api;
     if (api == null) return AnalyticsState(windowHours: windowHours);
 
     try {
-      final response =
-          await api.analytics.getAnalytics(window: windowHours);
-      return AnalyticsState(
-        summary: response.data!,
-        windowHours: windowHours,
-      );
+      final response = await api.analytics.getAnalytics(window: windowHours);
+      return AnalyticsState(summary: response.data!, windowHours: windowHours);
     } catch (e) {
-      return AnalyticsState(
-        windowHours: windowHours,
-        error: e.toString(),
-      );
+      return AnalyticsState(windowHours: windowHours, error: e.toString());
     }
   }
 
@@ -81,5 +72,5 @@ class AnalyticsNotifier extends AsyncNotifier<AnalyticsState> {
 /// Provider for [AnalyticsNotifier].
 final analyticsProvider =
     AsyncNotifierProvider.autoDispose<AnalyticsNotifier, AnalyticsState>(
-  AnalyticsNotifier.new,
-);
+      AnalyticsNotifier.new,
+    );

--- a/app/lib/features/chat/chat_provider.dart
+++ b/app/lib/features/chat/chat_provider.dart
@@ -7,16 +7,6 @@ import '../../api/api_client.dart';
 import '../../api/models/stream_event.dart';
 import '../connection/connection_provider.dart';
 
-// -- Client provider ---------------------------------------------------------
-
-/// Creates an [ApiClient] from the active [ServerProfile].
-/// Returns `null` when not connected.
-final apiClientProvider = Provider<ApiClient?>((ref) {
-  final profile = ref.watch(activeProfileProvider);
-  if (profile == null) return null;
-  return ApiClient(baseUrl: profile.baseUrl, token: profile.token);
-});
-
 // -- Conversation list -------------------------------------------------------
 
 /// State for the conversation list.
@@ -49,13 +39,9 @@ class ConversationListState {
 class ConversationListNotifier extends AsyncNotifier<ConversationListState> {
   @override
   Future<ConversationListState> build() async {
-    return _fetchAll();
-  }
-
-  ApiClient? get _api => ref.read(apiClientProvider);
-
-  Future<ConversationListState> _fetchAll() async {
-    final api = _api;
+    // Watch so we rebuild reactively when the API client becomes available
+    // (e.g. after the active context loads asynchronously on first launch).
+    final api = ref.watch(apiClientProvider);
     if (api == null) return const ConversationListState();
 
     try {
@@ -67,10 +53,21 @@ class ConversationListNotifier extends AsyncNotifier<ConversationListState> {
     }
   }
 
+  ApiClient? get _api => ref.read(apiClientProvider);
+
   /// Reload conversations from the server.
   Future<void> refresh() async {
+    final api = _api;
+    if (api == null) return;
+
     state = const AsyncLoading();
-    state = AsyncData(await _fetchAll());
+    try {
+      final response = await api.conversations.listConversations();
+      final conversations = response.data!.toList();
+      state = AsyncData(ConversationListState(conversations: conversations));
+    } catch (e) {
+      state = AsyncData(ConversationListState(error: e.toString()));
+    }
   }
 
   /// Create a new conversation and add it to the list.

--- a/app/lib/features/chat/chat_screen.dart
+++ b/app/lib/features/chat/chat_screen.dart
@@ -100,14 +100,15 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   /// On a hard reload / deep link, [_loadConversation] fires from [initState]
   /// before the active context has finished loading, so [loadConversation]
   /// finds no API client and returns immediately.  This listener fires when
-  /// [apiClientProvider] transitions null → non-null and retriggers the load
+  /// [apiClientProvider] transitions null → non-null (initial context load) or
+  /// switches to a different client (context switch) and retriggers the load
   /// if the conversation hasn't been set on the chat state yet.
   void _onApiClientAvailable(ApiClient? prev, ApiClient? next) {
-    if (prev != null || next == null) return; // only on null → non-null
+    if (next == null || identical(prev, next)) return;
     final id = widget.conversationId;
     if (id == null) return;
     final chatState = ref.read(chatProvider).value;
-    if (chatState?.conversationId != id) {
+    if (prev != null || chatState?.conversationId != id) {
       _loadConversation();
     }
   }
@@ -489,11 +490,9 @@ class _MessageBubble extends StatelessWidget {
                             ),
                         selectable: true,
                       ),
-                      // Play button for assistant messages where the server
-                      // explicitly produced audio (AudioReadyEvent received).
-                      if (capabilities.voiceReceive &&
-                          !message.isStreaming &&
-                          message.audioId != null)
+                      // Play button for assistant messages. Shows whenever
+                      // voice is enabled — fetches on-demand if no audioId.
+                      if (capabilities.voiceReceive && !message.isStreaming)
                         Padding(
                           padding: const EdgeInsets.only(top: 6),
                           child: AudioPlayerWidget(

--- a/app/lib/features/chat/chat_screen.dart
+++ b/app/lib/features/chat/chat_screen.dart
@@ -5,8 +5,10 @@ import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../api/api_client.dart';
 import '../../api/capabilities_provider.dart';
 import '../../api/models/server_capabilities.dart';
+import '../connection/connection_provider.dart';
 import '../personas/persona_picker.dart';
 import '../personas/personas_provider.dart';
 import 'audio_player_widget.dart';
@@ -93,6 +95,23 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     _scrollToBottom();
   }
 
+  /// Retry loading the conversation once the API client becomes available.
+  ///
+  /// On a hard reload / deep link, [_loadConversation] fires from [initState]
+  /// before the active context has finished loading, so [loadConversation]
+  /// finds no API client and returns immediately.  This listener fires when
+  /// [apiClientProvider] transitions null → non-null and retriggers the load
+  /// if the conversation hasn't been set on the chat state yet.
+  void _onApiClientAvailable(ApiClient? prev, ApiClient? next) {
+    if (prev != null || next == null) return; // only on null → non-null
+    final id = widget.conversationId;
+    if (id == null) return;
+    final chatState = ref.read(chatProvider).value;
+    if (chatState?.conversationId != id) {
+      _loadConversation();
+    }
+  }
+
   @override
   void dispose() {
     _inputFocus.removeListener(_onInputFocusChange);
@@ -132,6 +151,11 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
 
   @override
   Widget build(BuildContext context) {
+    // Retry loading the conversation once the API client becomes available.
+    // Handles deep-link / hard-reload races where the active context loads
+    // after the first _loadConversation() call.
+    ref.listen<ApiClient?>(apiClientProvider, _onApiClientAvailable);
+
     final chatAsync = ref.watch(chatProvider);
     final chatState = chatAsync.value ?? const ChatState();
     final isWide = MediaQuery.of(context).size.width > 700;
@@ -465,8 +489,11 @@ class _MessageBubble extends StatelessWidget {
                             ),
                         selectable: true,
                       ),
-                      // Play button for voice-capable assistant messages.
-                      if (capabilities.voiceReceive && !message.isStreaming)
+                      // Play button for assistant messages where the server
+                      // explicitly produced audio (AudioReadyEvent received).
+                      if (capabilities.voiceReceive &&
+                          !message.isStreaming &&
+                          message.audioId != null)
                         Padding(
                           padding: const EdgeInsets.only(top: 6),
                           child: AudioPlayerWidget(

--- a/app/lib/features/connection/connection_provider.dart
+++ b/app/lib/features/connection/connection_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../api/api_client.dart';
 import '../../api/models/server_profile.dart';
 import '../contexts/providers/context_providers.dart';
 
@@ -45,6 +46,17 @@ final isConnectedProvider = Provider<bool>((ref) {
 /// Provides the active [ServerProfile], or `null` if no context is active.
 final activeProfileProvider = Provider<ServerProfile?>((ref) {
   return ref.watch(serverProfileProvider).value?.profile;
+});
+
+/// Provides a configured [ApiClient] for the active context, or `null` when
+/// no context is selected or the context is still loading.
+///
+/// All feature providers should watch this in their [AsyncNotifier.build]
+/// so they rebuild reactively when the connection becomes available.
+final apiClientProvider = Provider<ApiClient?>((ref) {
+  final profile = ref.watch(activeProfileProvider);
+  if (profile == null) return null;
+  return ApiClient(baseUrl: profile.baseUrl, token: profile.token);
 });
 
 /// Returns `true` when running in a web browser.

--- a/app/lib/features/logs/logs_provider.dart
+++ b/app/lib/features/logs/logs_provider.dart
@@ -41,14 +41,12 @@ class LogsState {
 class LogsNotifier extends AsyncNotifier<LogsState> {
   @override
   Future<LogsState> build() async {
+    final api = ref.watch(apiClientProvider);
+    if (api == null) return const LogsState();
     return _fetchLogs('');
   }
 
-  ApiClient? get _api {
-    final profile = ref.read(activeProfileProvider);
-    if (profile == null) return null;
-    return ApiClient(baseUrl: profile.baseUrl, token: profile.token);
-  }
+  ApiClient? get _api => ref.read(apiClientProvider);
 
   Future<LogsState> _fetchLogs(String search) async {
     final api = _api;
@@ -81,7 +79,6 @@ class LogsNotifier extends AsyncNotifier<LogsState> {
 }
 
 /// Provider for [LogsNotifier].
-final logsProvider =
-    AsyncNotifierProvider.autoDispose<LogsNotifier, LogsState>(
+final logsProvider = AsyncNotifierProvider.autoDispose<LogsNotifier, LogsState>(
   LogsNotifier.new,
 );

--- a/app/lib/features/personas/persona_detail_provider.dart
+++ b/app/lib/features/personas/persona_detail_provider.dart
@@ -6,11 +6,7 @@ import '../connection/connection_provider.dart';
 
 /// State for the persona detail screen.
 class PersonaDetailState {
-  const PersonaDetailState({
-    this.detail,
-    this.isLoading = false,
-    this.error,
-  });
+  const PersonaDetailState({this.detail, this.isLoading = false, this.error});
 
   final PersonaDetail? detail;
   final bool isLoading;
@@ -25,14 +21,12 @@ class PersonaDetailNotifier extends AsyncNotifier<PersonaDetailState> {
 
   @override
   Future<PersonaDetailState> build() async {
+    final api = ref.watch(apiClientProvider);
+    if (api == null) return const PersonaDetailState();
     return _fetchDetail(_personaId);
   }
 
-  ApiClient? get _api {
-    final profile = ref.read(activeProfileProvider);
-    if (profile == null) return null;
-    return ApiClient(baseUrl: profile.baseUrl, token: profile.token);
-  }
+  ApiClient? get _api => ref.read(apiClientProvider);
 
   Future<PersonaDetailState> _fetchDetail(String personaId) async {
     final api = _api;
@@ -55,5 +49,5 @@ class PersonaDetailNotifier extends AsyncNotifier<PersonaDetailState> {
 /// Family provider for [PersonaDetailNotifier].
 final personaDetailProvider = AsyncNotifierProvider.autoDispose
     .family<PersonaDetailNotifier, PersonaDetailState, String>(
-  (arg) => PersonaDetailNotifier(arg),
-);
+      (arg) => PersonaDetailNotifier(arg),
+    );

--- a/app/lib/features/personas/personas_provider.dart
+++ b/app/lib/features/personas/personas_provider.dart
@@ -38,14 +38,12 @@ class PersonasState {
 class PersonasNotifier extends AsyncNotifier<PersonasState> {
   @override
   Future<PersonasState> build() async {
+    final api = ref.watch(apiClientProvider);
+    if (api == null) return const PersonasState();
     return _fetchPersonas();
   }
 
-  ApiClient? get _api {
-    final profile = ref.read(activeProfileProvider);
-    if (profile == null) return null;
-    return ApiClient(baseUrl: profile.baseUrl, token: profile.token);
-  }
+  ApiClient? get _api => ref.read(apiClientProvider);
 
   Future<PersonasState> _fetchPersonas() async {
     final api = _api;
@@ -55,11 +53,9 @@ class PersonasNotifier extends AsyncNotifier<PersonasState> {
       final response = await api.personas.listPersonas();
       final personas = response.data!.toList();
       final defaultPersona =
-          personas.where((p) => p.isDefault).firstOrNull ?? personas.firstOrNull;
-      return PersonasState(
-        personas: personas,
-        activePersona: defaultPersona,
-      );
+          personas.where((p) => p.isDefault).firstOrNull ??
+          personas.firstOrNull;
+      return PersonasState(personas: personas, activePersona: defaultPersona);
     } catch (e) {
       return PersonasState(error: e.toString());
     }
@@ -85,17 +81,11 @@ class PersonasNotifier extends AsyncNotifier<PersonasState> {
       );
       final updated = response.data!;
       state = AsyncData(
-        current.copyWith(
-          activePersona: updated,
-          isLoading: false,
-        ),
+        current.copyWith(activePersona: updated, isLoading: false),
       );
     } catch (e) {
       state = AsyncData(
-        current.copyWith(
-          isLoading: false,
-          error: e.toString(),
-        ),
+        current.copyWith(isLoading: false, error: e.toString()),
       );
     }
   }
@@ -104,5 +94,5 @@ class PersonasNotifier extends AsyncNotifier<PersonasState> {
 /// Provider for [PersonasNotifier].
 final personasProvider =
     AsyncNotifierProvider.autoDispose<PersonasNotifier, PersonasState>(
-  PersonasNotifier.new,
-);
+      PersonasNotifier.new,
+    );

--- a/app/lib/features/skills/skill_detail_provider.dart
+++ b/app/lib/features/skills/skill_detail_provider.dart
@@ -6,11 +6,7 @@ import '../connection/connection_provider.dart';
 
 /// State for the skill detail screen.
 class SkillDetailState {
-  const SkillDetailState({
-    this.skill,
-    this.isLoading = false,
-    this.error,
-  });
+  const SkillDetailState({this.skill, this.isLoading = false, this.error});
 
   final SkillDetail? skill;
   final bool isLoading;
@@ -25,14 +21,12 @@ class SkillDetailNotifier extends AsyncNotifier<SkillDetailState> {
 
   @override
   Future<SkillDetailState> build() async {
+    final api = ref.watch(apiClientProvider);
+    if (api == null) return const SkillDetailState();
     return _fetch(_skillName);
   }
 
-  ApiClient? get _api {
-    final profile = ref.read(activeProfileProvider);
-    if (profile == null) return null;
-    return ApiClient(baseUrl: profile.baseUrl, token: profile.token);
-  }
+  ApiClient? get _api => ref.read(apiClientProvider);
 
   Future<SkillDetailState> _fetch(String name) async {
     final api = _api;
@@ -54,5 +48,5 @@ class SkillDetailNotifier extends AsyncNotifier<SkillDetailState> {
 /// Family provider for [SkillDetailNotifier], parameterised by skill name.
 final skillDetailProvider = AsyncNotifierProvider.autoDispose
     .family<SkillDetailNotifier, SkillDetailState, String>(
-  (arg) => SkillDetailNotifier(arg),
-);
+      (arg) => SkillDetailNotifier(arg),
+    );

--- a/app/lib/features/skills/skills_provider.dart
+++ b/app/lib/features/skills/skills_provider.dart
@@ -50,14 +50,12 @@ class SkillsNotifier extends AsyncNotifier<SkillsState> {
       }
     });
 
+    final api = ref.watch(apiClientProvider);
+    if (api == null) return const SkillsState();
     return _fetchSkills();
   }
 
-  ApiClient? get _api {
-    final profile = ref.read(activeProfileProvider);
-    if (profile == null) return null;
-    return ApiClient(baseUrl: profile.baseUrl, token: profile.token);
-  }
+  ApiClient? get _api => ref.read(apiClientProvider);
 
   Future<SkillsState> _fetchSkills() async {
     final api = _api;
@@ -149,5 +147,5 @@ class SkillsNotifier extends AsyncNotifier<SkillsState> {
 /// Provider for [SkillsNotifier].
 final skillsProvider =
     AsyncNotifierProvider.autoDispose<SkillsNotifier, SkillsState>(
-  SkillsNotifier.new,
-);
+      SkillsNotifier.new,
+    );

--- a/app/lib/features/traces/traces_provider.dart
+++ b/app/lib/features/traces/traces_provider.dart
@@ -34,14 +34,12 @@ class TracesState {
 class TracesNotifier extends AsyncNotifier<TracesState> {
   @override
   Future<TracesState> build() async {
+    final api = ref.watch(apiClientProvider);
+    if (api == null) return const TracesState();
     return _fetchTraces();
   }
 
-  ApiClient? get _api {
-    final profile = ref.read(activeProfileProvider);
-    if (profile == null) return null;
-    return ApiClient(baseUrl: profile.baseUrl, token: profile.token);
-  }
+  ApiClient? get _api => ref.read(apiClientProvider);
 
   Future<TracesState> _fetchTraces() async {
     final api = _api;
@@ -65,16 +63,12 @@ class TracesNotifier extends AsyncNotifier<TracesState> {
 /// Provider for [TracesNotifier].
 final tracesProvider =
     AsyncNotifierProvider.autoDispose<TracesNotifier, TracesState>(
-  TracesNotifier.new,
-);
+      TracesNotifier.new,
+    );
 
 /// State for a single trace detail.
 class TraceDetailState {
-  const TraceDetailState({
-    this.detail,
-    this.isLoading = false,
-    this.error,
-  });
+  const TraceDetailState({this.detail, this.isLoading = false, this.error});
 
   final TraceDetailResponse? detail;
   final bool isLoading;
@@ -93,14 +87,12 @@ class TraceDetailNotifier extends AsyncNotifier<TraceDetailState> {
 
   @override
   Future<TraceDetailState> build() async {
+    final api = ref.watch(apiClientProvider);
+    if (api == null) return const TraceDetailState();
     return _fetchDetail(_traceId);
   }
 
-  ApiClient? get _api {
-    final profile = ref.read(activeProfileProvider);
-    if (profile == null) return null;
-    return ApiClient(baseUrl: profile.baseUrl, token: profile.token);
-  }
+  ApiClient? get _api => ref.read(apiClientProvider);
 
   Future<TraceDetailState> _fetchDetail(String traceId) async {
     final api = _api;
@@ -119,5 +111,5 @@ class TraceDetailNotifier extends AsyncNotifier<TraceDetailState> {
 /// Family provider for [TraceDetailNotifier].
 final traceDetailProvider = AsyncNotifierProvider.autoDispose
     .family<TraceDetailNotifier, TraceDetailState, String>(
-  (arg) => TraceDetailNotifier(arg),
-);
+      (arg) => TraceDetailNotifier(arg),
+    );

--- a/app/lib/features/webhooks/webhooks_provider.dart
+++ b/app/lib/features/webhooks/webhooks_provider.dart
@@ -21,14 +21,12 @@ class WebhooksState {
 class WebhooksNotifier extends AsyncNotifier<WebhooksState> {
   @override
   Future<WebhooksState> build() async {
+    final api = ref.watch(apiClientProvider);
+    if (api == null) return const WebhooksState();
     return _fetchWebhooks();
   }
 
-  ApiClient? get _api {
-    final profile = ref.read(activeProfileProvider);
-    if (profile == null) return null;
-    return ApiClient(baseUrl: profile.baseUrl, token: profile.token);
-  }
+  ApiClient? get _api => ref.read(apiClientProvider);
 
   Future<WebhooksState> _fetchWebhooks() async {
     final api = _api;
@@ -52,8 +50,8 @@ class WebhooksNotifier extends AsyncNotifier<WebhooksState> {
 /// Provider for [WebhooksNotifier].
 final webhooksProvider =
     AsyncNotifierProvider.autoDispose<WebhooksNotifier, WebhooksState>(
-  WebhooksNotifier.new,
-);
+      WebhooksNotifier.new,
+    );
 
 // ---------------------------------------------------------------------------
 // Webhook detail
@@ -81,14 +79,12 @@ class WebhookDetailNotifier extends AsyncNotifier<WebhookDetailState> {
 
   @override
   Future<WebhookDetailState> build() async {
+    final api = ref.watch(apiClientProvider);
+    if (api == null) return const WebhookDetailState();
     return _fetchDetail(_webhookId);
   }
 
-  ApiClient? get _api {
-    final profile = ref.read(activeProfileProvider);
-    if (profile == null) return null;
-    return ApiClient(baseUrl: profile.baseUrl, token: profile.token);
-  }
+  ApiClient? get _api => ref.read(apiClientProvider);
 
   Future<WebhookDetailState> _fetchDetail(String webhookId) async {
     final api = _api;
@@ -133,9 +129,7 @@ class WebhookDetailNotifier extends AsyncNotifier<WebhookDetailState> {
     try {
       await api.webhooks.rotateSecret(id: _webhookId);
       final updated = await _fetchDetail(_webhookId);
-      state = AsyncData(
-        updated.copyWith(actionMessage: 'Secret rotated'),
-      );
+      state = AsyncData(updated.copyWith(actionMessage: 'Secret rotated'));
     } catch (e) {
       state = AsyncData(
         current.copyWith(isLoading: false, error: e.toString()),
@@ -163,5 +157,5 @@ extension _WebhookDetailStateCopyWith on WebhookDetailState {
 /// Family provider for [WebhookDetailNotifier].
 final webhookDetailProvider = AsyncNotifierProvider.autoDispose
     .family<WebhookDetailNotifier, WebhookDetailState, String>(
-  (arg) => WebhookDetailNotifier(arg),
-);
+      (arg) => WebhookDetailNotifier(arg),
+    );

--- a/app/lib/features/workflows/workflows_provider.dart
+++ b/app/lib/features/workflows/workflows_provider.dart
@@ -8,11 +8,7 @@ import '../connection/connection_provider.dart';
 // ---------------------------------------------------------------------------
 // API client helper
 
-ApiClient? _apiClient(Ref ref) {
-  final profile = ref.read(activeProfileProvider);
-  if (profile == null) return null;
-  return ApiClient(baseUrl: profile.baseUrl, token: profile.token);
-}
+ApiClient? _apiClient(Ref ref) => ref.read(apiClientProvider);
 
 // ---------------------------------------------------------------------------
 // Workflows list
@@ -20,7 +16,11 @@ ApiClient? _apiClient(Ref ref) {
 /// Notifier for the workflows list.
 class WorkflowsNotifier extends AsyncNotifier<List<WorkflowSummary>> {
   @override
-  Future<List<WorkflowSummary>> build() => _fetch();
+  Future<List<WorkflowSummary>> build() async {
+    final api = ref.watch(apiClientProvider);
+    if (api == null) return [];
+    return _fetch();
+  }
 
   Future<List<WorkflowSummary>> _fetch() async {
     final client = _apiClient(ref);
@@ -129,32 +129,33 @@ class WorkflowsNotifier extends AsyncNotifier<List<WorkflowSummary>> {
 /// Provider for [WorkflowsNotifier].
 final workflowsProvider =
     AsyncNotifierProvider.autoDispose<WorkflowsNotifier, List<WorkflowSummary>>(
-  WorkflowsNotifier.new,
-);
+      WorkflowsNotifier.new,
+    );
 
 // ---------------------------------------------------------------------------
 // Workflow detail
 
 /// Combined detail + runs state.
 class WorkflowDetailState {
-  const WorkflowDetailState({
-    required this.detail,
-    required this.runs,
-  });
+  const WorkflowDetailState({required this.detail, required this.runs});
 
   final WorkflowDetail detail;
   final List<WorkflowRunSummary> runs;
 }
 
 /// Notifier for a single workflow detail (detail + recent runs).
-class WorkflowDetailNotifier
-    extends AsyncNotifier<WorkflowDetailState> {
+class WorkflowDetailNotifier extends AsyncNotifier<WorkflowDetailState> {
   WorkflowDetailNotifier(this._workflowId);
 
   final String _workflowId;
 
   @override
-  Future<WorkflowDetailState> build() => _fetch();
+  Future<WorkflowDetailState> build() async {
+    // Establish reactive dependency — rebuilds when the active context loads.
+    // _fetch() throws 'Not connected' if null, shown as error state.
+    ref.watch(apiClientProvider);
+    return _fetch();
+  }
 
   Future<WorkflowDetailState> _fetch() async {
     final client = _apiClient(ref);
@@ -184,18 +185,15 @@ class WorkflowDetailNotifier
 /// Family provider for [WorkflowDetailNotifier].
 final workflowDetailProvider = AsyncNotifierProvider.autoDispose
     .family<WorkflowDetailNotifier, WorkflowDetailState, String>(
-  (arg) => WorkflowDetailNotifier(arg),
-);
+      (arg) => WorkflowDetailNotifier(arg),
+    );
 
 // ---------------------------------------------------------------------------
 // Workflow run detail
 
 /// State for a single workflow run detail.
 class WorkflowRunDetailState {
-  const WorkflowRunDetailState({
-    this.runDetail,
-    this.error,
-  });
+  const WorkflowRunDetailState({this.runDetail, this.error});
 
   final WorkflowRunDetail? runDetail;
   final String? error;
@@ -205,14 +203,17 @@ class WorkflowRunDetailState {
 typedef WorkflowRunKey = ({String workflowId, String runId});
 
 /// Notifier for a single workflow run detail.
-class WorkflowRunDetailNotifier
-    extends AsyncNotifier<WorkflowRunDetailState> {
+class WorkflowRunDetailNotifier extends AsyncNotifier<WorkflowRunDetailState> {
   WorkflowRunDetailNotifier(this._key);
 
   final WorkflowRunKey _key;
 
   @override
-  Future<WorkflowRunDetailState> build() => _fetch();
+  Future<WorkflowRunDetailState> build() async {
+    final api = ref.watch(apiClientProvider);
+    if (api == null) return const WorkflowRunDetailState();
+    return _fetch();
+  }
 
   Future<WorkflowRunDetailState> _fetch() async {
     final client = _apiClient(ref);
@@ -237,5 +238,5 @@ class WorkflowRunDetailNotifier
 /// Family provider for [WorkflowRunDetailNotifier].
 final workflowRunDetailProvider = AsyncNotifierProvider.autoDispose
     .family<WorkflowRunDetailNotifier, WorkflowRunDetailState, WorkflowRunKey>(
-  (arg) => WorkflowRunDetailNotifier(arg),
-);
+      (arg) => WorkflowRunDetailNotifier(arg),
+    );

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -113,7 +113,7 @@ packages:
     source: hosted
     version: "2.1.2"
   built_collection:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: built_collection
       sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   path_provider: ^2.1.5
   url_launcher: ^6.3.2
   package_info_plus: ^9.0.1
-  built_value: '>=8.4.0 <9.0.0'
+  built_value: ">=8.4.0 <9.0.0"
   assistant_api:
     path: packages/assistant_api
   tray_manager: ^0.5.2
@@ -40,12 +40,13 @@ dev_dependencies:
   flutter_lints: ^6.0.0
   audioplayers_platform_interface: ^7.1.1
   flutter_launcher_icons: ^0.14.4
+  built_collection: ^5.0.0
 flutter_launcher_icons:
   web:
     generate: true
     image_path: macos/Runner/Assets.xcassets/AppIcon.appiconset/app_icon_1024.png
-    background_color: '#080C1A'
-    theme_color: '#080C1A'
+    background_color: "#080C1A"
+    theme_color: "#080C1A"
 flutter:
   uses-material-design: true
   assets:

--- a/app/test/unit/chat/chat_provider_test.dart
+++ b/app/test/unit/chat/chat_provider_test.dart
@@ -5,6 +5,7 @@ import 'package:assistant_api/assistant_api.dart';
 import 'package:assistant_app/api/api_client.dart';
 import 'package:assistant_app/api/models/stream_event.dart';
 import 'package:assistant_app/features/chat/chat_provider.dart';
+import 'package:assistant_app/features/connection/connection_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/app/test/unit/chat/conversation_list_provider_test.dart
+++ b/app/test/unit/chat/conversation_list_provider_test.dart
@@ -1,0 +1,371 @@
+import 'package:assistant_api/assistant_api.dart';
+import 'package:assistant_app/api/api_client.dart';
+import 'package:assistant_app/features/chat/chat_provider.dart';
+import 'package:assistant_app/features/connection/connection_provider.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// ---------------------------------------------------------------------------
+// Fake ConversationsApi — no HTTP, returns controlled data.
+
+class _FakeConversationsApi extends ConversationsApi {
+  _FakeConversationsApi({this.conversations = const [], this.error})
+    : super(Dio(), standardSerializers);
+
+  final List<ConversationSummary> conversations;
+  final Exception? error;
+
+  @override
+  Future<Response<BuiltList<ConversationSummary>>> listConversations({
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    if (error != null) throw error!;
+    return Response(
+      data: BuiltList.of(conversations),
+      requestOptions: RequestOptions(path: '/api/conversations'),
+      statusCode: 200,
+    );
+  }
+
+  @override
+  Future<Response<void>> deleteConversation({
+    required String id,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    conversations.removeWhere((c) => c.id == id);
+    return Response(
+      requestOptions: RequestOptions(path: '/api/conversations/$id'),
+      statusCode: 204,
+    );
+  }
+}
+
+// Wraps _FakeConversationsApi in an ApiClient-compatible surface.
+class _FakeApiClient extends ApiClient {
+  _FakeApiClient({required this.fakeApi})
+    : super(baseUrl: 'http://fake.test', token: 'test-token');
+
+  final _FakeConversationsApi fakeApi;
+
+  @override
+  ConversationsApi get conversations => fakeApi;
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+
+/// Build a minimal [ConversationSummary] for testing.
+ConversationSummary _makeConv({required String id, String title = 'Test'}) {
+  return ConversationSummary(
+    (b) => b
+      ..id = id
+      ..title = title
+      ..createdAt = DateTime(2024, 1, 1)
+      ..updatedAt = DateTime(2024, 1, 1),
+  );
+}
+
+/// Create a [ProviderContainer] with [apiClientProvider] pinned to [client].
+ProviderContainer _makeContainer({ApiClient? client}) {
+  return ProviderContainer(
+    overrides: [apiClientProvider.overrideWithValue(client)],
+  );
+}
+
+/// Keep an autoDispose provider alive for the duration of the test.
+ProviderSubscription<AsyncValue<ConversationListState>> _keepAlive(
+  ProviderContainer container,
+) {
+  return container.listen<AsyncValue<ConversationListState>>(
+    conversationListProvider,
+    (_, _) {},
+    fireImmediately: false,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Mutable holder used to simulate apiClientProvider transitioning from
+// null (context still loading) to a real client (context ready).
+// StateProvider was removed in Riverpod 3.x — use Notifier instead.
+
+class _ApiClientHolder extends Notifier<ApiClient?> {
+  @override
+  ApiClient? build() => null;
+
+  void set(ApiClient? client) => state = client;
+}
+
+final _apiClientHolderProvider = NotifierProvider<_ApiClientHolder, ApiClient?>(
+  _ApiClientHolder.new,
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+
+void main() {
+  group('ConversationListNotifier', () {
+    // -----------------------------------------------------------------------
+    // Null client (context not yet loaded)
+    // -----------------------------------------------------------------------
+
+    test('returns empty state when apiClientProvider is null', () async {
+      final container = _makeContainer();
+      addTearDown(container.dispose);
+      final sub = _keepAlive(container);
+      addTearDown(sub.close);
+
+      final state = await container.read(conversationListProvider.future);
+      expect(state.conversations, isEmpty);
+      expect(state.error, isNull);
+    });
+
+    // -----------------------------------------------------------------------
+    // Happy path
+    // -----------------------------------------------------------------------
+
+    test(
+      'loads conversations when apiClientProvider is available from the start',
+      () async {
+        final fakeApi = _FakeConversationsApi(
+          conversations: [
+            _makeConv(id: 'c1', title: 'First'),
+            _makeConv(id: 'c2', title: 'Second'),
+          ],
+        );
+        final container = _makeContainer(
+          client: _FakeApiClient(fakeApi: fakeApi),
+        );
+        addTearDown(container.dispose);
+        final sub = _keepAlive(container);
+        addTearDown(sub.close);
+
+        final state = await container.read(conversationListProvider.future);
+        expect(state.conversations.length, 2);
+        expect(state.conversations.map((c) => c.id), containsAll(['c1', 'c2']));
+        expect(state.error, isNull);
+      },
+    );
+
+    // -----------------------------------------------------------------------
+    // Error handling
+    // -----------------------------------------------------------------------
+
+    test('captures error when listConversations throws', () async {
+      final fakeApi = _FakeConversationsApi(
+        error: Exception('network failure'),
+      );
+      final container = _makeContainer(
+        client: _FakeApiClient(fakeApi: fakeApi),
+      );
+      addTearDown(container.dispose);
+      final sub = _keepAlive(container);
+      addTearDown(sub.close);
+
+      final state = await container.read(conversationListProvider.future);
+      expect(state.error, isNotNull);
+      expect(state.error, contains('network failure'));
+      expect(state.conversations, isEmpty);
+    });
+
+    // -----------------------------------------------------------------------
+    // REGRESSION: race condition — null → non-null rebuild
+    // -----------------------------------------------------------------------
+
+    test('REGRESSION: rebuilds and fetches when apiClientProvider transitions '
+        'from null (context loading) to non-null (context ready)', () async {
+      // Simulates the race condition that occurred on web:
+      // apiClientProvider starts null because the active context is still
+      // loading asynchronously. The fix (ref.watch instead of ref.read in
+      // build()) causes the notifier to rebuild when the client appears.
+      final container = ProviderContainer(
+        overrides: [
+          apiClientProvider.overrideWith(
+            (ref) => ref.watch(_apiClientHolderProvider),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      // Keep the autoDispose provider alive across the state transition.
+      final sub = _keepAlive(container);
+      addTearDown(sub.close);
+
+      // Phase 1: no client — must return empty state, no error.
+      await container.read(conversationListProvider.future);
+      expect(
+        container.read(conversationListProvider).value?.conversations,
+        isEmpty,
+        reason: 'no conversations expected while apiClientProvider is null',
+      );
+
+      // Phase 2: active context finishes loading → apiClient becomes available.
+      final fakeApi = _FakeConversationsApi(
+        conversations: [_makeConv(id: 'c-loaded')],
+      );
+      container
+          .read(_apiClientHolderProvider.notifier)
+          .set(_FakeApiClient(fakeApi: fakeApi));
+
+      // Yield so Riverpod can propagate the dependency invalidation.
+      await Future<void>.delayed(Duration.zero);
+
+      // Await the reactive rebuild triggered by the apiClient change.
+      await container.read(conversationListProvider.future);
+
+      expect(
+        container
+            .read(conversationListProvider)
+            .value
+            ?.conversations
+            .map((c) => c.id),
+        contains('c-loaded'),
+        reason:
+            'conversations must be loaded after apiClientProvider becomes non-null; '
+            'this regresses if ref.watch() is replaced with ref.read() in build()',
+      );
+    });
+
+    // -----------------------------------------------------------------------
+    // refresh()
+    // -----------------------------------------------------------------------
+
+    test('refresh() reloads conversations from the server', () async {
+      final fakeApi = _FakeConversationsApi(
+        conversations: [_makeConv(id: 'c1')],
+      );
+      final container = _makeContainer(
+        client: _FakeApiClient(fakeApi: fakeApi),
+      );
+      addTearDown(container.dispose);
+      final sub = _keepAlive(container);
+      addTearDown(sub.close);
+
+      await container.read(conversationListProvider.future);
+      expect(
+        container.read(conversationListProvider).value?.conversations.length,
+        1,
+      );
+
+      await container.read(conversationListProvider.notifier).refresh();
+
+      final after = container.read(conversationListProvider).value!;
+      expect(after.conversations.length, 1);
+      expect(after.conversations.first.id, 'c1');
+      expect(after.error, isNull);
+    });
+
+    test('refresh() with null apiClient is a no-op', () async {
+      final container = _makeContainer();
+      addTearDown(container.dispose);
+      final sub = _keepAlive(container);
+      addTearDown(sub.close);
+
+      await container.read(conversationListProvider.future);
+
+      // Should not throw.
+      await container.read(conversationListProvider.notifier).refresh();
+
+      final state = container.read(conversationListProvider).value!;
+      expect(state.conversations, isEmpty);
+      expect(state.error, isNull);
+    });
+
+    // -----------------------------------------------------------------------
+    // prependConversation()
+    // -----------------------------------------------------------------------
+
+    test('prependConversation inserts at the front of the list', () async {
+      final fakeApi = _FakeConversationsApi(
+        conversations: [_makeConv(id: 'old')],
+      );
+      final container = _makeContainer(
+        client: _FakeApiClient(fakeApi: fakeApi),
+      );
+      addTearDown(container.dispose);
+      final sub = _keepAlive(container);
+      addTearDown(sub.close);
+
+      await container.read(conversationListProvider.future);
+
+      final newConv = _makeConv(id: 'new', title: 'Brand new');
+      container
+          .read(conversationListProvider.notifier)
+          .prependConversation(newConv);
+
+      final state = container.read(conversationListProvider).value!;
+      expect(
+        state.conversations.first.id,
+        'new',
+        reason: 'new conversation must appear at the top',
+      );
+      expect(state.conversations.length, 2);
+    });
+
+    test('prependConversation works when list is initially empty', () async {
+      final container = _makeContainer();
+      addTearDown(container.dispose);
+      final sub = _keepAlive(container);
+      addTearDown(sub.close);
+
+      await container.read(conversationListProvider.future);
+
+      final conv = _makeConv(id: 'first');
+      container
+          .read(conversationListProvider.notifier)
+          .prependConversation(conv);
+
+      final state = container.read(conversationListProvider).value!;
+      expect(state.conversations.length, 1);
+      expect(state.conversations.first.id, 'first');
+    });
+
+    // -----------------------------------------------------------------------
+    // deleteConversation()
+    // -----------------------------------------------------------------------
+
+    test(
+      'deleteConversation removes the conversation from local state',
+      () async {
+        final fakeApi = _FakeConversationsApi(
+          conversations: [
+            _makeConv(id: 'keep'),
+            _makeConv(id: 'remove'),
+          ],
+        );
+        final container = _makeContainer(
+          client: _FakeApiClient(fakeApi: fakeApi),
+        );
+        addTearDown(container.dispose);
+        final sub = _keepAlive(container);
+        addTearDown(sub.close);
+
+        await container.read(conversationListProvider.future);
+        expect(
+          container.read(conversationListProvider).value?.conversations.length,
+          2,
+        );
+
+        await container
+            .read(conversationListProvider.notifier)
+            .deleteConversation('remove');
+
+        final state = container.read(conversationListProvider).value!;
+        expect(state.conversations.length, 1);
+        expect(state.conversations.first.id, 'keep');
+        expect(state.conversations.any((c) => c.id == 'remove'), isFalse);
+      },
+    );
+  });
+}

--- a/app/test/widget/features/agents/agents_screen_test.dart
+++ b/app/test/widget/features/agents/agents_screen_test.dart
@@ -1,0 +1,134 @@
+import 'package:assistant_api/assistant_api.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:assistant_app/features/agents/agents_provider.dart';
+import 'package:assistant_app/features/agents/agents_screen.dart';
+
+void main() {
+  group('AgentsScreen', () {
+    Widget buildUnderTest({required AgentsState state}) {
+      final router = GoRouter(
+        routes: [
+          GoRoute(path: '/', builder: (_, _) => const AgentsScreen()),
+          GoRoute(
+            path: '/agents/:agentId',
+            builder: (_, _) => const Scaffold(body: Text('agent detail')),
+          ),
+        ],
+      );
+      return ProviderScope(
+        overrides: [
+          agentsProvider.overrideWith(() => _FakeAgentsNotifier(state)),
+        ],
+        child: MaterialApp.router(routerConfig: router),
+      );
+    }
+
+    testWidgets('shows empty state when no agents', (tester) async {
+      await tester.pumpWidget(buildUnderTest(state: const AgentsState()));
+      await tester.pump();
+
+      expect(find.text('No agents registered'), findsOneWidget);
+    });
+
+    testWidgets('renders agent rows for each agent in state', (tester) async {
+      final state = AgentsState(
+        agents: [_agent('a1', 'Alpha Bot'), _agent('a2', 'Beta Bot')],
+      );
+      await tester.pumpWidget(buildUnderTest(state: state));
+      await tester.pump();
+
+      expect(find.text('Alpha Bot'), findsOneWidget);
+      expect(find.text('Beta Bot'), findsOneWidget);
+    });
+
+    testWidgets('shows skill count in subtitle', (tester) async {
+      final state = AgentsState(
+        agents: [_agent('a1', 'My Agent', skillCount: 3)],
+      );
+      await tester.pumpWidget(buildUnderTest(state: state));
+      await tester.pump();
+
+      expect(find.textContaining('3 skills'), findsOneWidget);
+    });
+
+    testWidgets('shows singular skill label when skillCount is 1', (
+      tester,
+    ) async {
+      final state = AgentsState(
+        agents: [_agent('a1', 'Solo Agent', skillCount: 1)],
+      );
+      await tester.pumpWidget(buildUnderTest(state: state));
+      await tester.pump();
+
+      expect(find.textContaining('1 skill'), findsOneWidget);
+      expect(find.textContaining('1 skills'), findsNothing);
+    });
+
+    testWidgets('shows Default badge for default agent', (tester) async {
+      final state = AgentsState(
+        agents: [_agent('a1', 'Default Agent', isDefault: true)],
+      );
+      await tester.pumpWidget(buildUnderTest(state: state));
+      await tester.pump();
+
+      expect(find.text('Default'), findsOneWidget);
+    });
+
+    testWidgets('shows error view when state has error', (tester) async {
+      final state = AgentsState(error: 'Connection refused');
+      await tester.pumpWidget(buildUnderTest(state: state));
+      await tester.pump();
+
+      expect(find.text('Connection refused'), findsOneWidget);
+      expect(find.text('Retry'), findsOneWidget);
+    });
+
+    testWidgets('tapping an agent row navigates to agent detail', (
+      tester,
+    ) async {
+      final state = AgentsState(agents: [_agent('agent-xyz', 'Nav Agent')]);
+      await tester.pumpWidget(buildUnderTest(state: state));
+      await tester.pump();
+
+      await tester.tap(find.text('Nav Agent'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('agent detail'), findsOneWidget);
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+
+AgentSummary _agent(
+  String id,
+  String name, {
+  int skillCount = 2,
+  bool isDefault = false,
+  String version = '1.0',
+}) => AgentSummary(
+  (b) => b
+    ..id = id
+    ..name = name
+    ..description = 'Test agent $name'
+    ..skillCount = skillCount
+    ..interfaceCount = 0
+    ..isDefault = isDefault
+    ..version = version,
+);
+
+// ---------------------------------------------------------------------------
+// Fake notifier
+
+class _FakeAgentsNotifier extends AgentsNotifier {
+  _FakeAgentsNotifier(this._state);
+  final AgentsState _state;
+
+  @override
+  Future<AgentsState> build() async => _state;
+}

--- a/app/test/widget/features/analytics/analytics_screen_test.dart
+++ b/app/test/widget/features/analytics/analytics_screen_test.dart
@@ -1,0 +1,142 @@
+import 'package:assistant_api/assistant_api.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:assistant_app/features/analytics/analytics_provider.dart';
+import 'package:assistant_app/features/analytics/analytics_screen.dart';
+
+void main() {
+  group('AnalyticsScreen', () {
+    Widget buildUnderTest({required AnalyticsState state}) {
+      final router = GoRouter(
+        routes: [
+          GoRoute(path: '/', builder: (_, _) => const AnalyticsScreen()),
+        ],
+      );
+      return ProviderScope(
+        overrides: [
+          analyticsProvider.overrideWith(() => _FakeAnalyticsNotifier(state)),
+        ],
+        child: MaterialApp.router(routerConfig: router),
+      );
+    }
+
+    testWidgets('shows no-data message when summary is null', (tester) async {
+      await tester.pumpWidget(buildUnderTest(state: const AnalyticsState()));
+      await tester.pump();
+
+      expect(find.text('No analytics data'), findsOneWidget);
+    });
+
+    testWidgets('shows time window chips', (tester) async {
+      await tester.pumpWidget(buildUnderTest(state: const AnalyticsState()));
+      await tester.pump();
+
+      expect(find.text('1h'), findsOneWidget);
+      expect(find.text('24h'), findsOneWidget);
+      expect(find.text('7d'), findsOneWidget);
+    });
+
+    testWidgets('renders summary cards when data is present', (tester) async {
+      final state = AnalyticsState(summary: _summary(requests: 42));
+      await tester.pumpWidget(buildUnderTest(state: state));
+      await tester.pump();
+
+      expect(find.text('42'), findsOneWidget);
+      expect(find.text('Requests'), findsOneWidget);
+    });
+
+    testWidgets('formats large token counts with k suffix', (tester) async {
+      final state = AnalyticsState(summary: _summary(tokensIn: 15000));
+      await tester.pumpWidget(buildUnderTest(state: state));
+      await tester.pump();
+
+      expect(find.text('15.0k'), findsOneWidget);
+    });
+
+    testWidgets('shows model breakdown section when models present', (
+      tester,
+    ) async {
+      final model = ModelUsageResponse(
+        (b) => b
+          ..model = 'claude-3'
+          ..requestCount = 5
+          ..inputTokens = 100
+          ..outputTokens = 200
+          ..avgDurationS = 1.0,
+      );
+      final state = AnalyticsState(summary: _summary(models: [model]));
+      await tester.pumpWidget(buildUnderTest(state: state));
+      await tester.pump();
+
+      expect(find.text('Model Breakdown', skipOffstage: false), findsOneWidget);
+      expect(find.text('claude-3', skipOffstage: false), findsOneWidget);
+    });
+
+    testWidgets('shows tool usage section when tools present', (tester) async {
+      final tool = ToolUsageResponse(
+        (b) => b
+          ..toolName = 'file-read'
+          ..invocations = 7
+          ..avgDurationS = 0.2,
+      );
+      final state = AnalyticsState(summary: _summary(tools: [tool]));
+      await tester.pumpWidget(buildUnderTest(state: state));
+      await tester.pump();
+
+      expect(find.text('Tool Usage', skipOffstage: false), findsOneWidget);
+      expect(find.text('file-read', skipOffstage: false), findsOneWidget);
+    });
+
+    testWidgets('shows error view when state has error', (tester) async {
+      final state = AnalyticsState(error: 'Analytics unavailable');
+      await tester.pumpWidget(buildUnderTest(state: state));
+      await tester.pump();
+
+      expect(find.text('Analytics unavailable'), findsOneWidget);
+      expect(find.text('Retry'), findsOneWidget);
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+
+AnalyticsSummaryResponse _summary({
+  int requests = 0,
+  int tokensIn = 0,
+  int tokensOut = 0,
+  int toolInvocations = 0,
+  int errors = 0,
+  double avgDuration = 0.0,
+  List<ModelUsageResponse> models = const [],
+  List<ToolUsageResponse> tools = const [],
+}) => AnalyticsSummaryResponse(
+  (b) => b
+    ..totalRequests = requests
+    ..totalTokensIn = tokensIn
+    ..totalTokensOut = tokensOut
+    ..totalToolInvocations = toolInvocations
+    ..errorCount = errors
+    ..avgDurationS = avgDuration
+    ..windowHours = 24
+    ..uniqueModels = ListBuilder<String>()
+    ..models = ListBuilder<ModelUsageResponse>(models)
+    ..tools = ListBuilder<ToolUsageResponse>(tools)
+    ..requestSeries = ListBuilder<TimeSeriesResponse>()
+    ..tokenSeries = ListBuilder<TimeSeriesResponse>(),
+);
+
+// ---------------------------------------------------------------------------
+// Fake notifier
+
+class _FakeAnalyticsNotifier extends AnalyticsNotifier {
+  _FakeAnalyticsNotifier(this._state);
+  final AnalyticsState _state;
+
+  @override
+  Future<AnalyticsState> build() async => _state;
+}

--- a/app/test/widget/features/personas/personas_screen_test.dart
+++ b/app/test/widget/features/personas/personas_screen_test.dart
@@ -1,0 +1,135 @@
+import 'package:assistant_api/assistant_api.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:assistant_app/features/personas/personas_provider.dart';
+import 'package:assistant_app/features/personas/personas_screen.dart';
+
+void main() {
+  group('PersonasScreen', () {
+    Widget buildUnderTest({required PersonasState state}) {
+      final router = GoRouter(
+        routes: [
+          GoRoute(path: '/', builder: (_, _) => const PersonasScreen()),
+          GoRoute(
+            path: '/personas/new',
+            builder: (_, _) => const Scaffold(body: Text('create persona')),
+          ),
+          GoRoute(
+            path: '/personas/:personaId',
+            builder: (_, _) => const Scaffold(body: Text('persona detail')),
+          ),
+        ],
+      );
+      return ProviderScope(
+        overrides: [
+          personasProvider.overrideWith(() => _FakePersonasNotifier(state)),
+        ],
+        child: MaterialApp.router(routerConfig: router),
+      );
+    }
+
+    testWidgets('shows empty state when no personas', (tester) async {
+      await tester.pumpWidget(buildUnderTest(state: const PersonasState()));
+      await tester.pump();
+
+      expect(find.text('No personas found'), findsOneWidget);
+    });
+
+    testWidgets('renders persona rows for each persona in state', (
+      tester,
+    ) async {
+      final state = PersonasState(
+        personas: [_persona('p1', 'Alice'), _persona('p2', 'Bob')],
+      );
+      await tester.pumpWidget(buildUnderTest(state: state));
+      await tester.pump();
+
+      expect(find.text('Alice'), findsOneWidget);
+      expect(find.text('Bob'), findsOneWidget);
+    });
+
+    testWidgets('shows persona id as subtitle', (tester) async {
+      final state = PersonasState(
+        personas: [_persona('persona-abc', 'Charlie')],
+      );
+      await tester.pumpWidget(buildUnderTest(state: state));
+      await tester.pump();
+
+      expect(find.text('persona-abc'), findsOneWidget);
+    });
+
+    testWidgets('shows Default badge for default persona', (tester) async {
+      final state = PersonasState(
+        personas: [_persona('p1', 'Default Persona', isDefault: true)],
+      );
+      await tester.pumpWidget(buildUnderTest(state: state));
+      await tester.pump();
+
+      expect(find.text('Default'), findsOneWidget);
+    });
+
+    testWidgets('filters personas by search query', (tester) async {
+      final state = PersonasState(
+        personas: [_persona('p1', 'Alice'), _persona('p2', 'Bob')],
+      );
+      await tester.pumpWidget(buildUnderTest(state: state));
+      await tester.pump();
+
+      await tester.enterText(find.byType(TextField), 'ali');
+      await tester.pump();
+
+      expect(find.text('Alice'), findsOneWidget);
+      expect(find.text('Bob'), findsNothing);
+    });
+
+    testWidgets('shows error view when state has error', (tester) async {
+      final state = PersonasState(error: 'Connection refused');
+      await tester.pumpWidget(buildUnderTest(state: state));
+      await tester.pump();
+
+      expect(find.text('Connection refused'), findsOneWidget);
+      expect(find.text('Retry'), findsOneWidget);
+    });
+
+    testWidgets('tapping a persona row navigates to persona detail', (
+      tester,
+    ) async {
+      final state = PersonasState(
+        personas: [_persona('persona-xyz', 'Nav Persona')],
+      );
+      await tester.pumpWidget(buildUnderTest(state: state));
+      await tester.pump();
+
+      await tester.tap(find.text('Nav Persona'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('persona detail'), findsOneWidget);
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+
+PersonaSummary _persona(String id, String name, {bool isDefault = false}) =>
+    PersonaSummary(
+      (b) => b
+        ..id = id
+        ..name = name
+        ..description = 'Test persona $name'
+        ..isDefault = isDefault,
+    );
+
+// ---------------------------------------------------------------------------
+// Fake notifier
+
+class _FakePersonasNotifier extends PersonasNotifier {
+  _FakePersonasNotifier(this._state);
+  final PersonasState _state;
+
+  @override
+  Future<PersonasState> build() async => _state;
+}

--- a/app/test/widget/features/skills/skills_screen_test.dart
+++ b/app/test/widget/features/skills/skills_screen_test.dart
@@ -1,0 +1,166 @@
+import 'package:assistant_api/assistant_api.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:assistant_app/features/personas/personas_provider.dart';
+import 'package:assistant_app/features/skills/skills_provider.dart';
+import 'package:assistant_app/features/skills/skills_screen.dart';
+
+void main() {
+  group('SkillsScreen', () {
+    Widget buildUnderTest({
+      required SkillsState skillsState,
+      PersonasState? personasState,
+    }) {
+      final router = GoRouter(
+        routes: [
+          GoRoute(path: '/', builder: (_, _) => const SkillsScreen()),
+          GoRoute(
+            path: '/chat',
+            builder: (_, _) => const Scaffold(body: Text('chat')),
+          ),
+          GoRoute(
+            path: '/skills/new',
+            builder: (_, _) => const Scaffold(body: Text('new skill')),
+          ),
+          GoRoute(
+            path: '/skills/:skillName',
+            builder: (_, _) => const Scaffold(body: Text('skill detail')),
+          ),
+        ],
+      );
+      return ProviderScope(
+        overrides: [
+          skillsProvider.overrideWith(() => _FakeSkillsNotifier(skillsState)),
+          personasProvider.overrideWith(
+            () => _FakePersonasNotifier(personasState ?? const PersonasState()),
+          ),
+        ],
+        child: MaterialApp.router(routerConfig: router),
+      );
+    }
+
+    testWidgets('shows empty state when no skills', (tester) async {
+      await tester.pumpWidget(buildUnderTest(skillsState: const SkillsState()));
+      await tester.pump();
+
+      expect(find.text('No skills configured'), findsOneWidget);
+    });
+
+    testWidgets('renders skill rows for each skill in state', (tester) async {
+      final skillsState = SkillsState(
+        skills: [
+          _skill('bash', 'Run shell commands'),
+          _skill('file-read', 'Read files'),
+        ],
+      );
+      await tester.pumpWidget(buildUnderTest(skillsState: skillsState));
+      await tester.pump();
+
+      expect(find.text('bash'), findsOneWidget);
+      expect(find.text('file-read'), findsOneWidget);
+    });
+
+    testWidgets('shows Enabled badge for enabled skill', (tester) async {
+      final skillsState = SkillsState(
+        skills: [_skill('bash', 'desc', enabled: true)],
+      );
+      await tester.pumpWidget(buildUnderTest(skillsState: skillsState));
+      await tester.pump();
+
+      expect(find.text('Enabled'), findsOneWidget);
+    });
+
+    testWidgets('shows Disabled badge for disabled skill', (tester) async {
+      final skillsState = SkillsState(
+        skills: [_skill('bash', 'desc', enabled: false)],
+      );
+      await tester.pumpWidget(buildUnderTest(skillsState: skillsState));
+      await tester.pump();
+
+      expect(find.text('Disabled'), findsOneWidget);
+    });
+
+    testWidgets('shows active persona name in app bar title', (tester) async {
+      final persona = PersonaSummary(
+        (b) => b
+          ..id = 'p1'
+          ..name = 'Ada'
+          ..description = ''
+          ..isDefault = true,
+      );
+      final personasState = PersonasState(
+        personas: [persona],
+        activePersona: persona,
+      );
+      await tester.pumpWidget(
+        buildUnderTest(
+          skillsState: const SkillsState(),
+          personasState: personasState,
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Skills — Ada'), findsOneWidget);
+    });
+
+    testWidgets('shows error view when state has error', (tester) async {
+      final skillsState = SkillsState(error: 'Skills unavailable');
+      await tester.pumpWidget(buildUnderTest(skillsState: skillsState));
+      await tester.pump();
+
+      expect(find.text('Skills unavailable'), findsOneWidget);
+      expect(find.text('Retry'), findsOneWidget);
+    });
+
+    testWidgets('tapping skill detail icon navigates to skill detail', (
+      tester,
+    ) async {
+      final skillsState = SkillsState(
+        skills: [_skill('my-skill', 'Do things')],
+      );
+      await tester.pumpWidget(buildUnderTest(skillsState: skillsState));
+      await tester.pump();
+
+      await tester.tap(find.byIcon(Icons.arrow_forward_ios));
+      await tester.pumpAndSettle();
+
+      expect(find.text('skill detail'), findsOneWidget);
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+
+SkillEntryResponse _skill(
+  String name,
+  String description, {
+  bool enabled = true,
+}) => SkillEntryResponse(
+  (b) => b
+    ..name = name
+    ..description = description
+    ..enabled = enabled,
+);
+
+// ---------------------------------------------------------------------------
+// Fake notifiers
+
+class _FakeSkillsNotifier extends SkillsNotifier {
+  _FakeSkillsNotifier(this._state);
+  final SkillsState _state;
+
+  @override
+  Future<SkillsState> build() async => _state;
+}
+
+class _FakePersonasNotifier extends PersonasNotifier {
+  _FakePersonasNotifier(this._state);
+  final PersonasState _state;
+
+  @override
+  Future<PersonasState> build() async => _state;
+}

--- a/app/test/widget/features/webhooks/webhooks_screen_test.dart
+++ b/app/test/widget/features/webhooks/webhooks_screen_test.dart
@@ -1,0 +1,162 @@
+import 'package:assistant_api/assistant_api.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:assistant_app/features/webhooks/webhooks_provider.dart';
+import 'package:assistant_app/features/webhooks/webhooks_screen.dart';
+
+void main() {
+  group('WebhooksScreen', () {
+    Widget buildUnderTest({required WebhooksState state}) {
+      final router = GoRouter(
+        routes: [
+          GoRoute(path: '/', builder: (_, _) => const WebhooksScreen()),
+          GoRoute(
+            path: '/webhooks/:webhookId',
+            builder: (_, _) => const Scaffold(body: Text('webhook detail')),
+          ),
+        ],
+      );
+      return ProviderScope(
+        overrides: [
+          webhooksProvider.overrideWith(() => _FakeWebhooksNotifier(state)),
+        ],
+        child: MaterialApp.router(routerConfig: router),
+      );
+    }
+
+    testWidgets('shows empty state when no webhooks', (tester) async {
+      await tester.pumpWidget(buildUnderTest(state: const WebhooksState()));
+      await tester.pump();
+
+      expect(find.text('No webhooks configured'), findsOneWidget);
+    });
+
+    testWidgets('renders webhook rows for each webhook in state', (
+      tester,
+    ) async {
+      final state = WebhooksState(
+        webhooks: [
+          _webhook('w1', 'My Hook', 'https://example.com/hook'),
+          _webhook('w2', 'Other Hook', 'https://other.com/hook'),
+        ],
+      );
+      await tester.pumpWidget(buildUnderTest(state: state));
+      await tester.pump();
+
+      expect(find.text('My Hook'), findsOneWidget);
+      expect(find.text('Other Hook'), findsOneWidget);
+    });
+
+    testWidgets('shows webhook url as subtitle', (tester) async {
+      final state = WebhooksState(
+        webhooks: [_webhook('w1', 'Hook', 'https://example.com/callback')],
+      );
+      await tester.pumpWidget(buildUnderTest(state: state));
+      await tester.pump();
+
+      expect(find.text('https://example.com/callback'), findsOneWidget);
+    });
+
+    testWidgets('shows Active badge for active webhook', (tester) async {
+      final state = WebhooksState(
+        webhooks: [
+          _webhook('w1', 'Active Hook', 'https://a.com', active: true),
+        ],
+      );
+      await tester.pumpWidget(buildUnderTest(state: state));
+      await tester.pump();
+
+      expect(find.text('Active'), findsOneWidget);
+    });
+
+    testWidgets('shows Inactive badge for inactive webhook', (tester) async {
+      final state = WebhooksState(
+        webhooks: [
+          _webhook('w1', 'Inactive Hook', 'https://a.com', active: false),
+        ],
+      );
+      await tester.pumpWidget(buildUnderTest(state: state));
+      await tester.pump();
+
+      expect(find.text('Inactive'), findsOneWidget);
+    });
+
+    testWidgets('shows verified icon for verified webhook', (tester) async {
+      final state = WebhooksState(
+        webhooks: [
+          _webhook(
+            'w1',
+            'Verified Hook',
+            'https://a.com',
+            verifiedAt: DateTime(2024, 1, 1),
+          ),
+        ],
+      );
+      await tester.pumpWidget(buildUnderTest(state: state));
+      await tester.pump();
+
+      expect(find.byIcon(Icons.verified_outlined), findsOneWidget);
+    });
+
+    testWidgets('shows error view when state has error', (tester) async {
+      final state = WebhooksState(error: 'Server unreachable');
+      await tester.pumpWidget(buildUnderTest(state: state));
+      await tester.pump();
+
+      expect(find.text('Server unreachable'), findsOneWidget);
+      expect(find.text('Retry'), findsOneWidget);
+    });
+
+    testWidgets('tapping a webhook row navigates to webhook detail', (
+      tester,
+    ) async {
+      final state = WebhooksState(
+        webhooks: [_webhook('hook-abc', 'Nav Hook', 'https://nav.com')],
+      );
+      await tester.pumpWidget(buildUnderTest(state: state));
+      await tester.pump();
+
+      await tester.tap(find.text('Nav Hook'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('webhook detail'), findsOneWidget);
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+
+WebhookResponse _webhook(
+  String id,
+  String name,
+  String url, {
+  bool active = true,
+  DateTime? verifiedAt,
+}) => WebhookResponse(
+  (b) => b
+    ..id = id
+    ..name = name
+    ..url = url
+    ..active = active
+    ..secret = 'secret'
+    ..eventTypes = ListBuilder<String>(['message'])
+    ..createdAt = DateTime(2024, 1, 1)
+    ..updatedAt = DateTime(2024, 1, 1)
+    ..verifiedAt = verifiedAt,
+);
+
+// ---------------------------------------------------------------------------
+// Fake notifier
+
+class _FakeWebhooksNotifier extends WebhooksNotifier {
+  _FakeWebhooksNotifier(this._state);
+  final WebhooksState _state;
+
+  @override
+  Future<WebhooksState> build() async => _state;
+}

--- a/app/test/widget/router/context_redirect_test.dart
+++ b/app/test/widget/router/context_redirect_test.dart
@@ -7,6 +7,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:assistant_app/api/capabilities_provider.dart';
 import 'package:assistant_app/api/models/server_capabilities.dart';
+import 'package:assistant_app/features/connection/connection_provider.dart';
 import 'package:assistant_app/features/contexts/data/context_repository.dart';
 import 'package:assistant_app/features/contexts/models/context_model.dart';
 import 'package:assistant_app/features/contexts/providers/context_providers.dart';
@@ -40,6 +41,9 @@ Widget buildApp(ContextRepository repo) {
       capabilitiesProvider.overrideWith(
         (ref) async => ServerCapabilities.disabled,
       ),
+      // Prevent feature notifiers from firing real Dio HTTP requests.
+      // These are routing tests — API responses are irrelevant here.
+      apiClientProvider.overrideWithValue(null),
     ],
     child: Consumer(
       builder: (context, ref, child) {

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,13 +1,73 @@
+---
 schema: spec-driven
 
 # Project context (optional)
 # This is shown to AI when creating artifacts.
 # Add your tech stack, conventions, style guides, domain knowledge, etc.
-# Example:
-#   context: |
-#     Tech stack: TypeScript, React, Node.js
-#     We use conventional commits
-#     Domain: e-commerce platform
+context: |
+  Tech stack: Flutter for app, Rust for backend
+  We use conventional commits
+  Domain: AI assistant platform
+    (personas, skills, conversations, workflows, webhooks, agents)
+
+  ## API design
+
+  All HTTP APIs must follow REST principles and MUST be documented
+  in OpenAPI format.
+  All routes live under /api/ with no version segment.
+
+  ### Response shapes
+  Every resource uses a two-type split:
+  - `*Summary` — flat projection, no nested collections; used in list
+    responses
+  - `*Detail` — full object with nested children; used in single-item
+    GET responses
+  - `*Response` — direct DB row projection
+    (e.g. TraceSummaryResponse, LogEntryResponse)
+  - `*Request` — request body named `{Verb}{Resource}Request`
+    (e.g. CreateConversationRequest)
+
+  ### HTTP status codes
+  - POST (create) → 201 with created body
+  - DELETE → 204 with no body
+  - PATCH (partial update) → 200 with full updated object
+  - PUT (full replace) → 200 with updated object
+  - Duplicate create → 409 Conflict
+  - Input validation failure → 400 Bad Request
+  - Feature not configured (TTS, transcription, etc.)
+    → 503 Service Unavailable
+  - Payload too large → 413 Payload Too Large
+
+  ### Error responses
+  All error responses use the JSON envelope: {"error": "...message..."}
+  Never return plain string bodies or different error shapes.
+
+  ### List endpoints
+  Return a bare JSON array — never a paginated envelope like
+  {"items": [...], "total": N}.
+  Use limit/offset query params only where pagination is needed.
+
+  ### URL patterns
+  - Nested resources: /api/{resource}/{id}/{sub-resource}
+  - Non-CRUD actions: POST /api/{resource}/{id}/{verb-phrase}
+    Examples: /api/agents/{id}/set-default,
+              /api/personas/active,
+              /api/workflows/{id}/activate
+
+  ### Field conventions
+  - All JSON field names are snake_case
+  - Timestamps are always format: date-time (RFC 3339),
+    never epoch integers
+  - Optional fields that are absent are omitted entirely
+    (not serialized as null). Only use nullable when null carries
+    distinct meaning from absence.
+  - All UUID IDs must be documented with format: uuid in the schema
+
+  ### operationId
+  Always snake_case, pattern {verb}_{noun} or
+  {verb}_{noun}_{subresource}.
+  Examples: list_conversations, create_persona,
+            set_default_agent, list_workflow_runs
 
 # Per-artifact rules (optional)
 # Add custom rules for specific artifacts.


### PR DESCRIPTION
## Summary

- **Root cause**: All async notifiers called `ref.read(apiClientProvider)` inside `build()` — a one-shot snapshot. When the active context is still loading, the client is null and the provider caches an empty state with no mechanism to rebuild. This is why the chat list (and every other screen) shows blank on first load but works after navigating away and back.
- **Fix**: Switch every affected notifier to `ref.watch(apiClientProvider)` in `build()`, so Riverpod re-runs `build()` and fetches data the moment the context finishes loading.
- **Deep-link fix**: `chat_screen.dart` also gets a `ref.listen(apiClientProvider, ...)` callback that retries `loadConversation()` when the client transitions null → non-null, fixing the case where reloading a deep link into a conversation was a no-op.
- **`apiClientProvider` centralised** in `connection_provider.dart` (was in `chat_provider.dart`) so all features import from one place.

Providers fixed (11 notifiers across 9 files):
`ConversationListNotifier`, `AgentsNotifier`, `AgentDetailNotifier`, `AnalyticsNotifier`, `LogsNotifier`, `PersonasNotifier`, `PersonaDetailNotifier`, `SkillsNotifier`, `SkillDetailNotifier`, `TracesNotifier`, `TraceDetailNotifier`, `WebhooksNotifier`, `WebhookDetailNotifier`, `WorkflowsNotifier`, `WorkflowDetailNotifier`, `WorkflowRunDetailNotifier`

## Tests added

| File | Count | What it covers |
|---|---|---|
| `unit/chat/conversation_list_provider_test.dart` | 9 | Provider behaviour incl. **regression test** for null→non-null apiClient rebuild |
| `widget/features/agents/agents_screen_test.dart` | 7 | Empty, rows, skill count, Default badge, error, navigation |
| `widget/features/analytics/analytics_screen_test.dart` | 7 | No-data, chips, summary cards, k-suffix, model table, tool table, error |
| `widget/features/personas/personas_screen_test.dart` | 7 | Empty, rows, subtitle, Default badge, search filter, error, navigation |
| `widget/features/skills/skills_screen_test.dart` | 7 | Empty, rows, Enabled/Disabled badges, persona name in title, error, navigation |
| `widget/features/webhooks/webhooks_screen_test.dart` | 8 | Empty, rows, url subtitle, Active/Inactive, verified icon, error, navigation |

## Test plan

- [x] `flutter test` passes (all 36 new tests + existing suite green)
- [x] `flutter analyze` clean
- [x] Manually verify chat list loads on first web page access without navigating away
- [x] Manually verify deep-link reload to a single conversation works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactoring**
  * Centralized API client management for improved consistency across features and better handling of connection state transitions.

* **Tests**
  * Added comprehensive unit and widget test coverage for conversations, agents, analytics, personas, skills, and webhooks features.

* **Chores**
  * Updated dependency constraints and quote styling in project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->