### PR TITLE
fix(ci): use ditto instead of zip to preserve macOS framework symlinks

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -259,6 +259,12 @@ jobs:
           codesign --force --sign "$IDENTITY" --options runtime --timestamp \
             --entitlements app/macos/Runner/Release.entitlements "$APP"
 
+      - name: Verify code signature
+        run: |
+          APP="app/build/macos/Build/Products/Release/assistant_app.app"
+          codesign --verify --deep --strict "$APP"
+          echo "Code signature verification passed"
+
       - name: Notarize macOS app
         run: |
           APP="app/build/macos/Build/Products/Release/assistant_app.app"
@@ -299,8 +305,13 @@ jobs:
         run: |
           TAG="${{ needs.release-please.outputs.tag_name }}"
           ARCHIVE_NAME="assistant-app-${TAG}-${{ matrix.archive_suffix }}.zip"
-          cd app/build/macos/Build/Products/Release
-          zip -r "${GITHUB_WORKSPACE}/${ARCHIVE_NAME}" "assistant_app.app"
+          # Use ditto instead of zip to preserve macOS framework symlinks.
+          # zip -r follows symlinks, turning them into real files, which breaks
+          # the framework bundle structure and causes Gatekeeper to reject the
+          # app with "bundle format is ambiguous (could be app or framework)".
+          ditto -c -k --keepParent \
+            "app/build/macos/Build/Products/Release/assistant_app.app" \
+            "${ARCHIVE_NAME}"
           echo "ARCHIVE=${ARCHIVE_NAME}" >> $GITHUB_ENV
 
       - name: Generate checksums


### PR DESCRIPTION
## Summary
- Replace `zip -r` with `ditto -c -k --keepParent` when creating the macOS release archive
- `zip -r` follows symlinks, destroying macOS framework bundle structure (`Versions/Current -> A` becomes a real directory), causing Gatekeeper to reject the app with "bundle format is ambiguous (could be app or framework)"
- Add `codesign --verify --deep --strict` step after signing to catch bundle issues before notarization

## Test plan
- [ ] Trigger a release build and verify the resulting `.app` passes `codesign --verify --deep --strict`
- [ ] Download the release ZIP, extract, and confirm `Versions/Current` inside frameworks are symlinks (not directories)
- [ ] Verify the app launches without "is damaged and can't be opened" error on macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added macOS code signing verification step in release pipeline
  * Updated macOS application packaging method to better preserve bundle and framework structure during releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->