### PR TITLE
fix(hooks): warm Flutter deps before dart_pre_commit

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -34,7 +34,7 @@ cargo fmt --all -- --check \
 # ── Flutter/Dart: dart_pre_commit (format, analyze, deps, OSV) ──────────────
 
 step "Running dart_pre_commit checks..."
-(cd app && flutter pub run dart_pre_commit) \
+(cd app && flutter pub get --suppress-analytics >/dev/null 2>&1 && flutter pub run dart_pre_commit) \
     || fail "dart_pre_commit failed — fix issues above before committing"
 
 # ── Rust: clippy ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add `flutter pub get` before `dart_pre_commit` in the pre-commit hook
- In fresh worktrees (and cold Flutter tool caches), `flutter pub run` performs dependency resolution that misreports the SDK version as `0.0.0-unknown`, causing `audioplayers_platform_interface` (requires `>=3.27.0`) to fail resolution
- Warming the cache with `flutter pub get` first ensures the SDK version is correctly detected

## Test plan

- [x] Verified full pre-commit hook passes in worktree after fix
- [x] All 313 Flutter tests pass
- [x] Clippy + fmt + machete all pass