### PR TITLE
fix(hooks): use flutter pub run for dart_pre_commit

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -34,7 +34,7 @@ cargo fmt --all -- --check \
 # ── Flutter/Dart: dart_pre_commit (format, analyze, deps, OSV) ──────────────
 
 step "Running dart_pre_commit checks..."
-(cd app && dart run dart_pre_commit) \
+(cd app && flutter pub run dart_pre_commit) \
     || fail "dart_pre_commit failed — fix issues above before committing"
 
 # ── Rust: clippy ─────────────────────────────────────────────────────────────

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ install-hooks:
 
 # Run dart_pre_commit (format, analyze, deps, OSV scanning) on the Flutter app.
 lint-flutter:
-	cd app && dart run dart_pre_commit
+	cd app && flutter pub run dart_pre_commit
 
 # Run Flutter unit and widget tests.
 test-flutter:
@@ -45,7 +45,7 @@ test-flutter:
 # Run all pre-commit checks manually (mirrors .githooks/pre-commit).
 precommit:
 	cargo fmt --all -- --check
-	cd app && dart run dart_pre_commit
+	cd app && flutter pub run dart_pre_commit
 	cargo clippy --workspace -- -D warnings
 	cargo machete --with-metadata
 	cd app && flutter test


### PR DESCRIPTION
## Summary
- Changes `dart run dart_pre_commit` to `flutter pub run dart_pre_commit` in the pre-commit hook and Makefile
- Flutter projects must use `flutter pub run` so the Flutter SDK is available during dependency resolution — `dart run` can't resolve Flutter-only packages like `audioplayers_platform_interface`

## Test plan
- [ ] Run `make lint-flutter` — should pass without dependency resolution errors
- [ ] Run `make precommit` — dart_pre_commit step should succeed