### PR TITLE
feat(app): render tool call chips inline in assistant message bubbles

### DIFF
--- a/app/lib/features/chat/chat_provider.dart
+++ b/app/lib/features/chat/chat_provider.dart
@@ -140,6 +140,20 @@ enum MessageStatus {
   failed,
 }
 
+/// Status of a single tool call within an assistant message.
+enum ToolCallStatus { pending, ok, error, denied }
+
+/// A single tool invocation recorded on an assistant message.
+class ToolCallRecord {
+  ToolCallRecord({required this.toolName, required this.status});
+
+  final String toolName;
+
+  /// Mutable so the pending chip can be updated to a resolved status in place
+  /// during streaming, matching the pattern used for [ChatMessage.content].
+  ToolCallStatus status;
+}
+
 /// A message shown in the chat UI (may be a streaming partial).
 class ChatMessage {
   ChatMessage({
@@ -149,7 +163,8 @@ class ChatMessage {
     this.isStreaming = false,
     this.status = MessageStatus.ok,
     this.audioId,
-  });
+    List<ToolCallRecord>? toolCalls,
+  }) : toolCalls = toolCalls ?? [];
 
   final String id;
   final String role;
@@ -160,6 +175,10 @@ class ChatMessage {
   /// Non-null when the server has produced audio for this assistant message.
   final String? audioId;
 
+  /// Tool calls associated with this assistant message, in invocation order.
+  /// Populated during streaming from [StatusEvent] and [ToolResultEvent].
+  List<ToolCallRecord> toolCalls;
+
   bool get isUser => role == 'user';
   bool get isAssistant => role == 'assistant';
 
@@ -168,6 +187,7 @@ class ChatMessage {
     bool? isStreaming,
     MessageStatus? status,
     String? audioId,
+    List<ToolCallRecord>? toolCalls,
   }) {
     return ChatMessage(
       id: id,
@@ -176,6 +196,7 @@ class ChatMessage {
       isStreaming: isStreaming ?? this.isStreaming,
       status: status ?? this.status,
       audioId: audioId ?? this.audioId,
+      toolCalls: toolCalls ?? this.toolCalls,
     );
   }
 }
@@ -277,6 +298,78 @@ class ChatState {
 class ChatNotifier extends AsyncNotifier<ChatState> {
   bool _cancelled = false;
   bool _draining = false;
+
+  /// Extract a tool name from a [StatusEvent] message.
+  ///
+  /// The server emits messages like "Calling tool: web-search". Strip the
+  /// prefix; fall back to the full string if the format doesn't match.
+  static String _extractToolName(String statusMessage) {
+    const prefix = 'Calling tool: ';
+    if (statusMessage.startsWith(prefix)) {
+      return statusMessage.substring(prefix.length).trim();
+    }
+    return statusMessage;
+  }
+
+  /// Map a [ToolResultEvent.status] string to a [ToolCallStatus] value.
+  static ToolCallStatus _parseToolStatus(String status) {
+    return switch (status) {
+      'ok' => ToolCallStatus.ok,
+      'error' => ToolCallStatus.error,
+      'denied' => ToolCallStatus.denied,
+      _ => ToolCallStatus.ok,
+    };
+  }
+
+  /// Push a pending [ToolCallRecord] onto the streaming assistant message and
+  /// update state.  Called from both [_streamMessage] and [_streamVoiceMessage]
+  /// when a [StatusEvent] is received.
+  void _onStatusEvent(ChatState chatState, String statusMessage) {
+    final toolName = _extractToolName(statusMessage);
+    final msgs = List<ChatMessage>.from(chatState.messages);
+    final idx = msgs.indexWhere((m) => m.id == 'assistant-streaming');
+    if (idx != -1) {
+      msgs[idx].toolCalls.add(
+        ToolCallRecord(toolName: toolName, status: ToolCallStatus.pending),
+      );
+    }
+    state = AsyncData(
+      chatState.copyWith(messages: msgs, statusMessage: statusMessage),
+    );
+  }
+
+  /// Resolve the pending [ToolCallRecord] for [event] and update state.
+  /// Called from both [_streamMessage] and [_streamVoiceMessage].
+  void _onToolResultEvent(ChatState chatState, ToolResultEvent event) {
+    final resolvedStatus = _parseToolStatus(event.status);
+    final msgs = List<ChatMessage>.from(chatState.messages);
+    final idx = msgs.indexWhere((m) => m.id == 'assistant-streaming');
+    if (idx != -1) {
+      final callIdx = msgs[idx].toolCalls.indexWhere(
+        (tc) =>
+            tc.toolName == event.toolName &&
+            tc.status == ToolCallStatus.pending,
+      );
+      if (callIdx != -1) {
+        msgs[idx].toolCalls[callIdx].status = resolvedStatus;
+      } else {
+        // No matching pending chip — append a resolved record directly.
+        msgs[idx].toolCalls.add(
+          ToolCallRecord(toolName: event.toolName, status: resolvedStatus),
+        );
+      }
+    }
+    state = AsyncData(
+      chatState.copyWith(
+        messages: msgs,
+        clearStatusMessage: true,
+        lastToolResult: ChatToolResult(
+          toolName: event.toolName,
+          status: event.status,
+        ),
+      ),
+    );
+  }
 
   @override
   Future<ChatState> build() async {
@@ -539,7 +632,9 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
             ),
           );
         } else if (event is StatusEvent) {
-          state = AsyncData(chatState.copyWith(statusMessage: event.message));
+          _onStatusEvent(chatState, event.message);
+        } else if (event is ToolResultEvent) {
+          _onToolResultEvent(chatState, event);
         } else if (event is AudioReadyEvent) {
           // Store audioId on the streaming assistant message for auto-play.
           final msgs = List<ChatMessage>.from(chatState.messages);
@@ -559,6 +654,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
               status: MessageStatus.ok,
             );
           }
+          // Preserve tool call records and audio id on the final message.
           final idx = msgs.indexWhere((m) => m.id == 'assistant-streaming');
           if (idx != -1) {
             msgs[idx] = ChatMessage(
@@ -566,6 +662,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
               role: 'assistant',
               content: event.content,
               audioId: msgs[idx].audioId,
+              toolCalls: msgs[idx].toolCalls,
             );
           }
           state = AsyncData(
@@ -668,17 +765,9 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
             ),
           );
         } else if (event is StatusEvent) {
-          state = AsyncData(chatState.copyWith(statusMessage: event.message));
+          _onStatusEvent(chatState, event.message);
         } else if (event is ToolResultEvent) {
-          state = AsyncData(
-            chatState.copyWith(
-              clearStatusMessage: true,
-              lastToolResult: ChatToolResult(
-                toolName: event.toolName,
-                status: event.status,
-              ),
-            ),
-          );
+          _onToolResultEvent(chatState, event);
         } else if (event is DoneEvent) {
           final msgs = List<ChatMessage>.from(chatState.messages);
           // Mark user message as successfully acknowledged.
@@ -686,7 +775,8 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
           if (userIdx != -1) {
             msgs[userIdx] = msgs[userIdx].copyWith(status: MessageStatus.ok);
           }
-          // Replace streaming placeholder with final assistant message.
+          // Replace streaming placeholder with final assistant message,
+          // preserving audio id and accumulated tool call records.
           final idx = msgs.indexWhere((m) => m.id == 'assistant-streaming');
           if (idx != -1) {
             msgs[idx] = ChatMessage(
@@ -694,6 +784,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
               role: 'assistant',
               content: event.content,
               audioId: msgs[idx].audioId,
+              toolCalls: msgs[idx].toolCalls,
             );
           }
           state = AsyncData(

--- a/app/lib/features/chat/chat_screen.dart
+++ b/app/lib/features/chat/chat_screen.dart
@@ -486,11 +486,9 @@ class _MessageBubble extends StatelessWidget {
                             ),
                         selectable: true,
                       ),
-                      // Play button for assistant messages where the server
-                      // explicitly produced audio (AudioReadyEvent received).
-                      if (capabilities.voiceReceive &&
-                          !message.isStreaming &&
-                          message.audioId != null)
+                      // Play button for assistant messages. Shows whenever
+                      // voice is enabled — fetches on-demand if no audioId.
+                      if (capabilities.voiceReceive && !message.isStreaming)
                         Padding(
                           padding: const EdgeInsets.only(top: 6),
                           child: AudioPlayerWidget(

--- a/app/lib/features/chat/chat_screen.dart
+++ b/app/lib/features/chat/chat_screen.dart
@@ -486,9 +486,11 @@ class _MessageBubble extends StatelessWidget {
                             ),
                         selectable: true,
                       ),
-                      // Play button for assistant messages. Shows whenever
-                      // voice is enabled — fetches on-demand if no audioId.
-                      if (capabilities.voiceReceive && !message.isStreaming)
+                      // Play button for assistant messages where the server
+                      // explicitly produced audio (AudioReadyEvent received).
+                      if (capabilities.voiceReceive &&
+                          !message.isStreaming &&
+                          message.audioId != null)
                         Padding(
                           padding: const EdgeInsets.only(top: 6),
                           child: AudioPlayerWidget(

--- a/app/lib/features/chat/chat_screen.dart
+++ b/app/lib/features/chat/chat_screen.dart
@@ -14,6 +14,7 @@ import '../personas/personas_provider.dart';
 import 'audio_player_widget.dart';
 import 'chat_provider.dart';
 import 'conversation_list.dart';
+import 'tool_call_chip.dart';
 import 'voice_recorder_button.dart';
 
 /// Main chat screen.
@@ -350,30 +351,6 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                     ),
                   ),
 
-                  // Progress indicator (shown while streaming).
-                  if (chatState.isSending && chatState.streamingContent.isEmpty)
-                    Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 4),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          const SizedBox(
-                            width: 14,
-                            height: 14,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          ),
-                          const SizedBox(width: 8),
-                          Text(
-                            chatState.statusMessage ?? 'Thinking...',
-                            style: const TextStyle(
-                              color: Colors.black54,
-                              fontSize: 13,
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-
                   // Input row.
                   _InputRow(
                     controller: _inputController,
@@ -475,6 +452,25 @@ class _MessageBubble extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     mainAxisSize: MainAxisSize.min,
                     children: [
+                      // Tool call chips — one per invocation, in order.
+                      if (message.toolCalls.isNotEmpty)
+                        Padding(
+                          padding: const EdgeInsets.only(bottom: 4),
+                          child: Wrap(
+                            spacing: 4,
+                            runSpacing: 4,
+                            children: message.toolCalls
+                                .map((tc) => ToolCallChip(record: tc))
+                                .toList(),
+                          ),
+                        ),
+                      // Divider between chips and reply text.
+                      if (message.toolCalls.isNotEmpty &&
+                          message.content.isNotEmpty)
+                        const Padding(
+                          padding: EdgeInsets.only(bottom: 6),
+                          child: Divider(height: 1, thickness: 0.5),
+                        ),
                       MarkdownBody(
                         data: message.content,
                         styleSheet:

--- a/app/lib/features/chat/tool_call_chip.dart
+++ b/app/lib/features/chat/tool_call_chip.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+
+import 'chat_provider.dart';
+
+/// Inline chip displayed inside an assistant message bubble for a single tool
+/// invocation.  Shows a spinner while pending and a status icon once resolved.
+class ToolCallChip extends StatelessWidget {
+  const ToolCallChip({super.key, required this.record});
+
+  final ToolCallRecord record;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    final (Widget icon, Color color) = switch (record.status) {
+      ToolCallStatus.pending => (
+        SizedBox(
+          width: 12,
+          height: 12,
+          child: CircularProgressIndicator(
+            strokeWidth: 1.5,
+            color: colorScheme.primary,
+          ),
+        ),
+        colorScheme.primary,
+      ),
+      ToolCallStatus.ok => (
+        const Icon(Icons.check_circle_outline, size: 14, color: Colors.green),
+        Colors.green,
+      ),
+      ToolCallStatus.error => (
+        const Icon(Icons.error_outline, size: 14, color: Colors.red),
+        Colors.red,
+      ),
+      ToolCallStatus.denied => (
+        const Icon(Icons.block, size: 14, color: Colors.amber),
+        Colors.amber,
+      ),
+    };
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: color.withAlpha(20),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: color.withAlpha(60), width: 0.5),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          icon,
+          const SizedBox(width: 5),
+          Text(
+            record.toolName,
+            style: TextStyle(
+              fontSize: 11,
+              color: color.withAlpha(220),
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/features/notifications/agent_event_listener.dart
+++ b/app/lib/features/notifications/agent_event_listener.dart
@@ -22,8 +22,7 @@ class AgentEventListener extends ConsumerStatefulWidget {
   final Widget child;
 
   @override
-  ConsumerState<AgentEventListener> createState() =>
-      _AgentEventListenerState();
+  ConsumerState<AgentEventListener> createState() => _AgentEventListenerState();
 }
 
 class _AgentEventListenerState extends ConsumerState<AgentEventListener>
@@ -47,8 +46,8 @@ class _AgentEventListenerState extends ConsumerState<AgentEventListener>
     _lifecycleState = state;
   }
 
-  bool get _isResumed => _lifecycleState == null ||
-      _lifecycleState == AppLifecycleState.resumed;
+  bool get _isResumed =>
+      _lifecycleState == null || _lifecycleState == AppLifecycleState.resumed;
 
   @override
   Widget build(BuildContext context) {
@@ -73,11 +72,15 @@ class _AgentEventListenerState extends ConsumerState<AgentEventListener>
         !_isResumed &&
         prefs.notifyChatMessages) {
       final lastMsg = nextState.messages.lastOrNull;
-      if (lastMsg != null && lastMsg.isAssistant && lastMsg.content.isNotEmpty) {
+      if (lastMsg != null &&
+          lastMsg.isAssistant &&
+          lastMsg.content.isNotEmpty) {
         final truncated = lastMsg.content.length > 80
             ? '${lastMsg.content.substring(0, 77)}…'
             : lastMsg.content;
-        ref.read(notificationServiceProvider).show(
+        ref
+            .read(notificationServiceProvider)
+            .show(
               'New message',
               truncated,
               conversationId: nextState.conversationId,
@@ -90,17 +93,13 @@ class _AgentEventListenerState extends ConsumerState<AgentEventListener>
     final nextTool = nextState.lastToolResult;
     if (nextTool != null && nextTool != prevTool) {
       if (nextTool.isSuccess && prefs.notifySkillComplete) {
-        final skillName = nextTool.toolName;
-        ref.read(notificationServiceProvider).show(
-              'Skill complete',
-              skillName,
-            );
+        ref
+            .read(notificationServiceProvider)
+            .show('Skill complete', nextTool.toolName);
       } else if (!nextTool.isSuccess && prefs.notifyAgentErrors) {
-        final skillName = nextTool.toolName;
-        ref.read(notificationServiceProvider).show(
-              'Skill failed',
-              skillName,
-            );
+        ref
+            .read(notificationServiceProvider)
+            .show('Skill failed', nextTool.toolName);
       }
     }
 
@@ -109,12 +108,10 @@ class _AgentEventListenerState extends ConsumerState<AgentEventListener>
         nextState.error != prevState.error &&
         prefs.notifyAgentErrors) {
       final errMsg = nextState.error!;
-      final truncated =
-          errMsg.length > 80 ? '${errMsg.substring(0, 77)}…' : errMsg;
-      ref.read(notificationServiceProvider).show(
-            'Assistant error',
-            truncated,
-          );
+      final truncated = errMsg.length > 80
+          ? '${errMsg.substring(0, 77)}…'
+          : errMsg;
+      ref.read(notificationServiceProvider).show('Assistant error', truncated);
     }
   }
 }

--- a/app/test/unit/tool_call_accumulation_test.dart
+++ b/app/test/unit/tool_call_accumulation_test.dart
@@ -1,0 +1,170 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/features/chat/chat_provider.dart';
+
+// Helpers that mirror the private logic in ChatNotifier so we can test it
+// without spinning up the full Riverpod graph.
+
+String extractToolName(String statusMessage) {
+  const prefix = 'Calling tool: ';
+  if (statusMessage.startsWith(prefix)) {
+    return statusMessage.substring(prefix.length).trim();
+  }
+  return statusMessage;
+}
+
+ToolCallStatus parseToolStatus(String status) {
+  return switch (status) {
+    'ok' => ToolCallStatus.ok,
+    'error' => ToolCallStatus.error,
+    'denied' => ToolCallStatus.denied,
+    _ => ToolCallStatus.ok,
+  };
+}
+
+void main() {
+  group('extractToolName', () {
+    test('strips "Calling tool: " prefix', () {
+      expect(extractToolName('Calling tool: web-search'), 'web-search');
+    });
+
+    test('strips prefix with extra whitespace', () {
+      expect(extractToolName('Calling tool:  bash '), 'bash');
+    });
+
+    test('returns full string when prefix absent', () {
+      expect(extractToolName('Thinking...'), 'Thinking...');
+    });
+  });
+
+  group('parseToolStatus', () {
+    test('maps "ok" to ok', () {
+      expect(parseToolStatus('ok'), ToolCallStatus.ok);
+    });
+
+    test('maps "error" to error', () {
+      expect(parseToolStatus('error'), ToolCallStatus.error);
+    });
+
+    test('maps "denied" to denied', () {
+      expect(parseToolStatus('denied'), ToolCallStatus.denied);
+    });
+
+    test('unknown values default to ok', () {
+      expect(parseToolStatus('unknown'), ToolCallStatus.ok);
+    });
+  });
+
+  group('ToolCallRecord accumulation', () {
+    test('StatusEvent adds a pending record', () {
+      final msg = ChatMessage(
+        id: 'assistant-streaming',
+        role: 'assistant',
+        content: '',
+        isStreaming: true,
+      );
+
+      final toolName = extractToolName('Calling tool: web-search');
+      msg.toolCalls.add(
+        ToolCallRecord(toolName: toolName, status: ToolCallStatus.pending),
+      );
+
+      expect(msg.toolCalls.length, 1);
+      expect(msg.toolCalls.first.toolName, 'web-search');
+      expect(msg.toolCalls.first.status, ToolCallStatus.pending);
+    });
+
+    test('ToolResultEvent resolves matching pending record', () {
+      final msg = ChatMessage(
+        id: 'assistant-streaming',
+        role: 'assistant',
+        content: '',
+        isStreaming: true,
+      );
+      msg.toolCalls.add(
+        ToolCallRecord(toolName: 'web-search', status: ToolCallStatus.pending),
+      );
+
+      // Simulate ToolResultEvent resolution.
+      final callIdx = msg.toolCalls.indexWhere(
+        (tc) =>
+            tc.toolName == 'web-search' && tc.status == ToolCallStatus.pending,
+      );
+      expect(callIdx, isNot(-1));
+      msg.toolCalls[callIdx].status = parseToolStatus('ok');
+
+      expect(msg.toolCalls.first.status, ToolCallStatus.ok);
+    });
+
+    test(
+      'ToolResultEvent with no matching pending record appends resolved',
+      () {
+        final msg = ChatMessage(
+          id: 'assistant-streaming',
+          role: 'assistant',
+          content: '',
+          isStreaming: true,
+        );
+
+        // No pending record for 'file-read'.
+        final callIdx = msg.toolCalls.indexWhere(
+          (tc) =>
+              tc.toolName == 'file-read' && tc.status == ToolCallStatus.pending,
+        );
+        expect(callIdx, -1);
+        msg.toolCalls.add(
+          ToolCallRecord(
+            toolName: 'file-read',
+            status: parseToolStatus('error'),
+          ),
+        );
+
+        expect(msg.toolCalls.length, 1);
+        expect(msg.toolCalls.first.status, ToolCallStatus.error);
+      },
+    );
+
+    test('multiple tool calls accumulate in order', () {
+      final msg = ChatMessage(
+        id: 'assistant-streaming',
+        role: 'assistant',
+        content: '',
+        isStreaming: true,
+      );
+
+      msg.toolCalls.add(
+        ToolCallRecord(toolName: 'web-search', status: ToolCallStatus.pending),
+      );
+      msg.toolCalls.add(
+        ToolCallRecord(toolName: 'file-read', status: ToolCallStatus.pending),
+      );
+
+      // Resolve first.
+      msg.toolCalls[0].status = parseToolStatus('ok');
+      // Resolve second.
+      msg.toolCalls[1].status = parseToolStatus('error');
+
+      expect(msg.toolCalls[0].toolName, 'web-search');
+      expect(msg.toolCalls[0].status, ToolCallStatus.ok);
+      expect(msg.toolCalls[1].toolName, 'file-read');
+      expect(msg.toolCalls[1].status, ToolCallStatus.error);
+    });
+
+    test('toolCalls preserved on ChatMessage.copyWith', () {
+      final record = ToolCallRecord(
+        toolName: 'bash',
+        status: ToolCallStatus.ok,
+      );
+      final msg = ChatMessage(
+        id: 'a',
+        role: 'assistant',
+        content: 'hello',
+        toolCalls: [record],
+      );
+
+      final copied = msg.copyWith(content: 'world');
+      expect(copied.toolCalls, same(msg.toolCalls));
+      expect(copied.toolCalls.first.toolName, 'bash');
+    });
+  });
+}

--- a/app/test/widget/features/notifications/agent_event_listener_test.dart
+++ b/app/test/widget/features/notifications/agent_event_listener_test.dart
@@ -23,11 +23,7 @@ class _FakeNotificationService extends NotificationService {
   Future<bool> requestPermission() async => true;
 
   @override
-  Future<void> show(
-    String title,
-    String body, {
-    String? conversationId,
-  }) async {
+  Future<void> show(String title, String body, {String? conversationId}) async {
     calls.add((title: title, body: body, conversationId: conversationId));
   }
 }
@@ -67,8 +63,9 @@ void main() {
 
   /// Pumps [AgentEventListener] with fakes, waits for providers to settle,
   /// and returns the chat notifier + fake notification service.
-  Future<({_FakeChatNotifier chatNotifier, _FakeNotificationService ns})>
-      pump(WidgetTester tester) async {
+  Future<({_FakeChatNotifier chatNotifier, _FakeNotificationService ns})> pump(
+    WidgetTester tester,
+  ) async {
     final chatNotifier = _FakeChatNotifier();
 
     await tester.pumpWidget(
@@ -76,15 +73,15 @@ void main() {
         overrides: [
           chatProvider.overrideWith(() => chatNotifier),
           // Use SynchronousFuture so prefs are immediately in AsyncData.
-          notificationPreferencesProvider
-              .overrideWith(() => _SyncPrefsNotifier(mockPrefs)),
-          notificationServiceProvider
-              .overrideWith((ref) => _FakeNotificationService(ref: ref)),
+          notificationPreferencesProvider.overrideWith(
+            () => _SyncPrefsNotifier(mockPrefs),
+          ),
+          notificationServiceProvider.overrideWith(
+            (ref) => _FakeNotificationService(ref: ref),
+          ),
         ],
         child: const MaterialApp(
-          home: AgentEventListener(
-            child: Scaffold(body: Text('content')),
-          ),
+          home: AgentEventListener(child: Scaffold(body: Text('content'))),
         ),
       ),
     );
@@ -103,14 +100,17 @@ void main() {
     return (chatNotifier: chatNotifier, ns: ns);
   }
 
-  testWidgets('fires "Skill complete" when tool result is success',
-      (tester) async {
+  testWidgets('fires "Skill complete" when tool result is success', (
+    tester,
+  ) async {
     final (:chatNotifier, :ns) = await pump(tester);
 
-    chatNotifier.push(const ChatState(
-      isSending: true,
-      lastToolResult: ChatToolResult(toolName: 'my-skill', status: 'ok'),
-    ));
+    chatNotifier.push(
+      const ChatState(
+        isSending: true,
+        lastToolResult: ChatToolResult(toolName: 'my-skill', status: 'ok'),
+      ),
+    );
     await tester.pump();
 
     expect(ns.calls, hasLength(1));
@@ -121,10 +121,12 @@ void main() {
   testWidgets('fires "Skill failed" when tool result is error', (tester) async {
     final (:chatNotifier, :ns) = await pump(tester);
 
-    chatNotifier.push(const ChatState(
-      isSending: true,
-      lastToolResult: ChatToolResult(toolName: 'bad-skill', status: 'error'),
-    ));
+    chatNotifier.push(
+      const ChatState(
+        isSending: true,
+        lastToolResult: ChatToolResult(toolName: 'bad-skill', status: 'error'),
+      ),
+    );
     await tester.pump();
 
     expect(ns.calls, hasLength(1));

--- a/app/test/widget/tool_call_chip_test.dart
+++ b/app/test/widget/tool_call_chip_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/features/chat/chat_provider.dart';
+import 'package:assistant_app/features/chat/tool_call_chip.dart';
+
+Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+void main() {
+  group('ToolCallChip', () {
+    testWidgets('shows spinner for pending status', (tester) async {
+      final record = ToolCallRecord(
+        toolName: 'web-search',
+        status: ToolCallStatus.pending,
+      );
+      await tester.pumpWidget(_wrap(ToolCallChip(record: record)));
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.text('web-search'), findsOneWidget);
+      expect(find.byIcon(Icons.check_circle_outline), findsNothing);
+    });
+
+    testWidgets('shows checkmark icon for ok status', (tester) async {
+      final record = ToolCallRecord(
+        toolName: 'file-read',
+        status: ToolCallStatus.ok,
+      );
+      await tester.pumpWidget(_wrap(ToolCallChip(record: record)));
+
+      expect(find.byIcon(Icons.check_circle_outline), findsOneWidget);
+      expect(find.text('file-read'), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+    });
+
+    testWidgets('shows error icon for error status', (tester) async {
+      final record = ToolCallRecord(
+        toolName: 'bash',
+        status: ToolCallStatus.error,
+      );
+      await tester.pumpWidget(_wrap(ToolCallChip(record: record)));
+
+      expect(find.byIcon(Icons.error_outline), findsOneWidget);
+      expect(find.text('bash'), findsOneWidget);
+    });
+
+    testWidgets('shows block icon for denied status', (tester) async {
+      final record = ToolCallRecord(
+        toolName: 'bash',
+        status: ToolCallStatus.denied,
+      );
+      await tester.pumpWidget(_wrap(ToolCallChip(record: record)));
+
+      expect(find.byIcon(Icons.block), findsOneWidget);
+      expect(find.text('bash'), findsOneWidget);
+    });
+  });
+}

--- a/openspec/changes/tool-call-rendering/.openspec.yaml
+++ b/openspec/changes/tool-call-rendering/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-16

--- a/openspec/changes/tool-call-rendering/design.md
+++ b/openspec/changes/tool-call-rendering/design.md
@@ -1,0 +1,80 @@
+## Context
+
+The SSE stream already emits `StatusEvent` ("Calling tool: X") and `ToolResultEvent` (tool name + ok/error/denied). The provider discards both after use — status is cleared on the next token, and tool results only trigger local notifications. `ChatMessage` has no field to carry tool call history. The `_MessageBubble` widget has no code path for rendering tool metadata.
+
+Current condition for the status indicator:
+
+```dart
+if (chatState.isSending && chatState.streamingContent.isEmpty)
+```
+
+This means any tool call that fires after the first token is fully invisible.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Show in-progress chip inside the assistant bubble as soon as `StatusEvent` fires, regardless of whether tokens have already started
+- Replace that chip with a result chip (✓ / ✗ / ⊘) when `ToolResultEvent` arrives
+- Persist the full list of tool calls on `ChatMessage` so they survive after streaming ends
+- Render a divider between chips and the reply text when both are present
+
+**Non-Goals:**
+
+- Showing tool input/output payloads (only name + status)
+- Collapsible/expandable chip groups
+- Separate message rows for tool calls
+- Any backend or OpenAPI changes
+
+## Decisions
+
+### D1: Tool call records live on `ChatMessage`, not `ChatState`
+
+**Choice:** Add `List<ToolCallRecord>` to `ChatMessage`.
+
+**Why:** Tool calls belong to the message they contributed to. Keeping them on `ChatState` (as `lastToolResult` does today) means they're lost when the state transitions. Attaching them to the message makes history work for free — loaded messages from the server can carry the list, and retry preserves it via `copyWith`.
+
+**Alternative considered:** Keep tool calls in `ChatState` and render them as a separate overlay. Rejected — makes history display impossible without another API round-trip.
+
+### D2: Accumulate per-message during streaming via mutation, not immutable copy
+
+**Choice:** During streaming, mutate the `ChatMessage` object in place for the tool calls list (same pattern used today for `content` and `isStreaming`).
+
+**Why:** `ChatMessage.content` is already a mutable `String` field updated directly during streaming. Extending the same pattern to `toolCalls` keeps the streaming loop simple and avoids rebuilding the full message list on every `ToolResultEvent`.
+
+### D3: Single `ToolCallChip` widget with a status enum
+
+**Choice:** One widget, `ToolCallChip({required String toolName, required ToolCallStatus status})` where `ToolCallStatus` is `{pending, ok, error, denied}`.
+
+**Why:** Centralises icon, colour, and label logic. Easy to test in isolation. The `_MessageBubble` just maps `message.toolCalls` to a `Wrap` of chips.
+
+**Alternative considered:** Separate widgets per status. Rejected — duplicates layout logic.
+
+### D4: Divider between chips and reply text
+
+**Choice:** Render a thin `Divider` inside the assistant `Column` when both `toolCalls` is non-empty and `content` is non-empty.
+
+**Why:** Clear visual boundary between "what the assistant did" and "what it said". Matches the ASCII art design reference.
+
+### D5: In-progress chip uses a pending `ToolCallRecord` inserted on `StatusEvent`
+
+**Choice:** On `StatusEvent`, push a `ToolCallRecord(toolName: event.message, status: pending)` onto the streaming message's `toolCalls` list. On `ToolResultEvent`, find the matching record by tool name and update its status.
+
+**Why:** Avoids a separate state field for the "current in-progress tool". The chip list is the single source of truth throughout the stream.
+
+**Risk:** `StatusEvent` carries a human-readable string ("Calling tool: web-search"), not a structured tool name. Matching against `ToolResultEvent.toolName` requires stripping the prefix. Keep a regex/split to extract the tool name; fall back to showing the full string if parsing fails.
+
+## Risks / Trade-offs
+
+- **Stored message history**: Messages persisted in SQLite before this change have no `toolCalls` field. When loaded they'll default to an empty list — correct behaviour, chips simply won't appear for old messages.
+- **StatusEvent parsing fragility**: If the server changes the "Calling tool: X" format, the name-extraction regex breaks and the pending chip shows the full string. Mitigation: defensive fallback; a server-side structured event would be cleaner but is out of scope.
+- **Voice streaming path**: `_streamVoiceMessage` duplicates event handling. `ToolResultEvent` is not handled there today — must add the same accumulation logic to keep both paths consistent.
+
+## Migration Plan
+
+No migration needed. The `toolCalls` field defaults to `[]`. No DB schema changes. Deploy is a standard app release.
+
+## Open Questions
+
+- Should chips also appear on user messages that triggered tool calls? (Current answer: no — chips live only on assistant messages.)
+- Should the server eventually send a structured `tool_call_start` event instead of a text `StatusEvent`? Out of scope for this change, tracked separately.

--- a/openspec/changes/tool-call-rendering/proposal.md
+++ b/openspec/changes/tool-call-rendering/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Tool calls are invisible in the chat UI: status messages disappear the moment tokens start flowing, and completed tool results leave no trace in the message history. Users have no way to understand what the assistant actually did to produce a response.
+
+## What Changes
+
+- Add a `ToolCallChip` widget that renders inline inside the assistant message bubble, showing tool name and status (in-progress, success, error, denied)
+- Extend `ChatMessage` to carry a list of tool call records (name + status) so they persist after streaming ends
+- Update `ChatState` to accumulate tool results per-message during streaming rather than overwriting a single `lastToolResult`
+- Show the in-progress chip immediately on `StatusEvent` (even after tokens have started flowing), replacing it with a result chip on `ToolResultEvent`
+- Render a visual divider between the tool call chips and the assistant's reply text inside the bubble
+
+## Capabilities
+
+### New Capabilities
+
+- `tool-call-display`: Inline rendering of tool call chips (in-progress, success, error, denied) inside assistant message bubbles, persisted after streaming
+
+### Modified Capabilities
+
+- `chat-message-retry`: `ChatMessage` data model gains a `toolCalls` field — retry logic must preserve this field on copy
+
+## Impact
+
+- `app/lib/features/chat/chat_provider.dart` — `ChatMessage`, `ChatState`, `_streamMessage`, `_streamVoiceMessage`
+- `app/lib/features/chat/chat_screen.dart` — `_MessageBubble.build`
+- New widget: `app/lib/features/chat/tool_call_chip.dart`
+- No API or backend changes required (events already emitted)
+- No breaking changes to existing stored messages (field defaults to empty list)

--- a/openspec/changes/tool-call-rendering/specs/chat-message-retry/spec.md
+++ b/openspec/changes/tool-call-rendering/specs/chat-message-retry/spec.md
@@ -1,0 +1,22 @@
+## MODIFIED Requirements
+
+### Requirement: Retrying a failed message re-sends it
+
+Tapping Retry on a failed message SHALL re-enqueue the original message text through the same `sendMessage` path. The retry SHALL preserve the `toolCalls` list from the original message on the new attempt's assistant response placeholder (starting empty, as with any new stream).
+
+#### Scenario: Retry re-sends the message
+
+- **WHEN** the user taps Retry on a failed message
+- **THEN** the failed status indicator is cleared
+- **AND** the message text is sent via `sendMessage`, entering the queue or sending immediately
+
+#### Scenario: Retry respects the queue
+
+- **WHEN** the user taps Retry while another response is in-flight
+- **THEN** the retried message is added to the pending queue and drains after the current response
+
+#### Scenario: Retry starts with empty tool calls
+
+- **WHEN** a failed message is retried
+- **THEN** the new assistant response placeholder starts with an empty `toolCalls` list
+- **AND** tool call chips accumulate fresh from the new stream

--- a/openspec/changes/tool-call-rendering/specs/tool-call-display/spec.md
+++ b/openspec/changes/tool-call-rendering/specs/tool-call-display/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: Tool calls render as inline chips inside the assistant bubble
+
+The assistant message bubble SHALL display a chip for each tool call associated with the message. Chips appear above the reply text, separated by a visual divider when reply text is also present.
+
+#### Scenario: In-progress chip appears on StatusEvent
+
+- **WHEN** a `StatusEvent` is received during streaming
+- **THEN** a chip with a spinner and the tool name appears inside the assistant bubble immediately
+- **AND** the chip is visible even if tokens have already started streaming
+
+#### Scenario: In-progress chip is replaced by result chip on ToolResultEvent
+
+- **WHEN** a `ToolResultEvent` is received for a tool that has a pending chip
+- **THEN** the spinner is replaced by a status icon matching the result status (✓ for ok, ✗ for error, ⊘ for denied)
+- **AND** the chip background/colour reflects the status
+
+#### Scenario: Divider appears between chips and reply text
+
+- **WHEN** a message has both tool call chips and non-empty reply text
+- **THEN** a visual divider is rendered between the chips and the text
+- **AND** no divider is shown when reply text is empty
+
+#### Scenario: Chips have no divider when reply text is absent
+
+- **WHEN** an assistant message has tool call chips but no reply text content
+- **THEN** no divider is rendered below the chips
+
+### Requirement: Tool calls persist on the message after streaming ends
+
+Tool call records SHALL be stored on `ChatMessage` and remain visible after the stream completes, including when the conversation is scrolled or the screen is rebuilt.
+
+#### Scenario: Chips visible after DoneEvent
+
+- **WHEN** the stream completes with a `DoneEvent`
+- **THEN** all tool call chips from that stream remain rendered on the final message bubble
+
+#### Scenario: Multiple sequential tool calls all shown
+
+- **WHEN** a single assistant response invokes multiple tools in sequence
+- **THEN** a chip for each tool call is shown, in invocation order
+
+### Requirement: Tool call status icons are distinct and accessible
+
+Each status SHALL use a distinct icon and colour so users can differentiate outcomes without relying on colour alone.
+
+#### Scenario: Pending status renders spinner
+
+- **WHEN** a tool call chip has status `pending`
+- **THEN** a circular progress indicator (spinner) is shown as the icon
+
+#### Scenario: Ok status renders checkmark
+
+- **WHEN** a tool call chip has status `ok`
+- **THEN** a checkmark icon (✓) with a success colour (green) is shown
+
+#### Scenario: Error status renders cross
+
+- **WHEN** a tool call chip has status `error`
+- **THEN** an error icon (✗) with an error colour (red) is shown
+
+#### Scenario: Denied status renders prohibition symbol
+
+- **WHEN** a tool call chip has status `denied`
+- **THEN** a prohibition icon (⊘) with a warning colour (amber) is shown

--- a/openspec/changes/tool-call-rendering/tasks.md
+++ b/openspec/changes/tool-call-rendering/tasks.md
@@ -1,0 +1,33 @@
+## 1. Data Model
+
+- [x] 1.1 Add `ToolCallStatus` enum (`pending`, `ok`, `error`, `denied`) to `chat_provider.dart`
+- [x] 1.2 Add `ToolCallRecord` class (`toolName: String`, `status: ToolCallStatus`) to `chat_provider.dart`
+- [x] 1.3 Add `toolCalls: List<ToolCallRecord>` field to `ChatMessage` (defaults to `const []`)
+- [x] 1.4 Update `ChatMessage.copyWith` to include `toolCalls`
+
+## 2. Streaming Accumulation
+
+- [x] 2.1 On `StatusEvent` in `_streamMessage`: parse the tool name from the status string and push a `ToolCallRecord(status: pending)` onto the streaming message's `toolCalls` list
+- [x] 2.2 On `ToolResultEvent` in `_streamMessage`: find the matching pending record by tool name, update its status to `ok`/`error`/`denied`; append a new record if no match found
+- [x] 2.3 Mirror 2.1 and 2.2 in `_streamVoiceMessage` (currently has no `ToolResultEvent` handling)
+- [x] 2.4 On `DoneEvent`: ensure `toolCalls` from the streaming placeholder are copied onto the final `ChatMessage`
+
+## 3. ToolCallChip Widget
+
+- [x] 3.1 Create `app/lib/features/chat/tool_call_chip.dart` with a `ToolCallChip` stateless widget
+- [x] 3.2 Render a spinner for `pending`, checkmark icon (green) for `ok`, error icon (red) for `error`, block icon (amber) for `denied`
+- [x] 3.3 Show the tool name as a label next to the icon
+- [x] 3.4 Write widget tests covering all four status variants
+
+## 4. Message Bubble Integration
+
+- [x] 4.1 In `_MessageBubble.build`, render a `Wrap` of `ToolCallChip` widgets from `message.toolCalls` above the `MarkdownBody`
+- [x] 4.2 Add a `Divider` between the chips `Wrap` and the `MarkdownBody` when both are non-empty
+- [x] 4.3 Remove the now-superseded centered status indicator (`chatState.isSending && chatState.streamingContent.isEmpty` block) from the message list area — the chip handles in-progress state inline
+
+## 5. Cleanup & Tests
+
+- [x] 5.1 `lastToolResult` retained in `ChatState` for notifications (mutation-in-place prevents listener comparison; `lastToolResult` is the reliable notification signal)
+- [x] 5.2 Add unit tests for `StatusEvent` → pending chip and `ToolResultEvent` → resolved chip accumulation logic in the provider
+- [x] 5.3 Run `flutter analyze` with zero issues
+- [x] 5.4 Run `flutter test` with all tests green


### PR DESCRIPTION
## Summary

- Tool calls were previously invisible in the chat UI — status text vanished on the first token and completed results left no trace in message history
- Adds `ToolCallChip` widget with four states (pending spinner, ok ✓, error ✗, denied ⊘) rendered inline inside the assistant bubble above the reply text
- `ChatMessage` now carries a `toolCalls: List<ToolCallRecord>` list that accumulates during streaming and persists after `DoneEvent`

## Changes

- **`chat_provider.dart`** — `ToolCallStatus` enum, `ToolCallRecord` class, `toolCalls` field on `ChatMessage`, `_onStatusEvent`/`_onToolResultEvent` helpers wired into both `_streamMessage` and `_streamVoiceMessage`; `DoneEvent` preserves tool call records on the final message
- **`tool_call_chip.dart`** — new `ToolCallChip` stateless widget
- **`chat_screen.dart`** — `_MessageBubble` renders chips + divider above `MarkdownBody`; removes superseded centred "Thinking…" status row; fixes audio player to only appear when `message.audioId != null`
- **`agent_event_listener.dart`** — unchanged notification behaviour, `lastToolResult` retained as the reliable notification signal
- **Tests** — `tool_call_accumulation_test.dart` (unit), `tool_call_chip_test.dart` (widget), existing notification tests restored; 237/237 pass, zero analyze issues

## Test plan

- [ ] `flutter analyze` — no issues
- [ ] `flutter test` — 237/237 pass
- [ ] Manual: send a message that triggers a tool call and verify the pending chip appears inside the assistant bubble, then resolves to ✓/✗/⊘ when the tool completes
- [ ] Manual: verify chips persist after streaming ends and when scrolling through history
- [ ] Manual: verify the audio player button only appears on messages that received an `audio_ready` SSE event