### PR TITLE
fix(app): animate streaming dots indicator

### DIFF
--- a/app/lib/features/chat/chat_screen.dart
+++ b/app/lib/features/chat/chat_screen.dart
@@ -1089,18 +1089,79 @@ class _ReadAloudActionState extends State<_ReadAloudAction> {
   }
 }
 
-class _Dot extends StatelessWidget {
+class _Dot extends StatefulWidget {
   const _Dot({this.delay = Duration.zero});
   final Duration delay;
 
   @override
+  State<_Dot> createState() => _DotState();
+}
+
+class _DotState extends State<_Dot> with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _opacity;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      duration: const Duration(milliseconds: 1200),
+      vsync: this,
+    );
+
+    // Stagger offset as a fraction of total duration.
+    final delay = widget.delay.inMilliseconds / 1200;
+    final end = (delay + 0.5).clamp(0.0, 1.0);
+
+    _opacity =
+        TweenSequence<double>([
+          TweenSequenceItem(
+            tween: Tween(
+              begin: 0.2,
+              end: 1.0,
+            ).chain(CurveTween(curve: Curves.easeInOut)),
+            weight: 50,
+          ),
+          TweenSequenceItem(
+            tween: Tween(
+              begin: 1.0,
+              end: 0.2,
+            ).chain(CurveTween(curve: Curves.easeInOut)),
+            weight: 50,
+          ),
+        ]).animate(
+          CurvedAnimation(parent: _controller, curve: Interval(delay, end)),
+        );
+
+    _controller.repeat();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return Container(
-      width: 6,
-      height: 6,
-      decoration: const BoxDecoration(
-        color: Colors.black38,
-        shape: BoxShape.circle,
+    final color = Theme.of(context).colorScheme.onSurfaceVariant;
+
+    if (MediaQuery.of(context).disableAnimations) {
+      return Container(
+        width: 6,
+        height: 6,
+        decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+      );
+    }
+
+    return AnimatedBuilder(
+      animation: _opacity,
+      builder: (context, child) =>
+          Opacity(opacity: _opacity.value, child: child),
+      child: Container(
+        width: 6,
+        height: 6,
+        decoration: BoxDecoration(color: color, shape: BoxShape.circle),
       ),
     );
   }


### PR DESCRIPTION
## Summary

- Convert static `_Dot` widget to animated `StatefulWidget` with staggered opacity pulse (0.2 → 1.0 → 0.2, 1200ms cycle)
- Fix dark mode: replace hard-coded `Colors.black38` with `colorScheme.onSurfaceVariant`
- Respect `MediaQuery.disableAnimations` for accessibility (static dots when reduced motion is on)

The `_Dot` widget accepted a `delay` parameter but never used it — all three dots were identical static circles.

## Test plan

- [x] `flutter analyze --fatal-infos` — no issues
- [x] `flutter test` — all 320 tests pass
- [ ] Visual verification: dots pulse with staggered wave effect during streaming
- [ ] Visual verification: dots visible in dark mode