### PR TITLE
chore: migrate workspace to Rust edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ resolver = "2"
 
 [workspace.package]
 version = "0.1.111"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 repository = "https://github.com/cedricziel/assistant"
 

--- a/crates/backup/src/archive.rs
+++ b/crates/backup/src/archive.rs
@@ -3,10 +3,10 @@
 use std::io::{Read, Write};
 use std::path::Path;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
+use flate2::Compression;
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
-use flate2::Compression;
 use tar::Archive;
 use tracing::debug;
 
@@ -222,7 +222,7 @@ pub fn extract_tar_gz(
 #[cfg(test)]
 pub fn make_test_archive(files: &[(&str, &[u8])]) -> Vec<u8> {
     use crate::checksum::sha256_hex;
-    use crate::manifest::{BackupManifest, ManifestEntry, MANIFEST_VERSION};
+    use crate::manifest::{BackupManifest, MANIFEST_VERSION, ManifestEntry};
 
     let entries: Vec<ManifestEntry> = files
         .iter()
@@ -266,7 +266,7 @@ mod tests {
 
     #[test]
     fn test_write_and_read_manifest() {
-        use crate::manifest::{BackupManifest, ManifestEntry, MANIFEST_VERSION};
+        use crate::manifest::{BackupManifest, MANIFEST_VERSION, ManifestEntry};
 
         let dir = TempDir::new().unwrap();
         let archive_path = dir.path().join("test.tar.gz");
@@ -296,7 +296,7 @@ mod tests {
 
     #[test]
     fn test_path_traversal_guard() {
-        use crate::manifest::{BackupManifest, ManifestEntry, MANIFEST_VERSION};
+        use crate::manifest::{BackupManifest, MANIFEST_VERSION, ManifestEntry};
 
         // The tar crate rejects '..' components on append_data, so we cannot
         // inject unsafe paths via the archive itself.  Instead we craft a manifest
@@ -360,7 +360,7 @@ mod tests {
 
     #[test]
     fn test_checksum_mismatch_rejected() {
-        use crate::manifest::{BackupManifest, ManifestEntry, MANIFEST_VERSION};
+        use crate::manifest::{BackupManifest, MANIFEST_VERSION, ManifestEntry};
 
         let dir = TempDir::new().unwrap();
         let archive_path = dir.path().join("mismatch.tar.gz");

--- a/crates/backup/src/lib.rs
+++ b/crates/backup/src/lib.rs
@@ -19,14 +19,14 @@ use std::io::{self, Write as IoWrite};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use async_trait::async_trait;
 use chrono::Utc;
 use tracing::{info, warn};
 
 use crate::archive::{extract_tar_gz, read_tar_gz_manifest, write_tar_gz};
 use crate::checksum::sha256_hex;
-use crate::manifest::{BackupManifest, ManifestEntry, MANIFEST_VERSION};
+use crate::manifest::{BackupManifest, MANIFEST_VERSION, ManifestEntry};
 use crate::paths::{
     checkpoint_sqlite, default_archive_name, default_backups_dir, default_install_dir,
     discover_files,
@@ -291,10 +291,10 @@ impl BackupEngine {
             .db_path
             .clone()
             .unwrap_or_else(|| opts.install_dir.join("assistant.db"));
-        if self.fs.file_exists(&db_path).await {
-            if let Err(e) = checkpoint_sqlite(&db_path).await {
-                warn!("WAL checkpoint failed (continuing): {}", e);
-            }
+        if self.fs.file_exists(&db_path).await
+            && let Err(e) = checkpoint_sqlite(&db_path).await
+        {
+            warn!("WAL checkpoint failed (continuing): {}", e);
         }
 
         // Discover files

--- a/crates/backup/tests/backup_integration.rs
+++ b/crates/backup/tests/backup_integration.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use tempfile::TempDir;
 
 use assistant_backup::{
-    archive::read_tar_gz_manifest, BackupEngine, BackupOptions, RestoreEngine, RestoreOptions,
+    BackupEngine, BackupOptions, RestoreEngine, RestoreOptions, archive::read_tar_gz_manifest,
 };
 
 /// Populate a fake installation directory.

--- a/crates/bus-nats/src/lib.rs
+++ b/crates/bus-nats/src/lib.rs
@@ -27,8 +27,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
-use async_nats::jetstream::consumer::pull;
 use async_nats::jetstream::consumer::Consumer;
+use async_nats::jetstream::consumer::pull;
 use async_nats::jetstream::stream::RetentionPolicy;
 use async_nats::jetstream::{self, AckKind};
 use async_trait::async_trait;
@@ -488,15 +488,15 @@ fn matches_filter(headers: Option<&async_nats::HeaderMap>, filter: &ClaimFilter)
         return false;
     };
 
-    if let Some(ref want) = filter.agent_id {
-        if header_str(h, H_AGENT_ID) != Some(want.as_str()) {
-            return false;
-        }
+    if let Some(ref want) = filter.agent_id
+        && header_str(h, H_AGENT_ID) != Some(want.as_str())
+    {
+        return false;
     }
-    if let Some(ref want) = filter.user_id {
-        if header_str(h, H_USER_ID) != Some(want.as_str()) {
-            return false;
-        }
+    if let Some(ref want) = filter.user_id
+        && header_str(h, H_USER_ID) != Some(want.as_str())
+    {
+        return false;
     }
     if let Some(ref want) = filter.conversation_id {
         let want_s = want.to_string();
@@ -510,10 +510,10 @@ fn matches_filter(headers: Option<&async_nats::HeaderMap>, filter: &ClaimFilter)
             return false;
         }
     }
-    if let Some(ref want) = filter.interface {
-        if header_str(h, H_INTERFACE) != Some(want.as_str()) {
-            return false;
-        }
+    if let Some(ref want) = filter.interface
+        && header_str(h, H_INTERFACE) != Some(want.as_str())
+    {
+        return false;
     }
 
     true

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -14,13 +14,13 @@ pub mod upload;
 
 pub use allowlist::AllowlistFilter;
 pub use attachment::{
-    is_resizable_mime_type, is_supported_mime_type, AttachmentMeta, MAX_ATTACHMENT_SIZE,
-    RESIZABLE_MIME_TYPES, SUPPORTED_MIME_TYPES,
+    AttachmentMeta, MAX_ATTACHMENT_SIZE, RESIZABLE_MIME_TYPES, SUPPORTED_MIME_TYPES,
+    is_resizable_mime_type, is_supported_mime_type,
 };
 pub use bus::{BusMessage, ClaimFilter, MessageBus, MessageStatus, PublishRequest};
 pub use bus_messages::{
-    topic, AgentReport, AgentReportStatus, AgentSpawn, ToolExecute, ToolResult, TurnPhase,
-    TurnRequest, TurnResult, TurnStatus,
+    AgentReport, AgentReportStatus, AgentSpawn, ToolExecute, ToolResult, TurnPhase, TurnRequest,
+    TurnResult, TurnStatus, topic,
 };
 pub use channel::{ChannelAdapter, ChannelContent, ChannelMessage, ChannelUser};
 pub use config::{default_config_path, load_config};
@@ -30,20 +30,20 @@ pub use context::{
     validate_agent_id,
 };
 pub use memory::{
-    base_dir, expand_tilde, resolve_dir, resolve_path, strip_html_comments, MemoryLoader,
+    MemoryLoader, base_dir, expand_tilde, resolve_dir, resolve_path, strip_html_comments,
 };
 pub use subagent::SubagentRunner;
 pub use text::{preview, sanitize_llm_output, strip_cite_tags, strip_think_tags};
 pub use tool::{Attachment, ToolHandler, ToolOutput};
 pub use types::{
     AgentConfig, AssistantConfig, BusConfig, BusKind, ChannelType, CompactionConfig,
-    EmbeddingConfig, EmbeddingProviderKind, ExecutionContext, IcebergConfig, Interface, LlmConfig,
-    LlmProviderKind, MatrixConfig, MattermostConfig, McpConfig, McpServerEntry, McpTransportConfig,
-    McpTrustLevel, MemoryConfig, Message, MessageRole, MirrorConfig, MoonshotOptions,
-    MoonshotWebSearchOptions, NextcloudConfig, NotificationsConfig, ObservabilityConfig,
-    OpenAIAuthMode, OpenAIOptions, OpenAIUserLocation, OpenAIWebSearchOptions, OtelExporter,
-    PartitionGranularity, SignalConfig, SkillsConfig, SlackConfig, SlackListenMode, StorageConfig,
-    TranscriptionConfig, TranscriptionProviderKind, TtsConfig, TtsProviderKind,
-    DEFAULT_MAX_AGENT_DEPTH,
+    DEFAULT_MAX_AGENT_DEPTH, EmbeddingConfig, EmbeddingProviderKind, ExecutionContext,
+    IcebergConfig, Interface, LlmConfig, LlmProviderKind, MatrixConfig, MattermostConfig,
+    McpConfig, McpServerEntry, McpTransportConfig, McpTrustLevel, MemoryConfig, Message,
+    MessageRole, MirrorConfig, MoonshotOptions, MoonshotWebSearchOptions, NextcloudConfig,
+    NotificationsConfig, ObservabilityConfig, OpenAIAuthMode, OpenAIOptions, OpenAIUserLocation,
+    OpenAIWebSearchOptions, OtelExporter, PartitionGranularity, SignalConfig, SkillsConfig,
+    SlackConfig, SlackListenMode, StorageConfig, TranscriptionConfig, TranscriptionProviderKind,
+    TtsConfig, TtsProviderKind,
 };
 pub use upload::resolve_upload_bytes;

--- a/crates/core/src/memory.rs
+++ b/crates/core/src/memory.rs
@@ -137,12 +137,11 @@ impl MemoryLoader {
         let mut total_chars: usize = 0;
 
         // Bootstrap goes first (only present on first run).
-        if self.bootstrap_path.exists() {
-            if let Some(section) =
+        if self.bootstrap_path.exists()
+            && let Some(section) =
                 self.read_section("Bootstrap", &self.bootstrap_path, &mut total_chars)
-            {
-                parts.push(section);
-            }
+        {
+            parts.push(section);
         }
 
         // Core memory files in load order.
@@ -529,11 +528,11 @@ fn move_path_if_needed(from: &Path, to: &Path) {
         );
         return;
     }
-    if let Some(parent) = to.parent() {
-        if let Err(e) = fs::create_dir_all(parent) {
-            warn!(path = %parent.display(), error = %e, "Failed to create destination directory");
-            return;
-        }
+    if let Some(parent) = to.parent()
+        && let Err(e) = fs::create_dir_all(parent)
+    {
+        warn!(path = %parent.display(), error = %e, "Failed to create destination directory");
+        return;
     }
 
     match fs::rename(from, to) {
@@ -570,15 +569,15 @@ fn move_dir_if_needed(from: &Path, to: &Path) {
     }
 
     if !to.exists() {
-        if let Some(parent) = to.parent() {
-            if let Err(e) = fs::create_dir_all(parent) {
-                warn!(
-                    path = %parent.display(),
-                    error = %e,
-                    "Failed to create destination parent directory"
-                );
-                return;
-            }
+        if let Some(parent) = to.parent()
+            && let Err(e) = fs::create_dir_all(parent)
+        {
+            warn!(
+                path = %parent.display(),
+                error = %e,
+                "Failed to create destination parent directory"
+            );
+            return;
         }
         match fs::rename(from, to) {
             Ok(_) => {
@@ -685,10 +684,10 @@ pub fn resolve_dir(opt: &Option<String>, base: &Path, dirname: &str) -> PathBuf 
 
 /// Expand a leading `~/` to the current user's home directory.
 pub fn expand_tilde(s: &str) -> PathBuf {
-    if let Some(rest) = s.strip_prefix("~/") {
-        if let Some(home) = dirs::home_dir() {
-            return home.join(rest);
-        }
+    if let Some(rest) = s.strip_prefix("~/")
+        && let Some(home) = dirs::home_dir()
+    {
+        return home.join(rest);
     }
     PathBuf::from(s)
 }
@@ -709,11 +708,11 @@ fn write_default(path: &Path, content: &str) {
     if path.exists() {
         return;
     }
-    if let Some(parent) = path.parent() {
-        if let Err(e) = fs::create_dir_all(parent) {
-            warn!(path = %parent.display(), error = %e, "Failed to create memory directory");
-            return;
-        }
+    if let Some(parent) = path.parent()
+        && let Err(e) = fs::create_dir_all(parent)
+    {
+        warn!(path = %parent.display(), error = %e, "Failed to create memory directory");
+        return;
     }
     if let Err(e) = fs::write(path, content) {
         warn!(path = %path.display(), error = %e, "Failed to write default memory file");

--- a/crates/core/src/upload.rs
+++ b/crates/core/src/upload.rs
@@ -54,7 +54,7 @@ pub fn resolve_upload_bytes(params: &HashMap<String, Value>) -> Result<Vec<u8>, 
 #[cfg(test)]
 mod tests {
     use super::resolve_upload_bytes;
-    use serde_json::{json, Value};
+    use serde_json::{Value, json};
     use std::collections::HashMap;
 
     fn params(pairs: &[(&str, Value)]) -> HashMap<String, Value> {

--- a/crates/integration-tests/tests/smoke.rs
+++ b/crates/integration-tests/tests/smoke.rs
@@ -13,16 +13,16 @@ use std::sync::Arc;
 use std::{env, time::Duration};
 
 use anyhow::Result;
-use assistant_core::{types::Interface, AssistantConfig, ExecutionContext, MessageBus};
+use assistant_core::{AssistantConfig, ExecutionContext, MessageBus, types::Interface};
 use assistant_llm::{LlmClient, LlmClientConfig};
 use assistant_runtime::Orchestrator;
 use assistant_skills::SkillSource;
-use assistant_storage::{registry::SkillRegistry, StorageLayer};
+use assistant_storage::{StorageLayer, registry::SkillRegistry};
 use assistant_tool_executor::ToolExecutor;
 use testcontainers::{
+    ContainerAsync, GenericImage,
     core::{IntoContainerPort, WaitFor},
     runners::AsyncRunner,
-    ContainerAsync, GenericImage,
 };
 use uuid::Uuid;
 

--- a/crates/interface-cli/src/cmd_backup.rs
+++ b/crates/interface-cli/src/cmd_backup.rs
@@ -6,9 +6,9 @@ use anyhow::Result;
 use clap::Subcommand;
 
 use assistant_backup::{
+    BackupEngine, BackupOptions, BackupResult, RestoreEngine, RestoreOptions, RestoreResult,
     list_backups,
     paths::{default_backups_dir, default_install_dir},
-    BackupEngine, BackupOptions, BackupResult, RestoreEngine, RestoreOptions, RestoreResult,
 };
 
 // ── Clap command definitions ──────────────────────────────────────────────────

--- a/crates/interface-cli/src/main.rs
+++ b/crates/interface-cli/src/main.rs
@@ -15,9 +15,9 @@ use tracing::{info, warn};
 use uuid::Uuid;
 
 use assistant_core::{
-    apply_agent_context, default_workspace_dir, set_runtime_agent_root, set_runtime_workspace_dir,
-    validate_agent_id, AssistantConfig, EmbeddingConfig, EmbeddingProviderKind, Interface,
-    LlmProviderKind, MemoryLoader, MessageBus,
+    AssistantConfig, EmbeddingConfig, EmbeddingProviderKind, Interface, LlmProviderKind,
+    MemoryLoader, MessageBus, apply_agent_context, default_workspace_dir, set_runtime_agent_root,
+    set_runtime_workspace_dir, validate_agent_id,
 };
 use assistant_llm::{
     EmbeddingProvider, LlmEmbedder, LlmProvider, VoyageConfig, VoyageEmbedder,
@@ -28,14 +28,14 @@ use assistant_provider_moonshot::MoonshotProvider;
 use assistant_provider_ollama::{OllamaConfig, OllamaProvider};
 use assistant_provider_openai::{OpenAIProvider, OpenAIProviderConfig};
 use assistant_runtime::{
-    init_tracing, orchestrator::ConfirmationCallback, spawn_memory_indexer, spawn_scheduler,
-    start_conversation_context, Orchestrator,
+    Orchestrator, init_tracing, orchestrator::ConfirmationCallback, spawn_memory_indexer,
+    spawn_scheduler, start_conversation_context,
 };
 use assistant_skills::SkillSource;
 use assistant_storage::{
-    registry::SkillRegistry, PersonaSkillAccessStore, PersonaStore, RefinementStatus, StorageLayer,
+    PersonaSkillAccessStore, PersonaStore, RefinementStatus, StorageLayer, registry::SkillRegistry,
 };
-use assistant_tool_executor::{install_skill_from_source, ToolExecutor};
+use assistant_tool_executor::{ToolExecutor, install_skill_from_source};
 
 // ── Argument parsing ──────────────────────────────────────────────────────────
 

--- a/crates/interface-matrix/src/adapter.rs
+++ b/crates/interface-matrix/src/adapter.rs
@@ -20,7 +20,7 @@ use assistant_transcription::{TranscriptionProvider, TranscriptionRequest};
 use async_trait::async_trait;
 use chrono::Utc;
 use futures::stream::Stream;
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{Mutex, mpsc};
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
@@ -481,10 +481,10 @@ impl ChannelAdapter for MatrixAdapter {
             .await
             .get_mut(room_id)
             .and_then(|q| q.pop_front());
-        if let Some(rid) = reaction_id {
-            if let Err(e) = self.client.redact_event(room_id, &rid).await {
-                debug!(error = %e, "matrix: failed to redact hourglass reaction (best-effort)");
-            }
+        if let Some(rid) = reaction_id
+            && let Err(e) = self.client.redact_event(room_id, &rid).await
+        {
+            debug!(error = %e, "matrix: failed to redact hourglass reaction (best-effort)");
         }
         if let Err(e) = self.client.send_typing(room_id, true).await {
             debug!(error = %e, "matrix: failed to send typing indicator (best-effort)");

--- a/crates/interface-matrix/src/tools.rs
+++ b/crates/interface-matrix/src/tools.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use assistant_core::{ExecutionContext, ToolHandler, ToolOutput};
 use async_trait::async_trait;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use tracing::warn;
 
 use crate::client::MatrixClient;

--- a/crates/interface-mattermost/src/adapter.rs
+++ b/crates/interface-mattermost/src/adapter.rs
@@ -15,9 +15,9 @@ use assistant_core::{
 };
 use async_trait::async_trait;
 use chrono::Utc;
-use futures::stream::Stream;
 use futures::SinkExt;
-use tokio::sync::{mpsc, Mutex};
+use futures::stream::Stream;
+use tokio::sync::{Mutex, mpsc};
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::Message as WsMessage;
 use tracing::{debug, error, info, warn};
@@ -171,11 +171,10 @@ impl ChannelAdapter for MattermostAdapter {
                                         &bot_user_id,
                                         &allowed_channels,
                                         &allowed_users,
-                                    ) {
-                                        if tx.send(msg).await.is_err() {
+                                    )
+                                        && tx.send(msg).await.is_err() {
                                             break; // receiver dropped
                                         }
-                                    }
                                 }
                                 Some(Ok(WsMessage::Ping(data))) => {
                                     let _ = ws_write.send(WsMessage::Pong(data)).await;
@@ -294,14 +293,13 @@ impl ChannelAdapter for MattermostAdapter {
             .unwrap_or_default();
         if !bot_user_id.is_empty() {
             let post_id = self.pending_post_ids.lock().await.remove(&user.platform_id);
-            if let Some(pid) = post_id {
-                if let Err(e) = self
+            if let Some(pid) = post_id
+                && let Err(e) = self
                     .client
                     .remove_reaction(&bot_user_id, &pid, "hourglass_flowing_sand")
                     .await
-                {
-                    debug!(error = %e, "mattermost: failed to remove hourglass reaction (best-effort)");
-                }
+            {
+                debug!(error = %e, "mattermost: failed to remove hourglass reaction (best-effort)");
             }
         }
         if let Err(e) = self.client.send_typing(&channel_id).await {

--- a/crates/interface-mattermost/src/tools.rs
+++ b/crates/interface-mattermost/src/tools.rs
@@ -4,9 +4,9 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::Result;
-use assistant_core::{resolve_upload_bytes, ExecutionContext, ToolHandler, ToolOutput};
+use assistant_core::{ExecutionContext, ToolHandler, ToolOutput, resolve_upload_bytes};
 use async_trait::async_trait;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use tracing::{debug, warn};
 
 use crate::client::MattermostClient;

--- a/crates/interface-nextcloud/src/adapter.rs
+++ b/crates/interface-nextcloud/src/adapter.rs
@@ -17,14 +17,14 @@ use assistant_core::{
     NextcloudConfig, ToolHandler,
 };
 use async_trait::async_trait;
+use axum::Router;
 use axum::body::Bytes;
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::routing::post;
-use axum::Router;
 use chrono::Utc;
 use futures::stream::Stream;
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{Mutex, mpsc};
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
@@ -402,10 +402,10 @@ pub(crate) async fn http_post_message(
     reply_to: Option<i64>,
 ) -> Result<()> {
     let mut body = serde_json::json!({ "message": message });
-    if let Some(r) = reply_to {
-        if r > 0 {
-            body["replyTo"] = serde_json::json!(r);
-        }
+    if let Some(r) = reply_to
+        && r > 0
+    {
+        body["replyTo"] = serde_json::json!(r);
     }
     let body_str = body.to_string();
     let (random, signature) = sign_request(secret, &body_str)?;

--- a/crates/interface-nextcloud/src/tools.rs
+++ b/crates/interface-nextcloud/src/tools.rs
@@ -13,7 +13,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use tracing::{debug, warn};
 
-use assistant_core::{sanitize_llm_output, ExecutionContext, ToolHandler, ToolOutput};
+use assistant_core::{ExecutionContext, ToolHandler, ToolOutput, sanitize_llm_output};
 
 use crate::signing::sign_request;
 

--- a/crates/interface-signal/src/adapter.rs
+++ b/crates/interface-signal/src/adapter.rs
@@ -15,14 +15,14 @@ use std::time::Duration;
 use anyhow::Result;
 use assistant_core::{ChannelAdapter, ChannelContent, ChannelMessage, ChannelType, ChannelUser};
 use async_trait::async_trait;
-use base64::engine::general_purpose::STANDARD as B64_STANDARD;
 use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as B64_STANDARD;
 use chrono::Utc;
 use futures::stream::Stream;
 use tokio::sync::mpsc;
 use tokio_tungstenite::connect_async;
-use tokio_tungstenite::tungstenite::http::Request;
 use tokio_tungstenite::tungstenite::Message as WsMessage;
+use tokio_tungstenite::tungstenite::http::Request;
 use tracing::{debug, error, info, warn};
 
 use crate::config::{SignalConfig, SignalConfigExt};
@@ -165,11 +165,10 @@ impl ChannelAdapter for SignalAdapter {
                                                 continue;
                                             }
 
-                                            if let Some(msg) = envelope_to_channel_message(env) {
-                                                if tx.send(msg).await.is_err() {
+                                            if let Some(msg) = envelope_to_channel_message(env)
+                                                && tx.send(msg).await.is_err() {
                                                     return; // receiver dropped
                                                 }
-                                            }
                                         }
                                     }
                                 }
@@ -304,10 +303,10 @@ impl ChannelAdapter for SignalAdapter {
 
     fn conversation_key(&self, msg: &ChannelMessage) -> String {
         // Use group_id as the conversation key for group messages, else use source.
-        if let Some(gid) = msg.metadata.get("group_id").and_then(|v| v.as_str()) {
-            if !gid.is_empty() {
-                return gid.to_string();
-            }
+        if let Some(gid) = msg.metadata.get("group_id").and_then(|v| v.as_str())
+            && !gid.is_empty()
+        {
+            return gid.to_string();
         }
         msg.sender.platform_id.clone()
     }

--- a/crates/interface-slack/src/adapter.rs
+++ b/crates/interface-slack/src/adapter.rs
@@ -16,12 +16,12 @@ use assistant_core::{
     SlackConfig, ToolHandler,
 };
 use assistant_storage::StorageLayer;
-use assistant_transcription::{is_audio_mime, TranscriptionProvider, TranscriptionRequest};
+use assistant_transcription::{TranscriptionProvider, TranscriptionRequest, is_audio_mime};
 use async_trait::async_trait;
 use chrono::Utc;
-use futures::stream::Stream;
 use futures::SinkExt;
-use tokio::sync::{mpsc, Mutex};
+use futures::stream::Stream;
+use tokio::sync::{Mutex, mpsc};
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::Message as WsMessage;
 use tracing::{debug, error, info, warn};
@@ -227,8 +227,8 @@ impl ChannelAdapter for SlackAdapter {
                                                 transcription_language.as_deref(),
                                             )
                                             .await;
-                                            if !transcript.is_empty() {
-                                                if let ChannelContent::Text(ref mut text) =
+                                            if !transcript.is_empty()
+                                                && let ChannelContent::Text(ref mut text) =
                                                     msg.content
                                                 {
                                                     if text.is_empty() {
@@ -238,7 +238,6 @@ impl ChannelAdapter for SlackAdapter {
                                                             format!("{transcript}\n{text}");
                                                     }
                                                 }
-                                            }
                                         }
 
                                         // Download image attachments from file_share events.
@@ -382,13 +381,14 @@ impl ChannelAdapter for SlackAdapter {
     /// Add ⏳ reaction immediately when a message arrives (before the conv lock).
     async fn on_message_received(&self, msg: &ChannelMessage) -> Result<()> {
         let (channel, _) = parse_platform_id(&msg.sender.platform_id);
-        if let Some(ts) = &msg.platform_message_id {
-            if !channel.is_empty() && !ts.is_empty() {
-                let _ = self
-                    .client
-                    .add_reaction(&channel, ts, "hourglass_flowing_sand")
-                    .await;
-            }
+        if let Some(ts) = &msg.platform_message_id
+            && !channel.is_empty()
+            && !ts.is_empty()
+        {
+            let _ = self
+                .client
+                .add_reaction(&channel, ts, "hourglass_flowing_sand")
+                .await;
         }
         Ok(())
     }
@@ -520,10 +520,10 @@ fn parse_event(
     if event.get("bot_id").is_some() {
         return None;
     }
-    if let Some(subtype) = event.get("subtype").and_then(|v| v.as_str()) {
-        if subtype != "file_share" {
-            return None;
-        }
+    if let Some(subtype) = event.get("subtype").and_then(|v| v.as_str())
+        && subtype != "file_share"
+    {
+        return None;
     }
 
     let channel_id = event.get("channel").and_then(|v| v.as_str())?.to_string();
@@ -722,10 +722,10 @@ async fn seed_thread_history(
 ) -> Result<()> {
     for msg in messages {
         let subtype = msg.get("subtype").and_then(|v| v.as_str());
-        if let Some(st) = subtype {
-            if st != "file_share" {
-                continue;
-            }
+        if let Some(st) = subtype
+            && st != "file_share"
+        {
+            continue;
         }
 
         let is_bot = msg.get("bot_id").is_some()

--- a/crates/interface-slack/src/client.rs
+++ b/crates/interface-slack/src/client.rs
@@ -8,7 +8,7 @@
 //! - `conversations.replies` — fetch thread history for context seeding
 //! - `files.getUploadURLExternal` + `files.completeUploadExternal` — upload files
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use serde::Deserialize;
 use tracing::debug;
 

--- a/crates/interface-slack/src/skills/slack_delete_message.rs
+++ b/crates/interface-slack/src/skills/slack_delete_message.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use assistant_core::{ExecutionContext, ToolHandler, ToolOutput};
 use async_trait::async_trait;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use tracing::warn;
 
 use crate::client::SlackApiClient;

--- a/crates/interface-slack/src/skills/slack_get_history.rs
+++ b/crates/interface-slack/src/skills/slack_get_history.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use assistant_core::{ExecutionContext, ToolHandler, ToolOutput};
 use async_trait::async_trait;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use tracing::warn;
 
 use crate::client::SlackApiClient;

--- a/crates/interface-slack/src/skills/slack_list_channels.rs
+++ b/crates/interface-slack/src/skills/slack_list_channels.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use assistant_core::{ExecutionContext, ToolHandler, ToolOutput};
 use async_trait::async_trait;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use tracing::warn;
 
 use crate::client::SlackApiClient;

--- a/crates/interface-slack/src/skills/slack_lookup_user.rs
+++ b/crates/interface-slack/src/skills/slack_lookup_user.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use assistant_core::{ExecutionContext, ToolHandler, ToolOutput};
 use async_trait::async_trait;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use tracing::warn;
 
 use crate::client::SlackApiClient;

--- a/crates/interface-slack/src/skills/slack_post.rs
+++ b/crates/interface-slack/src/skills/slack_post.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use assistant_core::{ExecutionContext, ToolHandler, ToolOutput};
 use async_trait::async_trait;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use tracing::warn;
 
 use crate::client::SlackApiClient;

--- a/crates/interface-slack/src/skills/slack_react.rs
+++ b/crates/interface-slack/src/skills/slack_react.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use assistant_core::{ExecutionContext, ToolHandler, ToolOutput};
 use async_trait::async_trait;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use tracing::warn;
 
 use crate::client::SlackApiClient;

--- a/crates/interface-slack/src/skills/slack_send_dm.rs
+++ b/crates/interface-slack/src/skills/slack_send_dm.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use assistant_core::{ExecutionContext, ToolHandler, ToolOutput};
 use async_trait::async_trait;
 use serde::Deserialize;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use tracing::warn;
 
 use crate::client::SlackApiClient;

--- a/crates/interface-slack/src/skills/slack_update_message.rs
+++ b/crates/interface-slack/src/skills/slack_update_message.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use assistant_core::{ExecutionContext, ToolHandler, ToolOutput};
 use async_trait::async_trait;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use tracing::warn;
 
 use crate::client::SlackApiClient;

--- a/crates/interface-slack/src/tools.rs
+++ b/crates/interface-slack/src/tools.rs
@@ -9,10 +9,10 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use assistant_core::{
-    strip_cite_tags, strip_think_tags, ExecutionContext, ToolHandler, ToolOutput,
+    ExecutionContext, ToolHandler, ToolOutput, strip_cite_tags, strip_think_tags,
 };
 use async_trait::async_trait;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use tracing::warn;
 
 use crate::client::SlackApiClient;

--- a/crates/llm/src/client.rs
+++ b/crates/llm/src/client.rs
@@ -2,7 +2,7 @@ use anyhow::Context as _;
 use async_trait::async_trait;
 use futures::StreamExt as _;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use tokio::sync::mpsc;
 use tracing::debug;
 
@@ -302,15 +302,16 @@ impl LlmClient {
         // the Slack auto-post path) to send an empty message.  Instead, if content is
         // empty but thinking is present, surface it as a Thinking step so the
         // orchestrator adds it to history and re-prompts the model for a visible reply.
-        if content.trim().is_empty() {
-            if let Some(thinking) = json
+        if content.trim().is_empty()
+            && let Some(thinking) = json
                 .pointer("/message/thinking")
                 .and_then(|v| v.as_str())
                 .filter(|s| !s.trim().is_empty())
-            {
-                debug!("Model returned empty content with non-empty thinking; surfacing as Thinking step");
-                return Ok(LlmResponse::Thinking(thinking.to_string(), meta));
-            }
+        {
+            debug!(
+                "Model returned empty content with non-empty thinking; surfacing as Thinking step"
+            );
+            return Ok(LlmResponse::Thinking(thinking.to_string(), meta));
         }
 
         debug!("Native request returned no tool_calls; treating as final answer");
@@ -386,10 +387,10 @@ impl LlmClient {
                             }
                         }
 
-                        if let Some(tc) = json.pointer("/message/tool_calls") {
-                            if tc.as_array().is_some_and(|a| !a.is_empty()) {
-                                tool_calls_json = Some(tc.clone());
-                            }
+                        if let Some(tc) = json.pointer("/message/tool_calls")
+                            && tc.as_array().is_some_and(|a| !a.is_empty())
+                        {
+                            tool_calls_json = Some(tc.clone());
                         }
 
                         // The final chunk carries `done: true` and the metadata.
@@ -403,26 +404,26 @@ impl LlmClient {
             }
         }
 
-        if !line_buf.is_empty() {
-            if let Ok(json) = serde_json::from_str::<Value>(&line_buf) {
-                if let Some(token) = json
-                    .pointer("/message/content")
-                    .and_then(|v| v.as_str())
-                    .filter(|s| !s.is_empty())
-                {
-                    content.push_str(token);
-                    if let Some(ref sink) = token_sink {
-                        let _ = sink.send(token.to_string()).await;
-                    }
+        if !line_buf.is_empty()
+            && let Ok(json) = serde_json::from_str::<Value>(&line_buf)
+        {
+            if let Some(token) = json
+                .pointer("/message/content")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+            {
+                content.push_str(token);
+                if let Some(ref sink) = token_sink {
+                    let _ = sink.send(token.to_string()).await;
                 }
-                if let Some(tc) = json.pointer("/message/tool_calls") {
-                    if tc.as_array().is_some_and(|a| !a.is_empty()) {
-                        tool_calls_json = Some(tc.clone());
-                    }
-                }
-                if json.get("done").and_then(|v| v.as_bool()).unwrap_or(false) {
-                    final_json = Some(json);
-                }
+            }
+            if let Some(tc) = json.pointer("/message/tool_calls")
+                && tc.as_array().is_some_and(|a| !a.is_empty())
+            {
+                tool_calls_json = Some(tc.clone());
+            }
+            if json.get("done").and_then(|v| v.as_bool()).unwrap_or(false) {
+                final_json = Some(json);
             }
         }
 
@@ -433,34 +434,34 @@ impl LlmClient {
             .map(extract_ollama_meta)
             .unwrap_or_default();
 
-        if let Some(tc) = tool_calls_json {
-            if let Some(arr) = tc.as_array() {
-                let items: Vec<ToolCallItem> = arr
-                    .iter()
-                    .filter_map(|entry| {
-                        let name = entry
-                            .pointer("/function/name")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("")
-                            .to_string();
-                        if name.is_empty() {
-                            return None;
-                        }
-                        let params = entry
-                            .pointer("/function/arguments")
-                            .cloned()
-                            .unwrap_or(Value::Object(serde_json::Map::new()));
-                        Some(ToolCallItem {
-                            name,
-                            params,
-                            id: None,
-                        })
+        if let Some(tc) = tool_calls_json
+            && let Some(arr) = tc.as_array()
+        {
+            let items: Vec<ToolCallItem> = arr
+                .iter()
+                .filter_map(|entry| {
+                    let name = entry
+                        .pointer("/function/name")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    if name.is_empty() {
+                        return None;
+                    }
+                    let params = entry
+                        .pointer("/function/arguments")
+                        .cloned()
+                        .unwrap_or(Value::Object(serde_json::Map::new()));
+                    Some(ToolCallItem {
+                        name,
+                        params,
+                        id: None,
                     })
-                    .collect();
-                if !items.is_empty() {
-                    debug!(count = items.len(), "Native streaming: tool calls received");
-                    return Ok(LlmResponse::ToolCalls(items, meta));
-                }
+                })
+                .collect();
+            if !items.is_empty() {
+                debug!(count = items.len(), "Native streaming: tool calls received");
+                return Ok(LlmResponse::ToolCalls(items, meta));
             }
         }
 
@@ -634,8 +635,8 @@ fn build_json_messages(
 #[cfg(test)]
 mod tests {
     use wiremock::{
-        matchers::{method, path},
         Mock, MockServer, ResponseTemplate,
+        matchers::{method, path},
     };
 
     use super::*;

--- a/crates/llm/src/http.rs
+++ b/crates/llm/src/http.rs
@@ -9,8 +9,8 @@
 use std::time::Duration;
 
 use reqwest_middleware::ClientWithMiddleware;
-use reqwest_retry::policies::ExponentialBackoff;
 use reqwest_retry::RetryTransientMiddleware;
+use reqwest_retry::policies::ExponentialBackoff;
 use reqwest_tracing::TracingMiddleware;
 
 use crate::retry::RetryConfig;

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -13,6 +13,6 @@ pub use client::{
 pub use embedding::{EmbeddingProvider, LlmEmbedder, WithEmbeddingOverride};
 pub use http::{build_http_client, build_reqwest_client};
 pub use provider::{Capabilities, HostedTool, LlmProvider, ToolSupport};
-pub use retry::{is_transient_error_message, is_transient_status, with_retry, RetryConfig};
+pub use retry::{RetryConfig, is_transient_error_message, is_transient_status, with_retry};
 pub use tool_spec::ToolSpec;
 pub use voyage::{VoyageConfig, VoyageEmbedder};

--- a/crates/llm/src/voyage.rs
+++ b/crates/llm/src/voyage.rs
@@ -218,9 +218,11 @@ mod tests {
 
         let result = embedder.embed("hello").await;
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("empty embedding data"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("empty embedding data")
+        );
     }
 }

--- a/crates/mcp-client/src/bridge.rs
+++ b/crates/mcp-client/src/bridge.rs
@@ -172,16 +172,15 @@ fn extract_text(content: &[Content]) -> String {
 fn extract_image_attachments(content: &[Content]) -> Vec<assistant_core::Attachment> {
     let mut attachments = Vec::new();
     for item in content {
-        if let RawContent::Image(img) = &item.raw {
-            if let Ok(bytes) =
+        if let RawContent::Image(img) = &item.raw
+            && let Ok(bytes) =
                 base64::Engine::decode(&base64::engine::general_purpose::STANDARD, &img.data)
-            {
-                attachments.push(assistant_core::Attachment::new(
-                    "image",
-                    img.mime_type.clone(),
-                    bytes,
-                ));
-            }
+        {
+            attachments.push(assistant_core::Attachment::new(
+                "image",
+                img.mime_type.clone(),
+                bytes,
+            ));
         }
     }
     attachments

--- a/crates/mcp-client/src/manager.rs
+++ b/crates/mcp-client/src/manager.rs
@@ -12,8 +12,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use rmcp::model::Tool;
 use rmcp::ServiceExt;
+use rmcp::model::Tool;
 use tokio::sync::RwLock;
 use tracing::{debug, error, info, warn};
 
@@ -317,19 +317,19 @@ impl McpClientManager {
                 };
 
                 // Check if a connected server has died.
-                if let Some(ref client) = state.client {
-                    if !client.is_connected() {
-                        warn!(server = %name, "MCP server disconnected, removing tools");
-                        let prefix = bridge::namespaced_name(&name, "");
-                        unregister_prefix(&prefix);
+                if let Some(ref client) = state.client
+                    && !client.is_connected()
+                {
+                    warn!(server = %name, "MCP server disconnected, removing tools");
+                    let prefix = bridge::namespaced_name(&name, "");
+                    unregister_prefix(&prefix);
 
-                        let mut handlers = self.handlers.write().await;
-                        handlers.retain(|h| !h.name().starts_with(&prefix));
-                        drop(handlers);
+                    let mut handlers = self.handlers.write().await;
+                    handlers.retain(|h| !h.name().starts_with(&prefix));
+                    drop(handlers);
 
-                        state.client = None;
-                        state.consecutive_failures = 0;
-                    }
+                    state.client = None;
+                    state.consecutive_failures = 0;
                 }
 
                 // Collect disconnected servers for parallel reconnection.
@@ -448,10 +448,10 @@ impl McpClientManager {
     pub async fn shutdown(&self) -> Result<()> {
         let servers = self.servers.read().await;
         for (name, state) in servers.iter() {
-            if let Some(ref client) = state.client {
-                if let Err(e) = client.shutdown().await {
-                    warn!(server = %name, error = %e, "error shutting down MCP client");
-                }
+            if let Some(ref client) = state.client
+                && let Err(e) = client.shutdown().await
+            {
+                warn!(server = %name, error = %e, "error shutting down MCP client");
             }
         }
         Ok(())

--- a/crates/mcp-server/src/lib.rs
+++ b/crates/mcp-server/src/lib.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use assistant_runtime::Orchestrator;
-use assistant_storage::{registry::SkillRegistry, StorageLayer};
+use assistant_storage::{StorageLayer, registry::SkillRegistry};
 use assistant_tool_executor::ToolExecutor;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tracing::{info, warn};

--- a/crates/mcp-server/src/server.rs
+++ b/crates/mcp-server/src/server.rs
@@ -7,8 +7,8 @@ use std::sync::Arc;
 use assistant_core::{ExecutionContext, Interface};
 use assistant_runtime::Orchestrator;
 use assistant_storage::registry::SkillRegistry;
-use assistant_tool_executor::{install_skill_from_source, ToolExecutor};
-use serde_json::{json, Value};
+use assistant_tool_executor::{ToolExecutor, install_skill_from_source};
+use serde_json::{Value, json};
 use tracing::{debug, warn};
 use uuid::Uuid;
 
@@ -265,10 +265,7 @@ pub async fn handle_request(
                                 match std::fs::read_to_string(&file_path) {
                                     Ok(text) => {
                                         let content = vec![ContentItem::text(text)];
-                                        JsonRpcResponse::ok(
-                                            req.id,
-                                            json!({ "contents": content }),
-                                        )
+                                        JsonRpcResponse::ok(req.id, json!({ "contents": content }))
                                     }
                                     Err(_) => JsonRpcResponse::err(
                                         req.id,

--- a/crates/opentelemetry-exporter-iceberg/src/catalog.rs
+++ b/crates/opentelemetry-exporter-iceberg/src/catalog.rs
@@ -6,9 +6,9 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use assistant_core::IcebergConfig;
 use iceberg::io::FileIO;
-use iceberg::memory::{MemoryCatalogBuilder, MEMORY_CATALOG_WAREHOUSE};
+use iceberg::memory::{MEMORY_CATALOG_WAREHOUSE, MemoryCatalogBuilder};
 use iceberg::{Catalog, CatalogBuilder, NamespaceIdent};
-use iceberg_catalog_rest::{RestCatalogBuilder, REST_CATALOG_PROP_URI};
+use iceberg_catalog_rest::{REST_CATALOG_PROP_URI, RestCatalogBuilder};
 
 /// A thread-safe reference to an Iceberg catalog.
 pub type CatalogRef = Arc<dyn Catalog>;

--- a/crates/opentelemetry-exporter-iceberg/src/log.rs
+++ b/crates/opentelemetry-exporter-iceberg/src/log.rs
@@ -8,28 +8,28 @@ use arrow_schema::Schema as ArrowSchema;
 use assistant_core::IcebergConfig;
 use iceberg::spec::DataFileFormat;
 use iceberg::transaction::{ApplyTransactionAction, Transaction};
+use iceberg::writer::IcebergWriter;
+use iceberg::writer::IcebergWriterBuilder;
 use iceberg::writer::base_writer::data_file_writer::DataFileWriterBuilder;
+use iceberg::writer::file_writer::ParquetWriterBuilder;
 use iceberg::writer::file_writer::location_generator::{
     DefaultFileNameGenerator, DefaultLocationGenerator,
 };
 use iceberg::writer::file_writer::rolling_writer::RollingFileWriterBuilder;
-use iceberg::writer::file_writer::ParquetWriterBuilder;
-use iceberg::writer::IcebergWriter;
-use iceberg::writer::IcebergWriterBuilder;
 use iceberg::{TableCreation, TableIdent};
 use opentelemetry::Key;
+use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::error::{OTelSdkError, OTelSdkResult};
 use opentelemetry_sdk::logs::{LogBatch, LogExporter};
-use opentelemetry_sdk::Resource;
 use opentelemetry_semantic_conventions::attribute::SERVICE_NAME;
 use parquet::file::properties::WriterProperties;
 use tokio::runtime::Handle;
 use tokio::sync::Mutex;
 use uuid::Uuid;
 
-use crate::catalog::{build_catalog, build_file_io, ensure_namespace, CatalogRef};
+use crate::catalog::{CatalogRef, build_catalog, build_file_io, ensure_namespace};
 use crate::partition::{batch_partition_key, partition_spec};
-use crate::schema::{arc, logs_schema, LOGS_TIMESTAMP_FIELD_ID};
+use crate::schema::{LOGS_TIMESTAMP_FIELD_ID, arc, logs_schema};
 
 /// OpenTelemetry log exporter that persists log records into an Apache Iceberg
 /// `assistant_logs` table using Parquet files.

--- a/crates/opentelemetry-exporter-iceberg/src/metric.rs
+++ b/crates/opentelemetry-exporter-iceberg/src/metric.rs
@@ -11,29 +11,29 @@ use arrow_schema::Schema as ArrowSchema;
 use assistant_core::IcebergConfig;
 use iceberg::spec::DataFileFormat;
 use iceberg::transaction::{ApplyTransactionAction, Transaction};
+use iceberg::writer::IcebergWriter;
+use iceberg::writer::IcebergWriterBuilder;
 use iceberg::writer::base_writer::data_file_writer::DataFileWriterBuilder;
+use iceberg::writer::file_writer::ParquetWriterBuilder;
 use iceberg::writer::file_writer::location_generator::{
     DefaultFileNameGenerator, DefaultLocationGenerator,
 };
 use iceberg::writer::file_writer::rolling_writer::RollingFileWriterBuilder;
-use iceberg::writer::file_writer::ParquetWriterBuilder;
-use iceberg::writer::IcebergWriter;
-use iceberg::writer::IcebergWriterBuilder;
 use iceberg::{TableCreation, TableIdent};
 use opentelemetry::KeyValue;
 use opentelemetry_sdk::error::{OTelSdkError, OTelSdkResult};
+use opentelemetry_sdk::metrics::Temporality;
 use opentelemetry_sdk::metrics::data::{
     AggregatedMetrics, Gauge, Histogram, MetricData, ResourceMetrics, Sum,
 };
 use opentelemetry_sdk::metrics::exporter::PushMetricExporter;
-use opentelemetry_sdk::metrics::Temporality;
 use parquet::file::properties::WriterProperties;
 use tokio::sync::Mutex;
 use uuid::Uuid;
 
-use crate::catalog::{build_catalog, build_file_io, ensure_namespace, CatalogRef};
+use crate::catalog::{CatalogRef, build_catalog, build_file_io, ensure_namespace};
 use crate::partition::{batch_partition_key, partition_spec};
-use crate::schema::{arc, metrics_schema, METRICS_RECORDED_AT_FIELD_ID};
+use crate::schema::{METRICS_RECORDED_AT_FIELD_ID, arc, metrics_schema};
 
 /// OpenTelemetry metric exporter that persists metric points into an Apache
 /// Iceberg `assistant_metric_points` table using Parquet files.

--- a/crates/opentelemetry-exporter-iceberg/src/span.rs
+++ b/crates/opentelemetry-exporter-iceberg/src/span.rs
@@ -9,19 +9,19 @@ use assistant_core::IcebergConfig;
 use iceberg::spec::DataFileFormat;
 use iceberg::transaction::ApplyTransactionAction;
 use iceberg::transaction::Transaction;
+use iceberg::writer::IcebergWriter;
+use iceberg::writer::IcebergWriterBuilder;
 use iceberg::writer::base_writer::data_file_writer::DataFileWriterBuilder;
+use iceberg::writer::file_writer::ParquetWriterBuilder;
 use iceberg::writer::file_writer::location_generator::{
     DefaultFileNameGenerator, DefaultLocationGenerator,
 };
 use iceberg::writer::file_writer::rolling_writer::RollingFileWriterBuilder;
-use iceberg::writer::file_writer::ParquetWriterBuilder;
-use iceberg::writer::IcebergWriter;
-use iceberg::writer::IcebergWriterBuilder;
 use iceberg::{TableCreation, TableIdent};
 use opentelemetry::{Key, Value};
+use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::error::{OTelSdkError, OTelSdkResult};
 use opentelemetry_sdk::trace::{SpanData, SpanExporter};
-use opentelemetry_sdk::Resource;
 use opentelemetry_semantic_conventions::attribute::{
     GEN_AI_USAGE_INPUT_TOKENS, GEN_AI_USAGE_OUTPUT_TOKENS, SERVICE_NAME,
 };
@@ -29,9 +29,9 @@ use parquet::file::properties::WriterProperties;
 use tokio::runtime::Handle;
 use tokio::sync::Mutex;
 
-use crate::catalog::{build_catalog, build_file_io, ensure_namespace, CatalogRef};
+use crate::catalog::{CatalogRef, build_catalog, build_file_io, ensure_namespace};
 use crate::partition::{batch_partition_key, partition_spec};
-use crate::schema::{arc, spans_schema, SPANS_START_TIME_FIELD_ID};
+use crate::schema::{SPANS_START_TIME_FIELD_ID, arc, spans_schema};
 
 /// OpenTelemetry span exporter that persists spans into an Apache Iceberg
 /// `assistant_spans` table using Parquet files.

--- a/crates/opentelemetry-exporter-iceberg/tests/e2e_write_read.rs
+++ b/crates/opentelemetry-exporter-iceberg/tests/e2e_write_read.rs
@@ -7,10 +7,10 @@ use std::time::SystemTime;
 
 use arrow_array::Array;
 use assistant_core::{IcebergConfig, PartitionGranularity};
+use opentelemetry::InstrumentationScope;
 use opentelemetry::trace::{
     SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId, TraceState,
 };
-use opentelemetry::InstrumentationScope;
 use opentelemetry_exporter_iceberg::IcebergSpanExporter;
 use opentelemetry_sdk::error::OTelSdkResult;
 use opentelemetry_sdk::trace::{SpanData, SpanEvents, SpanExporter, SpanLinks};

--- a/crates/opentelemetry-exporter-sqlite/src/log.rs
+++ b/crates/opentelemetry-exporter-sqlite/src/log.rs
@@ -1,11 +1,11 @@
 //! OpenTelemetry log exporter that persists log records into the `logs` SQLite table.
 
 use chrono::{DateTime, Utc};
-use opentelemetry::logs::{AnyValue, Severity};
 use opentelemetry::Key;
+use opentelemetry::logs::{AnyValue, Severity};
+use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::error::{OTelSdkError, OTelSdkResult};
 use opentelemetry_sdk::logs::{LogBatch, LogExporter, SdkLogRecord};
-use opentelemetry_sdk::Resource;
 use opentelemetry_semantic_conventions::attribute::SERVICE_NAME;
 use serde_json::{Map, Number};
 use sqlx::{SqliteConnection, SqlitePool};
@@ -221,11 +221,11 @@ fn any_value_to_json(value: &AnyValue) -> serde_json::Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use opentelemetry::InstrumentationScope;
     use opentelemetry::logs::{
         AnyValue, LogRecord as _, Logger as _, LoggerProvider as _, Severity,
     };
     use opentelemetry::trace::{SpanId, TraceFlags, TraceId};
-    use opentelemetry::InstrumentationScope;
     use opentelemetry_sdk::logs::{SdkLogRecord, SdkLoggerProvider};
 
     /// Create a logger from a no-op provider so we can call

--- a/crates/opentelemetry-exporter-sqlite/src/metric.rs
+++ b/crates/opentelemetry-exporter-sqlite/src/metric.rs
@@ -7,14 +7,14 @@
 use chrono::{DateTime, Utc};
 use opentelemetry::InstrumentationScope;
 use opentelemetry::{KeyValue, Value};
+use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::error::{OTelSdkError, OTelSdkResult};
+use opentelemetry_sdk::metrics::Temporality;
 use opentelemetry_sdk::metrics::data::{
     AggregatedMetrics, GaugeDataPoint, HistogramDataPoint, MetricData, ResourceMetrics,
     SumDataPoint,
 };
 use opentelemetry_sdk::metrics::exporter::PushMetricExporter;
-use opentelemetry_sdk::metrics::Temporality;
-use opentelemetry_sdk::Resource;
 use opentelemetry_semantic_conventions::attribute::{GEN_AI_OPERATION_NAME, GEN_AI_REQUEST_MODEL};
 use serde_json::{Map, Number};
 use sha2::{Digest, Sha256};

--- a/crates/opentelemetry-exporter-sqlite/src/span.rs
+++ b/crates/opentelemetry-exporter-sqlite/src/span.rs
@@ -1,9 +1,9 @@
 use chrono::{DateTime, Utc};
 use opentelemetry::trace::SpanId;
 use opentelemetry::{Key, KeyValue, Value};
+use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::error::{OTelSdkError, OTelSdkResult};
 use opentelemetry_sdk::trace::{SpanData, SpanExporter};
-use opentelemetry_sdk::Resource;
 use opentelemetry_semantic_conventions::attribute::{
     GEN_AI_USAGE_INPUT_TOKENS, GEN_AI_USAGE_OUTPUT_TOKENS, SERVICE_NAME,
 };
@@ -245,8 +245,8 @@ fn status_fields(status: &opentelemetry::trace::Status) -> (&'static str, Option
 #[cfg(test)]
 mod tests {
     use super::*;
-    use opentelemetry::trace::{SpanContext, SpanKind, Status, TraceFlags, TraceId, TraceState};
     use opentelemetry::InstrumentationScope;
+    use opentelemetry::trace::{SpanContext, SpanKind, Status, TraceFlags, TraceId, TraceState};
     use opentelemetry_sdk::trace::{SpanData, SpanEvents, SpanLinks};
     use std::time::{Duration, SystemTime};
 

--- a/crates/provider-anthropic/src/provider.rs
+++ b/crates/provider-anthropic/src/provider.rs
@@ -2,14 +2,14 @@
 
 use async_trait::async_trait;
 use futures::StreamExt as _;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use tokio::sync::mpsc;
 use tracing::debug;
 
+use assistant_core::LlmConfig;
 use assistant_core::types::{
     AnthropicUserLocation, AnthropicWebFetchOptions, AnthropicWebSearchOptions,
 };
-use assistant_core::LlmConfig;
 use assistant_llm::{
     Capabilities, ChatHistoryMessage, ChatRole, ContentBlock, HostedTool, LlmProvider, LlmResponse,
     LlmResponseMeta, ToolCallItem, ToolSpec, ToolSupport,
@@ -762,27 +762,23 @@ async fn process_sse_event(
                     }
                 }
                 "input_json_delta" => {
-                    if let Some(idx) = *current_block_idx {
-                        if let Some(partial) =
+                    if let Some(idx) = *current_block_idx
+                        && let Some(partial) =
                             json.pointer("/delta/partial_json").and_then(|v| v.as_str())
+                        && idx < tool_blocks.len()
+                    {
+                        tool_blocks[idx].partial_json.push_str(partial);
+                        // Stream the decoded text value of this tool block
+                        // so the caller can update a live preview (e.g. the
+                        // Slack placeholder message).
+                        if let Some(sink) = token_sink
+                            && let Some(text) = extract_partial_text(&tool_blocks[idx].partial_json)
                         {
-                            if idx < tool_blocks.len() {
-                                tool_blocks[idx].partial_json.push_str(partial);
-                                // Stream the decoded text value of this tool block
-                                // so the caller can update a live preview (e.g. the
-                                // Slack placeholder message).
-                                if let Some(sink) = token_sink {
-                                    if let Some(text) =
-                                        extract_partial_text(&tool_blocks[idx].partial_json)
-                                    {
-                                        let already = tool_blocks[idx].text_chars_sent;
-                                        if text.len() > already {
-                                            let new_text = text[already..].to_string();
-                                            tool_blocks[idx].text_chars_sent = text.len();
-                                            let _ = sink.send(new_text).await;
-                                        }
-                                    }
-                                }
+                            let already = tool_blocks[idx].text_chars_sent;
+                            if text.len() > already {
+                                let new_text = text[already..].to_string();
+                                tool_blocks[idx].text_chars_sent = text.len();
+                                let _ = sink.send(new_text).await;
                             }
                         }
                     }

--- a/crates/provider-moonshot/src/provider.rs
+++ b/crates/provider-moonshot/src/provider.rs
@@ -6,6 +6,7 @@
 //! because it uses the non-standard `"type": "builtin_function"` tool spec
 //! and requires an echo-back loop.
 
+use async_openai::Client;
 use async_openai::config::OpenAIConfig as AsyncOpenAIConfig;
 use async_openai::types::chat::{
     ChatCompletionMessageToolCall, ChatCompletionMessageToolCalls,
@@ -14,18 +15,17 @@ use async_openai::types::chat::{
     ChatCompletionRequestUserMessageArgs, ChatCompletionTool, ChatCompletionTools, CompletionUsage,
     CreateChatCompletionRequestArgs, FunctionCall, FunctionObjectArgs,
 };
-use async_openai::Client;
 use async_trait::async_trait;
 use futures::StreamExt as _;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use tokio::sync::mpsc;
 use tracing::{debug, warn};
 
 use assistant_core::LlmConfig;
 use assistant_llm::{
-    build_reqwest_client, is_transient_error_message, with_retry, Capabilities, ChatHistoryMessage,
-    ChatRole, ContentBlock, HostedTool, LlmProvider, LlmResponse, LlmResponseMeta, RetryConfig,
-    ToolCallItem, ToolSpec, ToolSupport,
+    Capabilities, ChatHistoryMessage, ChatRole, ContentBlock, HostedTool, LlmProvider, LlmResponse,
+    LlmResponseMeta, RetryConfig, ToolCallItem, ToolSpec, ToolSupport, build_reqwest_client,
+    is_transient_error_message, with_retry,
 };
 
 // ── Defaults ──────────────────────────────────────────────────────────────────
@@ -441,59 +441,59 @@ impl MoonshotProvider {
             };
 
             // Check for tool calls.
-            if finish_reason == "tool_calls" {
-                if let Some(tool_calls) = message["tool_calls"].as_array() {
-                    let mut web_search_calls: Vec<&Value> = Vec::new();
-                    let mut regular_calls: Vec<ToolCallItem> = Vec::new();
+            if finish_reason == "tool_calls"
+                && let Some(tool_calls) = message["tool_calls"].as_array()
+            {
+                let mut web_search_calls: Vec<&Value> = Vec::new();
+                let mut regular_calls: Vec<ToolCallItem> = Vec::new();
 
-                    for tc in tool_calls {
-                        let name = tc["function"]["name"].as_str().unwrap_or("");
-                        if name == "$web_search" {
-                            web_search_calls.push(tc);
-                        } else {
-                            let params: Value = serde_json::from_str(
-                                tc["function"]["arguments"].as_str().unwrap_or("{}"),
-                            )
-                            .unwrap_or(json!({}));
-                            regular_calls.push(ToolCallItem {
-                                name: name.to_string(),
-                                params,
-                                id: tc["id"].as_str().map(String::from),
-                            });
-                        }
+                for tc in tool_calls {
+                    let name = tc["function"]["name"].as_str().unwrap_or("");
+                    if name == "$web_search" {
+                        web_search_calls.push(tc);
+                    } else {
+                        let params: Value = serde_json::from_str(
+                            tc["function"]["arguments"].as_str().unwrap_or("{}"),
+                        )
+                        .unwrap_or(json!({}));
+                        regular_calls.push(ToolCallItem {
+                            name: name.to_string(),
+                            params,
+                            id: tc["id"].as_str().map(String::from),
+                        });
                     }
+                }
 
-                    if !regular_calls.is_empty() {
+                if !regular_calls.is_empty() {
+                    debug!(
+                        count = regular_calls.len(),
+                        "Moonshot: regular tool calls received alongside web search"
+                    );
+                    return Ok(LlmResponse::ToolCalls(regular_calls, meta));
+                }
+
+                if !web_search_calls.is_empty() {
+                    messages.push(message.clone());
+
+                    for tc in &web_search_calls {
+                        let call_id = tc["id"].as_str().unwrap_or("");
+                        let arguments = tc["function"]["arguments"].as_str().unwrap_or("{}");
+
                         debug!(
-                            count = regular_calls.len(),
-                            "Moonshot: regular tool calls received alongside web search"
+                            call_id,
+                            query = arguments,
+                            "Moonshot: echoing $web_search arguments"
                         );
-                        return Ok(LlmResponse::ToolCalls(regular_calls, meta));
+
+                        messages.push(json!({
+                            "role": "tool",
+                            "tool_call_id": call_id,
+                            "name": "$web_search",
+                            "content": arguments,
+                        }));
                     }
 
-                    if !web_search_calls.is_empty() {
-                        messages.push(message.clone());
-
-                        for tc in &web_search_calls {
-                            let call_id = tc["id"].as_str().unwrap_or("");
-                            let arguments = tc["function"]["arguments"].as_str().unwrap_or("{}");
-
-                            debug!(
-                                call_id,
-                                query = arguments,
-                                "Moonshot: echoing $web_search arguments"
-                            );
-
-                            messages.push(json!({
-                                "role": "tool",
-                                "tool_call_id": call_id,
-                                "name": "$web_search",
-                                "content": arguments,
-                            }));
-                        }
-
-                        continue;
-                    }
+                    continue;
                 }
             }
 
@@ -551,10 +551,10 @@ impl LlmProvider for MoonshotProvider {
             let result = self
                 .chat_with_web_search(system_prompt, history, tools)
                 .await?;
-            if let LlmResponse::FinalAnswer(ref text, _) = result {
-                if let Some(sink) = token_sink {
-                    let _ = sink.send(text.clone()).await;
-                }
+            if let LlmResponse::FinalAnswer(ref text, _) = result
+                && let Some(sink) = token_sink
+            {
+                let _ = sink.send(text.clone()).await;
             }
             Ok(result)
         } else {
@@ -594,13 +594,12 @@ fn build_chat_messages(
     let mut messages: Vec<ChatCompletionRequestMessage> = Vec::with_capacity(history.len() + 1);
     let mut pending_ids: Vec<(String, String)> = Vec::new();
 
-    if !system_prompt.is_empty() {
-        if let Ok(msg) = ChatCompletionRequestSystemMessageArgs::default()
+    if !system_prompt.is_empty()
+        && let Ok(msg) = ChatCompletionRequestSystemMessageArgs::default()
             .content(system_prompt)
             .build()
-        {
-            messages.push(ChatCompletionRequestMessage::System(msg));
-        }
+    {
+        messages.push(ChatCompletionRequestMessage::System(msg));
     }
 
     for entry in history {
@@ -972,10 +971,11 @@ mod tests {
             true,
         )
         .unwrap();
-        assert!(p
-            .capabilities()
-            .hosted_tools
-            .contains(&HostedTool::WebSearch));
+        assert!(
+            p.capabilities()
+                .hosted_tools
+                .contains(&HostedTool::WebSearch)
+        );
     }
 
     #[test]
@@ -989,10 +989,11 @@ mod tests {
             false,
         )
         .unwrap();
-        assert!(!p
-            .capabilities()
-            .hosted_tools
-            .contains(&HostedTool::WebSearch));
+        assert!(
+            !p.capabilities()
+                .hosted_tools
+                .contains(&HostedTool::WebSearch)
+        );
     }
 
     // ── Web-search echo-back tests (wiremock) ─────────────────────────────

--- a/crates/provider-openai/src/oauth.rs
+++ b/crates/provider-openai/src/oauth.rs
@@ -14,8 +14,8 @@
 
 use std::path::PathBuf;
 
-use anyhow::{bail, Context};
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use anyhow::{Context, bail};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -105,10 +105,10 @@ impl OAuthManager {
         // Fast path: valid cached token.
         {
             let guard = self.tokens.read().await;
-            if let Some(ref t) = *guard {
-                if t.expires_at > Utc::now() + Duration::seconds(REFRESH_MARGIN_SECS) {
-                    return Ok(t.access_token.clone());
-                }
+            if let Some(ref t) = *guard
+                && t.expires_at > Utc::now() + Duration::seconds(REFRESH_MARGIN_SECS)
+            {
+                return Ok(t.access_token.clone());
             }
         }
 

--- a/crates/provider-openai/src/provider.rs
+++ b/crates/provider-openai/src/provider.rs
@@ -10,6 +10,7 @@
 
 use std::sync::Arc;
 
+use async_openai::Client;
 use async_openai::config::OpenAIConfig as AsyncOpenAIConfig;
 use async_openai::types::embeddings::CreateEmbeddingRequestArgs;
 use async_openai::types::responses::{
@@ -19,19 +20,18 @@ use async_openai::types::responses::{
     Tool, WebSearchApproximateLocation, WebSearchApproximateLocationType, WebSearchTool,
     WebSearchToolSearchContextSize,
 };
-use async_openai::Client;
 use async_trait::async_trait;
 use futures::StreamExt as _;
 use serde_json::Value;
-use tokio::sync::{mpsc, RwLock};
+use tokio::sync::{RwLock, mpsc};
 use tracing::{debug, warn};
 
-use assistant_core::types::OpenAIUserLocation;
 use assistant_core::LlmConfig;
+use assistant_core::types::OpenAIUserLocation;
 use assistant_llm::{
-    build_reqwest_client, is_transient_error_message, with_retry, Capabilities, ChatHistoryMessage,
-    ChatRole, ContentBlock, HostedTool, LlmProvider, LlmResponse, LlmResponseMeta, RetryConfig,
-    ToolCallItem, ToolSpec, ToolSupport,
+    Capabilities, ChatHistoryMessage, ChatRole, ContentBlock, HostedTool, LlmProvider, LlmResponse,
+    LlmResponseMeta, RetryConfig, ToolCallItem, ToolSpec, ToolSupport, build_reqwest_client,
+    is_transient_error_message, with_retry,
 };
 
 use crate::oauth::OAuthManager;

--- a/crates/runtime/src/bootstrap.rs
+++ b/crates/runtime/src/bootstrap.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use assistant_core::{expand_tilde, AssistantConfig, MemoryConfig};
+use assistant_core::{AssistantConfig, MemoryConfig, expand_tilde};
 use assistant_llm::LlmProvider;
 use assistant_skills::SkillSource;
 use assistant_storage::StorageLayer;
@@ -110,10 +110,10 @@ pub fn skill_dirs(
         );
     }
 
-    if let Ok(exe) = std::env::current_exe() {
-        if let Some(exe_dir) = exe.parent() {
-            push_dir(exe_dir.join("skills"), SkillSource::Builtin);
-        }
+    if let Ok(exe) = std::env::current_exe()
+        && let Some(exe_dir) = exe.parent()
+    {
+        push_dir(exe_dir.join("skills"), SkillSource::Builtin);
     }
 
     dirs

--- a/crates/runtime/src/compaction.rs
+++ b/crates/runtime/src/compaction.rs
@@ -341,10 +341,10 @@ pub async fn maybe_compact(
     );
 
     // Persist so the next turn does not reload the full history.
-    if let Some((store, conv_id)) = conv_store {
-        if let Err(e) = persist_compacted(store, conv_id, history).await {
-            warn!(error = %e, "Failed to persist compacted history; in-memory compaction still applies");
-        }
+    if let Some((store, conv_id)) = conv_store
+        && let Err(e) = persist_compacted(store, conv_id, history).await
+    {
+        warn!(error = %e, "Failed to persist compacted history; in-memory compaction still applies");
     }
 
     true

--- a/crates/runtime/src/history.rs
+++ b/crates/runtime/src/history.rs
@@ -35,17 +35,17 @@ pub(crate) fn messages_to_chat_history(
         .into_iter()
         .filter_map(|m| match m.role {
             MessageRole::User => {
-                if let Some(atts) = attachment_map.get(&m.id) {
-                    if !atts.is_empty() {
-                        let mut blocks = vec![ContentBlock::Text(m.content)];
-                        for (mime_type, data) in atts {
-                            blocks.push(ContentBlock::Image {
-                                media_type: mime_type.clone(),
-                                data: data.clone(),
-                            });
-                        }
-                        return Some(ChatHistoryMessage::MultimodalUser { content: blocks });
+                if let Some(atts) = attachment_map.get(&m.id)
+                    && !atts.is_empty()
+                {
+                    let mut blocks = vec![ContentBlock::Text(m.content)];
+                    for (mime_type, data) in atts {
+                        blocks.push(ContentBlock::Image {
+                            media_type: mime_type.clone(),
+                            data: data.clone(),
+                        });
                     }
+                    return Some(ChatHistoryMessage::MultimodalUser { content: blocks });
                 }
                 Some(ChatHistoryMessage::Text {
                     role: ChatRole::User,
@@ -53,14 +53,12 @@ pub(crate) fn messages_to_chat_history(
                 })
             }
             MessageRole::Assistant => {
-                if let Some(tc_json) = m.tool_calls_json {
-                    if let Ok(items) =
+                if let Some(tc_json) = m.tool_calls_json
+                    && let Ok(items) =
                         serde_json::from_str::<Vec<assistant_llm::ToolCallItem>>(&tc_json)
-                    {
-                        if !items.is_empty() {
-                            return Some(ChatHistoryMessage::AssistantToolCalls(items));
-                        }
-                    }
+                    && !items.is_empty()
+                {
+                    return Some(ChatHistoryMessage::AssistantToolCalls(items));
                 }
                 Some(ChatHistoryMessage::Text {
                     role: ChatRole::Assistant,

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -23,4 +23,4 @@ pub use metrics::MetricsRecorder;
 pub use orchestrator::{Orchestrator, OrchestratorEvent, TurnResult};
 pub use otel_spans::start_conversation_context;
 pub use scheduler::spawn_scheduler;
-pub use telemetry::{init_tracing, OtelGuard};
+pub use telemetry::{OtelGuard, init_tracing};

--- a/crates/runtime/src/memory_indexer/mod.rs
+++ b/crates/runtime/src/memory_indexer/mod.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::Result;
-use assistant_core::{base_dir, resolve_dir, resolve_path, AssistantConfig};
+use assistant_core::{AssistantConfig, base_dir, resolve_dir, resolve_path};
 use assistant_llm::LlmProvider;
 use assistant_storage::{MemoryChunkStore, StorageLayer};
 use sha2::{Digest, Sha256};
@@ -207,14 +207,13 @@ fn chunk_text(text: &str) -> impl Iterator<Item = String> {
 
         if para.len() <= MAX_CHUNK_BYTES {
             // Merge tiny fragment into the last chunk if it fits.
-            if para.len() < 50 {
-                if let Some(last) = chunks.last_mut() {
-                    if last.len() + 1 + para.len() <= MAX_CHUNK_BYTES {
-                        last.push('\n');
-                        last.push_str(para);
-                        continue;
-                    }
-                }
+            if para.len() < 50
+                && let Some(last) = chunks.last_mut()
+                && last.len() + 1 + para.len() <= MAX_CHUNK_BYTES
+            {
+                last.push('\n');
+                last.push_str(para);
+                continue;
             }
             chunks.push(para.to_string());
         } else {

--- a/crates/runtime/src/metrics.rs
+++ b/crates/runtime/src/metrics.rs
@@ -4,7 +4,7 @@
 //! observations against the global `MeterProvider`.
 
 use opentelemetry::metrics::{Counter, Histogram};
-use opentelemetry::{global, KeyValue};
+use opentelemetry::{KeyValue, global};
 use opentelemetry_semantic_conventions::attribute::{
     ERROR_TYPE, GEN_AI_OPERATION_NAME, GEN_AI_REQUEST_MODEL, GEN_AI_TOKEN_TYPE,
 };

--- a/crates/runtime/src/orchestrator/dispatch.rs
+++ b/crates/runtime/src/orchestrator/dispatch.rs
@@ -8,13 +8,13 @@ use std::sync::Arc;
 use assistant_core::{Attachment, ExecutionContext, Message, MessageRole, ToolHandler};
 use assistant_llm::{Capabilities, ChatHistoryMessage, HostedTool, ToolCallItem, ToolSpec};
 use assistant_storage::conversations::ConversationStore;
-use opentelemetry::trace::Span as _;
 use opentelemetry::KeyValue;
+use opentelemetry::trace::Span as _;
 use tokio::sync::mpsc;
-use tracing::{debug, info, warn, Instrument};
+use tracing::{Instrument, debug, info, warn};
 use uuid::Uuid;
 
-use super::{value_to_params_map, DispatchOutcome, Orchestrator, OrchestratorEvent};
+use super::{DispatchOutcome, Orchestrator, OrchestratorEvent, value_to_params_map};
 use crate::webhook_dispatch;
 
 impl Orchestrator {
@@ -282,41 +282,37 @@ impl Orchestrator {
             .map(|h| h.requires_confirmation())
             .unwrap_or(false);
 
-        if requires_confirm && ctx.interactive {
-            if let Some(cb) = &self.confirmation_callback {
-                if !cb.confirm(name, params) {
-                    let observation = format!("User denied execution of '{name}'.");
-                    info!(%observation);
-                    otel_span.set_attribute(KeyValue::new("tool_status", "denied"));
-                    otel_span.set_attribute(KeyValue::new("tool_error", observation.clone()));
-                    crate::history::append_tool_result(history, name, &observation);
-                    let tr_msg = Self::make_tool_result_message(
-                        conversation_id,
-                        turn_index,
-                        name,
-                        &observation,
-                    );
-                    if let Err(e) = conv_store
-                        .save_message(&tr_msg)
-                        .instrument(instrument_span.clone())
-                        .await
-                    {
-                        warn!("Failed to persist tool-result message: {e}");
-                    }
-                    otel_span.end();
-                    if let Some(sink) = event_sink {
-                        let _ = sink
-                            .send(OrchestratorEvent::ToolResult {
-                                tool_name: name.to_string(),
-                                status: "denied".to_string(),
-                                arguments: Some(params.clone()),
-                                result: Some(observation.clone()),
-                            })
-                            .await;
-                    }
-                    return DispatchOutcome::Denied;
-                }
+        if requires_confirm
+            && ctx.interactive
+            && let Some(cb) = &self.confirmation_callback
+            && !cb.confirm(name, params)
+        {
+            let observation = format!("User denied execution of '{name}'.");
+            info!(%observation);
+            otel_span.set_attribute(KeyValue::new("tool_status", "denied"));
+            otel_span.set_attribute(KeyValue::new("tool_error", observation.clone()));
+            crate::history::append_tool_result(history, name, &observation);
+            let tr_msg =
+                Self::make_tool_result_message(conversation_id, turn_index, name, &observation);
+            if let Err(e) = conv_store
+                .save_message(&tr_msg)
+                .instrument(instrument_span.clone())
+                .await
+            {
+                warn!("Failed to persist tool-result message: {e}");
             }
+            otel_span.end();
+            if let Some(sink) = event_sink {
+                let _ = sink
+                    .send(OrchestratorEvent::ToolResult {
+                        tool_name: name.to_string(),
+                        status: "denied".to_string(),
+                        arguments: Some(params.clone()),
+                        result: Some(observation.clone()),
+                    })
+                    .await;
+            }
+            return DispatchOutcome::Denied;
         }
 
         if let Some(sink) = event_sink {

--- a/crates/runtime/src/orchestrator/mod.rs
+++ b/crates/runtime/src/orchestrator/mod.rs
@@ -7,22 +7,21 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use assistant_core::{
-    context::agent_base_dir, is_resizable_mime_type, strip_html_comments, Attachment,
-    ExecutionContext, Interface, MemoryLoader, Message, MessageBus, ToolHandler,
+    Attachment, ExecutionContext, Interface, MemoryLoader, Message, MessageBus, ToolHandler,
+    context::agent_base_dir, is_resizable_mime_type, strip_html_comments,
 };
 use assistant_llm::{
     ChatHistoryMessage, ChatRole, ContentBlock, LlmProvider, LlmResponse, ToolSpec,
 };
-use assistant_storage::{conversations::ConversationStore, SkillRegistry, StorageLayer};
+use assistant_storage::{SkillRegistry, StorageLayer, conversations::ConversationStore};
 use assistant_tool_executor::ToolExecutor;
 use opentelemetry::{
-    global,
+    Context as OtelContext, KeyValue, global,
     trace::{Span as _, Status as OtelStatus, TraceContextExt, Tracer as _},
-    Context as OtelContext, KeyValue,
 };
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info, info_span, warn, Instrument};
+use tracing::{Instrument, debug, info, info_span, warn};
 use uuid::Uuid;
 
 // ── Submodules ────────────────────────────────────────────────────────────────
@@ -597,16 +596,16 @@ impl Orchestrator {
             // Post-call compaction: use the accurate token count reported by
             // the provider as a secondary signal to catch any cases the pre-call
             // estimator missed.
-            if let Some(tokens) = response.meta().input_tokens {
-                if crate::compaction::should_compact(tokens, &self.compaction_config) {
-                    crate::compaction::maybe_compact(
-                        &mut history,
-                        &self.llm,
-                        &self.compaction_config,
-                        Some((&conv_store, conversation_id)),
-                    )
-                    .await;
-                }
+            if let Some(tokens) = response.meta().input_tokens
+                && crate::compaction::should_compact(tokens, &self.compaction_config)
+            {
+                crate::compaction::maybe_compact(
+                    &mut history,
+                    &self.llm,
+                    &self.compaction_config,
+                    Some((&conv_store, conversation_id)),
+                )
+                .await;
             }
 
             match response {
@@ -948,16 +947,16 @@ impl Orchestrator {
             );
 
             // Post-call compaction using the accurate provider-reported token count.
-            if let Some(tokens) = response.meta().input_tokens {
-                if crate::compaction::should_compact(tokens, &self.compaction_config) {
-                    crate::compaction::maybe_compact(
-                        &mut history,
-                        &self.llm,
-                        &self.compaction_config,
-                        Some((&conv_store, conversation_id)),
-                    )
-                    .await;
-                }
+            if let Some(tokens) = response.meta().input_tokens
+                && crate::compaction::should_compact(tokens, &self.compaction_config)
+            {
+                crate::compaction::maybe_compact(
+                    &mut history,
+                    &self.llm,
+                    &self.compaction_config,
+                    Some((&conv_store, conversation_id)),
+                )
+                .await;
             }
 
             match response {

--- a/crates/runtime/src/orchestrator/subagent.rs
+++ b/crates/runtime/src/orchestrator/subagent.rs
@@ -6,22 +6,21 @@
 
 use anyhow::Result;
 use assistant_core::{
-    AgentReport, AgentReportStatus, AgentSpawn, ExecutionContext, Interface, Message,
-    SubagentRunner, DEFAULT_MAX_AGENT_DEPTH,
+    AgentReport, AgentReportStatus, AgentSpawn, DEFAULT_MAX_AGENT_DEPTH, ExecutionContext,
+    Interface, Message, SubagentRunner,
 };
 use assistant_llm::{ChatHistoryMessage, ChatRole, LlmResponse};
 use async_trait::async_trait;
 use opentelemetry::{
-    global,
+    Context as OtelContext, KeyValue, global,
     trace::{Span as _, TraceContextExt, Tracer as _},
-    Context as OtelContext, KeyValue,
 };
 use opentelemetry_semantic_conventions::attribute::ERROR_MESSAGE;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info, info_span, warn, Instrument};
+use tracing::{Instrument, debug, info, info_span, warn};
 use uuid::Uuid;
 
-use super::{value_to_params_map, Orchestrator};
+use super::{Orchestrator, value_to_params_map};
 use crate::webhook_dispatch;
 
 #[async_trait]

--- a/crates/runtime/src/orchestrator/tests.rs
+++ b/crates/runtime/src/orchestrator/tests.rs
@@ -3,18 +3,18 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use assistant_core::{
-    bus_messages, topic, types::Interface, AssistantConfig, MessageBus, PublishRequest,
+    AssistantConfig, MessageBus, PublishRequest, bus_messages, topic, types::Interface,
 };
 use assistant_llm::{
     ChatHistoryMessage, ChatRole, LlmClient, LlmClientConfig, LlmProvider, ToolCallItem,
 };
-use assistant_storage::{registry::SkillRegistry, StorageLayer};
+use assistant_storage::{StorageLayer, registry::SkillRegistry};
 use assistant_tool_executor::ToolExecutor;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use uuid::Uuid;
 use wiremock::{
-    matchers::{body_string_contains, method, path},
     Mock, MockServer, ResponseTemplate,
+    matchers::{body_string_contains, method, path},
 };
 
 use super::Orchestrator;
@@ -1621,7 +1621,7 @@ async fn worker_propagates_submit_correlation_fields_to_turn_result() {
 
 // ── Subagent integration tests ────────────────────────────────────────────
 
-use assistant_core::{AgentReportStatus, AgentSpawn, SubagentRunner, DEFAULT_MAX_AGENT_DEPTH};
+use assistant_core::{AgentReportStatus, AgentSpawn, DEFAULT_MAX_AGENT_DEPTH, SubagentRunner};
 
 #[tokio::test]
 async fn subagent_spawn_complete_round_trip() {

--- a/crates/runtime/src/orchestrator/turn_control.rs
+++ b/crates/runtime/src/orchestrator/turn_control.rs
@@ -10,8 +10,8 @@ use anyhow::Result;
 use assistant_core::{ExecutionContext, Interface, Message, ToolHandler};
 use assistant_llm::ChatHistoryMessage;
 use assistant_storage::conversations::ConversationStore;
-use opentelemetry::trace::Span as _;
 use opentelemetry::KeyValue;
+use opentelemetry::trace::Span as _;
 use tracing::{info, warn};
 use uuid::Uuid;
 

--- a/crates/runtime/src/orchestrator/worker.rs
+++ b/crates/runtime/src/orchestrator/worker.rs
@@ -8,19 +8,19 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
-use assistant_core::{bus_messages, topic, ClaimFilter, Interface, PublishRequest, ToolHandler};
+use assistant_core::{ClaimFilter, Interface, PublishRequest, ToolHandler, bus_messages, topic};
 use assistant_llm::ContentBlock;
 use chrono::{DateTime, Local, Utc};
 use opentelemetry::{
-    trace::{Span as _, SpanKind, TraceContextExt},
     Context as OtelContext, KeyValue,
+    trace::{Span as _, SpanKind, TraceContextExt},
 };
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
-use super::{parse_interface, ExtensionRegistration, Orchestrator, TurnResult};
+use super::{ExtensionRegistration, Orchestrator, TurnResult, parse_interface};
 use crate::webhook_dispatch;
 
 impl Orchestrator {

--- a/crates/runtime/src/otel_spans.rs
+++ b/crates/runtime/src/otel_spans.rs
@@ -10,10 +10,9 @@ use assistant_llm::{
     ChatHistoryMessage, ChatRole, LlmProvider, LlmResponse, LlmResponseMeta, ToolSpec,
 };
 use opentelemetry::{
-    global,
+    Array, Context as OtelContext, KeyValue, StringValue, Value, global,
     propagation::{Extractor, Injector},
     trace::{Span as _, SpanKind, TraceContextExt, Tracer as _},
-    Array, Context as OtelContext, KeyValue, StringValue, Value,
 };
 use opentelemetry_semantic_conventions::attribute::{
     GEN_AI_CONVERSATION_ID, GEN_AI_OPERATION_NAME, GEN_AI_REQUEST_MODEL,

--- a/crates/runtime/src/scheduler.rs
+++ b/crates/runtime/src/scheduler.rs
@@ -13,15 +13,15 @@ use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use assistant_core::{
-    bus_messages, strip_html_comments, topic, ChannelContent, ChannelMessage, ChannelType,
-    ChannelUser, Interface, PublishRequest,
+    ChannelContent, ChannelMessage, ChannelType, ChannelUser, Interface, PublishRequest,
+    bus_messages, strip_html_comments, topic,
 };
 use assistant_storage::StorageLayer;
 use chrono::Utc;
 use cron::Schedule;
 use opentelemetry::{
-    trace::{Span as _, SpanKind},
     KeyValue,
+    trace::{Span as _, SpanKind},
 };
 use tracing::{error, info, warn};
 use uuid::Uuid;
@@ -405,13 +405,13 @@ async fn prune_conversation_events(storage: &StorageLayer) {
 mod tests {
     use std::sync::Arc;
 
-    use assistant_core::{topic, AssistantConfig, MessageBus};
+    use assistant_core::{AssistantConfig, MessageBus, topic};
     use assistant_storage::StorageLayer;
     use assistant_tool_executor::ToolExecutor;
     use chrono::{Duration, Timelike, Utc};
     use wiremock::{
-        matchers::{method, path},
         Mock, MockServer, ResponseTemplate,
+        matchers::{method, path},
     };
 
     use super::*;

--- a/crates/runtime/src/telemetry.rs
+++ b/crates/runtime/src/telemetry.rs
@@ -2,22 +2,22 @@ use std::time::Duration;
 
 use anyhow::Result;
 use assistant_core::{ObservabilityConfig, OtelExporter};
-use opentelemetry::{global, KeyValue};
+use opentelemetry::{KeyValue, global};
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
 use opentelemetry_exporter_iceberg::build_exporters;
 use opentelemetry_exporter_sqlite::{SqliteLogExporter, SqliteMetricExporter, SqliteSpanExporter};
 use opentelemetry_sdk::{
+    Resource,
     logs::{BatchLogProcessor, SdkLoggerProvider},
     metrics::{PeriodicReader, SdkMeterProvider},
     propagation::TraceContextPropagator,
     trace::{BatchSpanProcessor, SdkTracerProvider},
-    Resource,
 };
 use opentelemetry_semantic_conventions::attribute::{SERVICE_NAME, SERVICE_VERSION};
 use sqlx::SqlitePool;
 use tracing::info;
 use tracing_subscriber::{
-    filter::Targets, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer,
+    EnvFilter, Layer, filter::Targets, layer::SubscriberExt, util::SubscriberInitExt,
 };
 
 /// Guard that shuts down all OTel providers when dropped.
@@ -113,7 +113,9 @@ pub async fn init_tracing(
     let need_otel = enable_sqlite || enable_iceberg || enable_otlp;
 
     if enable_otlp {
-        info!("OTLP export enabled — the opentelemetry-otlp crate will read endpoint, headers, timeout, and compression from OTEL_EXPORTER_OTLP_* env vars");
+        info!(
+            "OTLP export enabled — the opentelemetry-otlp crate will read endpoint, headers, timeout, and compression from OTEL_EXPORTER_OTLP_* env vars"
+        );
     }
 
     if need_otel {

--- a/crates/runtime/src/webhook_dispatch.rs
+++ b/crates/runtime/src/webhook_dispatch.rs
@@ -1,9 +1,8 @@
 use anyhow::Result;
 use hmac::{Hmac, KeyInit, Mac};
 use opentelemetry::{
-    global,
+    Context as OtelContext, KeyValue, global,
     trace::{Span as _, TraceContextExt, Tracer as _},
-    Context as OtelContext, KeyValue,
 };
 use serde_json::Value;
 use sha2::Sha256;
@@ -125,9 +124,5 @@ fn compute_signature(secret: &str, body: &str) -> String {
 }
 
 fn payload_count_hint(payload: &Value) -> usize {
-    if payload.is_null() {
-        0
-    } else {
-        1
-    }
+    if payload.is_null() { 0 } else { 1 }
 }

--- a/crates/skills/src/parser.rs
+++ b/crates/skills/src/parser.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use anyhow::{Context, Result};
-use gray_matter::{engine::YAML, Matter};
+use gray_matter::{Matter, engine::YAML};
 use serde::Deserialize;
 use serde_json::Value;
 

--- a/crates/skills/src/skill.rs
+++ b/crates/skills/src/skill.rs
@@ -119,10 +119,10 @@ impl SkillDef {
                 if !path.is_file() {
                     continue;
                 }
-                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                    if name.starts_with('.') {
-                        continue;
-                    }
+                if let Some(name) = path.file_name().and_then(|n| n.to_str())
+                    && name.starts_with('.')
+                {
+                    continue;
                 }
                 let relative = PathBuf::from(category.dir_name()).join(entry.file_name());
                 result.push((category.clone(), relative));

--- a/crates/storage/src/attachments.rs
+++ b/crates/storage/src/attachments.rs
@@ -1,7 +1,7 @@
 //! Persistent attachment storage — filesystem for bytes, SQLite for metadata.
 
 use anyhow::{Context, Result};
-use assistant_core::{agent_base_dir, AttachmentMeta};
+use assistant_core::{AttachmentMeta, agent_base_dir};
 use chrono::{DateTime, Utc};
 use sqlx::{Row, SqlitePool};
 use std::path::PathBuf;

--- a/crates/storage/src/conversation_events.rs
+++ b/crates/storage/src/conversation_events.rs
@@ -11,7 +11,7 @@ use anyhow::Result;
 use chrono::{DateTime, Duration, Utc};
 use serde_json::Value;
 use sqlx::{Row, SqlitePool};
-use tokio::sync::{broadcast, RwLock};
+use tokio::sync::{RwLock, broadcast};
 use uuid::Uuid;
 
 /// Default TTL for conversation events: 24 hours.

--- a/crates/storage/src/registry.rs
+++ b/crates/storage/src/registry.rs
@@ -1,7 +1,7 @@
 //! Skill registry — maps skill names to `SkillDef` and keeps the `skills` SQLite table in sync.
 
 use anyhow::{Context, Result};
-use assistant_skills::{parse_skill_content, SkillDef, SkillSource};
+use assistant_skills::{SkillDef, SkillSource, parse_skill_content};
 use chrono::Utc;
 use sqlx::SqlitePool;
 use std::{collections::HashMap, path::Path, sync::Arc};

--- a/crates/storage/src/workflows.rs
+++ b/crates/storage/src/workflows.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashSet;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use chrono::{DateTime, Utc};
 use cron::Schedule;
 use serde::{Deserialize, Serialize};

--- a/crates/tool-executor/src/builtins/bash.rs
+++ b/crates/tool-executor/src/builtins/bash.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 
 use anyhow::Result;
 use assistant_core::{
-    runtime_workspace_dir, Attachment, ExecutionContext, ToolHandler, ToolOutput,
+    Attachment, ExecutionContext, ToolHandler, ToolOutput, runtime_workspace_dir,
 };
 use async_trait::async_trait;
 use tokio::time::Duration;

--- a/crates/tool-executor/src/builtins/file_edit.rs
+++ b/crates/tool-executor/src/builtins/file_edit.rs
@@ -80,7 +80,7 @@ impl ToolHandler for FileEditHandler {
                     "Failed to read '{}': {}",
                     path.display(),
                     e
-                )))
+                )));
             }
         };
 

--- a/crates/tool-executor/src/builtins/file_glob.rs
+++ b/crates/tool-executor/src/builtins/file_glob.rs
@@ -94,7 +94,7 @@ impl ToolHandler for FileGlobHandler {
                 return Ok(ToolOutput::error(format!(
                     "Invalid glob pattern '{}': {}",
                     pattern, e
-                )))
+                )));
             }
         };
 

--- a/crates/tool-executor/src/builtins/file_read.rs
+++ b/crates/tool-executor/src/builtins/file_read.rs
@@ -73,7 +73,7 @@ impl ToolHandler for FileReadHandler {
                     "Failed to read '{}': {}",
                     path.display(),
                     e
-                )))
+                )));
             }
         };
 
@@ -116,10 +116,10 @@ impl ToolHandler for FileReadHandler {
 }
 
 pub(crate) fn expand_tilde(s: &str) -> PathBuf {
-    if let Some(rest) = s.strip_prefix("~/") {
-        if let Some(home) = dirs::home_dir() {
-            return home.join(rest);
-        }
+    if let Some(rest) = s.strip_prefix("~/")
+        && let Some(home) = dirs::home_dir()
+    {
+        return home.join(rest);
     }
     PathBuf::from(s)
 }

--- a/crates/tool-executor/src/builtins/file_write.rs
+++ b/crates/tool-executor/src/builtins/file_write.rs
@@ -68,14 +68,14 @@ impl ToolHandler for FileWriteHandler {
         debug!(path = %path.display(), "file-write access");
 
         // Create parent directories if needed.
-        if let Some(parent) = path.parent() {
-            if let Err(e) = fs::create_dir_all(parent) {
-                return Ok(ToolOutput::error(format!(
-                    "Failed to create directories for '{}': {}",
-                    path.display(),
-                    e
-                )));
-            }
+        if let Some(parent) = path.parent()
+            && let Err(e) = fs::create_dir_all(parent)
+        {
+            return Ok(ToolOutput::error(format!(
+                "Failed to create directories for '{}': {}",
+                path.display(),
+                e
+            )));
         }
 
         match fs::write(&path, content.as_bytes()) {

--- a/crates/tool-executor/src/builtins/memory_append.rs
+++ b/crates/tool-executor/src/builtins/memory_append.rs
@@ -15,7 +15,7 @@ use tokio::fs::OpenOptions;
 use tokio::io::AsyncWriteExt;
 
 use assistant_core::{
-    base_dir, resolve_dir, resolve_path, AssistantConfig, ExecutionContext, ToolHandler, ToolOutput,
+    AssistantConfig, ExecutionContext, ToolHandler, ToolOutput, base_dir, resolve_dir, resolve_path,
 };
 
 /// Canonicalize as much of `p` as exists, then re-append non-existent tail
@@ -144,20 +144,20 @@ impl ToolHandler for MemoryAppendHandler {
             Some(p) => p,
             None => {
                 return Ok(ToolOutput::error(format!(
-                "Unknown target '{target}'. Use: soul, identity, user, tools, memory, or notes/YYYY-MM-DD"
-            )))
+                    "Unknown target '{target}'. Use: soul, identity, user, tools, memory, or notes/YYYY-MM-DD"
+                )));
             }
         };
 
         // Create parent directories if they don't exist yet (e.g. for a new notes/ day).
-        if let Some(parent) = path.parent() {
-            if let Err(e) = tokio::fs::create_dir_all(parent).await {
-                return Ok(ToolOutput::error(format!(
-                    "Failed to create directories for '{}': {}",
-                    path.display(),
-                    e
-                )));
-            }
+        if let Some(parent) = path.parent()
+            && let Err(e) = tokio::fs::create_dir_all(parent).await
+        {
+            return Ok(ToolOutput::error(format!(
+                "Failed to create directories for '{}': {}",
+                path.display(),
+                e
+            )));
         }
 
         let mut file = match OpenOptions::new()
@@ -172,7 +172,7 @@ impl ToolHandler for MemoryAppendHandler {
                     "Failed to open '{}': {}",
                     path.display(),
                     e
-                )))
+                )));
             }
         };
 

--- a/crates/tool-executor/src/builtins/memory_get.rs
+++ b/crates/tool-executor/src/builtins/memory_get.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use assistant_core::{
-    base_dir, resolve_dir, resolve_path, AssistantConfig, ExecutionContext, ToolHandler, ToolOutput,
+    AssistantConfig, ExecutionContext, ToolHandler, ToolOutput, base_dir, resolve_dir, resolve_path,
 };
 use async_trait::async_trait;
 
@@ -99,8 +99,8 @@ impl ToolHandler for MemoryGetHandler {
             Some(p) => p,
             None => {
                 return Ok(ToolOutput::error(format!(
-                "Unknown target '{target}'. Use: soul, identity, user, tools, memory, or notes/YYYY-MM-DD"
-            )))
+                    "Unknown target '{target}'. Use: soul, identity, user, tools, memory, or notes/YYYY-MM-DD"
+                )));
             }
         };
 

--- a/crates/tool-executor/src/builtins/process.rs
+++ b/crates/tool-executor/src/builtins/process.rs
@@ -9,16 +9,16 @@
 //! - `list`   — enumerate all tracked sessions
 
 use std::collections::{HashMap, VecDeque};
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use anyhow::Result;
-use assistant_core::{runtime_workspace_dir, ExecutionContext, ToolHandler, ToolOutput};
+use assistant_core::{ExecutionContext, ToolHandler, ToolOutput, runtime_workspace_dir};
 use async_trait::async_trait;
 use chrono::Utc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::ChildStdin;
-use tokio::sync::{oneshot, Mutex};
+use tokio::sync::{Mutex, oneshot};
 use tracing::debug;
 use uuid::Uuid;
 
@@ -149,7 +149,7 @@ impl ProcessHandler {
             None => {
                 return Ok(ToolOutput::error(
                     "Missing required parameter 'command' for action=start",
-                ))
+                ));
             }
         };
         let workdir = params
@@ -269,7 +269,7 @@ impl ProcessHandler {
             None => {
                 return Ok(ToolOutput::error(
                     "Missing required parameter 'session_id' for action=poll",
-                ))
+                ));
             }
         };
 
@@ -280,7 +280,7 @@ impl ProcessHandler {
                 None => {
                     return Ok(ToolOutput::error(format!(
                         "Session '{session_id}' not found"
-                    )))
+                    )));
                 }
             }
         };
@@ -308,7 +308,7 @@ impl ProcessHandler {
             None => {
                 return Ok(ToolOutput::error(
                     "Missing required parameter 'session_id' for action=log",
-                ))
+                ));
             }
         };
         let lines = params.get("lines").and_then(|v| v.as_u64()).unwrap_or(50) as usize;
@@ -320,7 +320,7 @@ impl ProcessHandler {
                 None => {
                     return Ok(ToolOutput::error(format!(
                         "Session '{session_id}' not found"
-                    )))
+                    )));
                 }
             }
         };
@@ -363,7 +363,7 @@ impl ProcessHandler {
             None => {
                 return Ok(ToolOutput::error(
                     "Missing required parameter 'session_id' for action=write",
-                ))
+                ));
             }
         };
         let data = match params.get("data").and_then(|v| v.as_str()) {
@@ -371,7 +371,7 @@ impl ProcessHandler {
             None => {
                 return Ok(ToolOutput::error(
                     "Missing required parameter 'data' for action=write",
-                ))
+                ));
             }
         };
 
@@ -382,7 +382,7 @@ impl ProcessHandler {
                 None => {
                     return Ok(ToolOutput::error(format!(
                         "Session '{session_id}' not found"
-                    )))
+                    )));
                 }
             }
         };
@@ -405,7 +405,7 @@ impl ProcessHandler {
             None => {
                 return Ok(ToolOutput::error(
                     "Missing required parameter 'session_id' for action=kill",
-                ))
+                ));
             }
         };
 
@@ -416,7 +416,7 @@ impl ProcessHandler {
                 None => {
                     return Ok(ToolOutput::error(format!(
                         "Session '{session_id}' not found"
-                    )))
+                    )));
                 }
             }
         };

--- a/crates/tool-executor/src/builtins/voice_response.rs
+++ b/crates/tool-executor/src/builtins/voice_response.rs
@@ -81,7 +81,7 @@ impl ToolHandler for VoiceResponseHandler {
             _ => {
                 return Ok(ToolOutput::error(
                     "voice-response: `text` parameter is required",
-                ))
+                ));
             }
         };
         let voice = params

--- a/crates/tool-executor/src/builtins/web_fetch.rs
+++ b/crates/tool-executor/src/builtins/web_fetch.rs
@@ -180,10 +180,10 @@ fn extract_text(document: &Html) -> String {
 
     let mut text_parts: Vec<&str> = Vec::new();
     for node in root.descendants() {
-        if let Some(el) = scraper::ElementRef::wrap(node) {
-            if skip_ids.contains(&el.id()) {
-                continue;
-            }
+        if let Some(el) = scraper::ElementRef::wrap(node)
+            && skip_ids.contains(&el.id())
+        {
+            continue;
         }
         if let Some(text) = node.value().as_text() {
             let t = text.trim();

--- a/crates/tool-executor/src/builtins/web_search.rs
+++ b/crates/tool-executor/src/builtins/web_search.rs
@@ -102,7 +102,7 @@ impl ToolHandler for WebSearchHandler {
                 return Ok(ToolOutput::error(format!(
                     "Failed to reach DuckDuckGo: {}",
                     e
-                )))
+                )));
             }
         };
 

--- a/crates/tool-executor/src/executor.rs
+++ b/crates/tool-executor/src/executor.rs
@@ -185,13 +185,13 @@ impl ToolExecutor {
         ctx: &ExecutionContext,
     ) -> Result<ToolOutput> {
         // Enforce the per-context tool allowlist when present.
-        if let Some(ref allowed) = ctx.allowed_tools {
-            if !allowed.iter().any(|a| a == name) {
-                return Ok(ToolOutput::error(format!(
-                    "Tool '{}' is not available in this execution context",
-                    name
-                )));
-            }
+        if let Some(ref allowed) = ctx.allowed_tools
+            && !allowed.iter().any(|a| a == name)
+        {
+            return Ok(ToolOutput::error(format!(
+                "Tool '{}' is not available in this execution context",
+                name
+            )));
         }
 
         // Clone Arc before releasing the read lock to avoid holding it across an await.

--- a/crates/tool-executor/src/installer.rs
+++ b/crates/tool-executor/src/installer.rs
@@ -7,8 +7,8 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use anyhow::{anyhow, Context, Result};
-use assistant_skills::{parse_skill_dir, SkillSource};
+use anyhow::{Context, Result, anyhow};
+use assistant_skills::{SkillSource, parse_skill_dir};
 use assistant_storage::SkillRegistry;
 use tracing::{debug, info};
 
@@ -137,13 +137,13 @@ async fn install_from_github(
         if resp.status().is_success() {
             // Guard against unexpectedly large responses (1 MB cap).
             const MAX_SKILL_MD_BYTES: u64 = 1024 * 1024;
-            if let Some(len) = resp.content_length() {
-                if len > MAX_SKILL_MD_BYTES {
-                    last_error = format!(
-                        "SKILL.md at '{url}' is too large ({len} bytes, limit {MAX_SKILL_MD_BYTES})"
-                    );
-                    continue;
-                }
+            if let Some(len) = resp.content_length()
+                && len > MAX_SKILL_MD_BYTES
+            {
+                last_error = format!(
+                    "SKILL.md at '{url}' is too large ({len} bytes, limit {MAX_SKILL_MD_BYTES})"
+                );
+                continue;
             }
             let bytes = resp.bytes().await.context("Failed to read response body")?;
             if bytes.len() as u64 > MAX_SKILL_MD_BYTES {

--- a/crates/transcription/src/converter.rs
+++ b/crates/transcription/src/converter.rs
@@ -7,7 +7,7 @@
 use std::process::Stdio;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use anyhow::{bail, Context};
+use anyhow::{Context, bail};
 use tokio::process::Command;
 use tracing::{debug, info, warn};
 

--- a/crates/transcription/src/deepgram.rs
+++ b/crates/transcription/src/deepgram.rs
@@ -3,7 +3,7 @@
 //! Uses Deepgram's `POST /v1/listen` pre-recorded audio endpoint.
 //! See <https://developers.deepgram.com/reference/listen-file> for API docs.
 
-use anyhow::{bail, Context};
+use anyhow::{Context, bail};
 use async_trait::async_trait;
 use reqwest_middleware::ClientWithMiddleware;
 use tracing::{debug, warn};

--- a/crates/transcription/src/deepgram_tts.rs
+++ b/crates/transcription/src/deepgram_tts.rs
@@ -1,6 +1,6 @@
 //! Deepgram TTS provider — `POST /v1/speak`.
 
-use anyhow::{bail, Context};
+use anyhow::{Context, bail};
 use async_trait::async_trait;
 use reqwest_middleware::ClientWithMiddleware;
 use tracing::debug;

--- a/crates/transcription/src/ollama.rs
+++ b/crates/transcription/src/ollama.rs
@@ -6,14 +6,14 @@
 //! The wire format is identical to OpenAI's Whisper API, so this
 //! implementation shares the same multipart upload logic.
 
-use anyhow::{bail, Context};
+use anyhow::{Context, bail};
 use async_trait::async_trait;
 use reqwest::multipart;
 use reqwest_middleware::ClientWithMiddleware;
 use tracing::{debug, warn};
 
 use crate::provider::{
-    extension_for_mime, TranscriptionProvider, TranscriptionRequest, TranscriptionResult,
+    TranscriptionProvider, TranscriptionRequest, TranscriptionResult, extension_for_mime,
 };
 
 /// Default timeout for transcription requests (120 s — audio can be long).

--- a/crates/transcription/src/openai_tts.rs
+++ b/crates/transcription/src/openai_tts.rs
@@ -1,6 +1,6 @@
 //! OpenAI TTS provider — `POST /v1/audio/speech`.
 
-use anyhow::{bail, Context};
+use anyhow::{Context, bail};
 use async_trait::async_trait;
 use reqwest_middleware::ClientWithMiddleware;
 use tracing::debug;

--- a/crates/transcription/src/whisper.rs
+++ b/crates/transcription/src/whisper.rs
@@ -4,14 +4,14 @@
 //! OpenAI's hosted API and any server that exposes the same endpoint
 //! (e.g. LocalAI, vLLM with Whisper).
 
-use anyhow::{bail, Context};
+use anyhow::{Context, bail};
 use async_trait::async_trait;
 use reqwest::multipart;
 use reqwest_middleware::ClientWithMiddleware;
 use tracing::{debug, warn};
 
 use crate::provider::{
-    extension_for_mime, TranscriptionProvider, TranscriptionRequest, TranscriptionResult,
+    TranscriptionProvider, TranscriptionRequest, TranscriptionResult, extension_for_mime,
 };
 
 /// Default timeout for transcription requests (120 s — audio can be long).

--- a/crates/web-ui/build.rs
+++ b/crates/web-ui/build.rs
@@ -201,7 +201,9 @@ fn inject_sw_version(app_dir: &Path, web_out: &Path) {
 
     let injected = sw_src.replace("__APP_VERSION__", &version);
     if injected == sw_src {
-        println!("cargo:warning=sw.js does not contain __APP_VERSION__ placeholder — version injection skipped");
+        println!(
+            "cargo:warning=sw.js does not contain __APP_VERSION__ placeholder — version injection skipped"
+        );
         return;
     }
     if let Err(e) = std::fs::write(&sw_path, injected) {

--- a/crates/web-ui/src/a2a/agent_store.rs
+++ b/crates/web-ui/src/a2a/agent_store.rs
@@ -240,8 +240,8 @@ impl AgentStore {
 
         // If we removed the default, pick a new one.
         let default_id = self.read_default_marker().await;
-        if default_id.as_deref() == Some(id) {
-            if let Ok(agents) = self.list().await {
+        if default_id.as_deref() == Some(id)
+            && let Ok(agents) = self.list().await {
                 if let Some(first) = agents.first() {
                     let _ = self.write_default_marker(&first.id).await;
                 } else {
@@ -250,7 +250,6 @@ impl AgentStore {
                     let _ = tokio::fs::remove_file(&marker).await;
                 }
             }
-        }
 
         true
     }

--- a/crates/web-ui/src/api/logs.rs
+++ b/crates/web-ui/src/api/logs.rs
@@ -134,16 +134,14 @@ pub async fn list_logs(
                 .into_iter()
                 .filter(|l| {
                     // Apply post-fetch time and conversation filters.
-                    if let Some(since) = params.since {
-                        if l.timestamp < since {
+                    if let Some(since) = params.since
+                        && l.timestamp < since {
                             return false;
                         }
-                    }
-                    if let Some(until) = params.until {
-                        if l.timestamp > until {
+                    if let Some(until) = params.until
+                        && l.timestamp > until {
                             return false;
                         }
-                    }
                     true
                 })
                 .map(|l| {

--- a/crates/web-ui/src/api/mod.rs
+++ b/crates/web-ui/src/api/mod.rs
@@ -416,11 +416,10 @@ pub async fn get_conversation(State(state): State<ApiState>, Path(id): Path<Stri
     let mut tool_results: std::collections::HashMap<(i64, String), String> =
         std::collections::HashMap::new();
     for m in &history {
-        if matches!(m.role, MessageRole::Tool) {
-            if let Some(ref name) = m.skill_name {
+        if matches!(m.role, MessageRole::Tool)
+            && let Some(ref name) = m.skill_name {
                 tool_results.insert((m.turn, name.clone()), m.content.clone());
             }
-        }
     }
 
     let messages = history
@@ -1641,13 +1640,11 @@ pub async fn serve_attachment(
     };
 
     // Conditional request: check If-None-Match.
-    if let Some(inm) = headers.get(header::IF_NONE_MATCH) {
-        if let Ok(inm_str) = inm.to_str() {
-            if inm_str == etag {
+    if let Some(inm) = headers.get(header::IF_NONE_MATCH)
+        && let Ok(inm_str) = inm.to_str()
+            && inm_str == etag {
                 return StatusCode::NOT_MODIFIED.into_response();
             }
-        }
-    }
 
     // Load original bytes.
     let original = match state.attachment_store.load_bytes(att_id).await {

--- a/crates/web-ui/src/api/traces.rs
+++ b/crates/web-ui/src/api/traces.rs
@@ -136,21 +136,18 @@ pub async fn list_traces(
                             return false;
                         }
                     }
-                    if let Some(conv_id) = filter.conversation {
-                        if t.conversation_id != Some(conv_id) {
+                    if let Some(conv_id) = filter.conversation
+                        && t.conversation_id != Some(conv_id) {
                             return false;
                         }
-                    }
-                    if let Some(since) = filter.since {
-                        if t.start_time < since {
+                    if let Some(since) = filter.since
+                        && t.start_time < since {
                             return false;
                         }
-                    }
-                    if let Some(until) = filter.until {
-                        if t.start_time > until {
+                    if let Some(until) = filter.until
+                        && t.start_time > until {
                             return false;
                         }
-                    }
                     true
                 })
                 .map(|t| {

--- a/crates/web-ui/src/api/webhooks.rs
+++ b/crates/web-ui/src/api/webhooks.rs
@@ -294,15 +294,14 @@ pub async fn update_webhook(
     let new_active = body.active.unwrap_or(existing.active);
 
     // Validate the URL if it changed.
-    if body.url.is_some() {
-        if let Err(e) = validate_webhook_url(new_url) {
+    if body.url.is_some()
+        && let Err(e) = validate_webhook_url(new_url) {
             return (
                 StatusCode::BAD_REQUEST,
                 Json(serde_json::json!({"error": e})),
             )
                 .into_response();
         }
-    }
 
     match store
         .update(&id, new_name, new_url, &new_event_types, new_active)
@@ -568,17 +567,15 @@ fn validate_webhook_url(url: &str) -> Result<(), String> {
     if lower == "localhost" || lower == "127.0.0.1" || lower == "::1" || lower == "[::1]" {
         return Err("Loopback addresses are not allowed".to_string());
     }
-    if let Ok(ip) = host.parse::<IpAddr>() {
-        if is_private_ip(ip) {
+    if let Ok(ip) = host.parse::<IpAddr>()
+        && is_private_ip(ip) {
             return Err(format!("Private/reserved IP address {ip} is not allowed"));
         }
-    }
     let trimmed = host.trim_start_matches('[').trim_end_matches(']');
-    if let Ok(ip) = trimmed.parse::<IpAddr>() {
-        if is_private_ip(ip) {
+    if let Ok(ip) = trimmed.parse::<IpAddr>()
+        && is_private_ip(ip) {
             return Err(format!("Private/reserved IP address {ip} is not allowed"));
         }
-    }
     Ok(())
 }
 

--- a/crates/web-ui/src/auth.rs
+++ b/crates/web-ui/src/auth.rs
@@ -96,27 +96,22 @@ pub async fn require_auth(
     next: Next,
 ) -> Response {
     // 1. Check session cookie.
-    if let Some(cookie_header) = request.headers().get(COOKIE) {
-        if let Ok(cookies) = cookie_header.to_str() {
-            if extract_cookie(cookies, SESSION_COOKIE)
+    if let Some(cookie_header) = request.headers().get(COOKIE)
+        && let Ok(cookies) = cookie_header.to_str()
+            && extract_cookie(cookies, SESSION_COOKIE)
                 .map(|v| constant_time_eq(v.as_bytes(), auth.session_value.as_bytes()))
                 .unwrap_or(false)
             {
                 return next.run(request).await;
             }
-        }
-    }
 
     // 2. Check Authorization: Bearer <token>.
-    if let Some(auth_header) = request.headers().get("authorization") {
-        if let Ok(value) = auth_header.to_str() {
-            if let Some(bearer) = value.strip_prefix("Bearer ") {
-                if constant_time_eq(bearer.trim().as_bytes(), auth.token.as_bytes()) {
+    if let Some(auth_header) = request.headers().get("authorization")
+        && let Ok(value) = auth_header.to_str()
+            && let Some(bearer) = value.strip_prefix("Bearer ")
+                && constant_time_eq(bearer.trim().as_bytes(), auth.token.as_bytes()) {
                     return next.run(request).await;
                 }
-            }
-        }
-    }
 
     // 3. Not authenticated — decide response type.
     let accepts_html = request

--- a/crates/web-ui/src/backends/iceberg.rs
+++ b/crates/web-ui/src/backends/iceberg.rs
@@ -34,11 +34,10 @@ fn warehouse_path(config: &IcebergConfig) -> PathBuf {
         .warehouse
         .clone()
         .unwrap_or_else(|| "~/.assistant/iceberg".to_string());
-    if let Some(rest) = raw.strip_prefix("~/") {
-        if let Some(home) = dirs::home_dir() {
+    if let Some(rest) = raw.strip_prefix("~/")
+        && let Some(home) = dirs::home_dir() {
             return home.join(rest);
         }
-    }
     PathBuf::from(raw)
 }
 
@@ -192,16 +191,14 @@ impl TraceBackend for IcebergTraceBackend {
                 let end = ts_col(batch, "end_time", i).unwrap_or(start);
 
                 // Apply time filters.
-                if let Some(since) = filter.since {
-                    if start < since {
+                if let Some(since) = filter.since
+                    && start < since {
                         continue;
                     }
-                }
-                if let Some(until) = filter.until {
-                    if start > until {
+                if let Some(until) = filter.until
+                    && start > until {
                         continue;
                     }
-                }
 
                 let tool_name = str_col(batch, "tool_name", i).map(str::to_string);
                 let tool_status = str_col(batch, "tool_status", i).map(str::to_string);
@@ -211,11 +208,10 @@ impl TraceBackend for IcebergTraceBackend {
                 let span_name = str_col(batch, "name", i).map(str::to_string);
 
                 // Apply skill filter.
-                if let Some(ref sk) = filter.skill {
-                    if tool_name.as_deref() != Some(sk.as_str()) {
+                if let Some(ref sk) = filter.skill
+                    && tool_name.as_deref() != Some(sk.as_str()) {
                         continue;
                     }
-                }
 
                 let attrs_str = str_col(batch, "attributes", i).unwrap_or("{}");
                 let attrs: Value = serde_json::from_str(attrs_str).unwrap_or(Value::Null);
@@ -225,11 +221,10 @@ impl TraceBackend for IcebergTraceBackend {
                     .map(str::to_string);
 
                 // Apply interface filter.
-                if let Some(ref iface) = filter.interface {
-                    if interface.as_deref() != Some(iface.as_str()) {
+                if let Some(ref iface) = filter.interface
+                    && interface.as_deref() != Some(iface.as_str()) {
                         continue;
                     }
-                }
 
                 let is_error = tool_status.as_deref() == Some("error");
                 let is_reply = matches!(tool_name.as_deref(), Some("reply" | "slack-post"));
@@ -424,44 +419,38 @@ impl LogBackend for IcebergLogBackend {
                 };
 
                 // Time range filter.
-                if let Some(s) = since {
-                    if ts < s {
+                if let Some(s) = since
+                    && ts < s {
                         continue;
                     }
-                }
-                if let Some(u) = until {
-                    if ts > u {
+                if let Some(u) = until
+                    && ts > u {
                         continue;
                     }
-                }
 
                 let sev = i32_col(batch, "severity_number", i);
-                if let Some(min) = min_severity {
-                    if sev.unwrap_or(0) < min {
+                if let Some(min) = min_severity
+                    && sev.unwrap_or(0) < min {
                         continue;
                     }
-                }
 
                 let target = str_col(batch, "target", i);
-                if let Some(tf) = target_filter {
-                    if target != Some(tf) {
+                if let Some(tf) = target_filter
+                    && target != Some(tf) {
                         continue;
                     }
-                }
 
                 let body = str_col(batch, "body", i);
-                if let Some(q) = search {
-                    if !body.unwrap_or("").contains(q) {
+                if let Some(q) = search
+                    && !body.unwrap_or("").contains(q) {
                         continue;
                     }
-                }
 
                 let tid = str_col(batch, "trace_id", i);
-                if let Some(f) = trace_id_filter {
-                    if tid != Some(f) {
+                if let Some(f) = trace_id_filter
+                    && tid != Some(f) {
                         continue;
                     }
-                }
 
                 let attrs_str = str_col(batch, "attributes", i).unwrap_or("{}");
                 let attributes: Value =

--- a/crates/web-ui/src/push.rs
+++ b/crates/web-ui/src/push.rs
@@ -51,12 +51,11 @@ pub async fn ensure_vapid_keys(
     private_key: Option<&str>,
     public_key: Option<&str>,
 ) -> Result<(String, String)> {
-    if let (Some(priv_k), Some(pub_k)) = (private_key, public_key) {
-        if !priv_k.is_empty() && !pub_k.is_empty() {
+    if let (Some(priv_k), Some(pub_k)) = (private_key, public_key)
+        && !priv_k.is_empty() && !pub_k.is_empty() {
             debug!("VAPID keys already present in config");
             return Ok((priv_k.to_string(), pub_k.to_string()));
         }
-    }
 
     info!("Generating new VAPID key pair…");
     let (priv_b64, pub_b64) = generate_vapid_keypair()?;

--- a/crates/workflow-http/src/lib.rs
+++ b/crates/workflow-http/src/lib.rs
@@ -69,10 +69,10 @@ impl HttpRequestActionExecutor {
         if self.blocked_hosts.contains(&host) {
             anyhow::bail!("host '{host}' is blocked by workflow policy");
         }
-        if let Some(allowed_hosts) = &self.allowed_hosts {
-            if !allowed_hosts.contains(&host) {
-                anyhow::bail!("host '{host}' is not in allowed workflow host list");
-            }
+        if let Some(allowed_hosts) = &self.allowed_hosts
+            && !allowed_hosts.contains(&host)
+        {
+            anyhow::bail!("host '{host}' is not in allowed workflow host list");
         }
         Ok(())
     }

--- a/crates/workflow/src/lib.rs
+++ b/crates/workflow/src/lib.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
-use assistant_core::{bus_messages, MessageBus, MessageStatus};
+use assistant_core::{MessageBus, MessageStatus, bus_messages};
 use assistant_storage::{
     StorageLayer, WorkflowGraph, WorkflowNode, WorkflowNodeKind, WorkflowRunRecord, WorkflowStore,
     WorkflowTriggerKind,
@@ -370,10 +370,10 @@ async fn process_event_triggers(
                         .get("event")
                         .or_else(|| node.config.get("topic"))
                         .and_then(|v| v.as_str());
-                    if let Some(expected_topic) = expected_topic {
-                        if expected_topic != msg.topic {
-                            continue;
-                        }
+                    if let Some(expected_topic) = expected_topic
+                        && expected_topic != msg.topic
+                    {
+                        continue;
                     }
 
                     let payload = serde_json::json!({

--- a/crates/workflow/tests/engine_integration.rs
+++ b/crates/workflow/tests/engine_integration.rs
@@ -2,14 +2,14 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
-use assistant_core::{bus_messages, MessageBus, PublishRequest};
+use assistant_core::{MessageBus, PublishRequest, bus_messages};
 use assistant_storage::{
     StorageLayer, WorkflowEdge, WorkflowExecutionLimits, WorkflowGraph, WorkflowNode,
     WorkflowNodeKind, WorkflowTriggerKind,
 };
 use assistant_workflow::{
-    spawn_event_trigger_adapter, spawn_schedule_trigger_adapter, spawn_workflow_runner,
-    WorkflowActionExecutor, WorkflowActionInput, WorkflowActionResult,
+    WorkflowActionExecutor, WorkflowActionInput, WorkflowActionResult, spawn_event_trigger_adapter,
+    spawn_schedule_trigger_adapter, spawn_workflow_runner,
 };
 use async_trait::async_trait;
 


### PR DESCRIPTION
## Summary

- Upgrade workspace edition from **2021** to **2024** in root `Cargo.toml`
- Apply mechanical code fixes from `cargo fix --edition` and `cargo clippy --fix`:
  - Collapse nested `if`/`if let` blocks into if-let chains (edition 2024 enables this by default)
  - Minor `cargo fmt` adjustments

**102 files changed** — all modifications are mechanical with no functional changes.

Depends on #494 (Rust 1.95.0 toolchain pin) which is already merged.

## Test plan

- [ ] CI passes (check, test, clippy, fmt)
- [ ] No behavioral changes — all fixes are syntactic