### PR TITLE
fix(chat): gate audio button on per-message ttsAvailable flag

### DIFF
--- a/app/lib/features/chat/chat_screen.dart
+++ b/app/lib/features/chat/chat_screen.dart
@@ -488,7 +488,9 @@ class _MessageBubble extends StatelessWidget {
                       ),
                       // Play button for assistant messages. Shows whenever
                       // voice is enabled — fetches on-demand if no audioId.
-                      if (capabilities.voiceReceive && !message.isStreaming)
+                      if (capabilities.voiceReceive &&
+                          message.ttsAvailable &&
+                          !message.isStreaming)
                         Padding(
                           padding: const EdgeInsets.only(top: 6),
                           child: AudioPlayerWidget(

--- a/app/test/widget/features/chat/chat_screen_test.dart
+++ b/app/test/widget/features/chat/chat_screen_test.dart
@@ -1,6 +1,11 @@
-import 'package:assistant_api/assistant_api.dart';
+import 'package:assistant_api/assistant_api.dart' hide ServerCapabilities;
+import 'package:assistant_app/api/api_client.dart';
+import 'package:assistant_app/api/capabilities_provider.dart';
+import 'package:assistant_app/api/models/server_capabilities.dart';
+import 'package:assistant_app/features/chat/audio_player_widget.dart';
 import 'package:assistant_app/features/chat/chat_provider.dart';
 import 'package:assistant_app/features/chat/chat_screen.dart';
+import 'package:assistant_app/features/connection/connection_provider.dart';
 import 'package:assistant_app/features/personas/personas_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -36,8 +41,9 @@ class _FakeConversationListNotifier extends ConversationListNotifier {
 // Widget builder — wraps ChatScreen in MaterialApp with provider fakes.
 
 Future<({_FakeChatNotifier notifier})> pumpChatScreen(
-  WidgetTester tester,
-) async {
+  WidgetTester tester, {
+  ServerCapabilities? capabilities,
+}) async {
   final chatNotifier = _FakeChatNotifier();
 
   // Use a narrow portrait viewport so no sidebar is shown (isWide = false).
@@ -54,6 +60,12 @@ Future<({_FakeChatNotifier notifier})> pumpChatScreen(
         conversationListProvider.overrideWith(
           () => _FakeConversationListNotifier(),
         ),
+        if (capabilities != null) ...[
+          apiClientProvider.overrideWithValue(
+            ApiClient(baseUrl: 'http://localhost', token: 'test'),
+          ),
+          capabilitiesProvider.overrideWith((ref) async => capabilities),
+        ],
       ],
       child: const MaterialApp(home: ChatScreen()),
     ),
@@ -212,5 +224,95 @@ void main() {
 
       expect(find.byKey(const Key('retry_button')), findsNothing);
     });
+  });
+
+  group('Chat screen — audio button visibility', () {
+    testWidgets(
+      'audio button hidden when ttsAvailable is false even with voiceReceive',
+      (tester) async {
+        final res = await pumpChatScreen(
+          tester,
+          capabilities: const ServerCapabilities(
+            voiceSend: false,
+            voiceReceive: true,
+          ),
+        );
+
+        final msg = ChatMessage(
+          id: 'a1',
+          role: 'assistant',
+          content: 'Hello there',
+          ttsAvailable: false,
+        );
+
+        res.notifier.push(ChatState(conversationId: 'c1', messages: [msg]));
+        await tester.pump();
+
+        expect(
+          find.byType(AudioPlayerWidget),
+          findsNothing,
+          reason: 'Audio button must not appear when ttsAvailable is false',
+        );
+      },
+    );
+
+    testWidgets(
+      'audio button shown when ttsAvailable is true and voiceReceive enabled',
+      (tester) async {
+        final res = await pumpChatScreen(
+          tester,
+          capabilities: const ServerCapabilities(
+            voiceSend: false,
+            voiceReceive: true,
+          ),
+        );
+
+        final msg = ChatMessage(
+          id: 'a2',
+          role: 'assistant',
+          content: 'Hello there',
+          ttsAvailable: true,
+        );
+
+        res.notifier.push(ChatState(conversationId: 'c1', messages: [msg]));
+        await tester.pump();
+
+        expect(
+          find.byType(AudioPlayerWidget),
+          findsOneWidget,
+          reason:
+              'Audio button should appear when ttsAvailable and voiceReceive are both true',
+        );
+      },
+    );
+
+    testWidgets(
+      'audio button hidden when voiceReceive is false even with ttsAvailable',
+      (tester) async {
+        final res = await pumpChatScreen(
+          tester,
+          capabilities: const ServerCapabilities(
+            voiceSend: false,
+            voiceReceive: false,
+          ),
+        );
+
+        final msg = ChatMessage(
+          id: 'a3',
+          role: 'assistant',
+          content: 'Hello there',
+          ttsAvailable: true,
+        );
+
+        res.notifier.push(ChatState(conversationId: 'c1', messages: [msg]));
+        await tester.pump();
+
+        expect(
+          find.byType(AudioPlayerWidget),
+          findsNothing,
+          reason: 'Audio button must not appear when voiceReceive is disabled',
+        );
+      },
+    );
   });
 }

--- a/crates/web-ui/src/backends/iceberg.rs
+++ b/crates/web-ui/src/backends/iceberg.rs
@@ -317,7 +317,7 @@ impl TraceBackend for IcebergTraceBackend {
             })
             .collect();
 
-        summaries.sort_by(|a, b| b.start_time.cmp(&a.start_time));
+        summaries.sort_by_key(|s| std::cmp::Reverse(s.start_time));
         summaries.truncate(limit as usize);
         Ok(summaries)
     }
@@ -484,7 +484,7 @@ impl LogBackend for IcebergLogBackend {
             }
         }
 
-        logs.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        logs.sort_by_key(|l| std::cmp::Reverse(l.timestamp));
         logs.truncate(limit as usize);
         Ok(logs)
     }


### PR DESCRIPTION
## Summary
- The audio play button was appearing on **every** assistant message when `voiceReceive` was enabled, ignoring the per-message `ttsAvailable` field
- Added `message.ttsAvailable` check to the render condition so the button only shows on messages where TTS is actually available
- Added 3 widget tests covering all combinations of `voiceReceive` × `ttsAvailable`

## Test plan
- [x] `flutter test test/widget/features/chat/chat_screen_test.dart` — all 9 tests pass
- [ ] Manual: verify audio button only appears on assistant messages with TTS content
- [ ] Manual: verify no audio button on tool-only or empty assistant messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chat audio playback button visibility so the audio control only appears when server voice support is enabled and the specific message has TTS available; the control is hidden otherwise to avoid nonfunctional playback options.

* **Tests**
  * Added widget tests to verify audio button visibility across combinations of server voice support and message TTS availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->