### PR TITLE
chore: pin Rust 1.95.0 via rust-toolchain.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        run: rustup show
 
       - name: Install mold linker
         uses: rui314/setup-mold@v1
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        run: rustup show
 
       - name: Install mold linker
         uses: rui314/setup-mold@v1
@@ -101,9 +101,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
+        run: rustup show
 
       - name: Install mold linker
         uses: rui314/setup-mold@v1
@@ -130,9 +128,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
+        run: rustup show
 
       - name: cargo fmt
         run: cargo fmt --all -- --check
@@ -146,7 +142,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        run: rustup show
 
       - name: Install mold linker
         uses: rui314/setup-mold@v1
@@ -467,7 +463,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        run: rustup show
 
       - name: Install mold linker
         uses: rui314/setup-mold@v1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,9 +19,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: x86_64-unknown-linux-musl,aarch64-unknown-linux-musl
+        run: |
+          rustup show
+          rustup target add x86_64-unknown-linux-musl aarch64-unknown-linux-musl
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -91,9 +91,9 @@ jobs:
           path: app/build/web/
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
+        run: |
+          rustup show
+          rustup target add ${{ matrix.target }}
 
       - name: Install mold linker
         if: ${{ !matrix.use_cross && runner.os == 'Linux' }}
@@ -195,9 +195,9 @@ jobs:
         working-directory: app
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-apple-darwin
+        run: |
+          rustup show
+          rustup target add aarch64-apple-darwin
 
       - name: Install protoc (macOS)
         run: brew install protobuf

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.95.0"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Summary

- Add `rust-toolchain.toml` pinning the workspace to Rust **1.95.0** with clippy + rustfmt components
- Replace `dtolnay/rust-toolchain@stable` in all CI workflows (`ci.yml`, `release-please.yml`, `docker.yml`) with `rustup show`, which auto-installs the pinned toolchain from the file
- Cross-compilation targets in release/docker workflows use explicit `rustup target add`

### Notable improvements from 1.95.0

- Faster `str::contains` on aarch64 (Apple Silicon)
- LLVM 22 upgrade (general codegen improvements)
- `if let` guards on match arms
- `Atomic::update()` / `try_update()`
- `cfg_select!` macro
- `core::hint::cold_path()` optimization hints

## Test plan

- [ ] CI passes (check, test, clippy, fmt) with the pinned toolchain
- [ ] Release workflow still resolves cross-compilation targets correctly
- [ ] Docker workflow builds musl targets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned Rust toolchain to version 1.95.0 for consistent builds across all CI workflows
  * Streamlined build infrastructure by refactoring toolchain installation processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->