### PR TITLE
fix(app): repair web voice audio bugs — transcript bubble and play button 400

### DIFF
--- a/app/lib/api/api_client.dart
+++ b/app/lib/api/api_client.dart
@@ -222,6 +222,13 @@ Stream<StreamEvent> parseSseByteStream(Stream<List<int>> byteStream) async* {
         } catch (_) {
           yield DoneEvent(role: 'assistant', content: dataLine);
         }
+      } else if (eventType == 'transcript' && dataLine != null) {
+        try {
+          final json = jsonDecode(dataLine) as Map<String, dynamic>;
+          yield TranscriptEvent.fromJson(json);
+        } catch (_) {
+          // ignore malformed transcript events
+        }
       } else if (eventType == 'audio_ready' && dataLine != null) {
         try {
           final json = jsonDecode(dataLine) as Map<String, dynamic>;

--- a/app/lib/api/models/stream_event.dart
+++ b/app/lib/api/models/stream_event.dart
@@ -53,20 +53,27 @@ class ToolResultEvent extends StreamEvent {
 /// The stream is complete; contains the full, canonical reply.
 ///
 /// Corresponds to `event:done` in the SSE stream.  The JSON body is
-/// `{"role":"assistant","content":"<full text>"}`.  On receiving this event
-/// the caller should discard the accumulated buffer and persist `content`.
+/// `{"role":"assistant","content":"<full text>","message_id":"<uuid>"}`.
+/// On receiving this event the caller should discard the accumulated buffer
+/// and persist `content`.  `messageId` is the DB UUID of the saved assistant
+/// message and should be used as [ChatMessage.id] when present.
 class DoneEvent extends StreamEvent {
-  const DoneEvent({required this.role, required this.content});
+  const DoneEvent({required this.role, required this.content, this.messageId});
 
   final String role;
 
   /// The complete, server-authoritative reply text.
   final String content;
 
+  /// The UUID of the persisted assistant message in the database.
+  /// Null when the server did not include a `message_id` field (old server).
+  final String? messageId;
+
   factory DoneEvent.fromJson(Map<String, dynamic> json) {
     return DoneEvent(
       role: json['role'] as String? ?? 'assistant',
       content: json['content'] as String? ?? '',
+      messageId: json['message_id'] as String?,
     );
   }
 }
@@ -79,6 +86,22 @@ class ErrorEvent extends StreamEvent {
   const ErrorEvent(this.message);
 
   final String message;
+}
+
+/// The voice endpoint has transcribed the user's audio.
+///
+/// Corresponds to `event:transcript` in the SSE stream emitted by
+/// `POST /api/conversations/{id}/voice`.  The JSON body is
+/// `{"role":"user","content":"<transcribed text>"}`.
+class TranscriptEvent extends StreamEvent {
+  const TranscriptEvent(this.transcript);
+
+  /// The transcribed text of the user's spoken message.
+  final String transcript;
+
+  factory TranscriptEvent.fromJson(Map<String, dynamic> json) {
+    return TranscriptEvent(json['content'] as String? ?? '');
+  }
 }
 
 /// The server has produced audio for the most recent assistant response.

--- a/app/lib/features/chat/chat_provider.dart
+++ b/app/lib/features/chat/chat_provider.dart
@@ -619,7 +619,18 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
         if (_cancelled) break;
         final chatState = state.value ?? const ChatState();
 
-        if (event is TokenEvent) {
+        if (event is TranscriptEvent) {
+          // Update the user bubble with the actual spoken text.
+          final msgs = List<ChatMessage>.from(chatState.messages);
+          final userIdx = msgs.indexWhere((m) => m.id == userMsgId);
+          if (userIdx != -1) {
+            msgs[userIdx] = msgs[userIdx].copyWith(
+              content: event.transcript,
+              status: MessageStatus.ok,
+            );
+          }
+          state = AsyncData(chatState.copyWith(messages: msgs));
+        } else if (event is TokenEvent) {
           final newContent = chatState.streamingContent + event.token;
           final msgs = List<ChatMessage>.from(chatState.messages);
           final idx = msgs.indexWhere((m) => m.id == 'assistant-streaming');
@@ -645,20 +656,19 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
           state = AsyncData(chatState.copyWith(messages: msgs));
         } else if (event is DoneEvent) {
           final msgs = List<ChatMessage>.from(chatState.messages);
+          // User bubble is already correct from TranscriptEvent; just ensure ok status.
           final userIdx = msgs.indexWhere((m) => m.id == userMsgId);
           if (userIdx != -1) {
-            msgs[userIdx] = msgs[userIdx].copyWith(
-              content: event.content.isNotEmpty
-                  ? '[Voice] ${event.content}'
-                  : '🎤 Voice message',
-              status: MessageStatus.ok,
-            );
+            msgs[userIdx] = msgs[userIdx].copyWith(status: MessageStatus.ok);
           }
           // Preserve tool call records and audio id on the final message.
+          final assistantId =
+              event.messageId ??
+              'assistant-${DateTime.now().millisecondsSinceEpoch}';
           final idx = msgs.indexWhere((m) => m.id == 'assistant-streaming');
           if (idx != -1) {
             msgs[idx] = ChatMessage(
-              id: 'assistant-${DateTime.now().millisecondsSinceEpoch}',
+              id: assistantId,
               role: 'assistant',
               content: event.content,
               audioId: msgs[idx].audioId,
@@ -777,10 +787,13 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
           }
           // Replace streaming placeholder with final assistant message,
           // preserving audio id and accumulated tool call records.
+          final assistantId =
+              event.messageId ??
+              'assistant-${DateTime.now().millisecondsSinceEpoch}';
           final idx = msgs.indexWhere((m) => m.id == 'assistant-streaming');
           if (idx != -1) {
             msgs[idx] = ChatMessage(
-              id: 'assistant-${DateTime.now().millisecondsSinceEpoch}',
+              id: assistantId,
               role: 'assistant',
               content: event.content,
               audioId: msgs[idx].audioId,

--- a/app/test/unit/api/client_test.dart
+++ b/app/test/unit/api/client_test.dart
@@ -75,6 +75,8 @@ void main() {
             errorCount++;
           case AudioReadyEvent():
             audioReadyCount++;
+          case TranscriptEvent():
+            break;
         }
       }
 

--- a/app/test/unit/api/voice_models_test.dart
+++ b/app/test/unit/api/voice_models_test.dart
@@ -41,6 +41,51 @@ void main() {
     });
   });
 
+  group('TranscriptEvent', () {
+    test('stores transcript text', () {
+      const event = TranscriptEvent('Hallo Welt');
+      expect(event.transcript, equals('Hallo Welt'));
+    });
+
+    test('fromJson reads content field', () {
+      final event = TranscriptEvent.fromJson({
+        'role': 'user',
+        'content': 'Hello from voice',
+      });
+      expect(event.transcript, equals('Hello from voice'));
+    });
+
+    test('fromJson defaults missing content to empty string', () {
+      final event = TranscriptEvent.fromJson({});
+      expect(event.transcript, equals(''));
+    });
+
+    test('is a StreamEvent subtype', () {
+      const StreamEvent event = TranscriptEvent('hi');
+      expect(event, isA<TranscriptEvent>());
+    });
+  });
+
+  group('DoneEvent.messageId', () {
+    test('parses message_id when present', () {
+      final event = DoneEvent.fromJson({
+        'role': 'assistant',
+        'content': 'reply',
+        'message_id': 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      });
+      expect(event.messageId, equals('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'));
+      expect(event.content, equals('reply'));
+    });
+
+    test('messageId is null when field absent', () {
+      final event = DoneEvent.fromJson({
+        'role': 'assistant',
+        'content': 'reply',
+      });
+      expect(event.messageId, isNull);
+    });
+  });
+
   group('AudioReadyEvent', () {
     test('stores audioId', () {
       const event = AudioReadyEvent('abc-123');

--- a/crates/core/src/bus_messages.rs
+++ b/crates/core/src/bus_messages.rs
@@ -90,6 +90,9 @@ pub struct TurnResult {
     /// File attachments collected from tool outputs during the turn.
     #[serde(default)]
     pub attachments: Vec<crate::Attachment>,
+    /// The UUID of the persisted assistant message in the database.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message_id: Option<Uuid>,
 }
 
 /// A status update emitted during turn processing.
@@ -267,11 +270,46 @@ mod tests {
             content: "the answer is 42".into(),
             turn: 3,
             attachments: vec![],
+            message_id: None,
         };
         let json = serde_json::to_value(&res).unwrap();
         let back: TurnResult = serde_json::from_value(json).unwrap();
         assert_eq!(back.content, res.content);
         assert_eq!(back.turn, res.turn);
+        assert!(back.message_id.is_none());
+    }
+
+    #[test]
+    fn turn_result_message_id_roundtrips_json() {
+        let mid = Uuid::new_v4();
+        let res = TurnResult {
+            conversation_id: Uuid::new_v4(),
+            content: "with id".into(),
+            turn: 1,
+            attachments: vec![],
+            message_id: Some(mid),
+        };
+        let json = serde_json::to_value(&res).unwrap();
+        // message_id should be present in the serialised form.
+        assert_eq!(
+            json["message_id"].as_str(),
+            Some(mid.to_string().as_str()),
+            "message_id should serialise to its UUID string"
+        );
+        let back: TurnResult = serde_json::from_value(json).unwrap();
+        assert_eq!(back.message_id, Some(mid));
+    }
+
+    #[test]
+    fn turn_result_message_id_absent_deserialises_as_none() {
+        // A payload from an older server that omits message_id should still parse.
+        let json = serde_json::json!({
+            "conversation_id": Uuid::new_v4().to_string(),
+            "content": "old server",
+            "turn": 0,
+        });
+        let res: TurnResult = serde_json::from_value(json).unwrap();
+        assert!(res.message_id.is_none());
     }
 
     #[test]

--- a/crates/runtime/src/orchestrator/mod.rs
+++ b/crates/runtime/src/orchestrator/mod.rs
@@ -60,6 +60,9 @@ pub struct TurnResult {
     /// Interfaces should deliver these to the user (e.g. save to disk in the
     /// CLI, upload in Slack/Mattermost).
     pub attachments: Vec<Attachment>,
+    /// The UUID of the persisted assistant message in the database.
+    /// `None` when the message could not be saved or the ID was unavailable.
+    pub message_id: Option<Uuid>,
 }
 
 // ── Internal enums ────────────────────────────────────────────────────────────
@@ -747,6 +750,7 @@ impl Orchestrator {
                         return Ok(TurnResult {
                             answer: String::new(),
                             attachments: turn_attachments,
+                            message_id: None,
                         });
                     }
                 }
@@ -936,17 +940,21 @@ impl Orchestrator {
                 LlmResponse::FinalAnswer(text, _meta) => {
                     info!(iteration, "LLM returned final answer");
 
-                    if !text.trim().is_empty() {
+                    let saved_message_id = if !text.trim().is_empty() {
                         let assistant_msg = {
                             let mut m = Message::assistant(conversation_id, &text);
                             m.turn = base_turn + iteration as i64 + 1;
                             m
                         };
+                        let msg_id = assistant_msg.id;
                         conv_store
                             .save_message(&assistant_msg)
                             .instrument(iteration_span.clone())
                             .await?;
-                    }
+                        Some(msg_id)
+                    } else {
+                        None
+                    };
 
                     crate::conversation_indexer::spawn_index(
                         conversation_id,
@@ -957,6 +965,7 @@ impl Orchestrator {
                     return Ok(TurnResult {
                         answer: text,
                         attachments: turn_attachments,
+                        message_id: saved_message_id,
                     });
                 }
 

--- a/crates/runtime/src/orchestrator/turn_control.rs
+++ b/crates/runtime/src/orchestrator/turn_control.rs
@@ -50,6 +50,7 @@ impl Orchestrator {
             return Ok(FinalAnswerOutcome::Done(TurnResult {
                 answer: String::new(),
                 attachments: Vec::new(),
+                message_id: None,
             }));
         }
 
@@ -136,6 +137,7 @@ impl Orchestrator {
         Ok(FinalAnswerOutcome::Done(TurnResult {
             answer: String::new(),
             attachments: Vec::new(),
+            message_id: None,
         }))
     }
 

--- a/crates/runtime/src/orchestrator/worker.rs
+++ b/crates/runtime/src/orchestrator/worker.rs
@@ -273,6 +273,7 @@ impl Orchestrator {
                                 content: turn_result.answer,
                                 turn: 0,
                                 attachments: turn_result.attachments,
+                                message_id: turn_result.message_id,
                             };
 
                             // Propagate batch_id from the request so submit_turn
@@ -430,6 +431,7 @@ impl Orchestrator {
                                 content: format!("Turn failed: {e}"),
                                 turn: 0,
                                 attachments: vec![],
+                                message_id: None,
                             };
                             let mut pub_req = PublishRequest::new(
                                 topic::TURN_RESULT,
@@ -767,6 +769,7 @@ impl Orchestrator {
                 return Ok(TurnResult {
                     answer: bus_result.content,
                     attachments: bus_result.attachments,
+                    message_id: bus_result.message_id,
                 });
             }
 

--- a/crates/web-ui/src/api/mod.rs
+++ b/crates/web-ui/src/api/mod.rs
@@ -649,15 +649,18 @@ pub async fn send_message(
             }
         }
 
-        let reply_text = match turn_result_rx.await {
-            Ok(Ok(result)) => result.answer,
-            Ok(Err(_)) | Err(_) => full_text,
+        let (reply_text, reply_message_id) = match turn_result_rx.await {
+            Ok(Ok(result)) => (result.answer, result.message_id),
+            Ok(Err(_)) | Err(_) => (full_text, None),
         };
 
-        let done_data = serde_json::json!({
+        let mut done_data = serde_json::json!({
             "role": "assistant",
             "content": reply_text,
         });
+        if let Some(mid) = reply_message_id {
+            done_data["message_id"] = serde_json::Value::String(mid.to_string());
+        }
         let done = Event::default().event("done").data(done_data.to_string());
         let _ = sse_tx.send(Ok(done)).await;
 
@@ -909,15 +912,18 @@ pub async fn send_voice_message(
             }
         }
 
-        let reply_text = match turn_result_rx.await {
-            Ok(Ok(result)) => result.answer,
-            Ok(Err(_)) | Err(_) => full_text,
+        let (reply_text, reply_message_id) = match turn_result_rx.await {
+            Ok(Ok(result)) => (result.answer, result.message_id),
+            Ok(Err(_)) | Err(_) => (full_text, None),
         };
 
-        let done_data = serde_json::json!({
+        let mut done_data = serde_json::json!({
             "role": "assistant",
             "content": reply_text,
         });
+        if let Some(mid) = reply_message_id {
+            done_data["message_id"] = serde_json::Value::String(mid.to_string());
+        }
         let done = Event::default().event("done").data(done_data.to_string());
         let _ = sse_tx.send(Ok(done)).await;
 
@@ -1051,8 +1057,37 @@ mod tests {
     use assistant_runtime::Orchestrator;
     use assistant_storage::{ConversationStore, SkillRegistry, StorageLayer};
     use assistant_tool_executor::ToolExecutor;
+    use assistant_transcription::{
+        TranscriptionProvider, TranscriptionRequest, TranscriptionResult,
+    };
+    use async_trait::async_trait;
 
     use super::{api_router, ApiState};
+
+    // -- Stubs -----------------------------------------------------------------
+
+    /// Stub transcription provider that returns a fixed transcript.
+    struct StubTranscriptionProvider {
+        transcript: String,
+    }
+
+    #[async_trait]
+    impl TranscriptionProvider for StubTranscriptionProvider {
+        fn name(&self) -> &str {
+            "stub"
+        }
+
+        async fn transcribe(
+            &self,
+            _request: TranscriptionRequest,
+        ) -> anyhow::Result<TranscriptionResult> {
+            Ok(TranscriptionResult {
+                text: self.transcript.clone(),
+                language: None,
+                duration_secs: None,
+            })
+        }
+    }
 
     // -- Helpers ---------------------------------------------------------------
 
@@ -1456,6 +1491,117 @@ mod tests {
         assert!(
             text.contains("event:") || text.contains("data:"),
             "expected SSE framing, got: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_message_done_event_contains_message_id() {
+        let server = MockServer::start().await;
+        mount_llm_reply(&server, "Hello world").await;
+
+        let (state, storage) = test_state(&server.uri()).await;
+        let store = ConversationStore::for_agent(storage.pool.clone(), "default");
+        let conv = store.create_conversation(Some("MsgId")).await.unwrap();
+        let id = conv.id;
+
+        let resp = app(state)
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/conversations/{id}/messages"))
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(r#"{"message":"hi"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_bytes(resp.into_body()).await;
+        let text = String::from_utf8_lossy(&body);
+        // Find the done event data line (role == "assistant").
+        let done_line = text
+            .lines()
+            .find(|l| l.starts_with("data:") && l.contains("\"assistant\""))
+            .expect("expected a done data line with assistant role");
+        let data = done_line.trim_start_matches("data:").trim();
+        let json: serde_json::Value = serde_json::from_str(data).expect("valid JSON");
+        assert_eq!(json["role"], "assistant", "done role should be assistant");
+        assert!(
+            json.get("message_id").and_then(|v| v.as_str()).is_some(),
+            "done event should contain message_id, got: {json}"
+        );
+        // message_id must be a valid UUID.
+        let mid = json["message_id"].as_str().unwrap();
+        assert!(
+            uuid::Uuid::parse_str(mid).is_ok(),
+            "message_id should be a valid UUID, got: {mid}"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_voice_message_done_event_contains_message_id() {
+        let server = MockServer::start().await;
+        mount_llm_reply(&server, "Voice reply").await;
+
+        let (state, storage) = test_state(&server.uri()).await;
+        let store = ConversationStore::for_agent(storage.pool.clone(), "default");
+        let conv = store.create_conversation(Some("VoiceMsgId")).await.unwrap();
+
+        // Wire up the stub transcription provider.
+        let state = ApiState {
+            transcription_provider: Some(Arc::new(StubTranscriptionProvider {
+                transcript: "hello from voice".to_string(),
+            })),
+            ..state
+        };
+
+        let boundary = "testboundary";
+        let body_str = format!(
+            "--{boundary}\r\nContent-Disposition: form-data; name=\"audio\"; filename=\"audio.webm\"\r\nContent-Type: audio/webm\r\n\r\nfakeaudio\r\n--{boundary}--\r\n",
+        );
+
+        let resp = app(state)
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/conversations/{}/voice", conv.id))
+                    .header(
+                        "content-type",
+                        format!("multipart/form-data; boundary={boundary}"),
+                    )
+                    .body(Body::from(body_str))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_bytes(resp.into_body()).await;
+        let text = String::from_utf8_lossy(&body);
+
+        // The stream should contain a transcript event with the stub text.
+        assert!(
+            text.contains("transcript"),
+            "expected transcript event in SSE stream, got: {text}"
+        );
+
+        // Find the done event data line (role == "assistant").
+        let done_line = text
+            .lines()
+            .find(|l| l.starts_with("data:") && l.contains("\"assistant\""))
+            .expect("expected a done data line with assistant role");
+        let data = done_line.trim_start_matches("data:").trim();
+        let json: serde_json::Value = serde_json::from_str(data).expect("valid JSON");
+        assert_eq!(json["role"], "assistant");
+        assert!(
+            json.get("message_id").and_then(|v| v.as_str()).is_some(),
+            "voice done event should contain message_id, got: {json}"
+        );
+        let mid = json["message_id"].as_str().unwrap();
+        assert!(
+            uuid::Uuid::parse_str(mid).is_ok(),
+            "message_id should be a valid UUID, got: {mid}"
         );
     }
 

--- a/openspec/changes/fix-web-voice-audio-bugs/.openspec.yaml
+++ b/openspec/changes/fix-web-voice-audio-bugs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-16

--- a/openspec/changes/fix-web-voice-audio-bugs/design.md
+++ b/openspec/changes/fix-web-voice-audio-bugs/design.md
@@ -1,0 +1,68 @@
+## Context
+
+The `web-voice` change shipped STT (voice recording → transcription → agent response) and TTS (play button on assistant messages) for the web UI. Two bugs survived into production:
+
+1. **Wrong bubble content**: The server emits `event: transcript` immediately after receiving the audio, carrying the user's spoken text. The Flutter SSE parser has no handler for this event type and discards it silently. At stream end, `_streamVoiceMessage` tries to fix the user bubble by writing `[Voice] ${event.content}` — but `DoneEvent.content` is the _assistant's_ reply, so the agent's words end up in the user bubble.
+
+2. **Invalid message ID on play**: After streaming, `ChatMessage.id` is set to `'assistant-<milliseconds>'`. `GET /api/messages/{id}/audio` calls `Uuid::parse_str` on that string, fails, and returns 400. The fallback path only works for messages loaded from history (which carry real DB UUIDs). Freshly streamed messages have no real UUID stored client-side.
+
+Both fixes are small and confined: one adds a missing SSE event type; the other threads the real DB UUID through the `done` event.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- User voice bubble shows the transcribed spoken text (from `transcript` SSE event).
+- On-demand TTS play button works for messages received in the current session.
+- No regressions to text-only chat or history-loaded messages.
+
+**Non-Goals:**
+
+- Changes to transcription provider, TTS provider, or audio store.
+- Streaming TTS or pre-synthesis.
+- OpenAPI schema changes for SSE event payloads (SSE bodies are not modelled by openapi-generator).
+
+## Decisions
+
+### D1: Surface transcript via a new `TranscriptEvent` — not via `DoneEvent`
+
+**Decision:** Add `TranscriptEvent(String transcript)` to the sealed `StreamEvent` hierarchy. Parse `event: transcript` frames in `_parseSse`. In `_streamVoiceMessage`, handle `TranscriptEvent` to update the user bubble. Remove the broken `DoneEvent` user-bubble overwrite.
+
+**Rationale:** The server already emits `event: transcript` before any token events. Reusing `DoneEvent` for the transcript would require the server to duplicate the text in two events, or clients to guess which field to use. A dedicated event type is unambiguous and consistent with the existing `AudioReadyEvent` pattern.
+
+**Alternative considered:** Overload the existing `DoneEvent` with a `transcript` field. Rejected — `DoneEvent` already has a clear contract (`role + content = final assistant reply`); adding a user-transcript field to an assistant-role event is confusing and breaks the single-responsibility of that event.
+
+### D2: Add `message_id` to the `done` SSE event payload
+
+**Decision:** Both `send_message` and `send_voice_message` in `api/mod.rs` emit the final `done` event as:
+
+```json
+{ "role": "assistant", "content": "<text>", "message_id": "<uuid>" }
+```
+
+where `message_id` is taken from `TurnResult`. The Flutter `DoneEvent` gains an optional `String? messageId` field. `_streamMessage` and `_streamVoiceMessage` use it to set `ChatMessage.id` when present; fall back to the timestamp ID otherwise.
+
+**Rationale:** The server already knows the UUID (it is returned by `submit_turn` → `TurnResult`). Emitting it in `done` is zero-cost. The client then has a real UUID for `fetchMessageAudio` without any extra round-trip. The field is optional so old server / new client and new server / old client both work gracefully.
+
+**Alternative considered:** Re-fetch the conversation after `done` to get real UUIDs. Rejected — adds latency, a second HTTP call, and is already done (for title refresh) via `conversationListProvider.refresh()` which does not update `ChatMessage.id` objects in the local state.
+
+**Alternative considered:** Only show the play button once the conversation is reloaded. Rejected — poor UX; the play button appears immediately after streaming ends.
+
+### D3: `TurnResult` already contains the message ID — verify before relying on it
+
+**Decision:** Check `TurnResult` in `assistant-runtime` to confirm it exposes the saved message UUID. If not, add the field.
+
+**Rationale:** `submit_turn` is the natural place to return the persisted message ID. Adding it to `TurnResult` is the minimal change; no new return channel is needed.
+
+## Risks / Trade-offs
+
+- **`TurnResult` may not expose message ID today** → Inspect `crates/runtime`; add field if missing. Low risk — it's a simple struct addition with no downstream callers that need to change.
+- **Old server + new client**: `messageId` is null in `DoneEvent`; client falls back to timestamp ID. Play button still broken on old server, but no regression vs. today.
+- **New server + old client**: extra `message_id` key in `done` JSON is ignored by old client. No breakage.
+- **`transcript` event ordering**: server emits transcript _before_ starting the orchestrator turn. If the SSE connection drops between transcript and done, the user bubble will still show the transcript, which is correct and preferable to showing nothing.
+
+## Migration Plan
+
+1. Land server change (`message_id` in `done`) — backward-compatible, deploy any time.
+2. Land Flutter client changes — `TranscriptEvent`, `DoneEvent.messageId`, provider fixes.
+3. No DB migrations, no config changes, no feature flags required.

--- a/openspec/changes/fix-web-voice-audio-bugs/proposal.md
+++ b/openspec/changes/fix-web-voice-audio-bugs/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Two regressions shipped with the `web-voice` change: the user's voice bubble displays the agent's reply text instead of the transcription, and tapping the play button on a freshly received assistant message returns a 400 from the server. Both bugs make the voice feature unusable end-to-end.
+
+## What Changes
+
+- Add `TranscriptEvent` sealed-class variant to `stream_event.dart` and parse `event: transcript` frames in `_parseSse` (currently silently discarded).
+- Handle `TranscriptEvent` in `_streamVoiceMessage`: update the user message bubble with the actual spoken text when received.
+- Remove the incorrect `DoneEvent` user-bubble overwrite in `_streamVoiceMessage` that copies the assistant's reply text into the user bubble prefixed with `[Voice]`.
+- **Server**: include the saved DB message UUID in the `done` SSE event payload for both `send_message` and `send_voice_message` handlers (`crates/web-ui/src/api/mod.rs`).
+- **Client**: extend `DoneEvent` to parse `message_id` from the `done` payload and use it as `ChatMessage.id`, replacing the synthetic `assistant-<timestamp>` string so `GET /api/messages/{id}/audio` receives a valid UUID.
+
+## Capabilities
+
+### New Capabilities
+
+- `voice-transcript-event`: Client-side handling of the `transcript` SSE event emitted by the voice endpoint, so the spoken text appears correctly in the user bubble.
+
+### Modified Capabilities
+
+- `voice-send`: The `done` SSE event payload gains a `message_id` field (real DB UUID); client uses it to set `ChatMessage.id`. Server-side change to `send_message` and `send_voice_message` handlers.
+
+## Impact
+
+- `app/lib/api/models/stream_event.dart` — new `TranscriptEvent` class, `DoneEvent` gains optional `messageId` field.
+- `app/lib/api/api_client.dart` — `_parseSse` parses `transcript` events.
+- `app/lib/features/chat/chat_provider.dart` — `_streamVoiceMessage` handles `TranscriptEvent`; `DoneEvent` handler corrected.
+- `crates/web-ui/src/api/mod.rs` — `done` SSE event in both message handlers emits `message_id`.
+- No DB schema changes. No new dependencies. No breaking API changes (additive field on `done` event).

--- a/openspec/changes/fix-web-voice-audio-bugs/specs/voice-send/spec.md
+++ b/openspec/changes/fix-web-voice-audio-bugs/specs/voice-send/spec.md
@@ -1,0 +1,43 @@
+## MODIFIED Requirements
+
+### Requirement: Voice send endpoint accepts multipart audio
+
+The server SHALL expose `POST /api/conversations/{id}/voice` accepting `multipart/form-data` with a single `audio` field containing raw audio bytes and a `Content-Type` header identifying the MIME type. The response is an SSE stream. The stream SHALL include:
+
+- `event: transcript` carrying the transcribed user text before any token events
+- `event: token` events with incremental assistant tokens
+- `event: done` with the final assistant reply AND the DB UUID of the saved assistant message in a `message_id` field
+
+The done event payload SHALL be: `{"role":"assistant","content":"<text>","message_id":"<uuid>"}`.
+
+#### Scenario: Valid audio uploaded
+
+- **WHEN** a client POSTs a valid audio file to the voice endpoint
+- **THEN** the server transcribes the audio and emits `event: transcript` with the spoken text
+- **AND** the server streams the assistant response as SSE token events
+- **AND** the server emits a final `event: done` containing the assistant reply and the UUID of the persisted message
+
+#### Scenario: Unsupported MIME type
+
+- **WHEN** a client POSTs a file with an unrecognised MIME type (not `audio/*`)
+- **THEN** the server returns HTTP 400
+
+#### Scenario: Audio exceeds 25 MB
+
+- **WHEN** the uploaded audio file exceeds 25 MB
+- **THEN** the server returns HTTP 400
+
+### Requirement: Text message send done event includes message ID
+
+The server SHALL include the DB UUID of the saved assistant message in the `done` SSE event for `POST /api/conversations/{id}/messages` as well, so the client can identify the message for on-demand TTS.
+
+#### Scenario: Text message done event carries message_id
+
+- **WHEN** a client sends a text message and the assistant completes its reply
+- **THEN** the `event: done` payload contains `message_id` set to the UUID of the persisted assistant message
+
+#### Scenario: Client uses message_id for audio playback
+
+- **WHEN** the client receives a `done` event with a `message_id` field
+- **THEN** `ChatMessage.id` is set to that UUID
+- **AND** `GET /api/messages/{message_id}/audio` returns HTTP 200 when TTS is configured

--- a/openspec/changes/fix-web-voice-audio-bugs/specs/voice-transcript-event/spec.md
+++ b/openspec/changes/fix-web-voice-audio-bugs/specs/voice-transcript-event/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Client parses transcript SSE event
+
+The Flutter client SHALL recognise `event: transcript` frames emitted by `POST /api/conversations/{id}/voice` and surface them as a typed `TranscriptEvent` in the `StreamEvent` hierarchy.
+
+#### Scenario: Transcript event is parsed
+
+- **WHEN** the SSE parser receives a frame with `event: transcript` and `data: {"role":"user","content":"<text>"}`
+- **THEN** it yields a `TranscriptEvent` whose `transcript` field equals `<text>`
+
+#### Scenario: Unknown event types are silently ignored
+
+- **WHEN** the SSE parser receives a frame with an unrecognised event type
+- **THEN** no `StreamEvent` is yielded and parsing continues normally
+
+### Requirement: Voice message user bubble shows spoken text
+
+After a voice recording is uploaded, the user message bubble SHALL display the transcribed spoken text received via `TranscriptEvent`, not a placeholder or the assistant's reply.
+
+#### Scenario: Transcript replaces placeholder
+
+- **WHEN** the client receives a `TranscriptEvent` during a voice stream
+- **THEN** the user message bubble content is updated to the transcript text
+
+#### Scenario: User bubble is not overwritten by DoneEvent
+
+- **WHEN** the client receives a `DoneEvent` at the end of a voice stream
+- **THEN** the user message bubble content is NOT changed (it already shows the transcript)
+- **AND** the assistant message is finalised with `DoneEvent.content`
+
+#### Scenario: Placeholder shown before transcript arrives
+
+- **WHEN** a voice recording has been uploaded but no `TranscriptEvent` has yet been received
+- **THEN** the user message bubble displays the initial `🎤 Voice message` placeholder

--- a/openspec/changes/fix-web-voice-audio-bugs/tasks.md
+++ b/openspec/changes/fix-web-voice-audio-bugs/tasks.md
@@ -1,0 +1,42 @@
+## 1. Server — expose message UUID in TurnResult
+
+- [x] 1.1 Add `pub message_id: Option<Uuid>` to `TurnResult` in `crates/runtime/src/orchestrator/mod.rs`
+- [x] 1.2 Populate `message_id` in the orchestrator turn loop where the assistant message is persisted to the DB (set it from the returned row ID)
+- [x] 1.3 Confirm all existing callers of `TurnResult` (CLI, Slack, Mattermost, Matrix, Signal, Nextcloud interfaces) compile cleanly with the new optional field — no behaviour change needed there
+
+## 2. Server — emit message_id in done SSE event
+
+- [x] 2.1 In `send_message` handler (`crates/web-ui/src/api/mod.rs`): update the `done_data` JSON to include `"message_id"` from `turn_result_rx` result when `TurnResult.message_id` is `Some`
+- [x] 2.2 In `send_voice_message` handler (same file): same change — include `"message_id"` in the `done_data` JSON
+- [x] 2.3 Add/update unit tests in `api/mod.rs` that assert the `done` event body contains a `message_id` field after a successful turn
+
+## 3. Flutter — TranscriptEvent
+
+- [x] 3.1 Add `class TranscriptEvent extends StreamEvent` with a `final String transcript` field to `app/lib/api/models/stream_event.dart`
+- [x] 3.2 Add a `TranscriptEvent.fromJson` factory that reads `content` from the JSON payload
+- [x] 3.3 In `parseSseByteStream` (`app/lib/api/api_client.dart`): add an `else if (eventType == 'transcript')` branch that yields `TranscriptEvent.fromJson(json)`
+- [x] 3.4 Add unit tests in `app/test/unit/api/` covering: transcript frame is parsed, unknown event type is ignored
+
+## 4. Flutter — DoneEvent gains optional messageId
+
+- [x] 4.1 Add `final String? messageId` to `DoneEvent` in `stream_event.dart`
+- [x] 4.2 Update `DoneEvent.fromJson` to parse `message_id` from the JSON payload (null if absent)
+- [x] 4.3 Add unit test: done event with `message_id` field parses correctly; done event without it yields `messageId == null`
+
+## 5. Flutter — fix \_streamVoiceMessage in chat_provider.dart
+
+- [x] 5.1 Add a `TranscriptEvent` handler in `_streamVoiceMessage`: when received, update the user message bubble content to `event.transcript` and set `status: MessageStatus.ok`
+- [x] 5.2 Remove the incorrect user-bubble overwrite from the `DoneEvent` handler in `_streamVoiceMessage` (the block that sets content to `'[Voice] ${event.content}'`)
+- [x] 5.3 In the `DoneEvent` handler of `_streamVoiceMessage`: use `event.messageId` (when non-null) as the ID for the finalized assistant `ChatMessage` instead of `'assistant-${DateTime.now().millisecondsSinceEpoch}'`
+
+## 6. Flutter — fix \_streamMessage in chat_provider.dart
+
+- [x] 6.1 In the `DoneEvent` handler of `_streamMessage`: use `event.messageId` (when non-null) as the ID for the finalized assistant `ChatMessage` instead of `'assistant-${DateTime.now().millisecondsSinceEpoch}'`
+
+## 7. Verification
+
+- [x] 7.1 Run `cargo test -p assistant-web-ui` — all existing and new server tests pass
+- [x] 7.2 Run `flutter test` in `app/` — all existing and new Dart tests pass
+- [ ] 7.3 Manual end-to-end: record a voice message in the web UI — user bubble shows transcribed text, assistant bubble shows agent reply
+- [ ] 7.4 Manual end-to-end: tap play button on a freshly received assistant message — audio plays without a 400 error
+- [x] 7.5 Run `make lint && make format` — no warnings or formatting changes


### PR DESCRIPTION
## Summary

- **Bug 1 — wrong user bubble**: The `event: transcript` SSE frame emitted by `POST /api/conversations/{id}/voice` was silently discarded by the Flutter SSE parser (no handler existed). The `DoneEvent` handler then incorrectly overwrote the user bubble with the agent's reply text prefixed `[Voice]`. Fixed by adding `TranscriptEvent` to the `StreamEvent` hierarchy, parsing `transcript` frames in `_parseSse`, handling it in `_streamVoiceMessage` to update the user bubble with the actual spoken words, and removing the incorrect `DoneEvent` overwrite.
- **Bug 2 — play button 400**: After streaming, `ChatMessage.id` was set to a synthetic `assistant-<timestamp>` string. `GET /api/messages/{id}/audio` calls `Uuid::parse_str` on that ID, fails, and returns 400 "Invalid message ID". Fixed by threading the real DB message UUID through `TurnResult.message_id` → `bus_messages::TurnResult.message_id` → the `done` SSE event payload as `"message_id"`. Both `DoneEvent` and the provider handlers now use this UUID as `ChatMessage.id`.

## Changes

**Rust**
- `crates/core/src/bus_messages.rs` — `TurnResult` gains optional `message_id: Option<Uuid>` (serde-optional; old payloads without the field still deserialise)
- `crates/runtime/src/orchestrator/mod.rs` — captures saved message UUID in `FinalAnswer` path; populates `TurnResult.message_id`
- `crates/runtime/src/orchestrator/worker.rs` — threads `message_id` through bus result to `submit_turn` waiter
- `crates/runtime/src/orchestrator/turn_control.rs` — fills `message_id: None` on non-persist paths
- `crates/web-ui/src/api/mod.rs` — both `send_message` and `send_voice_message` include `"message_id"` in `done` SSE event; `StubTranscriptionProvider` added for tests

**Flutter**
- `app/lib/api/models/stream_event.dart` — new `TranscriptEvent`; `DoneEvent` gains optional `messageId`
- `app/lib/api/api_client.dart` — `_parseSse` handles `event: transcript`
- `app/lib/features/chat/chat_provider.dart` — `_streamVoiceMessage` handles `TranscriptEvent`; both handlers use `event.messageId` for `ChatMessage.id`

## Test plan

- [ ] `cargo test -p assistant-core -p assistant-web-ui` — 198 tests pass (4 new Rust tests)
- [ ] `flutter test` in `app/` — 227 tests pass (7 new Dart tests)
- [ ] Manual: record voice in web UI → user bubble shows transcribed speech, not agent reply
- [ ] Manual: tap play on freshly received assistant message → audio plays, no 400