### PR TITLE
fix(app): show image thumbnails immediately when sending

### DIFF
--- a/app/lib/features/chat/chat_provider.dart
+++ b/app/lib/features/chat/chat_provider.dart
@@ -263,10 +263,15 @@ class PendingMessage {
     required this.text,
     required this.conversationId,
     this.attachmentIds = const [],
+    this.attachments = const [],
   });
   final String text;
   final String conversationId;
   final List<String> attachmentIds;
+
+  /// Pre-built attachment metadata from upload responses, used to show
+  /// thumbnails immediately in the user bubble without waiting for a reload.
+  final List<ChatAttachment> attachments;
 }
 
 /// A completed tool result recorded during streaming — used by
@@ -560,6 +565,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
   Future<void> sendMessage(
     String message, {
     List<String> attachmentIds = const [],
+    List<ChatAttachment> attachments = const [],
   }) async {
     if (message.trim().isEmpty && attachmentIds.isEmpty) return;
 
@@ -601,6 +607,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
             text: message,
             conversationId: conversationId,
             attachmentIds: attachmentIds,
+            attachments: attachments,
           ),
         ],
       ),
@@ -819,6 +826,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
           pending.text,
           pending.conversationId,
           attachmentIds: pending.attachmentIds,
+          attachments: pending.attachments,
         );
       }
     } finally {
@@ -991,6 +999,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
     String message,
     String conversationId, {
     List<String> attachmentIds = const [],
+    List<ChatAttachment> attachments = const [],
   }) async {
     final api = _api;
     if (api == null) return;
@@ -1010,6 +1019,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
       role: 'user',
       content: message,
       status: MessageStatus.sending,
+      attachments: attachments.isNotEmpty ? attachments : null,
     );
     final assistantPlaceholder = ChatMessage(
       id: 'assistant-streaming',

--- a/app/lib/features/chat/chat_screen.dart
+++ b/app/lib/features/chat/chat_screen.dart
@@ -153,6 +153,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
 
     // Upload pending attachments first, then send with IDs.
     final attachmentIds = <String>[];
+    final attachments = <ChatAttachment>[];
     if (pending.isNotEmpty) {
       ref.read(pendingAttachmentsProvider.notifier).clear();
       final api = ref.read(apiClientProvider);
@@ -179,6 +180,14 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
               mimeType: p.mimeType,
             );
             attachmentIds.add(meta.id);
+            attachments.add(
+              ChatAttachment(
+                id: meta.id,
+                filename: meta.filename,
+                mimeType: meta.mimeType,
+                url: meta.url,
+              ),
+            );
           } catch (e) {
             // Skip failed uploads — don't block sending the message.
           }
@@ -186,10 +195,16 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
       }
     }
 
-    final msg = text.isNotEmpty ? text : '[Image attached]';
+    // Server rejects empty messages, so use a Unicode zero-width space when
+    // only images are attached. The bubble hides this when attachments exist.
+    final msg = text.isNotEmpty ? text : '\u200B';
     await ref
         .read(chatProvider.notifier)
-        .sendMessage(msg, attachmentIds: attachmentIds);
+        .sendMessage(
+          msg,
+          attachmentIds: attachmentIds,
+          attachments: attachments,
+        );
     _scrollToBottom();
   }
 
@@ -567,26 +582,29 @@ class _MessageBubble extends StatelessWidget {
                     children: [
                       if (message.attachments.isNotEmpty)
                         _attachmentThumbnails(context),
-                      Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          if (isFailed)
-                            Padding(
-                              padding: const EdgeInsets.only(right: 6),
-                              child: Icon(
-                                Icons.error_outline,
-                                size: 16,
-                                color: Colors.red.shade300,
+                      // Hide text row when content is only whitespace /
+                      // zero-width space and attachments provide the visual.
+                      if (message.content.trim().isNotEmpty)
+                        Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            if (isFailed)
+                              Padding(
+                                padding: const EdgeInsets.only(right: 6),
+                                child: Icon(
+                                  Icons.error_outline,
+                                  size: 16,
+                                  color: Colors.red.shade300,
+                                ),
+                              ),
+                            Flexible(
+                              child: SelectableText(
+                                message.content,
+                                style: TextStyle(color: colorScheme.onPrimary),
                               ),
                             ),
-                          Flexible(
-                            child: SelectableText(
-                              message.content,
-                              style: TextStyle(color: colorScheme.onPrimary),
-                            ),
-                          ),
-                        ],
-                      ),
+                          ],
+                        ),
                     ],
                   )
                 : Column(


### PR DESCRIPTION
## Summary

- Preserve full `AttachmentMetaResponse` (id, filename, mimeType, **url**) from image uploads instead of discarding everything except the ID
- Pass `ChatAttachment` objects through `sendMessage()` → `_streamMessage()` → user `ChatMessage`, so thumbnails render immediately via the existing `_attachmentThumbnails()` widget
- When only images are sent with no text, hide the text row instead of showing "[Image attached]"

**Before:** User sends images → sees "[Image attached]" text. Thumbnails only appear after reloading the conversation.

**After:** User sends images → sees thumbnails immediately in the bubble.

## Changes

- `chat_screen.dart`: Collect `ChatAttachment` from upload responses, pass to `sendMessage()`, hide text row when content is whitespace-only and attachments exist
- `chat_provider.dart`: Thread `attachments` through `PendingMessage` → `sendMessage()` → `_drainQueue()` → `_streamMessage()` → user `ChatMessage`

## Test plan

- [x] `flutter analyze --fatal-infos` — no issues
- [x] `flutter test` — all 320 tests pass
- [ ] Send single image → verify thumbnail appears in bubble without reload
- [ ] Send multiple images → verify all thumbnails appear
- [ ] Send image with text → verify both text and thumbnails appear
- [ ] Reload conversation → verify thumbnails still appear from history