### PR TITLE
feat(hooks): add Flutter quality checks to pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,7 +4,6 @@ set -euo pipefail
 BOLD='\033[1m'
 RED='\033[0;31m'
 GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
 RESET='\033[0m'
 
 fail() {
@@ -16,16 +15,44 @@ step() {
     echo -e "${BOLD}==> $1${RESET}"
 }
 
-step "Checking formatting..."
+# ── Preflight: verify required toolchains ────────────────────────────────────
+
+step "Checking required tools..."
+command -v cargo >/dev/null 2>&1 \
+    || fail "cargo not found on PATH — install Rust: https://rustup.rs"
+command -v flutter >/dev/null 2>&1 \
+    || fail "flutter not found on PATH — install Flutter: https://docs.flutter.dev/get-started/install"
+command -v dart >/dev/null 2>&1 \
+    || fail "dart not found on PATH — install Flutter/Dart: https://docs.flutter.dev/get-started/install"
+
+# ── Rust: formatting ────────────────────────────────────────────────────────
+
+step "Checking Rust formatting..."
 cargo fmt --all -- --check \
     || fail "cargo fmt check failed — run 'make format' to fix"
+
+# ── Flutter/Dart: dart_pre_commit (format, analyze, deps, OSV) ──────────────
+
+step "Running dart_pre_commit checks..."
+(cd app && dart run dart_pre_commit) \
+    || fail "dart_pre_commit failed — fix issues above before committing"
+
+# ── Rust: clippy ─────────────────────────────────────────────────────────────
 
 step "Running clippy..."
 cargo clippy --workspace -- -D warnings \
     || fail "cargo clippy failed — fix warnings before committing"
 
+# ── Rust: unused dependencies ────────────────────────────────────────────────
+
 step "Checking for unused dependencies (machete)..."
 cargo machete --with-metadata \
     || fail "cargo machete found unused dependencies — remove them before committing"
+
+# ── Flutter: tests ───────────────────────────────────────────────────────────
+
+step "Running Flutter tests..."
+(cd app && flutter test) \
+    || fail "flutter test failed — fix failing tests before committing"
 
 echo -e "${GREEN}All pre-commit checks passed.${RESET}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,9 @@ make check            # cargo check --workspace  (fast, no codegen)
 make test             # cargo test --workspace
 make lint             # cargo clippy --workspace -- -D warnings
 make format           # cargo fmt --all
+make lint-flutter     # dart_pre_commit (format, analyze, deps, OSV)
+make test-flutter     # flutter test
+make precommit        # run all pre-commit checks manually
 make test-integration # cargo test -p assistant-integration-tests --test smoke -- --ignored --nocapture
 ```
 
@@ -35,7 +38,8 @@ cargo test -p assistant-tool-executor test_name -- --nocapture
 Run targets: `make run` (orchestrator), `make run-mcp` (MCP stdio), `make run-slack`, `make run-mattermost`, `make run-matrix`, `make run-nextcloud`, `make run-signal`, `make run-webui`, `make run-worker`.
 
 **Always run `make lint` and `make format` before committing.** Pre-commit hooks
-enforce `cargo fmt --check`, `cargo clippy -D warnings`, and `cargo machete --with-metadata`.
+enforce `cargo fmt --check`, `cargo clippy -D warnings`, `cargo machete --with-metadata`,
+`dart_pre_commit` (format, analyze, deps, OSV), and `flutter test`.
 Install hooks after cloning: `make install-hooks`.
 
 **Note:** `cargo check --all-features` may require `protoc` (protobuf compiler) for certain features.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build test lint lint-signal format clean check install-hooks run run-mcp run-slack run-mattermost run-matrix run-nextcloud run-signal run-webui run-worker build-signal build-macos-binary build-macos-bundle
+.PHONY: all build test lint lint-signal lint-flutter format clean check install-hooks run run-mcp run-slack run-mattermost run-matrix run-nextcloud run-signal run-webui run-worker build-signal build-macos-binary build-macos-bundle test-flutter precommit
 
 all: build
 
@@ -31,6 +31,24 @@ clean:
 
 install-hooks:
 	git config core.hooksPath .githooks
+
+# ── Flutter quality checks ───────────────────────────────────────────────────
+
+# Run dart_pre_commit (format, analyze, deps, OSV scanning) on the Flutter app.
+lint-flutter:
+	cd app && dart run dart_pre_commit
+
+# Run Flutter unit and widget tests.
+test-flutter:
+	cd app && flutter test
+
+# Run all pre-commit checks manually (mirrors .githooks/pre-commit).
+precommit:
+	cargo fmt --all -- --check
+	cd app && dart run dart_pre_commit
+	cargo clippy --workspace -- -D warnings
+	cargo machete --with-metadata
+	cd app && flutter test
 
 # Run the interactive REPL (Slack/Mattermost start in background if configured)
 run:

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -184,6 +184,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  console:
+    dependency: transitive
+    description:
+      name: console
+      sha256: e04e7824384c5b39389acdd6dc7d33f3efe6b232f6f16d7626f194f6a01ad69a
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   convert:
     dependency: transitive
     description:
@@ -216,6 +224,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
+  dart_pre_commit:
+    dependency: "direct dev"
+    description:
+      name: dart_pre_commit
+      sha256: "2b1bbfb743412cf951fed41e27c693a1e1419e94c87d871531b3d3d5422ffd35"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.1+1"
   dbus:
     dependency: transitive
     description:
@@ -399,6 +415,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  freezed_annotation:
+    dependency: transitive
+    description:
+      name: freezed_annotation
+      sha256: "7294967ff0a6d98638e7acb774aac3af2550777accd8149c90af5b014e6d44d8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -407,6 +431,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  get_it:
+    dependency: transitive
+    description:
+      name: get_it
+      sha256: "568d62f0e68666fb5d95519743b3c24a34c7f19d834b0658c46e26d778461f66"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.2.1"
   glob:
     dependency: transitive
     description:
@@ -463,6 +495,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.8.0"
+  injectable:
+    dependency: transitive
+    description:
+      name: injectable
+      sha256: "32b36a9d87f18662bee0b1951b81f47a01f2bf28cd6ea94f60bc5453c7bf598c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.1+4"
   io:
     dependency: transitive
     description:
@@ -743,6 +783,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  pubspec_parse:
+    dependency: transitive
+    description:
+      name: pubspec_parse
+      sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.0"
   pwa_install:
     dependency: "direct main"
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   path_provider: ^2.1.5
   url_launcher: ^6.3.2
   package_info_plus: ^9.0.1
-  built_value: '>=8.4.0 <9.0.0'
+  built_value: ">=8.4.0 <9.0.0"
   assistant_api:
     path: packages/assistant_api
   tray_manager: ^0.5.2
@@ -41,12 +41,13 @@ dev_dependencies:
   audioplayers_platform_interface: ^7.1.1
   flutter_launcher_icons: ^0.14.4
   built_collection: ^5.0.0
+  dart_pre_commit: ^6.1.1
 flutter_launcher_icons:
   web:
     generate: true
     image_path: macos/Runner/Assets.xcassets/AppIcon.appiconset/app_icon_1024.png
-    background_color: '#080C1A'
-    theme_color: '#080C1A'
+    background_color: "#080C1A"
+    theme_color: "#080C1A"
 flutter:
   uses-material-design: true
   assets:

--- a/openspec/changes/archive/2026-04-16-pre-commit-hook/design.md
+++ b/openspec/changes/archive/2026-04-16-pre-commit-hook/design.md
@@ -1,0 +1,57 @@
+# Design: Pre-commit Hook
+
+## Architecture
+
+The pre-commit hook is a single bash script at `.githooks/pre-commit`. It runs
+sequentially through checks, exiting on first failure (fail-fast).
+
+```
+git commit
+    │
+    ▼
+.githooks/pre-commit
+    │
+    ├─ preflight: cargo, flutter, dart on PATH
+    ├─ cargo fmt --all -- --check
+    ├─ (cd app && dart run dart_pre_commit)
+    ├─ cargo clippy --workspace -- -D warnings
+    ├─ cargo machete --with-metadata
+    └─ (cd app && flutter test)
+```
+
+## Key Decisions
+
+### Use `dart_pre_commit` package
+
+Instead of hand-rolling `dart format` + `flutter analyze`, we use the
+`dart_pre_commit` pub package. It provides formatting, static analysis,
+dependency freshness, and OSV vulnerability scanning with zero config.
+
+Configured implicitly via existing `analysis_options.yaml` (which already
+excludes `packages/assistant_api/`).
+
+### Fail-fast ordering
+
+Checks are ordered cheapest to most expensive so developers get fast feedback
+on trivial issues (formatting) before waiting for slow checks (tests).
+
+### Hard fail on missing tools
+
+No graceful degradation. If `cargo`, `flutter`, or `dart` is missing, the hook
+fails immediately with a clear error message. This ensures every committer has
+the full toolchain.
+
+### Makefile targets
+
+New targets mirror the hook steps for manual use:
+
+- `lint-flutter` — runs `dart run dart_pre_commit` in `app/`
+- `test-flutter` — runs `flutter test` in `app/`
+- `precommit` — runs the full hook sequence for manual invocation
+
+## Integration Points
+
+- `.githooks/pre-commit` — the hook script itself
+- `Makefile` — new targets for manual use
+- `app/pubspec.yaml` — `dart_pre_commit` dev dependency
+- `app/analysis_options.yaml` — already excludes generated code (no changes needed)

--- a/openspec/changes/archive/2026-04-16-pre-commit-hook/proposal.md
+++ b/openspec/changes/archive/2026-04-16-pre-commit-hook/proposal.md
@@ -1,0 +1,56 @@
+# Pre-commit Hook: Rust + Flutter Quality Gate
+
+## Problem
+
+The existing pre-commit hook (`.githooks/pre-commit`) only covers Rust checks
+(cargo fmt, clippy, machete). The Flutter app under `app/` has no pre-commit
+quality gate — formatting, analysis, and test regressions can slip through to CI.
+
+## Proposal
+
+Extend the pre-commit hook to enforce quality checks for **both** Rust and
+Flutter, and add corresponding Makefile targets for manual use.
+
+## Design Decisions
+
+- **Always run all checks** — no selective skipping based on changed files. If
+  you commit to this repo, you need both toolchains.
+- **Hard fail on missing toolchains** — `cargo`, `flutter`, and `dart` must be
+  on PATH. No graceful degradation.
+- **Fail fast** — stop on first failing check, ordered cheap-to-expensive.
+- **Use `dart_pre_commit`** — the
+  [`dart_pre_commit`](https://pub.dev/packages/dart_pre_commit) package replaces
+  hand-rolled `dart format` + `flutter analyze` calls. It provides formatting,
+  analysis, dependency freshness checks, and OSV vulnerability scanning
+  out-of-the-box with zero config and optional tuning via `pubspec.yaml`.
+  Generated code in `app/packages/assistant_api/` is excluded via
+  `analysis_options.yaml` (already in place).
+- **Include flutter test** — tests run as the final (most expensive) step,
+  separate from `dart_pre_commit` since the package doesn't cover tests.
+
+## Check Order (fail-fast, cheap → expensive)
+
+| Step | Check                                        | ~Time   |
+| ---- | -------------------------------------------- | ------- |
+| 1    | Preflight: verify `cargo`, `flutter`, `dart` | instant |
+| 2    | `cargo fmt --all -- --check`                 | ~0s     |
+| 3    | `dart run dart_pre_commit` (from `app/`)     | ~5s     |
+| 4    | `cargo clippy --workspace -- -D warnings`    | ~10s    |
+| 5    | `cargo machete --with-metadata`              | ~3s     |
+| 6    | `flutter test` (from `app/`)                 | ~30s+   |
+
+## Dependencies Added
+
+- `dart_pre_commit` as a dev dependency in `app/pubspec.yaml`
+
+## Files Changed
+
+- `.githooks/pre-commit` — rewrite with preflight + Flutter checks
+- `Makefile` — add `lint-flutter`, `test-flutter`, and `precommit` targets
+- `app/pubspec.yaml` — add `dart_pre_commit` dev dependency
+
+## Out of Scope
+
+- Commit message linting (conventional commits enforcement)
+- Running Rust tests in the hook (kept for CI)
+- Husky / lefthook or any third-party hook manager

--- a/openspec/changes/archive/2026-04-16-pre-commit-hook/specs/pre-commit-hook/spec.md
+++ b/openspec/changes/archive/2026-04-16-pre-commit-hook/specs/pre-commit-hook/spec.md
@@ -1,0 +1,52 @@
+# Spec: Pre-commit Hook
+
+## Requirements
+
+### REQ-1: Preflight toolchain check
+
+The hook MUST verify that `cargo`, `flutter`, and `dart` are available on PATH
+before running any checks. If any is missing, it MUST exit with a non-zero code
+and a clear error message naming the missing tool.
+
+### REQ-2: Rust formatting check
+
+The hook MUST run `cargo fmt --all -- --check` and fail if any files are
+unformatted.
+
+### REQ-3: Dart pre-commit checks
+
+The hook MUST run `dart run dart_pre_commit` from the `app/` directory. This
+covers dart formatting, static analysis, dependency freshness, and OSV
+vulnerability scanning.
+
+### REQ-4: Rust linting
+
+The hook MUST run `cargo clippy --workspace -- -D warnings` and fail on any
+warning.
+
+### REQ-5: Unused Rust dependency check
+
+The hook MUST run `cargo machete --with-metadata` and fail if unused
+dependencies are found.
+
+### REQ-6: Flutter tests
+
+The hook MUST run `flutter test` from the `app/` directory and fail if any test
+fails.
+
+### REQ-7: Fail-fast execution
+
+The hook MUST stop on the first failing check. Checks MUST run in order from
+cheapest to most expensive (as listed in REQ-1 through REQ-6).
+
+### REQ-8: Dev dependency
+
+`dart_pre_commit` MUST be added as a dev dependency in `app/pubspec.yaml`.
+
+### REQ-9: Makefile targets
+
+The Makefile MUST include:
+
+- `lint-flutter` — runs `dart run dart_pre_commit` in `app/`
+- `test-flutter` — runs `flutter test` in `app/`
+- `precommit` — runs all hook checks in order for manual invocation

--- a/openspec/changes/archive/2026-04-16-pre-commit-hook/tasks.md
+++ b/openspec/changes/archive/2026-04-16-pre-commit-hook/tasks.md
@@ -1,0 +1,6 @@
+# Tasks: Pre-commit Hook
+
+- [x] Add `dart_pre_commit` as a dev dependency in `app/pubspec.yaml` and run `flutter pub get`
+- [x] Rewrite `.githooks/pre-commit` with preflight checks, Rust checks, `dart_pre_commit`, and `flutter test` in fail-fast order
+- [x] Add `lint-flutter`, `test-flutter`, and `precommit` targets to the Makefile
+- [x] Update CLAUDE.md / AGENTS.md to document the new Flutter hook checks and Makefile targets


### PR DESCRIPTION
## Summary
- Extend pre-commit hook to cover both Rust and Flutter, with toolchain preflight checks and fail-fast ordering
- Add `dart_pre_commit` dev dependency for Dart formatting, analysis, dependency freshness, and OSV vulnerability scanning
- Add `lint-flutter`, `test-flutter`, and `precommit` Makefile targets for manual use

## Test plan
- [ ] Run `make install-hooks` then attempt a commit — verify all 6 checks run in order
- [ ] Verify hook fails fast on a formatting issue (e.g. unformatted Dart file)
- [ ] Verify `make precommit` mirrors the hook behavior
- [ ] Verify `make lint-flutter` and `make test-flutter` work standalone