### PR TITLE
fix(cli): wire AudioStore into orchestrator for outbound audio delivery

### DIFF
--- a/crates/interface-cli/src/main.rs
+++ b/crates/interface-cli/src/main.rs
@@ -1116,6 +1116,7 @@ async fn bootstrap(
         .ok()
         .flatten()
         .and_then(|p| p.turn_timeout_secs);
+    let audio_store = Arc::new(assistant_transcription::AudioStore::new());
     let orchestrator = Arc::new({
         let mut o = Orchestrator::new(
             llm,
@@ -1125,7 +1126,8 @@ async fn bootstrap(
             bus,
             &config,
         )
-        .with_confirmation_callback(confirmation_cb);
+        .with_confirmation_callback(confirmation_cb)
+        .with_audio_store(audio_store.clone());
         if let Some(secs) = persona_timeout {
             o = o.with_submit_timeout(secs);
         }


### PR DESCRIPTION
## Summary

- Wire `AudioStore` into the CLI entrypoint's orchestrator so TTS audio from `voice-response` reaches `TurnResult::attachments`
- Without this, all channel adapters (Slack, Signal, Mattermost, Matrix, Nextcloud) running through the CLI could not deliver synthesized audio files — the orchestrator silently skipped audio retrieval because `audio_store` was `None`
- One-line fix: create `AudioStore` and call `.with_audio_store()` on the orchestrator

## Test plan

- [x] `make lint` passes
- [x] `make format` passes  
- [x] `cargo check --workspace` succeeds
- [ ] Manual: trigger `voice-response` tool via Slack → verify audio file is uploaded to channel