### PR TITLE
fix(runtime): thread attachment_ids through run_turn* methods

### DIFF
--- a/crates/integration-tests/tests/smoke.rs
+++ b/crates/integration-tests/tests/smoke.rs
@@ -232,7 +232,13 @@ async fn test_tool_loop_terminates() -> Result<()> {
 
     let result = f
         .orchestrator
-        .run_turn("What is 2 + 2?", f.conversation_id, Interface::Cli, None)
+        .run_turn(
+            "What is 2 + 2?",
+            f.conversation_id,
+            Interface::Cli,
+            None,
+            vec![],
+        )
         .await?;
 
     assert!(!result.answer.is_empty());
@@ -255,6 +261,7 @@ async fn test_self_analyze_runs() -> Result<()> {
             f.conversation_id,
             Interface::Cli,
             None,
+            vec![],
         )
         .await?;
 
@@ -266,6 +273,7 @@ async fn test_self_analyze_runs() -> Result<()> {
             f.conversation_id,
             Interface::Cli,
             None,
+            vec![],
         )
         .await?;
 

--- a/crates/runtime/src/channel_runner.rs
+++ b/crates/runtime/src/channel_runner.rs
@@ -136,7 +136,7 @@ impl ChannelRunner {
         }
 
         let result = orchestrator
-            .run_turn_with_tools(&text, conv_id, interface, tools, None, attachments)
+            .run_turn_with_tools(&text, conv_id, interface, tools, None, attachments, vec![])
             .await;
 
         match result {

--- a/crates/runtime/src/orchestrator/mod.rs
+++ b/crates/runtime/src/orchestrator/mod.rs
@@ -336,6 +336,7 @@ impl Orchestrator {
     ///
     /// Extension tools are injected by the calling interface (e.g. Slack,
     /// Mattermost) and are checked before the global tool executor.
+    #[allow(clippy::too_many_arguments)]
     pub async fn run_turn_with_tools(
         &self,
         user_message: &str,
@@ -344,6 +345,7 @@ impl Orchestrator {
         extensions: Vec<Arc<dyn ToolHandler>>,
         trace_cx: Option<&OtelContext>,
         attachments: Vec<ContentBlock>,
+        attachment_ids: Vec<Uuid>,
     ) -> Result<TurnResult> {
         let turn_span = info_span!(
             "conversation_turn",
@@ -359,6 +361,7 @@ impl Orchestrator {
             trace_cx,
             attachments,
             None,
+            attachment_ids,
         )
         .instrument(turn_span)
         .await
@@ -379,6 +382,7 @@ impl Orchestrator {
         trace_cx: Option<&OtelContext>,
         attachments: Vec<ContentBlock>,
         token_sink: mpsc::Sender<OrchestratorEvent>,
+        attachment_ids: Vec<Uuid>,
     ) -> Result<TurnResult> {
         let turn_span = info_span!(
             "conversation_turn",
@@ -395,6 +399,7 @@ impl Orchestrator {
             trace_cx,
             attachments,
             Some(token_sink),
+            attachment_ids,
         )
         .instrument(turn_span)
         .await
@@ -407,9 +412,17 @@ impl Orchestrator {
         conversation_id: Uuid,
         interface: Interface,
         trace_cx: Option<&OtelContext>,
+        attachment_ids: Vec<Uuid>,
     ) -> Result<TurnResult> {
-        self.run_turn_core(user_message, conversation_id, interface, None, trace_cx)
-            .await
+        self.run_turn_core(
+            user_message,
+            conversation_id,
+            interface,
+            None,
+            trace_cx,
+            attachment_ids,
+        )
+        .await
     }
 
     /// Like [`run_turn`] but streams final-answer tokens through `token_sink`.
@@ -420,6 +433,7 @@ impl Orchestrator {
         interface: Interface,
         token_sink: mpsc::Sender<OrchestratorEvent>,
         trace_cx: Option<&OtelContext>,
+        attachment_ids: Vec<Uuid>,
     ) -> Result<TurnResult> {
         self.run_turn_core(
             user_message,
@@ -427,6 +441,7 @@ impl Orchestrator {
             interface,
             Some(token_sink),
             trace_cx,
+            attachment_ids,
         )
         .await
     }
@@ -443,6 +458,7 @@ impl Orchestrator {
         trace_cx: Option<&OtelContext>,
         attachments: Vec<ContentBlock>,
         token_sink: Option<mpsc::Sender<OrchestratorEvent>>,
+        attachment_ids: Vec<Uuid>,
     ) -> Result<TurnResult> {
         self.metrics
             .record_turn(&self.agent_id, None, &format!("{interface:?}"));
@@ -479,7 +495,7 @@ impl Orchestrator {
                 user_message,
                 conversation_id,
                 attachments,
-                &[],
+                &attachment_ids,
                 &self.agent_id,
             )
             .await?;
@@ -815,6 +831,7 @@ impl Orchestrator {
         interface: Interface,
         token_sink: Option<mpsc::Sender<OrchestratorEvent>>,
         trace_cx: Option<&OtelContext>,
+        attachment_ids: Vec<Uuid>,
     ) -> Result<TurnResult> {
         let streaming = token_sink.is_some();
         self.metrics
@@ -834,7 +851,7 @@ impl Orchestrator {
                 user_message,
                 conversation_id,
                 Vec::new(),
-                &[],
+                &attachment_ids,
                 &self.agent_id,
             )
             .await?;

--- a/crates/runtime/src/orchestrator/tests.rs
+++ b/crates/runtime/src/orchestrator/tests.rs
@@ -96,7 +96,7 @@ async fn first_turn_sends_only_current_message() {
     let (orch, _) = build(&server.uri()).await;
     let conv_id = Uuid::new_v4();
 
-    orch.run_turn("hello", conv_id, Interface::Cli, None)
+    orch.run_turn("hello", conv_id, Interface::Cli, None, vec![])
         .await
         .unwrap();
 
@@ -118,10 +118,10 @@ async fn second_turn_includes_prior_history() {
     let (orch, _) = build(&server.uri()).await;
     let conv_id = Uuid::new_v4();
 
-    orch.run_turn("first message", conv_id, Interface::Cli, None)
+    orch.run_turn("first message", conv_id, Interface::Cli, None, vec![])
         .await
         .unwrap();
-    orch.run_turn("second message", conv_id, Interface::Cli, None)
+    orch.run_turn("second message", conv_id, Interface::Cli, None, vec![])
         .await
         .unwrap();
 
@@ -147,10 +147,10 @@ async fn current_message_not_duplicated() {
     let (orch, _) = build(&server.uri()).await;
     let conv_id = Uuid::new_v4();
 
-    orch.run_turn("turn one", conv_id, Interface::Cli, None)
+    orch.run_turn("turn one", conv_id, Interface::Cli, None, vec![])
         .await
         .unwrap();
-    orch.run_turn("turn two", conv_id, Interface::Cli, None)
+    orch.run_turn("turn two", conv_id, Interface::Cli, None, vec![])
         .await
         .unwrap();
 
@@ -189,7 +189,7 @@ async fn seeded_history_included_in_llm_call() {
     seed_bot.turn = 1;
     conv_store.save_message(&seed_bot).await.unwrap();
 
-    orch.run_turn("follow-up", conv_id, Interface::Slack, None)
+    orch.run_turn("follow-up", conv_id, Interface::Slack, None, vec![])
         .await
         .unwrap();
 
@@ -214,13 +214,13 @@ async fn three_turns_accumulate_history() {
     let (orch, _) = build(&server.uri()).await;
     let conv_id = Uuid::new_v4();
 
-    orch.run_turn("turn 1", conv_id, Interface::Cli, None)
+    orch.run_turn("turn 1", conv_id, Interface::Cli, None, vec![])
         .await
         .unwrap();
-    orch.run_turn("turn 2", conv_id, Interface::Cli, None)
+    orch.run_turn("turn 2", conv_id, Interface::Cli, None, vec![])
         .await
         .unwrap();
-    orch.run_turn("turn 3", conv_id, Interface::Cli, None)
+    orch.run_turn("turn 3", conv_id, Interface::Cli, None, vec![])
         .await
         .unwrap();
 
@@ -245,10 +245,10 @@ async fn different_conversations_are_isolated() {
     let conv_a = Uuid::new_v4();
     let conv_b = Uuid::new_v4();
 
-    orch.run_turn("conv-a message", conv_a, Interface::Cli, None)
+    orch.run_turn("conv-a message", conv_a, Interface::Cli, None, vec![])
         .await
         .unwrap();
-    orch.run_turn("conv-b message", conv_b, Interface::Cli, None)
+    orch.run_turn("conv-b message", conv_b, Interface::Cli, None, vec![])
         .await
         .unwrap();
 
@@ -300,7 +300,7 @@ async fn single_tool_call_adds_observation_to_next_request() {
 
     let (orch, _) = build(&server.uri()).await;
     let result = orch
-        .run_turn("go", Uuid::new_v4(), Interface::Cli, None)
+        .run_turn("go", Uuid::new_v4(), Interface::Cli, None, vec![])
         .await
         .unwrap();
     assert_eq!(result.answer, "done");
@@ -342,7 +342,7 @@ async fn two_tool_calls_handled_in_single_iteration() {
         .await;
 
     let (orch, _) = build(&server.uri()).await;
-    orch.run_turn("go", Uuid::new_v4(), Interface::Cli, None)
+    orch.run_turn("go", Uuid::new_v4(), Interface::Cli, None, vec![])
         .await
         .unwrap();
 
@@ -375,7 +375,7 @@ async fn two_tool_calls_both_observations_sent_to_llm() {
         .await;
 
     let (orch, _) = build(&server.uri()).await;
-    orch.run_turn("go", Uuid::new_v4(), Interface::Cli, None)
+    orch.run_turn("go", Uuid::new_v4(), Interface::Cli, None, vec![])
         .await
         .unwrap();
 
@@ -422,7 +422,7 @@ async fn three_tool_calls_handled_in_single_iteration() {
         .await;
 
     let (orch, _) = build(&server.uri()).await;
-    orch.run_turn("go", Uuid::new_v4(), Interface::Cli, None)
+    orch.run_turn("go", Uuid::new_v4(), Interface::Cli, None, vec![])
         .await
         .unwrap();
 
@@ -587,6 +587,7 @@ async fn end_turn_rejected_when_reply_tool_exists_but_not_called() {
         vec![reply_handler.clone() as Arc<dyn ToolHandler>],
         None,
         vec![],
+        vec![],
     )
     .await
     .unwrap();
@@ -638,9 +639,17 @@ async fn end_turn_accepted_without_reply_tool_in_cli_mode() {
     let (orch, _) = build(&server.uri()).await;
 
     // No extension tools — CLI mode, end_turn should be accepted.
-    orch.run_turn_with_tools("hi", Uuid::new_v4(), Interface::Cli, vec![], None, vec![])
-        .await
-        .unwrap();
+    orch.run_turn_with_tools(
+        "hi",
+        Uuid::new_v4(),
+        Interface::Cli,
+        vec![],
+        None,
+        vec![],
+        vec![],
+    )
+    .await
+    .unwrap();
 
     let reqs = server.received_requests().await.unwrap();
     assert_eq!(
@@ -675,6 +684,7 @@ async fn end_turn_accepted_after_reply_tool_called() {
         Interface::Slack,
         vec![reply_handler.clone() as Arc<dyn ToolHandler>],
         None,
+        vec![],
         vec![],
     )
     .await
@@ -719,6 +729,7 @@ async fn end_turn_accepted_after_react_tool_called() {
             react_handler.clone() as Arc<dyn ToolHandler>,
         ],
         None,
+        vec![],
         vec![],
     )
     .await
@@ -782,6 +793,7 @@ async fn empty_final_answer_not_persisted_and_retries() {
         Interface::Slack,
         vec![reply_handler.clone() as Arc<dyn ToolHandler>],
         None,
+        vec![],
         vec![],
     )
     .await
@@ -850,7 +862,7 @@ async fn empty_final_answer_not_persisted_in_run_turn() {
     let conv_id = Uuid::new_v4();
 
     let result = orch
-        .run_turn("hello", conv_id, Interface::Cli, None)
+        .run_turn("hello", conv_id, Interface::Cli, None, vec![])
         .await
         .unwrap();
 
@@ -1074,7 +1086,7 @@ async fn run_turn_collects_attachments_from_tool_output() {
     ])));
 
     let result = orch
-        .run_turn("make a chart", Uuid::new_v4(), Interface::Cli, None)
+        .run_turn("make a chart", Uuid::new_v4(), Interface::Cli, None, vec![])
         .await
         .unwrap();
 
@@ -1117,7 +1129,7 @@ async fn run_turn_collects_multiple_attachments_across_tool_calls() {
     ])));
 
     let result = orch
-        .run_turn("go", Uuid::new_v4(), Interface::Cli, None)
+        .run_turn("go", Uuid::new_v4(), Interface::Cli, None, vec![])
         .await
         .unwrap();
 
@@ -1138,7 +1150,7 @@ async fn run_turn_no_attachments_when_tools_return_none() {
     let (orch, _, _) = build_with_executor(&server.uri()).await;
 
     let result = orch
-        .run_turn("hello", Uuid::new_v4(), Interface::Cli, None)
+        .run_turn("hello", Uuid::new_v4(), Interface::Cli, None, vec![])
         .await
         .unwrap();
 
@@ -1180,7 +1192,14 @@ async fn run_turn_streaming_collects_attachments() {
     tokio::spawn(async move { while rx.recv().await.is_some() {} });
 
     let result = orch
-        .run_turn_streaming("generate report", Uuid::new_v4(), Interface::Cli, tx, None)
+        .run_turn_streaming(
+            "generate report",
+            Uuid::new_v4(),
+            Interface::Cli,
+            tx,
+            None,
+            vec![],
+        )
         .await
         .unwrap();
 
@@ -1248,6 +1267,7 @@ async fn run_turn_with_tools_collects_attachments_from_extension() {
             reply_handler.clone() as Arc<dyn ToolHandler>,
         ],
         None,
+        vec![],
         vec![],
     )
     .await
@@ -1705,7 +1725,13 @@ async fn conversation_can_delegate_to_anonymous_subagent() {
     let conv_id = Uuid::new_v4();
 
     let turn = orch
-        .run_turn("please delegate anonymously", conv_id, Interface::Cli, None)
+        .run_turn(
+            "please delegate anonymously",
+            conv_id,
+            Interface::Cli,
+            None,
+            vec![],
+        )
         .await
         .unwrap();
     assert_eq!(turn.answer, "parent acknowledged anonymous result");
@@ -1788,7 +1814,13 @@ async fn conversation_can_delegate_to_existing_agent_context() {
 
     let conv_id = Uuid::new_v4();
     let turn = orch
-        .run_turn("please use marketing", conv_id, Interface::Cli, None)
+        .run_turn(
+            "please use marketing",
+            conv_id,
+            Interface::Cli,
+            None,
+            vec![],
+        )
         .await
         .unwrap();
     assert_eq!(turn.answer, "parent acknowledged marketing result");
@@ -2155,7 +2187,7 @@ async fn run_turn_max_iterations_returns_error() {
     let (orch, _) = build_with_config(&server.uri(), config).await;
 
     let result = orch
-        .run_turn("trigger loop", Uuid::new_v4(), Interface::Cli, None)
+        .run_turn("trigger loop", Uuid::new_v4(), Interface::Cli, None, vec![])
         .await;
 
     match result {
@@ -2343,7 +2375,9 @@ async fn failed_turn_propagates_error() {
     let (orch, _storage) = build(&server.uri()).await;
     let conv_id = Uuid::new_v4();
 
-    let result = orch.run_turn("test", conv_id, Interface::Cli, None).await;
+    let result = orch
+        .run_turn("test", conv_id, Interface::Cli, None, vec![])
+        .await;
     assert!(
         result.is_err(),
         "expected run_turn to return Err on LLM failure"
@@ -2466,6 +2500,7 @@ async fn failed_turn_with_tools_llm_error_propagates() {
             vec![],
             None,
             vec![],
+            vec![],
         )
         .await;
     assert!(
@@ -2500,6 +2535,7 @@ async fn failed_turn_with_tools_max_iterations_returns_error() {
             Interface::Cli,
             vec![],
             None,
+            vec![],
             vec![],
         )
         .await;
@@ -2566,6 +2602,7 @@ async fn run_turn_with_tools_streaming_emits_tokens_through_sink() {
         None,
         vec![],
         tx,
+        vec![],
     )
     .await
     .unwrap();
@@ -2607,6 +2644,7 @@ async fn run_turn_with_tools_streaming_tokens_arrive_in_order() {
         None,
         vec![],
         tx,
+        vec![],
     )
     .await
     .unwrap();

--- a/crates/runtime/src/orchestrator/worker.rs
+++ b/crates/runtime/src/orchestrator/worker.rs
@@ -223,6 +223,7 @@ impl Orchestrator {
                                         Some(&bus_consume_cx),
                                         reg.attachments,
                                         sink,
+                                        turn_req.attachment_ids.clone(),
                                     )
                                     .await
                                 } else {
@@ -234,6 +235,7 @@ impl Orchestrator {
                                         reg.tools,
                                         Some(&bus_consume_cx),
                                         reg.attachments,
+                                        turn_req.attachment_ids.clone(),
                                     )
                                     .await
                                 }
@@ -245,12 +247,19 @@ impl Orchestrator {
                                     interface,
                                     sink,
                                     Some(&bus_consume_cx),
+                                    turn_req.attachment_ids.clone(),
                                 )
                                 .await
                             } else {
                                 // Standard non-streaming turn.
-                                self.run_turn(&prompt, conv_id, interface, Some(&bus_consume_cx))
-                                    .await
+                                self.run_turn(
+                                    &prompt,
+                                    conv_id,
+                                    interface,
+                                    Some(&bus_consume_cx),
+                                    turn_req.attachment_ids.clone(),
+                                )
+                                .await
                             }
                         } => r,
                         _ = turn_cancel.cancelled() => {


### PR DESCRIPTION
## Summary

- **Bug**: When a user uploads an image via web UI or app, the `attachment_ids` from `TurnRequest` were deserialized by the worker but never passed to any `run_turn*` method. All four dispatch branches dropped them, causing `prepare_history()` to always receive an empty slice — so uploaded images were never linked to messages or loaded for the LLM.
- **Effect**: The agent would see stale images from prior turns (or no image at all) instead of the one just uploaded.
- **Fix**: Thread `attachment_ids: Vec<Uuid>` through `run_turn()`, `run_turn_streaming()`, `run_turn_with_tools()`, `run_turn_with_tools_streaming()`, `run_turn_with_tools_impl()`, and `run_turn_core()`, forwarding the IDs from the worker dispatch to `prepare_history()`.

## Test plan

- [ ] Upload an image via web UI → agent should describe the correct image
- [ ] Upload an image via app → agent should describe the correct image
- [ ] Send multiple images across turns in the same conversation → each turn sees the right image
- [ ] Existing tests pass (`cargo test -p assistant-runtime`)