### PR TITLE
fix: gate PwaUpdateListener to web-only

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -40,21 +40,21 @@ Future<void> main() async {
   // Register for PWA update notifications after the first frame so the
   // ScaffoldMessenger key is bound and can show the SnackBar.
   //
-  // Flutter's flutter_service_worker.js calls skipWaiting() on install, so
-  // the new SW never enters the 'waiting' state.  We listen for the
-  // 'controllerchange' event via JS instead (see index.html).  The stub
-  // implementation is a no-op on non-web platforms.
-  WidgetsBinding.instance.addPostFrameCallback((_) {
-    registerPwaUpdateCallback(() {
-      _scaffoldMessengerKey.currentState?.showSnackBar(
-        SnackBar(
-          content: const Text('A new version is available.'),
-          action: SnackBarAction(label: 'Reload', onPressed: reloadPwa),
-          duration: const Duration(days: 1),
-        ),
-      );
+  // Only register on web — reloadPwa is a web-only operation and calling it
+  // on iOS/macOS/desktop is dead code at best, a crash risk at worst.
+  if (kIsWeb) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      registerPwaUpdateCallback(() {
+        _scaffoldMessengerKey.currentState?.showSnackBar(
+          SnackBar(
+            content: const Text('A new version is available.'),
+            action: SnackBarAction(label: 'Reload', onPressed: reloadPwa),
+            duration: const Duration(days: 1),
+          ),
+        );
+      });
     });
-  });
+  }
 }
 
 /// Root application widget.


### PR DESCRIPTION
## Summary

- Gates `registerPwaUpdateCallback` and `reloadPwa` behind `kIsWeb` in `app/lib/main.dart`
- Previously the PWA update callback was registered unconditionally on all platforms including iOS, where `reloadPwa` is a web-only operation
- This is dead code at best and a crash risk at worst on non-web platforms

Closes #419

## Test plan

- [ ] Verify web build still shows "A new version is available" SnackBar when a PWA update is available
- [ ] Verify iOS build no longer attempts to register the PWA update callback

🤖 Generated with [Claude Code](https://claude.com/claude-code)