### PR TITLE
fix(updater): disable self-update feature on iOS to prevent crash

### DIFF
--- a/app/lib/features/updater/installer_launcher.dart
+++ b/app/lib/features/updater/installer_launcher.dart
@@ -9,6 +9,9 @@ abstract final class InstallerLauncher {
   /// Throws if the installer launch fails so the caller can surface an error
   /// rather than silently exiting.
   static Future<void> launch(String path, String filename) async {
+    // Self-update is not supported on iOS
+    if (Platform.isIOS) return;
+
     if (Platform.isMacOS) {
       await _launchMacOS(path, filename);
     } else if (Platform.isLinux) {

--- a/app/lib/features/updater/update_banner.dart
+++ b/app/lib/features/updater/update_banner.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -15,6 +17,9 @@ class UpdateBannerWrapper extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    // Self-update is not supported on iOS - skip banner entirely
+    if (Platform.isIOS) return child;
+
     final updateAsync = ref.watch(updateCheckProvider);
 
     return updateAsync.when(

--- a/app/lib/features/updater/update_service.dart
+++ b/app/lib/features/updater/update_service.dart
@@ -148,6 +148,8 @@ class UpdateService {
   /// Always returns [null] in debug/profile builds or on web.
   Future<UpdateInfo?> checkForUpdate() async {
     if (kIsWeb || !kReleaseMode) return null;
+    // Self-update is not supported on mobile platforms (iOS, Android)
+    if (Platform.isIOS || Platform.isAndroid) return null;
     if (!Platform.isMacOS && !Platform.isLinux && !Platform.isWindows) {
       return null;
     }


### PR DESCRIPTION
The self-update feature throws UnsupportedError on iOS. The update banner in NavShell could become visible and crash the app if tapped.

## Changes

- `update_service.dart`: Add iOS/Android check to return null early in `checkForUpdate()`
- `update_banner.dart`: Skip banner widget entirely on iOS
- `installer_launcher.dart`: Add early return for iOS in `launch()`

Fixes #420

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled automatic update checking on iOS and Android devices, which manage updates through the App Store and Play Store respectively
  * Removed the update banner UI from iOS to prevent conflicts with platform-native update handling
  * Prevented independent installer launch attempts on iOS

<!-- end of auto-generated comment: release notes by coderabbit.ai -->