### PR TITLE
fix(macos): add file picker entitlement for sandboxed app

### DIFF
--- a/app/macos/Runner/DebugProfile.entitlements
+++ b/app/macos/Runner/DebugProfile.entitlements
@@ -12,6 +12,8 @@
 	<true/>
 	<key>com.apple.security.device.audio-input</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
 	<key>com.apple.security.inherit</key>
 	<true/>
 	<key>keychain-access-groups</key>

--- a/app/macos/Runner/Release.entitlements
+++ b/app/macos/Runner/Release.entitlements
@@ -8,6 +8,8 @@
 	<true/>
 	<key>com.apple.security.device.audio-input</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
 	<key>keychain-access-groups</key>


### PR DESCRIPTION
## Summary
- Adds `com.apple.security.files.user-selected.read-only` entitlement to both DebugProfile and Release entitlements
- Fixes `PlatformException(ENTITLEMENT_NOT_FOUND)` when using `file_picker` to attach images in the macOS sandboxed app

## Test plan
- [ ] Run macOS app in debug mode, open chat, tap the image attach button — file picker should open without error
- [ ] Verify image selection completes and the attachment appears in the chat input

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS application sandbox permissions to enable read-only access to user-selected files in both debug and release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->