### PR TITLE
fix(notifications): add iOS notification permission request and badge support

### DIFF
--- a/app/lib/features/notifications/notification_service.dart
+++ b/app/lib/features/notifications/notification_service.dart
@@ -96,6 +96,12 @@ class NotificationService {
                 MacOSFlutterLocalNotificationsPlugin>()
             ?.requestPermissions(alert: true, badge: true, sound: true);
         _permissionGranted = granted ?? false;
+      } else if (defaultTargetPlatform == TargetPlatform.iOS) {
+        final granted = await _plugin
+            .resolvePlatformSpecificImplementation<
+                IOSFlutterLocalNotificationsPlugin>()
+            ?.requestPermissions(alert: true, badge: true, sound: true);
+        _permissionGranted = granted ?? false;
       } else if (kIsWeb) {
         // Web permission is requested by the browser when subscribing to push.
         _permissionGranted = await web_impl.requestWebPermission();
@@ -149,8 +155,10 @@ class NotificationService {
       return;
     }
 
-    // Increment badge counter on macOS.
-    if (!kIsWeb && defaultTargetPlatform == TargetPlatform.macOS) {
+    // Increment badge counter on macOS and iOS.
+    if (!kIsWeb &&
+        (defaultTargetPlatform == TargetPlatform.macOS ||
+            defaultTargetPlatform == TargetPlatform.iOS)) {
       _ref.read(notificationBadgeProvider.notifier).increment();
     }
   }
@@ -184,6 +192,7 @@ class NotificationService {
   bool get _isSupportedPlatform {
     if (kIsWeb) return true;
     if (defaultTargetPlatform == TargetPlatform.macOS) return true;
+    if (defaultTargetPlatform == TargetPlatform.iOS) return true;
     return false;
   }
 


### PR DESCRIPTION
This PR fixes issue #421 by adding iOS support to the notification service.

## Changes

- **`\_isSupportedPlatform`**: Added iOS to the supported platforms check
- **`requestPermission()`**: Added iOS-specific permission request handling using `IOSFlutterLocalNotificationsPlugin` with `requestPermissions(alert: true, badge: true, sound: true)`
- **Badge increment**: Extended badge counter logic to include iOS alongside macOS

## Testing

- [ ] iOS permission request flow
- [ ] Badge increment on iOS when notifications are received
- [ ] macOS functionality remains unchanged

Fixes #421