### PR TITLE
fix(transcription): use valid Deepgram TTS model name

### DIFF
--- a/crates/transcription/src/deepgram_tts.rs
+++ b/crates/transcription/src/deepgram_tts.rs
@@ -8,7 +8,7 @@ use tracing::debug;
 use crate::provider::{TtsProvider, TtsRequest, TtsResult};
 
 const DEFAULT_TIMEOUT_SECS: u64 = 60;
-const DEFAULT_MODEL: &str = "aura-2-en-us";
+const DEFAULT_MODEL: &str = "aura-2-thalia-en";
 
 pub struct DeepgramTtsProvider {
     api_key: String,


### PR DESCRIPTION
## Summary

- Fix default TTS model from `aura-2-en-us` (invalid) to `aura-2-thalia-en` (valid Deepgram Aura 2 model name)
- Root cause: Deepgram TTS model names follow the format `aura-2-{voice}-{lang}`, not `aura-2-{lang}`. The invalid name caused all TTS requests to fail with 403 `INSUFFICIENT_PERMISSIONS`

Confirmed via server logs on schorschvm:
```
WARN TTS synthesis failed: Deepgram TTS API returned 403 Forbidden:
     {"err_code":"INSUFFICIENT_PERMISSIONS","err_msg":"Project does not have access to the requested model."}
```

Confirmed fix via direct API test — `aura-2-thalia-en` returns 200 OK with valid MP3.

## Test plan

- [x] `cargo test -p assistant-transcription` — all 36 tests pass
- [ ] Deploy to schorschvm, verify "read aloud" works on assistant messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the default text-to-speech voice model to deliver improved audio quality and enhanced voice synthesis performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->