### PR TITLE
feat(chat): render mermaid diagrams and streaming markdown natively

### DIFF
--- a/app/lib/features/chat/chat_provider.dart
+++ b/app/lib/features/chat/chat_provider.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:assistant_api/assistant_api.dart' hide ServerCapabilities;
@@ -178,6 +179,7 @@ class ChatMessage {
     this.status = MessageStatus.ok,
     this.audioId,
     this.ttsAvailable = false,
+    this.tokenStream,
     List<ToolCallRecord>? toolCalls,
   }) : toolCalls = toolCalls ?? [];
 
@@ -200,6 +202,10 @@ class ChatMessage {
   /// Populated during streaming from [StatusEvent] and [ToolResultEvent].
   List<ToolCallRecord> toolCalls;
 
+  /// Live stream of token chunks during streaming. Used by [StreamMarkdown]
+  /// for throttled incremental rendering. Null for non-streaming messages.
+  Stream<String>? tokenStream;
+
   bool get isUser => role == 'user';
   bool get isAssistant => role == 'assistant';
 
@@ -210,6 +216,8 @@ class ChatMessage {
     String? audioId,
     bool? ttsAvailable,
     List<ToolCallRecord>? toolCalls,
+    Stream<String>? tokenStream,
+    bool clearTokenStream = false,
   }) {
     return ChatMessage(
       id: id,
@@ -220,6 +228,7 @@ class ChatMessage {
       audioId: audioId ?? this.audioId,
       ttsAvailable: ttsAvailable ?? this.ttsAvailable,
       toolCalls: toolCalls ?? this.toolCalls,
+      tokenStream: clearTokenStream ? null : (tokenStream ?? this.tokenStream),
     );
   }
 }
@@ -783,6 +792,9 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
     _cancelled = false;
     final current = state.value ?? const ChatState();
 
+    // Create a broadcast stream controller for token-by-token rendering.
+    final tokenController = StreamController<String>.broadcast();
+
     // Show a placeholder user message while transcribing.
     final userMsgId = 'user-${DateTime.now().millisecondsSinceEpoch}';
     final userMsg = ChatMessage(
@@ -796,6 +808,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
       role: 'assistant',
       content: '',
       isStreaming: true,
+      tokenStream: tokenController.stream,
     );
     state = AsyncData(
       current.copyWith(
@@ -826,6 +839,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
           }
           state = AsyncData(chatState.copyWith(messages: msgs));
         } else if (event is TokenEvent) {
+          tokenController.add(event.token);
           final newContent = chatState.streamingContent + event.token;
           final msgs = List<ChatMessage>.from(chatState.messages);
           final idx = msgs.indexWhere((m) => m.id == 'assistant-streaming');
@@ -853,6 +867,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
           }
           state = AsyncData(chatState.copyWith(messages: msgs));
         } else if (event is DoneEvent) {
+          unawaited(tokenController.close());
           final msgs = List<ChatMessage>.from(chatState.messages);
           // User bubble is already correct from TranscriptEvent; just ensure ok status.
           final userIdx = msgs.indexWhere((m) => m.id == userMsgId);
@@ -891,6 +906,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
           ref.read(conversationListProvider.notifier).refresh();
           return;
         } else if (event is ErrorEvent) {
+          unawaited(tokenController.close());
           final msgs = List<ChatMessage>.from(chatState.messages)
             ..removeWhere((m) => m.id == 'assistant-streaming');
           final userIdx = msgs.indexWhere((m) => m.id == userMsgId);
@@ -911,6 +927,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
         }
       }
     } catch (e) {
+      unawaited(tokenController.close());
       final chatState = state.value ?? const ChatState();
       final msgs = List<ChatMessage>.from(chatState.messages)
         ..removeWhere((m) => m.id == 'assistant-streaming');
@@ -939,6 +956,9 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
     _lastSeq = 0;
     final current = state.value ?? const ChatState();
 
+    // Create a broadcast stream controller for token-by-token rendering.
+    final tokenController = StreamController<String>.broadcast();
+
     // Add user message with status=sending and assistant streaming placeholder.
     final userMsgId = 'user-${DateTime.now().millisecondsSinceEpoch}';
     final userMsg = ChatMessage(
@@ -952,6 +972,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
       role: 'assistant',
       content: '',
       isStreaming: true,
+      tokenStream: tokenController.stream,
     );
 
     state = AsyncData(
@@ -975,6 +996,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
           continue;
         } else if (event is TokenEvent) {
           _lastSeq++;
+          tokenController.add(event.token);
           final newContent = chatState.streamingContent + event.token;
           final msgs = List<ChatMessage>.from(chatState.messages);
           final idx = msgs.indexWhere((m) => m.id == 'assistant-streaming');
@@ -996,6 +1018,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
           _onToolResultEvent(chatState, event);
         } else if (event is DoneEvent) {
           _lastSeq++;
+          unawaited(tokenController.close());
           final msgs = List<ChatMessage>.from(chatState.messages);
           // Mark user message as successfully acknowledged.
           final userIdx = msgs.indexWhere((m) => m.id == userMsgId);
@@ -1048,6 +1071,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
           state = AsyncData(chatState.copyWith(messages: msgs));
         } else if (event is ErrorEvent) {
           _lastSeq++;
+          unawaited(tokenController.close());
           final msgs = List<ChatMessage>.from(chatState.messages)
             ..removeWhere((m) => m.id == 'assistant-streaming');
           // Mark user message as failed (keep it in the list for retry).
@@ -1069,7 +1093,9 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
         }
       }
 
-      // Stream ended without DoneEvent — treat accumulated buffer as final.
+      // Stream ended without DoneEvent — close token controller and treat
+      // accumulated buffer as final.
+      unawaited(tokenController.close());
       final finalState = state.value ?? const ChatState();
       if (finalState.isSending) {
         final msgs = List<ChatMessage>.from(finalState.messages);
@@ -1102,6 +1128,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
         );
       }
     } catch (e) {
+      unawaited(tokenController.close());
       // If we have a run ID, attempt replay before marking as failed.
       if (_currentRunId != null) {
         final replayed = await _replayRun(

--- a/app/lib/features/chat/chat_screen.dart
+++ b/app/lib/features/chat/chat_screen.dart
@@ -1,7 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
+import 'package:flutter_smooth_markdown/flutter_smooth_markdown.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
@@ -471,21 +471,51 @@ class _MessageBubble extends StatelessWidget {
                           padding: EdgeInsets.only(bottom: 6),
                           child: Divider(height: 1, thickness: 0.5),
                         ),
-                      MarkdownBody(
-                        data: message.content,
-                        styleSheet:
-                            MarkdownStyleSheet.fromTheme(
-                              Theme.of(context),
-                            ).copyWith(
-                              p: TextStyle(color: colorScheme.onSurface),
-                              code: TextStyle(
-                                color: colorScheme.onSurface,
-                                backgroundColor:
-                                    colorScheme.surfaceContainerLowest,
+                      if (message.isStreaming && message.tokenStream != null)
+                        StreamMarkdown(
+                          stream: message.tokenStream!,
+                          styleSheet:
+                              MarkdownStyleSheet.fromTheme(
+                                Theme.of(context),
+                              ).copyWith(
+                                paragraphStyle: TextStyle(
+                                  color: colorScheme.onSurface,
+                                ),
+                                inlineCodeStyle: TextStyle(
+                                  color: colorScheme.onSurface,
+                                  backgroundColor:
+                                      colorScheme.surfaceContainerLowest,
+                                ),
                               ),
-                            ),
-                        selectable: true,
-                      ),
+                          useEnhancedComponents: true,
+                          plugins: ParserPluginRegistry()
+                            ..registerBlock(MermaidPlugin()),
+                          builderRegistry: BuilderRegistry()
+                            ..register('mermaid', const MermaidBuilder()),
+                        )
+                      else
+                        SmoothMarkdown(
+                          data: message.content,
+                          styleSheet:
+                              MarkdownStyleSheet.fromTheme(
+                                Theme.of(context),
+                              ).copyWith(
+                                paragraphStyle: TextStyle(
+                                  color: colorScheme.onSurface,
+                                ),
+                                inlineCodeStyle: TextStyle(
+                                  color: colorScheme.onSurface,
+                                  backgroundColor:
+                                      colorScheme.surfaceContainerLowest,
+                                ),
+                              ),
+                          selectable: true,
+                          useEnhancedComponents: true,
+                          plugins: ParserPluginRegistry()
+                            ..registerBlock(MermaidPlugin()),
+                          builderRegistry: BuilderRegistry()
+                            ..register('mermaid', const MermaidBuilder()),
+                        ),
                       // Play button for assistant messages. Shows whenever
                       // voice is enabled — fetches on-demand if no audioId.
                       if (capabilities.voiceReceive && !message.isStreaming)

--- a/app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -12,6 +12,7 @@ import package_info_plus
 import record_macos
 import screen_retriever_macos
 import shared_preferences_foundation
+import sqflite_darwin
 import tray_manager
 import url_launcher_macos
 import window_manager
@@ -24,6 +25,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   RecordMacOsPlugin.register(with: registry.registrar(forPlugin: "RecordMacOsPlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
   TrayManagerPlugin.register(with: registry.registrar(forPlugin: "TrayManagerPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -128,6 +128,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.12.5"
+  cached_network_image:
+    dependency: transitive
+    description:
+      name: cached_network_image
+      sha256: "7c1183e361e5c8b0a0f21a28401eecdbde252441106a9816400dd4c2b2424916"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.1"
+  cached_network_image_platform_interface:
+    dependency: transitive
+    description:
+      name: cached_network_image_platform_interface
+      sha256: "35814b016e37fbdc91f7ae18c8caf49ba5c88501813f73ce8a07027a395e2829"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.1"
+  cached_network_image_web:
+    dependency: transitive
+    description:
+      name: cached_network_image_web
+      sha256: "980842f4e8e2535b8dbd3d5ca0b1f0ba66bf61d14cc3a17a9b4788a3685ba062"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.1"
   characters:
     dependency: transitive
     description:
@@ -277,6 +301,22 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_cache_manager:
+    dependency: transitive
+    description:
+      name: flutter_cache_manager
+      sha256: "400b6592f16a4409a7f2bb929a9a7e38c72cceb8ffb99ee57bbf2cb2cecf8386"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.1"
+  flutter_highlight:
+    dependency: transitive
+    description:
+      name: flutter_highlight
+      sha256: "7b96333867aa07e122e245c033b8ad622e4e3a42a1a2372cbb098a2541d8782c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.0"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -325,14 +365,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
-  flutter_markdown_plus:
-    dependency: "direct main"
+  flutter_math_fork:
+    dependency: transitive
     description:
-      name: flutter_markdown_plus
-      sha256: "039177906850278e8fb1cd364115ee0a46281135932fa8ecea8455522166d2de"
+      name: flutter_math_fork
+      sha256: "6d5f2f1aa57ae539ffb0a04bb39d2da67af74601d685a161aff7ce5bda5fa407"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.7"
+    version: "0.7.4"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -389,6 +429,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.0"
+  flutter_smooth_markdown:
+    dependency: "direct main"
+    description:
+      name: flutter_smooth_markdown
+      sha256: "7a59bbc06f2670bd920e26161e9fce68b126a0b6279a95c47049dfb0f38165ee"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.2"
+  flutter_svg:
+    dependency: transitive
+    description:
+      name: flutter_svg
+      sha256: "1ded017b39c8e15c8948ea855070a5ff8ff8b3d5e83f3446e02d6bb12add7ad9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.4"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -423,6 +479,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "17.2.1"
+  highlight:
+    dependency: transitive
+    description:
+      name: highlight
+      sha256: "5353a83ffe3e3eca7df0abfb72dcf3fa66cc56b953728e7113ad4ad88497cf21"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.0"
   hooks:
     dependency: transitive
     description:
@@ -527,14 +591,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
-  markdown:
-    dependency: transitive
-    description:
-      name: markdown
-      sha256: ee85086ad7698b42522c6ad42fe195f1b9898e4d974a1af4576c1a3a176cada9
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.3.1"
   matcher:
     dependency: transitive
     description:
@@ -583,6 +639,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.17.6"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   node_preamble:
     dependency: transitive
     description:
@@ -599,6 +663,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.3.0"
+  octo_image:
+    dependency: transitive
+    description:
+      name: octo_image
+      sha256: "34faa6639a78c7e3cbe79be6f9f96535867e879748ade7d17c9b1ae7536293bd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   one_of:
     dependency: transitive
     description:
@@ -647,6 +719,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_parsing:
+    dependency: transitive
+    description:
+      name: path_parsing
+      sha256: "883402936929eac138ee0a45da5b0f2c80f89913e6dc3bf77eb65b84b409c6ca"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   path_provider:
     dependency: "direct main"
     description:
@@ -735,6 +815,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.5.0"
+  provider:
+    dependency: transitive
+    description:
+      name: provider
+      sha256: "4e82183fa20e5ca25703ead7e05de9e4cceed1fbd1eadc1ac3cb6f565a09f272"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.5+1"
   pub_semver:
     dependency: "direct main"
     description:
@@ -831,6 +919,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.28.0"
   screen_retriever:
     dependency: transitive
     description:
@@ -996,6 +1092,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.2"
+  sqflite:
+    dependency: transitive
+    description:
+      name: sqflite
+      sha256: e2297b1da52f127bc7a3da11439985d9b536f75070f3325e62ada69a5c585d03
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  sqflite_android:
+    dependency: transitive
+    description:
+      name: sqflite_android
+      sha256: "881e28efdcc9950fd8e9bb42713dcf1103e62a2e7168f23c9338d82db13dec40"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2+3"
+  sqflite_common:
+    dependency: transitive
+    description:
+      name: sqflite_common
+      sha256: "6ef422a4525ecc601db6c0a2233ff448c731307906e92cabc9ba292afaae16a6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.6"
+  sqflite_darwin:
+    dependency: transitive
+    description:
+      name: sqflite_darwin
+      sha256: "279832e5cde3fe99e8571879498c9211f3ca6391b0d818df4e17d9fff5c6ccb3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  sqflite_platform_interface:
+    dependency: transitive
+    description:
+      name: sqflite_platform_interface
+      sha256: "8dd4515c7bdcae0a785b0062859336de775e8c65db81ae33dd5445f35be61920"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   stack_trace:
     dependency: transitive
     description:
@@ -1084,6 +1220,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.2"
+  tuple:
+    dependency: transitive
+    description:
+      name: tuple
+      sha256: a97ce2013f240b2f3807bcbaf218765b6f301c3eff91092bcfa23a039e7dd151
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   typed_data:
     dependency: transitive
     description:
@@ -1164,6 +1308,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.5.3"
+  vector_graphics:
+    dependency: transitive
+    description:
+      name: vector_graphics
+      sha256: "81da85e9ca8885ade47f9685b953cb098970d11be4821ac765580a6607ea4373"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.21"
+  vector_graphics_codec:
+    dependency: transitive
+    description:
+      name: vector_graphics_codec
+      sha256: "99fd9fbd34d9f9a32efd7b6a6aae14125d8237b10403b422a6a6dfeac2806146"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.13"
+  vector_graphics_compiler:
+    dependency: transitive
+    description:
+      name: vector_graphics_compiler
+      sha256: "5a88dd14c0954a5398af544651c7fb51b457a2a556949bfb25369b210ef73a74"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
   vector_math:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -23,12 +23,12 @@ dependencies:
   path_provider: ^2.1.5
   url_launcher: ^6.3.2
   package_info_plus: ^9.0.1
-  built_value: '>=8.4.0 <9.0.0'
+  built_value: ">=8.4.0 <9.0.0"
   assistant_api:
     path: packages/assistant_api
   tray_manager: ^0.5.2
   window_manager: ^0.5.1
-  flutter_markdown_plus: ^1.0.0
+  flutter_smooth_markdown: ^0.7.2
   pwa_install: 0.0.6
   flutter_local_notifications: ^21.0.0
   web: ^1.1.1
@@ -45,8 +45,8 @@ flutter_launcher_icons:
   web:
     generate: true
     image_path: macos/Runner/Assets.xcassets/AppIcon.appiconset/app_icon_1024.png
-    background_color: '#080C1A'
-    theme_color: '#080C1A'
+    background_color: "#080C1A"
+    theme_color: "#080C1A"
 flutter:
   uses-material-design: true
   assets:

--- a/app/test/unit/chat/chat_provider_test.dart
+++ b/app/test/unit/chat/chat_provider_test.dart
@@ -661,4 +661,49 @@ void main() {
       },
     );
   });
+
+  // -- tokenStream tests ------------------------------------------------------
+
+  group('ChatNotifier.tokenStream', () {
+    testWidgets('streaming assistant message has a tokenStream', (
+      tester,
+    ) async {
+      final fakeApi = _FakeApiClient();
+      final ctrl = fakeApi.enqueueStream();
+
+      final notifier = await _pumpTestApp(tester, fakeApi);
+
+      unawaited(notifier.sendMessage('hello'));
+      await tester.pump();
+
+      // Grab the token stream from the streaming assistant message.
+      final streamingMsg = notifier.state.value!.messages.firstWhere(
+        (m) => m.id == 'assistant-streaming',
+      );
+      expect(
+        streamingMsg.tokenStream,
+        isNotNull,
+        reason: 'streaming message should expose a tokenStream',
+      );
+
+      // Complete the stream cleanly.
+      await tester.runAsync(() async {
+        ctrl
+          ..add(const DoneEvent(role: 'assistant', content: 'done'))
+          ..close();
+        await Future<void>.delayed(Duration.zero);
+      });
+      await tester.pumpAndSettle();
+
+      // After DoneEvent, the final message should not have a tokenStream.
+      final finalMsg = notifier.state.value!.messages.firstWhere(
+        (m) => !m.isUser,
+      );
+      expect(
+        finalMsg.tokenStream,
+        isNull,
+        reason: 'finalized message should not carry a tokenStream',
+      );
+    });
+  });
 }

--- a/openspec/changes/pretty-graphs/design.md
+++ b/openspec/changes/pretty-graphs/design.md
@@ -1,0 +1,142 @@
+## Architecture
+
+### Package Swap
+
+Replace `flutter_markdown_plus: ^1.0.0` with `flutter_smooth_markdown: ^0.7.2`.
+
+This brings in transitively: `flutter_svg`, `flutter_highlight`, `flutter_math_fork`, `cached_network_image`. Removes the direct `flutter_markdown_plus` dependency.
+
+### Widget Mapping
+
+```
+BEFORE                              AFTER
+──────                              ─────
+MarkdownBody(                       SmoothMarkdown(
+  data: message.content,              data: message.content,
+  styleSheet: ...,                    styleSheet: ...,
+  selectable: true,                   selectable: true,
+)                                     useEnhancedComponents: true,
+                                      plugins: ParserPluginRegistry([
+                                        MermaidPlugin(),
+                                      ]),
+                                    )
+```
+
+For streaming messages, use `StreamMarkdown` instead:
+
+```
+StreamMarkdown(
+  stream: tokenStream,          // Stream<String> of chunks
+  styleSheet: ...,
+  plugins: ParserPluginRegistry([
+    MermaidPlugin(),
+  ]),
+)
+```
+
+### Streaming Architecture
+
+Currently, `chat_provider.dart` accumulates tokens into `ChatMessage.content` via string concatenation, and the UI rebuilds `MarkdownBody` on every state change.
+
+The new approach:
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  chat_provider.dart                                      │
+│                                                          │
+│  _streamMessage() {                                      │
+│    final controller = StreamController<String>();         │
+│    // expose controller.stream on ChatMessage             │
+│                                                          │
+│    for await (event in sseStream) {                       │
+│      if (event is ContentDelta) {                         │
+│        controller.add(event.text);  // raw chunks         │
+│        accumulated += event.text;   // keep for history   │
+│      }                                                   │
+│    }                                                     │
+│    controller.close();                                   │
+│    // finalize: message.content = accumulated             │
+│  }                                                       │
+└──────────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────┐
+│  chat_screen.dart                                        │
+│                                                          │
+│  if (message.isStreaming && message.tokenStream != null)  │
+│    StreamMarkdown(stream: message.tokenStream!, ...)      │
+│  else                                                    │
+│    SmoothMarkdown(data: message.content, ...)             │
+└──────────────────────────────────────────────────────────┘
+```
+
+`StreamMarkdown` internally accumulates chunks via `StringBuffer` with 50ms throttled rebuilds. After streaming completes, the widget is replaced by `SmoothMarkdown` with the final accumulated string (which enables caching and selection).
+
+### Theme Mapping
+
+`flutter_smooth_markdown`'s `MarkdownStyleSheet` is a different class with different property names:
+
+```
+flutter_markdown_plus          flutter_smooth_markdown
+─────────────────────          ───────────────────────
+MarkdownStyleSheet             MarkdownStyleSheet
+  .fromTheme(theme)              .fromTheme(theme)
+  .copyWith(                     .copyWith(
+    p: TextStyle(...)              paragraphStyle: TextStyle(...)
+    code: TextStyle(...)           inlineCodeStyle: TextStyle(...)
+  )                              )
+```
+
+Use `MarkdownStyleSheet.fromTheme(Theme.of(context))` as the base (auto light/dark), then `.copyWith()` to match our current color overrides.
+
+### Mermaid Rendering Pipeline (from flutter_smooth_markdown)
+
+````
+```mermaid code block
+    │
+    ▼
+MermaidPlugin.parse()          ← parser plugin, priority 10
+    │                            intercepts before CodeBlockParser
+    ▼
+MermaidDiagramNode { code, theme }
+    │
+    ▼
+MermaidBuilder                 ← registered in BuilderRegistry
+    │
+    ├── Dart mermaid parser (flowchart_parser, sequence_parser, etc.)
+    ├── Model objects (nodes, edges, slices, bars)
+    ├── Layout algorithm (position computation)
+    ├── CustomPainter (Canvas drawing)
+    └── InteractiveViewer (pan + zoom)
+````
+
+Theme cascade: node-level `theme=dark` > builder default > stylesheet background luminance > light.
+
+### SVG Rendering
+
+SVG in code blocks is handled by `flutter_svg` (bundled dependency). The code block builder detects `language == 'svg'` and renders via `SvgPicture.string()`. No additional wiring needed beyond the package being present.
+
+### Plugin Configuration
+
+Only enable `MermaidPlugin` initially. The package also offers `ThinkingPlugin`, `ToolCallPlugin`, and `ArtifactPlugin` — evaluate these post-launch since we already have custom `ToolCallChip` rendering.
+
+## Decisions
+
+| Decision             | Choice                                                     | Rationale                                                                      |
+| -------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Mermaid renderer     | Native Flutter (CustomPainter) via flutter_smooth_markdown | No WebView overhead, no JS bundle, works on all platforms, theme-aware         |
+| Markdown package     | flutter_smooth_markdown                                    | Mermaid + SVG + streaming + syntax highlighting + LaTeX in one package         |
+| Streaming widget     | StreamMarkdown with Stream<String>                         | Built-in 50ms throttle, purpose-built for token streams                        |
+| Non-streaming widget | SmoothMarkdown with accumulated string                     | Enables parse caching and text selection                                       |
+| Enhanced components  | Enabled                                                    | Copy buttons on code blocks and fullscreen diagrams improve UX                 |
+| Chart rendering      | Deferred (Phase 1.5)                                       | Mermaid's xychart-beta covers basic bar/line; fl_chart for richer charts later |
+| ThinkingPlugin       | Deferred                                                   | Evaluate overlap with existing UI patterns                                     |
+| ToolCallPlugin       | Deferred                                                   | We already render tool calls via ToolCallChip                                  |
+
+## File Changes
+
+| File                                       | Change                                                                                       |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| `app/pubspec.yaml`                         | Remove `flutter_markdown_plus`, add `flutter_smooth_markdown: ^0.7.2`                        |
+| `app/lib/features/chat/chat_screen.dart`   | Replace `MarkdownBody` with `SmoothMarkdown`/`StreamMarkdown`, configure plugins + theme     |
+| `app/lib/features/chat/chat_provider.dart` | Add `StreamController<String>` for token streaming, expose `Stream<String>` on `ChatMessage` |
+| `app/lib/features/chat/chat_provider.dart` | Add `tokenStream` field to `ChatMessage`                                                     |

--- a/openspec/changes/pretty-graphs/proposal.md
+++ b/openspec/changes/pretty-graphs/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+The assistant produces structured visual content — flowcharts, sequence diagrams, pie charts, architecture sketches — but the Flutter app renders all of it as plain monospace code blocks. Users see raw Mermaid syntax instead of the diagram it describes. This makes the assistant's output harder to understand and less useful than competing AI chat interfaces.
+
+## What Changes
+
+- Replace `flutter_markdown_plus` with `flutter_smooth_markdown` for markdown rendering in chat messages
+- Enable the Mermaid parser plugin so ` ```mermaid ` code blocks render as native Flutter diagrams (flowcharts, sequence, pie, gantt, kanban, timeline, radar, xy charts) via CustomPainter — no WebView, no JS, no external service
+- Enable SVG rendering via the bundled `flutter_svg` dependency for ` ```svg ` code blocks
+- Switch streaming messages from rebuilding `SmoothMarkdown` on each token to using `StreamMarkdown` with a `Stream<String>`, gaining built-in 50ms throttle and optimised re-rendering
+- Enable enhanced components (copy buttons on code blocks, fullscreen diagrams) for richer interaction
+- Syntax highlighting for all code blocks comes free with the switch
+
+## Capabilities
+
+### New Capabilities
+
+- `mermaid-diagram-rendering`: Native rendering of Mermaid diagrams in chat bubbles with pan/zoom, theme-aware styling, and optional fullscreen view
+- `svg-inline-rendering`: Inline SVG rendering in chat messages
+- `stream-markdown`: Token-stream-aware markdown rendering with throttled rebuilds
+- `syntax-highlighting`: Language-aware code block highlighting
+
+### Modified Capabilities
+
+- `chat-message-display`: Message bubbles gain rich content rendering; the markdown widget changes from `MarkdownBody` to `SmoothMarkdown`/`StreamMarkdown`
+- `chat-streaming`: Streaming messages switch from accumulated-string rebuilds to `Stream<String>`-based rendering
+
+## Impact
+
+- `app/pubspec.yaml` — swap `flutter_markdown_plus` for `flutter_smooth_markdown`, add `fl_chart` (optional, for custom chart JSON blocks later)
+- `app/lib/features/chat/chat_screen.dart` — replace `MarkdownBody` with `SmoothMarkdown`/`StreamMarkdown`, configure plugins and theme
+- `app/lib/features/chat/chat_provider.dart` — expose a `Stream<String>` for streaming message tokens alongside the current accumulated string
+- Theme mapping: `MarkdownStyleSheet.fromTheme()` API differs between packages; need to remap our `copyWith` overrides
+- No backend/Rust changes required — the LLM already produces Mermaid naturally
+- No breaking changes to stored messages or API
+
+## Risks
+
+- `flutter_smooth_markdown` is v0.7.2 (pre-1.0, single author) — API may shift. Mitigation: pin version, the widget surface we use is small.
+- Native Mermaid parser covers flowcharts, sequences, pie, gantt, kanban, timeline, radar, xy charts. Does NOT cover class diagrams, state diagrams, ER, mindmap, git graph. LLMs most commonly produce flowcharts and sequences, so coverage is adequate.
+- Rendering fidelity won't match mermaid.js pixel-for-pixel. Acceptable for an AI assistant where diagrams are explanatory.
+
+## Future (out of scope)
+
+- Server-side rendering (Kroki/resvg/plotters) for thin clients (Slack, Matrix, Signal, CLI) — Phase 2
+- Custom ` ```chart ` JSON spec with `fl_chart` rendering — Phase 1.5
+- Thinking block rendering via ThinkingPlugin — evaluate after initial rollout
+- Tool call rendering via ToolCallPlugin — we already have `ToolCallChip`, evaluate overlap

--- a/openspec/changes/pretty-graphs/tasks.md
+++ b/openspec/changes/pretty-graphs/tasks.md
@@ -1,0 +1,61 @@
+## Tasks
+
+### 1. Swap markdown dependency
+
+- [x] Remove `flutter_markdown_plus: ^1.0.0` from `app/pubspec.yaml`
+- [x] Add `flutter_smooth_markdown: ^0.7.2` to `app/pubspec.yaml`
+- [x] Run `flutter pub get` and verify resolution
+- [x] Remove `flutter_markdown_plus` import from `chat_screen.dart`
+
+### 2. Replace MarkdownBody with SmoothMarkdown for non-streaming messages
+
+- [x] Import `flutter_smooth_markdown` in `chat_screen.dart`
+- [x] Replace `MarkdownBody(...)` with `SmoothMarkdown(...)` in `_MessageBubble`
+- [x] Map theme: `MarkdownStyleSheet.fromTheme(Theme.of(context)).copyWith(paragraphStyle: ..., inlineCodeStyle: ...)`
+- [x] Set `selectable: true`
+- [x] Set `useEnhancedComponents: true`
+- [x] Configure `plugins: ParserPluginRegistry` with `MermaidPlugin` + `MermaidBuilder`
+- [x] Verify existing chat messages render correctly (flutter analyze clean, 305 tests pass)
+
+### 3. Expose token stream from chat provider
+
+- [x] Add `Stream<String>? tokenStream` field to `ChatMessage`
+- [x] In `_streamMessage()`, create a `StreamController<String>.broadcast()`
+- [x] On each `TokenEvent`, `controller.add(event.token)` alongside existing accumulation
+- [x] Close the controller when streaming ends (DoneEvent, ErrorEvent, stream-ended, catch)
+- [x] Set `tokenStream` on the `ChatMessage` during streaming, clear on finalization
+- [x] Also wired up `_streamVoiceMessage()` with same pattern
+- [x] Write test: verify streaming message has tokenStream, finalized message does not
+
+### 4. Use StreamMarkdown for streaming messages
+
+- [x] In `_MessageBubble`, check `message.isStreaming && message.tokenStream != null`
+- [x] Render `StreamMarkdown(stream: message.tokenStream!, ...)` for active streams
+- [x] Apply same styleSheet and plugins as SmoothMarkdown
+- [x] Fall back to `SmoothMarkdown(data: message.content)` when streaming completes
+- [ ] Verify streaming renders token-by-token without flicker (manual test)
+
+### 5. Test mermaid rendering
+
+- [ ] Send a message that triggers a mermaid flowchart response, verify diagram renders
+- [ ] Test sequence diagram rendering
+- [ ] Test pie chart rendering
+- [ ] Verify pan/zoom works on diagrams (InteractiveViewer)
+- [ ] Verify dark/light theme auto-detection works
+- [ ] Verify mermaid renders correctly after streaming completes (SmoothMarkdown path)
+
+### 6. Test SVG rendering
+
+- [ ] Verify ```svg code blocks render as inline SVG via flutter_svg
+- [ ] Test with a simple SVG shape
+- [ ] Verify fallback to code block on malformed SVG
+
+### 7. Verify no regressions
+
+- [x] Run `flutter analyze` — zero issues
+- [x] Run `flutter test` — all 306 tests pass (305 existing + 1 new)
+- [ ] Manual test: regular markdown (headers, lists, bold, italic, links, images)
+- [ ] Manual test: inline code and fenced code blocks with syntax highlighting
+- [ ] Manual test: long messages, empty messages, messages with only code blocks
+- [ ] Manual test: message retry preserves content correctly
+- [ ] Manual test: web and macOS targets both work


### PR DESCRIPTION
## Summary

- **Swap `flutter_markdown_plus` → `flutter_smooth_markdown`** for native Mermaid diagram rendering (pure Dart/CustomPainter — no WebView, no JS, no external service), inline SVG support, and syntax-highlighted code blocks
- **Token-by-token streaming** via `StreamMarkdown` widget backed by a broadcast `StreamController<String>` wired into the chat provider's SSE token events
- **Mermaid support** via `MermaidPlugin` (parser) + `MermaidBuilder` (renderer) registered in both streaming and static markdown paths — supports flowcharts, sequence diagrams, pie charts, gantt, kanban, timeline, and more
- **Enhanced components** enabled: copy buttons on code blocks, fullscreen diagram viewing

## Changes

| File | What changed |
|------|-------------|
| `app/pubspec.yaml` | Dependency swap |
| `app/lib/features/chat/chat_screen.dart` | Conditional `StreamMarkdown` / `SmoothMarkdown` rendering with Mermaid plugin |
| `app/lib/features/chat/chat_provider.dart` | `tokenStream` field on `ChatMessage`, broadcast `StreamController` in `_streamMessage` and `_streamVoiceMessage` |
| `app/test/unit/chat/chat_provider_test.dart` | New test verifying tokenStream lifecycle |
| `openspec/changes/pretty-graphs/` | Proposal, design, and task tracking |

## Test plan

- [x] `flutter analyze` — zero issues
- [x] `flutter test` — all 306 tests pass (305 existing + 1 new)
- [ ] Manual: regular markdown renders correctly (headers, lists, bold, italic, links)
- [ ] Manual: fenced code blocks with syntax highlighting
- [ ] Manual: mermaid flowchart / sequence / pie diagram renders
- [ ] Manual: streaming renders token-by-token without flicker
- [ ] Manual: web and macOS targets both work