### PR TITLE
fix(matrix): collapse nested if-let to satisfy clippy

### DIFF
--- a/crates/interface-matrix/src/client.rs
+++ b/crates/interface-matrix/src/client.rs
@@ -250,10 +250,10 @@ impl MatrixClient {
             "mimetype": mime_type,
             "size": size_bytes
         });
-        if let Some(duration) = duration_ms {
-            if let serde_json::Value::Object(ref mut map) = info {
-                map.insert("duration".to_string(), serde_json::json!(duration));
-            }
+        if let Some(duration) = duration_ms
+            && let serde_json::Value::Object(ref mut map) = info
+        {
+            map.insert("duration".to_string(), serde_json::json!(duration));
         }
 
         let body = serde_json::json!({


### PR DESCRIPTION
## Summary
- Collapses nested `if let` into a single `if let ... && let ...` expression in the Matrix client to fix a `clippy::collapsible_if` lint error on main.

## Test plan
- [x] `make lint` passes