### PR TITLE
perf(ci): speed up release pipeline with thin LTO and dedup macOS build

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -233,6 +233,31 @@ jobs:
       - name: Build universal Rust binary for macOS bundle
         run: make build-macos-binary
 
+      # Package and upload the standalone CLI tarball early, so that a later
+      # Flutter/notarization failure does not block this artifact.
+      - name: Create standalone macOS tarball
+        shell: bash
+        run: |
+          TAG="${{ needs.release-please.outputs.tag_name }}"
+          STANDALONE="assistant-${TAG}-macos-arm64"
+          mkdir -p "${STANDALONE}"
+          cp target/aarch64-apple-darwin/release/assistant "${STANDALONE}/"
+          cp config.toml "${STANDALONE}/config.toml.example"
+          tar czf "${STANDALONE}.tar.gz" "${STANDALONE}"
+          echo "STANDALONE_ARCHIVE=${STANDALONE}.tar.gz" >> $GITHUB_ENV
+
+      - name: Upload standalone binary artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: binary-macos-arm64
+          path: ${{ env.STANDALONE_ARCHIVE }}
+          retention-days: 1
+
+      - name: Upload standalone macOS tarball to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload ${{ needs.release-please.outputs.tag_name }} ${{ env.STANDALONE_ARCHIVE }}
+
       - name: Build Flutter macOS app
         run: |
           TAG="${{ needs.release-please.outputs.tag_name }}"
@@ -322,32 +347,6 @@ jobs:
         run: |
           gh release upload ${{ needs.release-please.outputs.tag_name }} \
             "${{ env.ARCHIVE }}" checksums.sha256
-
-      # Reuse the Rust binary already built above to produce the standalone
-      # macOS ARM64 tarball, avoiding a duplicate 18-min compile on a second
-      # macOS runner.
-      - name: Create standalone macOS tarball
-        shell: bash
-        run: |
-          TAG="${{ needs.release-please.outputs.tag_name }}"
-          STANDALONE="assistant-${TAG}-macos-arm64"
-          mkdir -p "${STANDALONE}"
-          cp target/aarch64-apple-darwin/release/assistant "${STANDALONE}/"
-          cp config.toml "${STANDALONE}/config.toml.example"
-          tar czf "${STANDALONE}.tar.gz" "${STANDALONE}"
-          echo "STANDALONE_ARCHIVE=${STANDALONE}.tar.gz" >> $GITHUB_ENV
-
-      - name: Upload standalone binary artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: binary-macos-arm64
-          path: ${{ env.STANDALONE_ARCHIVE }}
-          retention-days: 1
-
-      - name: Upload standalone macOS tarball to GitHub Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ needs.release-please.outputs.tag_name }} ${{ env.STANDALONE_ARCHIVE }}
 
   build-docker:
     name: Build and push Docker image (Alpine)

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -337,6 +337,13 @@ jobs:
           tar czf "${STANDALONE}.tar.gz" "${STANDALONE}"
           echo "STANDALONE_ARCHIVE=${STANDALONE}.tar.gz" >> $GITHUB_ENV
 
+      - name: Upload standalone binary artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: binary-macos-arm64
+          path: ${{ env.STANDALONE_ARCHIVE }}
+          retention-days: 1
+
       - name: Upload standalone macOS tarball to GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -80,10 +80,6 @@ jobs:
             runner: ubuntu-latest
             use_cross: true
             archive_suffix: linux-aarch64-musl
-          - target: aarch64-apple-darwin
-            runner: macos-latest
-            use_cross: false
-            archive_suffix: macos-arm64
 
     steps:
       - uses: actions/checkout@v6
@@ -326,6 +322,25 @@ jobs:
         run: |
           gh release upload ${{ needs.release-please.outputs.tag_name }} \
             "${{ env.ARCHIVE }}" checksums.sha256
+
+      # Reuse the Rust binary already built above to produce the standalone
+      # macOS ARM64 tarball, avoiding a duplicate 18-min compile on a second
+      # macOS runner.
+      - name: Create standalone macOS tarball
+        shell: bash
+        run: |
+          TAG="${{ needs.release-please.outputs.tag_name }}"
+          STANDALONE="assistant-${TAG}-macos-arm64"
+          mkdir -p "${STANDALONE}"
+          cp target/aarch64-apple-darwin/release/assistant "${STANDALONE}/"
+          cp config.toml "${STANDALONE}/config.toml.example"
+          tar czf "${STANDALONE}.tar.gz" "${STANDALONE}"
+          echo "STANDALONE_ARCHIVE=${STANDALONE}.tar.gz" >> $GITHUB_ENV
+
+      - name: Upload standalone macOS tarball to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload ${{ needs.release-please.outputs.tag_name }} ${{ env.STANDALONE_ARCHIVE }}
 
   build-docker:
     name: Build and push Docker image (Alpine)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,7 +195,7 @@ opt-level = 1
 
 [profile.release]
 opt-level = 3
-lto = true
-codegen-units = 1
+lto = "thin"
+codegen-units = 4
 # Strip debug symbols to reduce binary size and link time
 strip = "symbols"


### PR DESCRIPTION
## Summary

- Switch release profile from fat LTO (`lto=true`, `codegen-units=1`) to thin LTO (`lto="thin"`, `codegen-units=4`) — expected ~30-50% faster Rust compilation with negligible binary size impact
- Eliminate duplicate `aarch64-apple-darwin` build by reusing the Rust binary from the Flutter desktop job to produce the standalone macOS tarball, avoiding a second 18-min macOS compile and runner contention

## Test plan

- [ ] Verify next release produces the same set of artifacts (standalone macOS tarball + Flutter .app ZIP)
- [ ] Compare binary size of thin LTO vs fat LTO build (expect <5% difference)
- [ ] Confirm release pipeline wall-clock time drops from ~49 min to ~25-30 min

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS ARM64 binary packaging in the release pipeline for standalone distribution.
  * Optimized release build compilation configuration for improved performance and faster builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->