### PR TITLE
fix(hooks): make pre-commit hook work in git worktrees

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Ensure we're at the working tree root (handles worktrees where CWD may differ)
+cd "$(git rev-parse --show-toplevel)"
+
+# Git sets GIT_DIR when running hooks, which breaks Flutter SDK version
+# detection in worktrees (reports 0.0.0-unknown). Unsetting it lets Flutter
+# discover its SDK normally while cargo/git commands still work fine.
+unset GIT_DIR
+
 BOLD='\033[1m'
 RED='\033[0;31m'
 GREEN='\033[0;32m'


### PR DESCRIPTION
## Summary
- Fix pre-commit hook failing in git worktrees (including Claude Code worktree isolation)
- `cd` to `git rev-parse --show-toplevel` so relative paths resolve correctly
- `unset GIT_DIR` to prevent Flutter SDK version detection from breaking (`0.0.0-unknown`)

## Test plan
- [x] Verified hook passes when run from worktree root
- [x] Verified hook passes when run from a subdirectory (`crates/core/`)
- [x] Verified commit succeeds in a Claude Code worktree with all checks (fmt, dart_pre_commit, clippy, machete, flutter test)