### PR TITLE
fix(chat): fix inline image 401 by watching auth profile reactively

### DIFF
--- a/app/lib/features/chat/chat_screen.dart
+++ b/app/lib/features/chat/chat_screen.dart
@@ -274,6 +274,12 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
         ? (ref.watch(capabilitiesProvider).value ?? ServerCapabilities.disabled)
         : ServerCapabilities.disabled;
 
+    // Watch the active profile reactively so image auth headers update when
+    // the profile loads (e.g. after a deep-link hard reload).
+    final activeProfile = ref.watch(activeProfileProvider);
+    final imageBaseUrl = activeProfile?.baseUrl;
+    final imageAuthToken = activeProfile?.token;
+
     return Scaffold(
       appBar: AppBar(
         title: Text(activePersonaName),
@@ -452,12 +458,8 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                                         return api?.fetchMessageAudio(msg.id) ??
                                             Future.value(null);
                                       },
-                                      imageBaseUrl: ref
-                                          .read(activeProfileProvider)
-                                          ?.baseUrl,
-                                      imageAuthToken: ref
-                                          .read(activeProfileProvider)
-                                          ?.token,
+                                      imageBaseUrl: imageBaseUrl,
+                                      imageAuthToken: imageAuthToken,
                                     );
                                   },
                                 ),
@@ -712,9 +714,30 @@ class _MessageBubble extends StatelessWidget {
         spacing: 6,
         runSpacing: 6,
         children: message.attachments.map((att) {
-          final thumbUrl = imageBaseUrl != null
-              ? '$imageBaseUrl${att.url}?w=300'
-              : '${att.url}?w=300';
+          // Without a base URL the relative path cannot be resolved.
+          if (imageBaseUrl == null) {
+            return Container(
+              width: 150,
+              height: 150,
+              decoration: BoxDecoration(
+                color: colorScheme.surfaceContainerLowest,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(Icons.image, color: colorScheme.outline),
+                  const SizedBox(height: 4),
+                  Text(
+                    att.filename,
+                    style: TextStyle(fontSize: 10, color: colorScheme.outline),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
+              ),
+            );
+          }
+          final thumbUrl = '$imageBaseUrl${att.url}?w=300';
           return GestureDetector(
             onTap: () => _showFullImage(context, att),
             child: ClipRRect(
@@ -739,24 +762,30 @@ class _MessageBubble extends StatelessWidget {
                     ),
                   ),
                 ),
-                errorWidget: (_, _, _) => Container(
-                  width: 150,
-                  height: 150,
-                  color: colorScheme.surfaceContainerLowest,
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Icon(Icons.broken_image, color: colorScheme.outline),
-                      const SizedBox(height: 4),
-                      Text(
-                        att.filename,
-                        style: TextStyle(
-                          fontSize: 10,
-                          color: colorScheme.outline,
+                errorWidget: (_, url, _) => GestureDetector(
+                  onTap: () {
+                    CachedNetworkImage.evictFromCache(url);
+                    // Trigger a rebuild to retry loading.
+                    (context as Element).markNeedsBuild();
+                  },
+                  child: Container(
+                    width: 150,
+                    height: 150,
+                    color: colorScheme.surfaceContainerLowest,
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Icon(Icons.refresh, color: colorScheme.outline),
+                        const SizedBox(height: 4),
+                        Text(
+                          'Tap to retry',
+                          style: TextStyle(
+                            fontSize: 10,
+                            color: colorScheme.outline,
+                          ),
                         ),
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ],
+                      ],
+                    ),
                   ),
                 ),
               ),
@@ -768,9 +797,8 @@ class _MessageBubble extends StatelessWidget {
   }
 
   void _showFullImage(BuildContext context, ChatAttachment attachment) {
-    final fullUrl = imageBaseUrl != null
-        ? '$imageBaseUrl${attachment.url}?w=1920'
-        : '${attachment.url}?w=1920';
+    if (imageBaseUrl == null) return;
+    final fullUrl = '$imageBaseUrl${attachment.url}?w=1920';
     showDialog(
       context: context,
       builder: (ctx) => Dialog(

--- a/app/test/widget/features/chat/chat_screen_test.dart
+++ b/app/test/widget/features/chat/chat_screen_test.dart
@@ -2,6 +2,7 @@ import 'package:assistant_api/assistant_api.dart' hide ServerCapabilities;
 import 'package:assistant_app/api/api_client.dart';
 import 'package:assistant_app/api/capabilities_provider.dart';
 import 'package:assistant_app/api/models/server_capabilities.dart';
+import 'package:assistant_app/api/models/server_profile.dart';
 import 'package:assistant_app/features/chat/audio_player_widget.dart';
 import 'package:assistant_app/features/chat/chat_provider.dart';
 import 'package:assistant_app/features/chat/chat_screen.dart';
@@ -60,6 +61,10 @@ Future<({_FakeChatNotifier notifier})> pumpChatScreen(
         personasProvider.overrideWith(() => _FakePersonasNotifier()),
         conversationListProvider.overrideWith(
           () => _FakeConversationListNotifier(),
+        ),
+        // Provide a profile so image auth headers and base URL are available.
+        activeProfileProvider.overrideWithValue(
+          const ServerProfile(baseUrl: 'http://localhost', token: 'test-token'),
         ),
         if (capabilities != null) ...[
           apiClientProvider.overrideWithValue(

--- a/openspec/changes/inline-image-auth-fix/design.md
+++ b/openspec/changes/inline-image-auth-fix/design.md
@@ -1,0 +1,73 @@
+## Context
+
+Inline image attachments in chat messages return 401 Unauthorized. The browser console shows:
+
+```
+Failed to load resource: the server responded with a status of 401 ()
+https://assistant.58lab.org/api/attachments/4dffd8b4-83a4-4fc4-9721-1261531e3848?w=300
+```
+
+The rendering code in `chat_screen.dart` `_attachmentThumbnails()` (line 694) uses `CachedNetworkImage` with:
+
+```dart
+httpHeaders: imageAuthToken != null
+    ? {'Authorization': 'Bearer $imageAuthToken'}
+    : const {},
+```
+
+Where `imageAuthToken` comes from `ref.read(activeProfileProvider)?.token` (line 438).
+
+The server's auth middleware in `crates/web-ui/src/auth.rs` (line 108) correctly validates Bearer tokens. The attachment endpoint at `/api/attachments/{id}` is protected by `require_auth` (line 691 of `main.rs`).
+
+Potential failure modes:
+
+1. `imageAuthToken` is `null` at render time (auth state not yet loaded — race condition similar to deep-link issue)
+2. `CachedNetworkImage` caches the 401 response and serves it on subsequent attempts
+3. `imageBaseUrl` is null, causing `CachedNetworkImage` to resolve `/api/attachments/{id}` as a relative URL that the HTTP client can't handle
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Inline image attachments load reliably with proper authentication
+- Diagnose and fix the specific cause of the 401 (token availability vs. URL construction vs. cache poisoning)
+- Show a retry-capable placeholder when image loading fails
+- Ensure auth token is reactively available (watched, not just read once)
+
+**Non-Goals:**
+
+- Changing the server auth mechanism
+- Adding token refresh / re-authentication logic
+- Thumbnail resizing or format changes
+
+## Decisions
+
+### D1: Watch `activeProfileProvider` reactively for auth token
+
+**Choice:** The `imageAuthToken` and `imageBaseUrl` are currently read via `ref.read()` inside `itemBuilder` (line 434-438). This is a one-shot read that captures the value at build time. If the provider hasn't resolved yet (e.g. during deep-link reload), the token is `null` and images fail with 401.
+
+Change to pass these values from a `ref.watch()` higher up in the build tree, so the message list rebuilds when auth becomes available.
+
+**Why:** `ref.read()` inside a builder callback doesn't trigger rebuilds. Images rendered before auth loads will permanently fail because the widget never rebuilds with the correct token.
+
+### D2: Add error widget with retry
+
+**Choice:** Replace the `errorWidget` in `CachedNetworkImage` (line 730) with a tappable retry button that clears the cache entry and reloads.
+
+**Why:** If a 401 response is cached, the image will never load even after auth becomes available. A retry button lets the user force a fresh request. `CachedNetworkImage` supports `evictFromCache()` to clear a specific URL.
+
+### D3: Guard against null `imageBaseUrl`
+
+**Choice:** If `imageBaseUrl` is null, skip image rendering entirely (show a placeholder) rather than attempting to load from a relative URL.
+
+**Why:** `CachedNetworkImage` requires an absolute URL. A relative path like `/api/attachments/{id}` will fail in the HTTP client. The `imageBaseUrl` should always be set when auth is available, but the guard prevents silent failures.
+
+## Risks / Trade-offs
+
+- **Cache invalidation:** Calling `evictFromCache()` on retry adds a small disk I/O cost. Acceptable for a user-initiated action.
+- **Reactive rebuild:** Switching `imageAuthToken` from `ref.read()` to a watched value means the message list rebuilds when auth state changes. This is a one-time rebuild on app start — negligible performance impact.
+- **Relationship to deep-link-reload-fix:** Both issues stem from the same root cause (auth state not ready at render time). Fixing the deep-link issue may partially fix this one, but the image auth fix should be independent and defensive.
+
+## Migration Plan
+
+No migration. Behavioural fix only.

--- a/openspec/changes/inline-image-auth-fix/proposal.md
+++ b/openspec/changes/inline-image-auth-fix/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Inline image attachments in chat messages return 401 Unauthorized errors. The browser console shows:
+
+```
+Failed to load resource: the server responded with a status of 401 ()
+https://assistant.58lab.org/api/attachments/{id}?w=300
+```
+
+The `CachedNetworkImage` widget is configured to send `Authorization: Bearer $token` headers, but the token is either not available at render time or not being sent correctly.
+
+## What Changes
+
+- Diagnose and fix the auth token flow for inline image rendering
+- Ensure `imageAuthToken` is reliably available when `CachedNetworkImage` renders (may be a race condition similar to the deep-link issue where `activeProfileProvider` hasn't loaded yet)
+- Add error handling: show a placeholder with retry capability instead of a broken image icon when auth fails
+- Investigate whether `CachedNetworkImage` caches 401 responses and serves them on subsequent attempts (cache poisoning)
+
+## Capabilities
+
+### Modified Capabilities
+
+- `image-attachments`: Inline image thumbnails load reliably with proper authentication
+- `image-error-handling`: Failed image loads show a retry-capable placeholder instead of a silent broken icon
+
+## Impact
+
+- `app/lib/features/chat/chat_screen.dart` — Fix `imageAuthToken` availability timing; add retry on error widget; possibly switch from `CachedNetworkImage` to a provider-aware image widget that watches auth state
+- `app/lib/features/connection/connection_provider.dart` — Ensure `activeProfileProvider` is reliably available before image rendering
+- May relate to deep-link-reload-fix (same auth state race condition)
+- No backend changes (server auth middleware is correctly configured)

--- a/openspec/changes/inline-image-auth-fix/tasks.md
+++ b/openspec/changes/inline-image-auth-fix/tasks.md
@@ -1,0 +1,11 @@
+## Tasks
+
+- [ ] Investigate: add debug logging to `_attachmentThumbnails()` to confirm whether `imageAuthToken` is null at render time
+- [ ] Move `imageBaseUrl` and `imageAuthToken` from `ref.read()` inside `itemBuilder` to `ref.watch()` at the `build()` level so the list rebuilds when auth becomes available
+- [ ] Add null guard: if `imageBaseUrl` is null, render a placeholder instead of attempting image load
+- [ ] Replace `errorWidget` in `CachedNetworkImage` with a tappable retry widget that calls `CachedNetworkImage.evictFromCache(url)` and triggers rebuild
+- [ ] Verify `CachedNetworkImage` sends `httpHeaders` on the actual HTTP request (not just the cache lookup) — add integration test or manual verification
+- [ ] Test: load conversation with images, verify thumbnails load with correct auth
+- [ ] Test: hard reload on a conversation with images, verify thumbnails load after auth resolves
+- [ ] Test: tap retry on a failed image, verify it reloads successfully
+- [ ] Test: verify full-size image dialog also sends auth headers correctly


### PR DESCRIPTION
## Summary

- Inline image attachments returned 401 because `imageAuthToken` and `imageBaseUrl` were read via `ref.read()` (one-shot) inside the ListView item builder, capturing `null` during the async auth loading window
- Changed to `ref.watch(activeProfileProvider)` at the build level so the message list rebuilds when the profile loads
- Added null guard: if `imageBaseUrl` is null, renders a placeholder instead of attempting to load from an invalid relative URL
- Replaced broken-image error widget with a tap-to-retry widget that evicts the cached 401 response via `CachedNetworkImage.evictFromCache()`
- Includes OpenSpec proposal, design, and tasks

## Test plan

- [x] All 20 chat screen tests pass (including 4 attachment thumbnail tests)
- [x] Full Flutter test suite passes (322 tests)
- [ ] Manual: reload a conversation with images — thumbnails should load after auth resolves
- [ ] Manual: tap a failed image thumbnail — should retry and load

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authentication failures when loading inline image thumbnails in chat.
  * Improved error handling for failed image loads with a retry option instead of a broken image icon.
  * Added safeguards for missing authentication context during image rendering.

* **Tests**
  * Updated test helpers to properly supply authentication context for image-dependent features.

* **Documentation**
  * Added design and task documentation for inline image authentication improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->