### PR TITLE
feat(matrix): add voice message support

### DIFF
--- a/crates/interface-matrix/src/adapter.rs
+++ b/crates/interface-matrix/src/adapter.rs
@@ -406,9 +406,17 @@ impl ChannelAdapter for MatrixAdapter {
                     .client
                     .upload_media(data, &filename, &mime_type)
                     .await?;
-                self.client
-                    .send_image(room_id, &mxc_uri, &filename, &mime_type, size)
-                    .await?;
+
+                // Route audio files to send_audio, images to send_image
+                if is_audio_mime_type(&mime_type) {
+                    self.client
+                        .send_audio(room_id, &mxc_uri, &filename, &mime_type, size, None)
+                        .await?;
+                } else {
+                    self.client
+                        .send_image(room_id, &mxc_uri, &filename, &mime_type, size)
+                        .await?;
+                }
             }
             _ => {}
         }
@@ -516,6 +524,22 @@ impl ChannelAdapter for MatrixAdapter {
             .await;
         Ok(())
     }
+}
+
+/// Check if a MIME type represents an audio file.
+fn is_audio_mime_type(mime_type: &str) -> bool {
+    matches!(
+        mime_type,
+        "audio/ogg"
+            | "audio/mpeg"
+            | "audio/wav"
+            | "audio/webm"
+            | "audio/mp4"
+            | "audio/aac"
+            | "audio/flac"
+            | "audio/x-wav"
+            | "audio/opus"
+    ) || mime_type.starts_with("audio/")
 }
 
 fn build_message(

--- a/crates/interface-matrix/src/client.rs
+++ b/crates/interface-matrix/src/client.rs
@@ -226,6 +226,58 @@ impl MatrixClient {
         Ok(())
     }
 
+    /// Send an `m.audio` message to a room using an already-uploaded `mxc://` URI.
+    ///
+    /// Optionally includes duration in milliseconds if provided.
+    pub async fn send_audio(
+        &self,
+        room_id: &str,
+        mxc_uri: &str,
+        filename: &str,
+        mime_type: &str,
+        size_bytes: usize,
+        duration_ms: Option<u64>,
+    ) -> Result<()> {
+        let txn_id = Uuid::new_v4().to_string();
+        let path = format!(
+            "rooms/{}/send/m.room.message/{}",
+            urlencoding::encode(room_id),
+            txn_id
+        );
+        let url = self.cs_url(&path);
+
+        let mut info = serde_json::json!({
+            "mimetype": mime_type,
+            "size": size_bytes
+        });
+        if let Some(duration) = duration_ms {
+            if let serde_json::Value::Object(ref mut map) = info {
+                map.insert("duration".to_string(), serde_json::json!(duration));
+            }
+        }
+
+        let body = serde_json::json!({
+            "msgtype": "m.audio",
+            "body": filename,
+            "url": mxc_uri,
+            "info": info
+        });
+        debug!(url = %url, room_id, filename, "Matrix send_audio");
+        let resp = self
+            .client
+            .put(&url)
+            .json(&body)
+            .send()
+            .await
+            .context("Matrix send_audio")?;
+        let status = resp.status();
+        if !status.is_success() {
+            let err = resp.text().await.unwrap_or_default();
+            anyhow::bail!("Matrix send_audio failed ({status}): {err}");
+        }
+        Ok(())
+    }
+
     // ── Media download ────────────────────────────────────────────────────────
 
     /// Download a Matrix Content Repository resource identified by an `mxc://` URI.


### PR DESCRIPTION
Add support for sending audio messages via Matrix.

## Changes

### crates/interface-matrix/src/client.rs
- Added new send_audio() method that sends m.audio messages
- Follows the same pattern as send_image() but for audio content
- Uses proper Matrix m.audio format with mxc:// URI
- Includes optional duration in milliseconds in the info field

### crates/interface-matrix/src/adapter.rs
- Extended the send() method to handle audio MIME types in FileData
- Added is_audio_mime_type() helper function to detect audio files
- Routes audio files to the new send_audio() method instead of falling through to send_image
- Supports common audio MIME types: audio/ogg, audio/mpeg, audio/wav, audio/webm, audio/mp4, audio/aac, audio/flac, audio/x-wav, audio/opus, and any other audio/* type

## Implementation Details
- Audio files are uploaded via upload_media() to get an mxc:// URI
- Sent as m.audio events with proper metadata (mimetype, size, optional duration)
- Falls back to send_image for non-audio content (backward compatible)

## Testing
- cargo check -p assistant-interface-matrix passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **Enhanced media upload handling**: Audio files are now processed separately from other file types during uploads for better handling
* **Audio message support**: Added ability to send audio messages with associated metadata including file type, size, and optional duration information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->