### PR TITLE
fix(workflow): await task handle after abort to fix flaky test

### DIFF
--- a/crates/workflow/tests/engine_integration.rs
+++ b/crates/workflow/tests/engine_integration.rs
@@ -93,6 +93,7 @@ async fn runner_executes_action_and_persists_step_output() {
     let handle = spawn_workflow_runner(storage.clone(), Duration::from_millis(20), executors);
     tokio::time::sleep(Duration::from_millis(150)).await;
     handle.abort();
+    let _ = handle.await; // ensure the task's DB connection is returned to the pool
 
     let run = store
         .get_run(workflow_id, run_id)
@@ -134,6 +135,7 @@ async fn schedule_adapter_creates_schedule_run() {
     let handle = spawn_schedule_trigger_adapter(storage.clone(), Duration::from_millis(20));
     tokio::time::sleep(Duration::from_millis(120)).await;
     handle.abort();
+    let _ = handle.await; // ensure the task's DB connection is returned to the pool
 
     let runs = store
         .list_runs(workflow_id, 10)
@@ -186,6 +188,7 @@ async fn event_adapter_creates_run_from_done_bus_message() {
 
     tokio::time::sleep(Duration::from_millis(150)).await;
     handle.abort();
+    let _ = handle.await; // ensure the task's DB connection is returned to the pool
 
     let runs = store
         .list_runs(workflow_id, 10)


### PR DESCRIPTION
## Summary

- Fix flaky CI test `runner_executes_action_and_persists_step_output` that intermittently fails with `no such table: workflow_runs`
- Root cause: `handle.abort()` can cancel a tokio task mid-query, leaving the SQLite pool connection in a bad state. The pool then creates a fresh `:memory:` connection that lacks migrated tables.
- Fix: `let _ = handle.await;` after each `abort()` ensures the task's DB connection is fully returned to the pool before the test continues querying

## Test plan

- [x] `cargo test -p assistant-workflow --test engine_integration` passes locally
- [x] CI should no longer flake on this test