### PR TITLE
fix(images): three bugs breaking image attachment flow

### DIFF
--- a/crates/provider-moonshot/src/provider.rs
+++ b/crates/provider-moonshot/src/provider.rs
@@ -656,8 +656,32 @@ fn build_chat_messages(
                     .collect();
 
                 let msg_json = json!({"role": "user", "content": parts_json});
-                if let Ok(msg) = serde_json::from_value::<ChatCompletionRequestMessage>(msg_json) {
-                    messages.push(msg);
+                match serde_json::from_value::<ChatCompletionRequestMessage>(msg_json) {
+                    Ok(msg) => messages.push(msg),
+                    Err(e) => {
+                        // async-openai may not support content arrays; fall back
+                        // to extracting only the text parts so the message is not
+                        // silently dropped.
+                        warn!(
+                            error = %e,
+                            "Failed to deserialize multimodal message for Moonshot; \
+                             falling back to text-only"
+                        );
+                        let text: String = content
+                            .iter()
+                            .filter_map(|b| match b {
+                                ContentBlock::Text(t) => Some(t.as_str()),
+                                _ => None,
+                            })
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                        if let Ok(msg) = ChatCompletionRequestUserMessageArgs::default()
+                            .content(text.as_str())
+                            .build()
+                        {
+                            messages.push(ChatCompletionRequestMessage::User(msg));
+                        }
+                    }
                 }
             }
 

--- a/crates/runtime/src/orchestrator/mod.rs
+++ b/crates/runtime/src/orchestrator/mod.rs
@@ -1160,6 +1160,22 @@ impl Orchestrator {
         };
         conv_store.save_message(&user_msg).await?;
 
+        // Link uploaded attachments to the persisted user message so that
+        // `build_attachment_map()` can find them on subsequent turns.
+        if !attachment_ids.is_empty() {
+            let store = self.storage.attachment_store();
+            for &att_id in attachment_ids {
+                if let Err(e) = store.link_to_message(att_id, user_msg.id).await {
+                    warn!(
+                        attachment_id = %att_id,
+                        message_id = %user_msg.id,
+                        error = %e,
+                        "Failed to link attachment to message"
+                    );
+                }
+            }
+        }
+
         // Build an attachment map for history replay: load all attachments
         // linked to messages in this conversation and base64-encode them so
         // the LLM sees previously-sent images.

--- a/crates/web-ui/src/api/mod.rs
+++ b/crates/web-ui/src/api/mod.rs
@@ -83,7 +83,7 @@ use assistant_storage::{
 };
 use axum::{
     body::Body,
-    extract::{Multipart, Path, State},
+    extract::{DefaultBodyLimit, Multipart, Path, State},
     http::{header, StatusCode},
     response::{
         sse::{Event, Sse},
@@ -267,7 +267,10 @@ pub fn api_router() -> Router<ApiState> {
         .route("/conversations/{id}", patch(update_conversation))
         .route("/conversations/{id}/messages", post(send_message))
         .route("/conversations/{id}/voice", post(send_voice_message))
-        .route("/conversations/{id}/attachments", post(upload_attachment))
+        .route(
+            "/conversations/{id}/attachments",
+            post(upload_attachment).layer(DefaultBodyLimit::max(12 * 1024 * 1024)), // 12 MB
+        )
         .route("/attachments/{id}", get(serve_attachment))
         .route(
             "/conversations/{id}/runs/{run_id}/events/stream",


### PR DESCRIPTION
## Summary

- **Raise body limit on attachment upload** from axum's 2MB default to 12MB. Phone photos (3-10MB) caused `Error parsing multipart/form-data request`, silently preventing uploads.
- **Call `link_to_message()`** after persisting the user message so `build_attachment_map()` can replay images in subsequent turns. Previously attachments stayed with `message_id=NULL` forever.
- **Fix silent message drop in Moonshot provider** where `serde_json::from_value` failure on multimodal content arrays caused the entire user message (text + image) to be discarded without logging. Now logs the error and falls back to text-only.

## Test plan

- [x] `cargo check` passes for all three affected crates
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test` — 115 tests pass (web-ui, runtime, provider-moonshot)
- [ ] Deploy to schorschvm and verify image upload no longer returns multipart parse error
- [ ] Verify thumbnail appears in chat timeline
- [ ] Verify agent (Moonshot kimi-k2.5) can describe the attached image
- [ ] Send a follow-up message and verify the image is still visible in history replay