### PR TITLE
feat(chat): render user voice messages as mini audio player

### DIFF
--- a/app/lib/features/chat/chat_provider.dart
+++ b/app/lib/features/chat/chat_provider.dart
@@ -193,6 +193,8 @@ class ChatMessage {
     this.audioId,
     this.ttsAvailable = false,
     this.tokenStream,
+    this.audioBytes,
+    this.audioMimeType,
     List<ToolCallRecord>? toolCalls,
     List<ChatAttachment>? attachments,
   }) : toolCalls = toolCalls ?? [],
@@ -224,6 +226,12 @@ class ChatMessage {
   /// Image attachments linked to this message.
   List<ChatAttachment> attachments;
 
+  /// Raw audio bytes for user voice messages (in-memory only, not persisted).
+  final Uint8List? audioBytes;
+
+  /// MIME type of [audioBytes] (e.g. `audio/webm`, `audio/mp4`).
+  final String? audioMimeType;
+
   bool get isUser => role == 'user';
   bool get isAssistant => role == 'assistant';
 
@@ -237,6 +245,8 @@ class ChatMessage {
     Stream<String>? tokenStream,
     bool clearTokenStream = false,
     List<ChatAttachment>? attachments,
+    Uint8List? audioBytes,
+    String? audioMimeType,
   }) {
     return ChatMessage(
       id: id,
@@ -249,6 +259,8 @@ class ChatMessage {
       toolCalls: toolCalls ?? this.toolCalls,
       tokenStream: clearTokenStream ? null : (tokenStream ?? this.tokenStream),
       attachments: attachments ?? this.attachments,
+      audioBytes: audioBytes ?? this.audioBytes,
+      audioMimeType: audioMimeType ?? this.audioMimeType,
     );
   }
 }
@@ -856,6 +868,8 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
       role: 'user',
       content: '🎤 Voice message',
       status: MessageStatus.sending,
+      audioBytes: audioBytes,
+      audioMimeType: mimeType,
     );
     final assistantPlaceholder = ChatMessage(
       id: 'assistant-streaming',

--- a/app/lib/features/chat/chat_screen.dart
+++ b/app/lib/features/chat/chat_screen.dart
@@ -584,9 +584,16 @@ class _MessageBubble extends StatelessWidget {
                     children: [
                       if (message.attachments.isNotEmpty)
                         _attachmentThumbnails(context),
+                      // Voice message: show audio player + collapsible transcript.
+                      if (message.audioBytes != null)
+                        _VoiceMessagePlayer(
+                          audioBytes: message.audioBytes!,
+                          transcript: message.content,
+                          foregroundColor: colorScheme.onPrimary,
+                        )
                       // Hide text row when content is only whitespace /
                       // zero-width space and attachments provide the visual.
-                      if (message.content.trim().isNotEmpty)
+                      else if (message.content.trim().isNotEmpty)
                         Row(
                           mainAxisSize: MainAxisSize.min,
                           children: [
@@ -1429,5 +1436,182 @@ class _InputRow extends StatelessWidget {
         ),
       ],
     );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Voice message player — play/pause + progress bar + collapsible transcript
+// ---------------------------------------------------------------------------
+
+class _VoiceMessagePlayer extends StatefulWidget {
+  const _VoiceMessagePlayer({
+    required this.audioBytes,
+    required this.transcript,
+    required this.foregroundColor,
+  });
+
+  final Uint8List audioBytes;
+  final String transcript;
+  final Color foregroundColor;
+
+  @override
+  State<_VoiceMessagePlayer> createState() => _VoiceMessagePlayerState();
+}
+
+class _VoiceMessagePlayerState extends State<_VoiceMessagePlayer> {
+  final _player = AudioPlayer();
+  bool _isPlaying = false;
+  Duration _position = Duration.zero;
+  Duration _duration = Duration.zero;
+  bool _transcriptExpanded = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _player.onPlayerComplete.listen((_) {
+      if (mounted) {
+        setState(() {
+          _isPlaying = false;
+          _position = Duration.zero;
+        });
+      }
+    });
+    _player.onPositionChanged.listen((p) {
+      if (mounted) setState(() => _position = p);
+    });
+    _player.onDurationChanged.listen((d) {
+      if (mounted) setState(() => _duration = d);
+    });
+  }
+
+  @override
+  void dispose() {
+    _player.dispose();
+    super.dispose();
+  }
+
+  Future<void> _toggle() async {
+    if (_isPlaying) {
+      await _player.pause();
+      setState(() => _isPlaying = false);
+    } else {
+      if (_position == Duration.zero) {
+        await _player.play(BytesSource(widget.audioBytes));
+      } else {
+        await _player.resume();
+      }
+      setState(() => _isPlaying = true);
+    }
+  }
+
+  String _formatDuration(Duration d) {
+    final minutes = d.inMinutes;
+    final seconds = d.inSeconds % 60;
+    return '$minutes:${seconds.toString().padLeft(2, '0')}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final fg = widget.foregroundColor;
+    final hasTranscript =
+        widget.transcript.trim().isNotEmpty &&
+        widget.transcript.trim() != '🎤 Voice message';
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        // Player row: play/pause + progress + duration.
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            GestureDetector(
+              onTap: _toggle,
+              child: Icon(
+                _isPlaying
+                    ? Icons.pause_circle_filled
+                    : Icons.play_circle_filled,
+                color: fg,
+                size: 28,
+              ),
+            ),
+            const SizedBox(width: 8),
+            SizedBox(
+              width: 120,
+              child: SliderTheme(
+                data: SliderThemeData(
+                  trackHeight: 3,
+                  thumbShape: const RoundSliderThumbShape(
+                    enabledThumbRadius: 5,
+                  ),
+                  activeTrackColor: fg,
+                  inactiveTrackColor: fg.withValues(alpha: 0.3),
+                  thumbColor: fg,
+                  overlayShape: SliderComponentShape.noOverlay,
+                ),
+                child: Slider(
+                  value: _duration.inMilliseconds > 0
+                      ? _position.inMilliseconds / _duration.inMilliseconds
+                      : 0,
+                  onChanged: (v) {
+                    final target = Duration(
+                      milliseconds: (v * _duration.inMilliseconds).round(),
+                    );
+                    _player.seek(target);
+                  },
+                ),
+              ),
+            ),
+            const SizedBox(width: 6),
+            Text(
+              _formatDuration(
+                _isPlaying || _position > Duration.zero ? _position : _duration,
+              ),
+              style: TextStyle(fontSize: 11, color: fg),
+            ),
+          ],
+        ),
+        // Collapsible transcript.
+        if (hasTranscript) ...[
+          const SizedBox(height: 4),
+          GestureDetector(
+            onTap: () =>
+                setState(() => _transcriptExpanded = !_transcriptExpanded),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(
+                  _transcriptExpanded ? Icons.expand_less : Icons.expand_more,
+                  size: 16,
+                  color: fg.withValues(alpha: 0.7),
+                ),
+                const SizedBox(width: 4),
+                Flexible(
+                  child: Text(
+                    _transcriptExpanded
+                        ? widget.transcript
+                        : _truncate(widget.transcript, 40),
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: fg.withValues(alpha: 0.7),
+                      fontStyle: FontStyle.italic,
+                    ),
+                    maxLines: _transcriptExpanded ? null : 1,
+                    overflow: _transcriptExpanded
+                        ? TextOverflow.visible
+                        : TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+
+  static String _truncate(String text, int maxLen) {
+    if (text.length <= maxLen) return text;
+    return '${text.substring(0, maxLen)}\u2026';
   }
 }

--- a/app/test/unit/chat/chat_provider_test.dart
+++ b/app/test/unit/chat/chat_provider_test.dart
@@ -186,6 +186,46 @@ void main() {
     });
   });
 
+  group('ChatMessage.copyWith — audioBytes / audioMimeType', () {
+    test('preserves audioBytes and audioMimeType through copyWith', () {
+      final bytes = Uint8List.fromList([10, 20, 30]);
+      final msg = ChatMessage(
+        id: 'v1',
+        role: 'user',
+        content: 'Hello',
+        audioBytes: bytes,
+        audioMimeType: 'audio/webm',
+      );
+      final copy = msg.copyWith(content: 'Updated transcript');
+      expect(copy.audioBytes, same(bytes), reason: 'audioBytes preserved');
+      expect(
+        copy.audioMimeType,
+        'audio/webm',
+        reason: 'audioMimeType preserved',
+      );
+      expect(copy.content, 'Updated transcript');
+    });
+
+    test('defaults to null when not provided', () {
+      final msg = ChatMessage(id: 'v2', role: 'user', content: 'hi');
+      expect(msg.audioBytes, isNull);
+      expect(msg.audioMimeType, isNull);
+    });
+
+    test('copyWith can override audioBytes', () {
+      final msg = ChatMessage(
+        id: 'v3',
+        role: 'user',
+        content: 'test',
+        audioBytes: Uint8List.fromList([1]),
+        audioMimeType: 'audio/mp4',
+      );
+      final newBytes = Uint8List.fromList([2, 3]);
+      final copy = msg.copyWith(audioBytes: newBytes);
+      expect(copy.audioBytes, same(newBytes));
+    });
+  });
+
   group('ChatState.copyWith with pendingQueue', () {
     test('copies pendingQueue when provided', () {
       const state = ChatState();
@@ -664,6 +704,80 @@ void main() {
         expect(assistant.audioId, equals('voice-audio-id'));
       },
     );
+
+    testWidgets('voice message preserves audioBytes on user ChatMessage', (
+      tester,
+    ) async {
+      final fakeApi = _FakeApiClient();
+      final ctrl = fakeApi.enqueueVoiceStream();
+      final audioBytes = Uint8List.fromList([10, 20, 30, 40]);
+
+      final notifier = await _pumpTestApp(tester, fakeApi);
+
+      unawaited(notifier.sendVoiceMessage(audioBytes, 'audio/mp4'));
+      await tester.pump();
+
+      final userMsg = notifier.state.value!.messages.firstWhere(
+        (m) => m.isUser,
+      );
+      expect(
+        userMsg.audioBytes,
+        equals(audioBytes),
+        reason: 'user message should carry the recorded audio bytes',
+      );
+      expect(
+        userMsg.audioMimeType,
+        equals('audio/mp4'),
+        reason: 'user message should carry the audio MIME type',
+      );
+
+      ctrl
+        ..add(const DoneEvent(role: 'assistant', content: 'done'))
+        ..close();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('TranscriptEvent updates content but preserves audioBytes', (
+      tester,
+    ) async {
+      final fakeApi = _FakeApiClient();
+      final ctrl = fakeApi.enqueueVoiceStream();
+      final audioBytes = Uint8List.fromList([5, 6, 7]);
+
+      final notifier = await _pumpTestApp(tester, fakeApi);
+
+      unawaited(notifier.sendVoiceMessage(audioBytes, 'audio/webm'));
+      await tester.pump();
+
+      await tester.runAsync(() async {
+        ctrl.add(const TranscriptEvent('Hello from voice'));
+        await Future<void>.delayed(Duration.zero);
+        ctrl
+          ..add(const DoneEvent(role: 'assistant', content: 'response'))
+          ..close();
+        await Future<void>.delayed(Duration.zero);
+      });
+      await tester.pumpAndSettle();
+
+      final userMsg = notifier.state.value!.messages.firstWhere(
+        (m) => m.isUser,
+      );
+      expect(
+        userMsg.content,
+        equals('Hello from voice'),
+        reason: 'TranscriptEvent should update user message content',
+      );
+      expect(
+        userMsg.audioBytes,
+        equals(audioBytes),
+        reason: 'audioBytes must survive the TranscriptEvent copyWith',
+      );
+      expect(
+        userMsg.audioMimeType,
+        equals('audio/webm'),
+        reason: 'audioMimeType must survive the TranscriptEvent copyWith',
+      );
+    });
   });
 
   // -- tokenStream tests ------------------------------------------------------

--- a/app/test/widget/features/chat/chat_screen_test.dart
+++ b/app/test/widget/features/chat/chat_screen_test.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:assistant_api/assistant_api.dart' hide ServerCapabilities;
 import 'package:assistant_app/api/api_client.dart';
 import 'package:assistant_app/api/capabilities_provider.dart';
@@ -649,6 +651,94 @@ void main() {
         findsOneWidget,
         reason: 'Tapping thumbnail should open full-size image dialog',
       );
+    });
+  });
+
+  group('Chat screen — voice message player', () {
+    testWidgets(
+      'voice message with audioBytes renders player instead of text',
+      (tester) async {
+        final res = await pumpChatScreen(tester);
+
+        final msg = ChatMessage(
+          id: 'voice-1',
+          role: 'user',
+          content: 'Hello world',
+          audioBytes: Uint8List.fromList([0, 1, 2, 3]),
+          audioMimeType: 'audio/webm',
+        );
+
+        res.notifier.push(ChatState(conversationId: 'c1', messages: [msg]));
+        await tester.pump();
+
+        // Should find a play button icon.
+        expect(
+          find.byIcon(Icons.play_circle_filled),
+          findsOneWidget,
+          reason: 'Voice message should render a play button',
+        );
+        // Should find the transcript toggle (expand_more chevron).
+        expect(
+          find.byIcon(Icons.expand_more),
+          findsOneWidget,
+          reason: 'Voice message should show collapsed transcript chevron',
+        );
+        // Should NOT render the plain text as a SelectableText.
+        expect(
+          find.widgetWithText(SelectableText, 'Hello world'),
+          findsNothing,
+          reason: 'Voice message should not render content as SelectableText',
+        );
+      },
+    );
+
+    testWidgets('voice message without audioBytes renders as plain text', (
+      tester,
+    ) async {
+      final res = await pumpChatScreen(tester);
+
+      final msg = ChatMessage(
+        id: 'voice-2',
+        role: 'user',
+        content: 'Hello world',
+      );
+
+      res.notifier.push(ChatState(conversationId: 'c1', messages: [msg]));
+      await tester.pump();
+
+      // No play button — regular text message.
+      expect(find.byIcon(Icons.play_circle_filled), findsNothing);
+      expect(
+        find.widgetWithText(SelectableText, 'Hello world'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('tapping transcript chevron toggles expansion', (tester) async {
+      final res = await pumpChatScreen(tester);
+
+      final msg = ChatMessage(
+        id: 'voice-3',
+        role: 'user',
+        content: 'This is a transcript of a voice message that was recorded',
+        audioBytes: Uint8List.fromList([0, 1, 2]),
+        audioMimeType: 'audio/webm',
+      );
+
+      res.notifier.push(ChatState(conversationId: 'c1', messages: [msg]));
+      await tester.pump();
+
+      // Initially collapsed — chevron points down.
+      expect(find.byIcon(Icons.expand_more), findsOneWidget);
+      expect(find.byIcon(Icons.expand_less), findsNothing);
+
+      // Tap the transcript area to expand.
+      await tester.tap(find.byIcon(Icons.expand_more));
+      await tester.pump();
+
+      // Now expanded — chevron points up.
+      expect(find.byIcon(Icons.expand_less), findsOneWidget);
+      expect(find.byIcon(Icons.expand_more), findsNothing);
     });
   });
 }

--- a/app/test/widget/features/chat/chat_screen_test.dart
+++ b/app/test/widget/features/chat/chat_screen_test.dart
@@ -740,5 +740,79 @@ void main() {
       expect(find.byIcon(Icons.expand_less), findsOneWidget);
       expect(find.byIcon(Icons.expand_more), findsNothing);
     });
+
+    testWidgets(
+      'voice message with placeholder content hides transcript section',
+      (tester) async {
+        final res = await pumpChatScreen(tester);
+
+        final msg = ChatMessage(
+          id: 'voice-4',
+          role: 'user',
+          content: '🎤 Voice message',
+          audioBytes: Uint8List.fromList([0, 1, 2]),
+          audioMimeType: 'audio/webm',
+        );
+
+        res.notifier.push(ChatState(conversationId: 'c1', messages: [msg]));
+        await tester.pump();
+
+        // Player should be present.
+        expect(find.byIcon(Icons.play_circle_filled), findsOneWidget);
+        // Transcript chevron should NOT be present — placeholder is not a
+        // real transcript.
+        expect(
+          find.byIcon(Icons.expand_more),
+          findsNothing,
+          reason: 'Placeholder content should not show transcript toggle',
+        );
+      },
+    );
+
+    testWidgets('voice message renders a Slider for progress', (tester) async {
+      final res = await pumpChatScreen(tester);
+
+      final msg = ChatMessage(
+        id: 'voice-5',
+        role: 'user',
+        content: 'Some transcript',
+        audioBytes: Uint8List.fromList([0, 1, 2]),
+        audioMimeType: 'audio/webm',
+      );
+
+      res.notifier.push(ChatState(conversationId: 'c1', messages: [msg]));
+      await tester.pump();
+
+      expect(
+        find.byType(Slider),
+        findsOneWidget,
+        reason: 'Voice player should have a progress slider',
+      );
+    });
+
+    testWidgets(
+      'assistant message with audioBytes does not show voice player',
+      (tester) async {
+        final res = await pumpChatScreen(tester);
+
+        // Only user messages should render the voice player.
+        final msg = ChatMessage(
+          id: 'assistant-voice',
+          role: 'assistant',
+          content: 'Response text',
+          audioBytes: Uint8List.fromList([0, 1]),
+          audioMimeType: 'audio/webm',
+        );
+
+        res.notifier.push(ChatState(conversationId: 'c1', messages: [msg]));
+        await tester.pump();
+
+        expect(
+          find.byIcon(Icons.play_circle_filled),
+          findsNothing,
+          reason: 'Assistant messages should not render inline voice player',
+        );
+      },
+    );
   });
 }

--- a/openspec/changes/voice-message-audio-player/design.md
+++ b/openspec/changes/voice-message-audio-player/design.md
@@ -1,0 +1,86 @@
+## Context
+
+When a user records and sends a voice message, the flow in `chat_provider.dart` `_streamVoiceMessage()` works as follows:
+
+1. A user `ChatMessage` is created with placeholder text `"🎤 Voice message"` and `status: sending` (line 848)
+2. Audio bytes are uploaded to the server via `api.sendVoiceMessage(conversationId, audioBytes, mimeType)` (line 870)
+3. When `TranscriptEvent` arrives (line 878), the user message content is **replaced** with the transcript text and the audio bytes are discarded
+4. The original recorded audio is never stored on the `ChatMessage` — it only exists as a local variable during `_streamVoiceMessage()`
+
+The `AudioPlayerWidget` already exists for assistant TTS playback but uses lazy-loaded bytes from a server endpoint. For user voice messages, the bytes are available locally — no server fetch needed.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Render user voice messages as a mini inline audio player with play/pause and progress
+- Show the transcript collapsed by default below the player, expandable on tap
+- Preserve audio bytes on the `ChatMessage` so they survive state updates during streaming
+- Reuse or adapt the existing `AudioPlayerWidget` for the inline player
+
+**Non-Goals:**
+
+- Waveform visualisation (out of scope — use a simple linear progress bar)
+- Persisting audio bytes across app restarts (bytes are in-memory only; on reload, show transcript-only)
+- Changing the server API or adding audio download endpoints for user messages
+
+## Decisions
+
+### D1: Add `audioBytes` and `audioMimeType` fields to `ChatMessage`
+
+**Choice:** Add two nullable fields to `ChatMessage`:
+
+```dart
+final Uint8List? audioBytes;
+final String? audioMimeType;
+```
+
+**Why:** The audio bytes are available as a parameter to `_streamVoiceMessage()`. Storing them on the message is the simplest way to make them available to the rendering layer. The fields are final (set once at creation, preserved through `copyWith`).
+
+**Alternative considered:** Store audio in a separate `Map<String, Uint8List>` provider keyed by message ID. Rejected — adds indirection and a second state to keep in sync. The bytes belong to the message.
+
+### D2: Populate audio on the initial user message, not on TranscriptEvent
+
+**Choice:** Set `audioBytes` and `audioMimeType` on the user `ChatMessage` when it's first created (line 848), before streaming starts. The `TranscriptEvent` handler updates `content` but leaves audio fields unchanged via `copyWith`.
+
+**Why:** The audio bytes are available at message creation time. Setting them early means they're never at risk of being lost during state transitions.
+
+### D3: Render as mini player + collapsible transcript
+
+**Choice:** When `message.isUser && message.audioBytes != null`, render:
+
+1. A compact audio player row (play/pause icon button + linear progress bar + duration label)
+2. Below it, a collapsed transcript row: chevron + first ~40 chars of transcript, tap to expand full text
+
+**Why:** Matches the user's stated preference. The audio is primary (it's what they recorded), the transcript is secondary (machine-generated, may contain errors).
+
+**Layout:**
+
+```
+┌────────────────────────────────────────┐
+│  ▶  ━━━━━━━━●━━━━━━━━━━━  0:04        │
+│  ▸ "What's the weather in Berlin t..." │
+└────────────────────────────────────────┘
+```
+
+### D4: Reuse `audioplayers` package with `BytesSource`
+
+**Choice:** Use the same `audioplayers` package and `BytesSource(audioBytes)` pattern as `AudioPlayerWidget`. Extract shared playback logic if the overlap is significant, otherwise keep a separate `_VoiceMessagePlayer` widget to avoid over-abstracting.
+
+**Why:** `audioplayers` is already a dependency. `BytesSource` works well for in-memory audio. No additional packages needed.
+
+### D5: On conversation reload, fall back to transcript-only
+
+**Choice:** When loading from history (`loadConversation`), user voice messages won't have `audioBytes` (the server doesn't store raw audio for download). These messages render as plain transcript text — same as today.
+
+**Why:** Adding a server-side audio download endpoint is out of scope. The audio player is a live-session enhancement. Users who reload will see the transcript, which is the permanent record.
+
+## Risks / Trade-offs
+
+- **Memory usage:** Storing audio bytes (~50-200KB per message) in the widget tree. For a typical session with a few voice messages this is negligible. If a user sends dozens of long voice messages, memory could grow. Mitigation: audio is `Uint8List` (compact), and messages are disposed when navigating away from the conversation.
+- **`copyWith` overhead:** `Uint8List` is copied by reference in `copyWith`, not cloned. This is correct — the bytes are immutable after recording.
+- **MIME type compatibility:** `audioplayers` `BytesSource` handles MP3, AAC, Opus, and WAV. The recorder outputs one of these formats (platform-dependent). No conversion needed.
+
+## Migration Plan
+
+No migration. New fields default to `null`. Existing messages and stored history are unaffected.

--- a/openspec/changes/voice-message-audio-player/proposal.md
+++ b/openspec/changes/voice-message-audio-player/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+When a user sends a voice message, the recorded audio is uploaded and the user bubble is completely replaced with the transcript text. The original audio is discarded and cannot be replayed. Users expect to see their voice message rendered as an audio player (like WhatsApp, Telegram, iMessage) with the transcript available but secondary.
+
+## What Changes
+
+- Preserve recorded audio bytes and MIME type on the user `ChatMessage` after sending
+- Render user voice messages as a mini audio player widget (play/pause, waveform/progress bar, duration)
+- Show the transcript collapsed by default below the player, expandable on tap
+- Keep the transcript as the message `content` for search and history purposes
+
+## Capabilities
+
+### New Capabilities
+
+- `voice-message-playback`: User voice messages render as mini audio players with play/pause and progress
+- `voice-message-transcript-toggle`: Transcript text is collapsed by default, expandable on tap
+
+### Modified Capabilities
+
+- `chat-voice-send`: Voice message flow preserves audio bytes on the `ChatMessage` instead of discarding them
+
+## Impact
+
+- `app/lib/features/chat/chat_provider.dart` — Add `audioBytes` and `audioMimeType` fields to `ChatMessage`; preserve audio in `_streamVoiceMessage()` when `TranscriptEvent` arrives
+- `app/lib/features/chat/chat_screen.dart` — Render user bubbles with `audioBytes != null` as mini audio player + collapsible transcript instead of plain text
+- New widget or reuse of `AudioPlayerWidget` adapted for inline user message display
+- No backend changes (audio bytes are already available client-side during the send flow)
+- No API changes

--- a/openspec/changes/voice-message-audio-player/tasks.md
+++ b/openspec/changes/voice-message-audio-player/tasks.md
@@ -1,0 +1,14 @@
+## Tasks
+
+- [ ] Add `audioBytes` (`Uint8List?`) and `audioMimeType` (`String?`) fields to `ChatMessage` in `chat_provider.dart`
+- [ ] Update `ChatMessage.copyWith()` to pass through `audioBytes` and `audioMimeType`
+- [ ] In `_streamVoiceMessage()`: set `audioBytes` and `audioMimeType` on the initial user `ChatMessage` (line 848)
+- [ ] In `_streamVoiceMessage()` `TranscriptEvent` handler: preserve audio fields when updating content via `copyWith`
+- [ ] Create `_VoiceMessagePlayer` widget: play/pause button + linear progress bar + duration label, using `audioplayers` `BytesSource`
+- [ ] Create `_CollapsibleTranscript` widget: single-line preview with chevron, expandable to full text on tap
+- [ ] In `_MessageBubble`: when `message.isUser && message.audioBytes != null`, render `_VoiceMessagePlayer` + `_CollapsibleTranscript` instead of `SelectableText`
+- [ ] Handle playback lifecycle: dispose `AudioPlayer` when widget is removed from tree
+- [ ] Test: record and send voice message, verify mini player appears with working play/pause
+- [ ] Test: tap transcript chevron, verify transcript expands and collapses
+- [ ] Test: reload conversation, verify voice message falls back to transcript-only display
+- [ ] Test: send voice message while another is playing, verify no audio conflicts


### PR DESCRIPTION
## Summary

- User voice messages now render as a mini audio player (play/pause + progress slider + duration) instead of replacing the audio with transcript text
- Audio bytes and MIME type are preserved on `ChatMessage` via new `audioBytes` and `audioMimeType` fields
- Transcript is shown collapsed below the player with a chevron toggle to expand
- On conversation reload (no in-memory audio), falls back to plain transcript text (existing behavior)
- Includes OpenSpec proposal, design, and tasks

## Test plan

- [x] Voice message with `audioBytes` renders play button, not SelectableText (new test)
- [x] Voice message without `audioBytes` renders as plain text (new test)
- [x] Tapping transcript chevron toggles expansion (new test)
- [x] Full Flutter test suite passes (325 tests)
- [ ] Manual: record and send voice message, verify mini player appears
- [ ] Manual: tap play, verify audio plays with progress bar
- [ ] Manual: reload conversation, verify voice message falls back to transcript