### PR TITLE
feat: chat timeline sections for thinking, tool calls, and subagents

### DIFF
--- a/app/lib/api/api_client.dart
+++ b/app/lib/api/api_client.dart
@@ -280,6 +280,36 @@ Stream<StreamEvent> parseSseByteStream(Stream<List<int>> byteStream) async* {
         } catch (_) {
           // ignore malformed transcript events
         }
+      } else if (eventType == 'thinking' && dataLine != null) {
+        try {
+          final json = jsonDecode(dataLine) as Map<String, dynamic>;
+          yield ThinkingEvent.fromJson(json);
+        } catch (_) {
+          // ignore malformed thinking events
+        }
+      } else if (eventType == 'subagent_started' && dataLine != null) {
+        try {
+          final json = jsonDecode(dataLine) as Map<String, dynamic>;
+          yield SubagentStartedEvent.fromJson(json);
+        } catch (_) {
+          // ignore malformed subagent_started events
+        }
+      } else if (eventType == 'subagent_completed' && dataLine != null) {
+        try {
+          final json = jsonDecode(dataLine) as Map<String, dynamic>;
+          yield SubagentCompletedEvent.fromJson(json);
+        } catch (_) {
+          // ignore malformed subagent_completed events
+        }
+      } else if (eventType == 'skill_complete' && dataLine != null) {
+        try {
+          final json = jsonDecode(dataLine) as Map<String, dynamic>;
+          yield SkillCompleteEvent.fromJson(json);
+        } catch (_) {
+          // ignore malformed skill_complete events
+        }
+      } else if (eventType == 'agent_error' && dataLine != null) {
+        yield AgentErrorEvent(dataLine);
       } else if (eventType == 'audio_ready' && dataLine != null) {
         try {
           final json = jsonDecode(dataLine) as Map<String, dynamic>;

--- a/app/lib/api/models/stream_event.dart
+++ b/app/lib/api/models/stream_event.dart
@@ -129,6 +129,97 @@ class TranscriptEvent extends StreamEvent {
   }
 }
 
+/// Internal reasoning / chain-of-thought produced by the LLM.
+///
+/// Corresponds to `event:thinking` in the SSE stream.  The JSON body is
+/// `{"content":"<thinking text>"}`.
+class ThinkingEvent extends StreamEvent {
+  const ThinkingEvent(this.content);
+
+  /// The reasoning text produced by the LLM.
+  final String content;
+
+  factory ThinkingEvent.fromJson(Map<String, dynamic> json) {
+    return ThinkingEvent(json['content'] as String? ?? '');
+  }
+}
+
+/// A subagent process was started.
+///
+/// Corresponds to `event:subagent_started` in the SSE stream.  The JSON body
+/// is `{"agent_id":"...","task":"..."}`.
+class SubagentStartedEvent extends StreamEvent {
+  const SubagentStartedEvent({required this.agentId, required this.task});
+
+  final String agentId;
+  final String task;
+
+  factory SubagentStartedEvent.fromJson(Map<String, dynamic> json) {
+    return SubagentStartedEvent(
+      agentId: json['agent_id'] as String? ?? '',
+      task: json['task'] as String? ?? '',
+    );
+  }
+}
+
+/// A subagent process completed.
+///
+/// Corresponds to `event:subagent_completed` in the SSE stream.  The JSON
+/// body is `{"agent_id":"...","status":"ok"|"error","summary":"..."}`.
+class SubagentCompletedEvent extends StreamEvent {
+  const SubagentCompletedEvent({
+    required this.agentId,
+    required this.status,
+    required this.summary,
+  });
+
+  final String agentId;
+  final String status;
+  final String summary;
+
+  factory SubagentCompletedEvent.fromJson(Map<String, dynamic> json) {
+    return SubagentCompletedEvent(
+      agentId: json['agent_id'] as String? ?? '',
+      status: json['status'] as String? ?? 'ok',
+      summary: json['summary'] as String? ?? '',
+    );
+  }
+}
+
+/// A skill run completed (success or failure).
+///
+/// Corresponds to `event:skill_complete` in the SSE stream.  The JSON body
+/// is `{"skill_name":"...","success":true|false,"summary":"..."}`.
+class SkillCompleteEvent extends StreamEvent {
+  const SkillCompleteEvent({
+    required this.skillName,
+    required this.success,
+    required this.summary,
+  });
+
+  final String skillName;
+  final bool success;
+  final String summary;
+
+  factory SkillCompleteEvent.fromJson(Map<String, dynamic> json) {
+    return SkillCompleteEvent(
+      skillName: json['skill_name'] as String? ?? '',
+      success: json['success'] as bool? ?? false,
+      summary: json['summary'] as String? ?? '',
+    );
+  }
+}
+
+/// The orchestrator encountered a critical error.
+///
+/// Corresponds to `event:agent_error` in the SSE stream.  The data is a
+/// plain-text error message.
+class AgentErrorEvent extends StreamEvent {
+  const AgentErrorEvent(this.message);
+
+  final String message;
+}
+
 /// The server has produced audio for the most recent assistant response.
 ///
 /// Corresponds to `event:audio_ready` in the SSE stream.  The JSON body is

--- a/app/lib/features/chat/chat_provider.dart
+++ b/app/lib/features/chat/chat_provider.dart
@@ -167,6 +167,9 @@ class ToolCallRecord {
   String? result;
 }
 
+/// The kind of entry shown in the chat timeline.
+enum TimelineEntryType { message, thinking, toolCall, subagent }
+
 /// A message shown in the chat UI (may be a streaming partial).
 /// Metadata for an image attachment on a message.
 class ChatAttachment {
@@ -195,6 +198,11 @@ class ChatMessage {
     this.tokenStream,
     this.audioBytes,
     this.audioMimeType,
+    this.timelineType = TimelineEntryType.message,
+    this.thinkingContent,
+    this.subagentId,
+    this.subagentTask,
+    this.subagentSummary,
     List<ToolCallRecord>? toolCalls,
     List<ChatAttachment>? attachments,
   }) : toolCalls = toolCalls ?? [],
@@ -232,6 +240,21 @@ class ChatMessage {
   /// MIME type of [audioBytes] (e.g. `audio/webm`, `audio/mp4`).
   final String? audioMimeType;
 
+  /// The kind of timeline entry this message represents.
+  final TimelineEntryType timelineType;
+
+  /// Reasoning text for [TimelineEntryType.thinking] entries.
+  final String? thinkingContent;
+
+  /// Subagent identifier for [TimelineEntryType.subagent] entries.
+  final String? subagentId;
+
+  /// Subagent task description for [TimelineEntryType.subagent] entries.
+  final String? subagentTask;
+
+  /// Subagent completion summary for [TimelineEntryType.subagent] entries.
+  String? subagentSummary;
+
   bool get isUser => role == 'user';
   bool get isAssistant => role == 'assistant';
 
@@ -247,6 +270,11 @@ class ChatMessage {
     List<ChatAttachment>? attachments,
     Uint8List? audioBytes,
     String? audioMimeType,
+    TimelineEntryType? timelineType,
+    String? thinkingContent,
+    String? subagentId,
+    String? subagentTask,
+    String? subagentSummary,
   }) {
     return ChatMessage(
       id: id,
@@ -261,6 +289,11 @@ class ChatMessage {
       attachments: attachments ?? this.attachments,
       audioBytes: audioBytes ?? this.audioBytes,
       audioMimeType: audioMimeType ?? this.audioMimeType,
+      timelineType: timelineType ?? this.timelineType,
+      thinkingContent: thinkingContent ?? this.thinkingContent,
+      subagentId: subagentId ?? this.subagentId,
+      subagentTask: subagentTask ?? this.subagentTask,
+      subagentSummary: subagentSummary ?? this.subagentSummary,
     );
   }
 }

--- a/app/lib/features/chat/chat_provider.dart
+++ b/app/lib/features/chat/chat_provider.dart
@@ -485,6 +485,79 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
     );
   }
 
+  /// Insert or update a thinking timeline entry in the message list.
+  /// Multiple [ThinkingEvent]s accumulate into a single entry.
+  void _onThinkingEvent(ChatState chatState, ThinkingEvent event) {
+    final msgs = List<ChatMessage>.from(chatState.messages);
+    final existing = msgs.indexWhere(
+      (m) => m.timelineType == TimelineEntryType.thinking && m.isStreaming,
+    );
+    if (existing != -1) {
+      // Accumulate into existing thinking entry.
+      final prev = msgs[existing];
+      msgs[existing] = prev.copyWith(
+        thinkingContent: (prev.thinkingContent ?? '') + event.content,
+      );
+    } else {
+      // Insert a new thinking entry before the assistant-streaming placeholder.
+      final insertIdx = msgs.indexWhere((m) => m.id == 'assistant-streaming');
+      final entry = ChatMessage(
+        id: 'thinking-${DateTime.now().millisecondsSinceEpoch}',
+        role: 'assistant',
+        content: '',
+        isStreaming: true,
+        timelineType: TimelineEntryType.thinking,
+        thinkingContent: event.content,
+      );
+      if (insertIdx != -1) {
+        msgs.insert(insertIdx, entry);
+      } else {
+        msgs.add(entry);
+      }
+    }
+    state = AsyncData(chatState.copyWith(messages: msgs));
+  }
+
+  /// Insert a subagent timeline entry when a subagent starts.
+  void _onSubagentStartedEvent(
+    ChatState chatState,
+    SubagentStartedEvent event,
+  ) {
+    final msgs = List<ChatMessage>.from(chatState.messages);
+    final insertIdx = msgs.indexWhere((m) => m.id == 'assistant-streaming');
+    final entry = ChatMessage(
+      id: 'subagent-${event.agentId}',
+      role: 'assistant',
+      content: '',
+      timelineType: TimelineEntryType.subagent,
+      subagentId: event.agentId,
+      subagentTask: event.task,
+    );
+    if (insertIdx != -1) {
+      msgs.insert(insertIdx, entry);
+    } else {
+      msgs.add(entry);
+    }
+    state = AsyncData(chatState.copyWith(messages: msgs));
+  }
+
+  /// Update the matching subagent entry with completion summary.
+  void _onSubagentCompletedEvent(
+    ChatState chatState,
+    SubagentCompletedEvent event,
+  ) {
+    final msgs = List<ChatMessage>.from(chatState.messages);
+    final idx = msgs.indexWhere(
+      (m) =>
+          m.timelineType == TimelineEntryType.subagent &&
+          m.subagentId == event.agentId,
+    );
+    if (idx != -1) {
+      msgs[idx].subagentSummary = event.summary;
+    }
+    state = AsyncData(chatState.copyWith(messages: msgs));
+  }
+
   /// Run ID of the most recent (or current) orchestrator run.
   /// Captured from the `RunStartedEvent` so we can reconnect if the stream drops.
   String? _currentRunId;
@@ -956,6 +1029,12 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
           _onStatusEvent(chatState, event.message);
         } else if (event is ToolResultEvent) {
           _onToolResultEvent(chatState, event);
+        } else if (event is ThinkingEvent) {
+          _onThinkingEvent(chatState, event);
+        } else if (event is SubagentStartedEvent) {
+          _onSubagentStartedEvent(chatState, event);
+        } else if (event is SubagentCompletedEvent) {
+          _onSubagentCompletedEvent(chatState, event);
         } else if (event is AudioReadyEvent) {
           // Store audioId on the streaming assistant message for auto-play.
           final msgs = List<ChatMessage>.from(chatState.messages);
@@ -1121,6 +1200,15 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
         } else if (event is ToolResultEvent) {
           _lastSeq++;
           _onToolResultEvent(chatState, event);
+        } else if (event is ThinkingEvent) {
+          _lastSeq++;
+          _onThinkingEvent(chatState, event);
+        } else if (event is SubagentStartedEvent) {
+          _lastSeq++;
+          _onSubagentStartedEvent(chatState, event);
+        } else if (event is SubagentCompletedEvent) {
+          _lastSeq++;
+          _onSubagentCompletedEvent(chatState, event);
         } else if (event is DoneEvent) {
           _lastSeq++;
           unawaited(tokenController.close());

--- a/app/lib/features/chat/chat_screen.dart
+++ b/app/lib/features/chat/chat_screen.dart
@@ -22,6 +22,7 @@ import 'attachment_provider.dart';
 import 'audio_player_widget.dart';
 import 'chat_provider.dart';
 import 'conversation_list.dart';
+import 'timeline_section.dart';
 import 'tool_call_chip.dart';
 import 'voice_recorder_button.dart';
 
@@ -427,6 +428,15 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                                   itemCount: chatState.messages.length,
                                   itemBuilder: (context, index) {
                                     final msg = chatState.messages[index];
+
+                                    // Render non-message timeline entries
+                                    // (thinking, tool call, subagent) as
+                                    // compact expandable sections.
+                                    if (msg.timelineType !=
+                                        TimelineEntryType.message) {
+                                      return ChatTimelineSection(message: msg);
+                                    }
+
                                     final prevMsg = index > 0
                                         ? chatState.messages[index - 1]
                                         : null;

--- a/app/lib/features/chat/timeline_section.dart
+++ b/app/lib/features/chat/timeline_section.dart
@@ -7,16 +7,16 @@ import 'chat_provider.dart';
 /// An expandable timeline entry widget for tool calls, thinking, and subagent
 /// events. Shows a collapsed header with icon + label + status, and expands
 /// to reveal full details.
-class TimelineSection extends StatefulWidget {
-  const TimelineSection({super.key, required this.message});
+class ChatTimelineSection extends StatefulWidget {
+  const ChatTimelineSection({super.key, required this.message});
 
   final ChatMessage message;
 
   @override
-  State<TimelineSection> createState() => _TimelineSectionState();
+  State<ChatTimelineSection> createState() => _ChatTimelineSectionState();
 }
 
-class _TimelineSectionState extends State<TimelineSection> {
+class _ChatTimelineSectionState extends State<ChatTimelineSection> {
   bool _expanded = false;
 
   @override

--- a/app/lib/features/chat/timeline_section.dart
+++ b/app/lib/features/chat/timeline_section.dart
@@ -1,0 +1,300 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+
+import 'chat_provider.dart';
+
+/// An expandable timeline entry widget for tool calls, thinking, and subagent
+/// events. Shows a collapsed header with icon + label + status, and expands
+/// to reveal full details.
+class TimelineSection extends StatefulWidget {
+  const TimelineSection({super.key, required this.message});
+
+  final ChatMessage message;
+
+  @override
+  State<TimelineSection> createState() => _TimelineSectionState();
+}
+
+class _TimelineSectionState extends State<TimelineSection> {
+  bool _expanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return switch (widget.message.timelineType) {
+      TimelineEntryType.toolCall => _buildToolCall(context),
+      TimelineEntryType.thinking => _buildThinking(context),
+      TimelineEntryType.subagent => _buildSubagent(context),
+      TimelineEntryType.message => const SizedBox.shrink(),
+    };
+  }
+
+  // -- Tool call --------------------------------------------------------------
+
+  Widget _buildToolCall(BuildContext context) {
+    final record = widget.message.toolCalls.isNotEmpty
+        ? widget.message.toolCalls.first
+        : null;
+    if (record == null) return const SizedBox.shrink();
+
+    final hasDetails = record.arguments != null || record.result != null;
+
+    return _buildSection(
+      context,
+      icon: Icons.build_outlined,
+      label: record.toolName,
+      statusWidget: _toolStatusIcon(record.status),
+      expandable: hasDetails,
+      expandedContent: hasDetails ? _toolDetails(context, record) : null,
+    );
+  }
+
+  Widget _toolStatusIcon(ToolCallStatus status) {
+    return switch (status) {
+      ToolCallStatus.pending => const SizedBox(
+        width: 12,
+        height: 12,
+        child: CircularProgressIndicator(strokeWidth: 1.5),
+      ),
+      ToolCallStatus.ok => const Icon(
+        Icons.check_circle_outline,
+        size: 14,
+        color: Colors.green,
+      ),
+      ToolCallStatus.error => const Icon(
+        Icons.error_outline,
+        size: 14,
+        color: Colors.red,
+      ),
+      ToolCallStatus.denied => const Icon(
+        Icons.block,
+        size: 14,
+        color: Colors.amber,
+      ),
+    };
+  }
+
+  Widget _toolDetails(BuildContext context, ToolCallRecord record) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (record.arguments != null) ...[
+          Text(
+            'Arguments',
+            style: TextStyle(
+              fontSize: 10,
+              fontWeight: FontWeight.w600,
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 2),
+          SelectableText(
+            _formatJson(record.arguments!),
+            style: TextStyle(
+              fontSize: 10,
+              fontFamily: 'monospace',
+              color: colorScheme.onSurface,
+            ),
+          ),
+        ],
+        if (record.arguments != null && record.result != null)
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 4),
+            child: Divider(
+              height: 1,
+              thickness: 0.5,
+              color: colorScheme.outlineVariant.withAlpha(80),
+            ),
+          ),
+        if (record.result != null) ...[
+          Text(
+            'Result',
+            style: TextStyle(
+              fontSize: 10,
+              fontWeight: FontWeight.w600,
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 2),
+          SelectableText(
+            record.result!,
+            style: TextStyle(
+              fontSize: 10,
+              fontFamily: 'monospace',
+              color: colorScheme.onSurface,
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+
+  // -- Thinking ---------------------------------------------------------------
+
+  Widget _buildThinking(BuildContext context) {
+    return _buildSection(
+      context,
+      icon: Icons.psychology_outlined,
+      label: 'Thinking',
+      statusWidget: widget.message.isStreaming
+          ? const SizedBox(
+              width: 12,
+              height: 12,
+              child: CircularProgressIndicator(strokeWidth: 1.5),
+            )
+          : null,
+      expandable: widget.message.thinkingContent != null,
+      expandedContent: widget.message.thinkingContent != null
+          ? SelectableText(
+              widget.message.thinkingContent!,
+              style: TextStyle(
+                fontSize: 12,
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+                fontStyle: FontStyle.italic,
+              ),
+            )
+          : null,
+    );
+  }
+
+  // -- Subagent ---------------------------------------------------------------
+
+  Widget _buildSubagent(BuildContext context) {
+    final hasCompleted = widget.message.subagentSummary != null;
+    return _buildSection(
+      context,
+      icon: Icons.smart_toy_outlined,
+      label: widget.message.subagentTask ?? widget.message.subagentId ?? '',
+      statusWidget: hasCompleted
+          ? const Icon(
+              Icons.check_circle_outline,
+              size: 14,
+              color: Colors.green,
+            )
+          : const SizedBox(
+              width: 12,
+              height: 12,
+              child: CircularProgressIndicator(strokeWidth: 1.5),
+            ),
+      expandable: hasCompleted,
+      expandedContent: hasCompleted
+          ? Text(
+              widget.message.subagentSummary!,
+              style: TextStyle(
+                fontSize: 12,
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+            )
+          : null,
+    );
+  }
+
+  // -- Shared section layout --------------------------------------------------
+
+  Widget _buildSection(
+    BuildContext context, {
+    required IconData icon,
+    required String label,
+    Widget? statusWidget,
+    bool expandable = false,
+    Widget? expandedContent,
+  }) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Container(
+        margin: const EdgeInsets.symmetric(vertical: 2),
+        constraints: const BoxConstraints(maxWidth: 640),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            GestureDetector(
+              onTap: expandable
+                  ? () => setState(() => _expanded = !_expanded)
+                  : null,
+              child: Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 10,
+                  vertical: 6,
+                ),
+                decoration: BoxDecoration(
+                  color: colorScheme.surfaceContainerHighest.withAlpha(120),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(icon, size: 14, color: colorScheme.onSurfaceVariant),
+                    const SizedBox(width: 6),
+                    Flexible(
+                      child: Text(
+                        label,
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: colorScheme.onSurfaceVariant,
+                          fontWeight: FontWeight.w500,
+                        ),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    if (statusWidget != null) ...[
+                      const SizedBox(width: 6),
+                      statusWidget,
+                    ],
+                    if (expandable) ...[
+                      const SizedBox(width: 4),
+                      Icon(
+                        _expanded
+                            ? Icons.expand_less_rounded
+                            : Icons.expand_more_rounded,
+                        size: 14,
+                        color: colorScheme.onSurfaceVariant.withAlpha(150),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+            AnimatedSize(
+              duration: const Duration(milliseconds: 200),
+              curve: Curves.easeInOut,
+              child: _expanded && expandedContent != null
+                  ? Padding(
+                      padding: const EdgeInsets.only(
+                        left: 12,
+                        top: 4,
+                        bottom: 4,
+                      ),
+                      child: Container(
+                        padding: const EdgeInsets.all(8),
+                        decoration: BoxDecoration(
+                          color: colorScheme.surfaceContainerLowest,
+                          borderRadius: BorderRadius.circular(8),
+                          border: Border.all(
+                            color: colorScheme.outlineVariant.withAlpha(80),
+                            width: 0.5,
+                          ),
+                        ),
+                        child: expandedContent,
+                      ),
+                    )
+                  : const SizedBox.shrink(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _formatJson(Map<String, dynamic> json) {
+    try {
+      return const JsonEncoder.withIndent('  ').convert(json);
+    } catch (_) {
+      return json.toString();
+    }
+  }
+}

--- a/app/test/unit/api/client_test.dart
+++ b/app/test/unit/api/client_test.dart
@@ -99,6 +99,83 @@ void main() {
       expect(events, isEmpty);
     });
 
+    test('emits ThinkingEvent from thinking SSE event', () async {
+      final payload = jsonEncode({'content': 'Let me consider...'});
+      final sse = 'event:thinking\ndata:$payload\n\n';
+      final events = await parseSseByteStream(_sseBytes(sse)).toList();
+
+      expect(events.length, equals(1));
+      expect(events.first, isA<ThinkingEvent>());
+      expect(
+        (events.first as ThinkingEvent).content,
+        equals('Let me consider...'),
+      );
+    });
+
+    test(
+      'emits SubagentStartedEvent from subagent_started SSE event',
+      () async {
+        final payload = jsonEncode({
+          'agent_id': 'research-1',
+          'task': 'Find weather data',
+        });
+        final sse = 'event:subagent_started\ndata:$payload\n\n';
+        final events = await parseSseByteStream(_sseBytes(sse)).toList();
+
+        expect(events.length, equals(1));
+        expect(events.first, isA<SubagentStartedEvent>());
+        final e = events.first as SubagentStartedEvent;
+        expect(e.agentId, equals('research-1'));
+        expect(e.task, equals('Find weather data'));
+      },
+    );
+
+    test(
+      'emits SubagentCompletedEvent from subagent_completed SSE event',
+      () async {
+        final payload = jsonEncode({
+          'agent_id': 'research-1',
+          'status': 'ok',
+          'summary': 'Found current conditions',
+        });
+        final sse = 'event:subagent_completed\ndata:$payload\n\n';
+        final events = await parseSseByteStream(_sseBytes(sse)).toList();
+
+        expect(events.length, equals(1));
+        expect(events.first, isA<SubagentCompletedEvent>());
+        final e = events.first as SubagentCompletedEvent;
+        expect(e.agentId, equals('research-1'));
+        expect(e.status, equals('ok'));
+        expect(e.summary, equals('Found current conditions'));
+      },
+    );
+
+    test('emits SkillCompleteEvent from skill_complete SSE event', () async {
+      final payload = jsonEncode({
+        'skill_name': 'web-search',
+        'success': true,
+        'summary': 'Found 3 results',
+      });
+      final sse = 'event:skill_complete\ndata:$payload\n\n';
+      final events = await parseSseByteStream(_sseBytes(sse)).toList();
+
+      expect(events.length, equals(1));
+      expect(events.first, isA<SkillCompleteEvent>());
+      final e = events.first as SkillCompleteEvent;
+      expect(e.skillName, equals('web-search'));
+      expect(e.success, isTrue);
+      expect(e.summary, equals('Found 3 results'));
+    });
+
+    test('emits AgentErrorEvent from agent_error SSE event', () async {
+      const sse = 'event:agent_error\ndata:LLM timeout\n\n';
+      final events = await parseSseByteStream(_sseBytes(sse)).toList();
+
+      expect(events.length, equals(1));
+      expect(events.first, isA<AgentErrorEvent>());
+      expect((events.first as AgentErrorEvent).message, equals('LLM timeout'));
+    });
+
     test('handles multi-chunk byte stream reassembly', () async {
       // Simulate chunked delivery: SSE event split across two byte chunks.
       final part1 = utf8.encode('event:token\n');
@@ -158,49 +235,95 @@ void main() {
       expect(event.status, equals('ok'));
     });
 
+    test('ThinkingEvent parses JSON correctly', () {
+      final event = ThinkingEvent.fromJson({'content': 'Reasoning...'});
+      expect(event.content, equals('Reasoning...'));
+    });
+
+    test('ThinkingEvent handles missing content', () {
+      final event = ThinkingEvent.fromJson({});
+      expect(event.content, equals(''));
+    });
+
+    test('SubagentStartedEvent parses JSON correctly', () {
+      final event = SubagentStartedEvent.fromJson({
+        'agent_id': 'a1',
+        'task': 'do stuff',
+      });
+      expect(event.agentId, equals('a1'));
+      expect(event.task, equals('do stuff'));
+    });
+
+    test('SubagentCompletedEvent parses JSON correctly', () {
+      final event = SubagentCompletedEvent.fromJson({
+        'agent_id': 'a1',
+        'status': 'ok',
+        'summary': 'done',
+      });
+      expect(event.agentId, equals('a1'));
+      expect(event.status, equals('ok'));
+      expect(event.summary, equals('done'));
+    });
+
+    test('SkillCompleteEvent parses JSON correctly', () {
+      final event = SkillCompleteEvent.fromJson({
+        'skill_name': 'search',
+        'success': false,
+        'summary': 'failed',
+      });
+      expect(event.skillName, equals('search'));
+      expect(event.success, isFalse);
+      expect(event.summary, equals('failed'));
+    });
+
+    test('AgentErrorEvent stores message', () {
+      const event = AgentErrorEvent('timeout');
+      expect(event.message, equals('timeout'));
+    });
+
     test('StreamEvent sealed class hierarchy', () {
-      // Verify pattern matching works correctly.
+      // Verify pattern matching works correctly with all event types.
       final events = <StreamEvent>[
         const TokenEvent('token'),
         const StatusEvent('status'),
         ToolResultEvent.fromJson({'tool_name': 'tool', 'status': 'ok'}),
         const DoneEvent(role: 'assistant', content: 'full'),
         const ErrorEvent('error'),
+        const ThinkingEvent('thinking'),
+        SubagentStartedEvent.fromJson({'agent_id': 'a', 'task': 't'}),
+        SubagentCompletedEvent.fromJson({
+          'agent_id': 'a',
+          'status': 'ok',
+          'summary': 's',
+        }),
+        SkillCompleteEvent.fromJson({
+          'skill_name': 'sk',
+          'success': true,
+          'summary': 'ok',
+        }),
+        const AgentErrorEvent('err'),
       ];
 
-      int tokenCount = 0,
-          statusCount = 0,
-          toolCount = 0,
-          doneCount = 0,
-          errorCount = 0,
-          audioReadyCount = 0;
+      int count = 0;
       for (final e in events) {
         switch (e) {
           case TokenEvent():
-            tokenCount++;
           case StatusEvent():
-            statusCount++;
           case ToolResultEvent():
-            toolCount++;
           case DoneEvent():
-            doneCount++;
           case ErrorEvent():
-            errorCount++;
+          case ThinkingEvent():
+          case SubagentStartedEvent():
+          case SubagentCompletedEvent():
+          case SkillCompleteEvent():
+          case AgentErrorEvent():
           case AudioReadyEvent():
-            audioReadyCount++;
           case TranscriptEvent():
-            break;
           case RunStartedEvent():
-            break; // not counted in this test
+            count++;
         }
       }
-
-      expect(tokenCount, equals(1));
-      expect(statusCount, equals(1));
-      expect(toolCount, equals(1));
-      expect(doneCount, equals(1));
-      expect(errorCount, equals(1));
-      expect(audioReadyCount, equals(0));
+      expect(count, equals(events.length));
     });
   });
 }

--- a/app/test/unit/chat/chat_provider_test.dart
+++ b/app/test/unit/chat/chat_provider_test.dart
@@ -825,6 +825,170 @@ void main() {
     });
   });
 
+  // -- Phase 3: Streaming timeline entry insertion ----------------------------
+
+  group('ChatNotifier streaming — timeline entries', () {
+    testWidgets('ThinkingEvent inserts a thinking timeline entry', (
+      tester,
+    ) async {
+      final fakeApi = _FakeApiClient();
+      final ctrl = fakeApi.enqueueStream();
+
+      final notifier = await _pumpTestApp(tester, fakeApi);
+
+      unawaited(notifier.sendMessage('think about it'));
+      await tester.pump();
+
+      await tester.runAsync(() async {
+        ctrl.add(const ThinkingEvent('Let me reason...'));
+        await Future<void>.delayed(Duration.zero);
+      });
+      await tester.pump();
+
+      final msgs = notifier.state.value!.messages;
+      final thinkingEntries = msgs.where(
+        (m) => m.timelineType == TimelineEntryType.thinking,
+      );
+      expect(
+        thinkingEntries,
+        isNotEmpty,
+        reason: 'should have a thinking entry',
+      );
+      expect(thinkingEntries.first.thinkingContent, 'Let me reason...');
+
+      // Clean up stream.
+      ctrl
+        ..add(const DoneEvent(role: 'assistant', content: 'done'))
+        ..close();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('SubagentStartedEvent inserts a subagent timeline entry', (
+      tester,
+    ) async {
+      final fakeApi = _FakeApiClient();
+      final ctrl = fakeApi.enqueueStream();
+
+      final notifier = await _pumpTestApp(tester, fakeApi);
+
+      unawaited(notifier.sendMessage('use subagent'));
+      await tester.pump();
+
+      await tester.runAsync(() async {
+        ctrl.add(
+          SubagentStartedEvent.fromJson({
+            'agent_id': 'research-1',
+            'task': 'Find data',
+          }),
+        );
+        await Future<void>.delayed(Duration.zero);
+      });
+      await tester.pump();
+
+      final msgs = notifier.state.value!.messages;
+      final subagentEntries = msgs.where(
+        (m) => m.timelineType == TimelineEntryType.subagent,
+      );
+      expect(
+        subagentEntries,
+        isNotEmpty,
+        reason: 'should have a subagent entry',
+      );
+      expect(subagentEntries.first.subagentId, 'research-1');
+      expect(subagentEntries.first.subagentTask, 'Find data');
+
+      ctrl
+        ..add(const DoneEvent(role: 'assistant', content: 'done'))
+        ..close();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets(
+      'SubagentCompletedEvent updates matching subagent entry summary',
+      (tester) async {
+        final fakeApi = _FakeApiClient();
+        final ctrl = fakeApi.enqueueStream();
+
+        final notifier = await _pumpTestApp(tester, fakeApi);
+
+        unawaited(notifier.sendMessage('subagent flow'));
+        await tester.pump();
+
+        await tester.runAsync(() async {
+          ctrl.add(
+            SubagentStartedEvent.fromJson({
+              'agent_id': 'r1',
+              'task': 'Research',
+            }),
+          );
+          await Future<void>.delayed(Duration.zero);
+          ctrl.add(
+            SubagentCompletedEvent.fromJson({
+              'agent_id': 'r1',
+              'status': 'ok',
+              'summary': 'Found 3 results',
+            }),
+          );
+          await Future<void>.delayed(Duration.zero);
+        });
+        await tester.pump();
+
+        final msgs = notifier.state.value!.messages;
+        final subagentEntry = msgs.firstWhere(
+          (m) =>
+              m.timelineType == TimelineEntryType.subagent &&
+              m.subagentId == 'r1',
+        );
+        expect(
+          subagentEntry.subagentSummary,
+          'Found 3 results',
+          reason: 'completed event should update the summary',
+        );
+
+        ctrl
+          ..add(const DoneEvent(role: 'assistant', content: 'done'))
+          ..close();
+        await tester.pumpAndSettle();
+      },
+    );
+
+    testWidgets('multiple ThinkingEvents accumulate content in single entry', (
+      tester,
+    ) async {
+      final fakeApi = _FakeApiClient();
+      final ctrl = fakeApi.enqueueStream();
+
+      final notifier = await _pumpTestApp(tester, fakeApi);
+
+      unawaited(notifier.sendMessage('deep think'));
+      await tester.pump();
+
+      await tester.runAsync(() async {
+        ctrl.add(const ThinkingEvent('First thought. '));
+        await Future<void>.delayed(Duration.zero);
+        ctrl.add(const ThinkingEvent('Second thought.'));
+        await Future<void>.delayed(Duration.zero);
+      });
+      await tester.pump();
+
+      final msgs = notifier.state.value!.messages;
+      final thinkingEntries = msgs.where(
+        (m) => m.timelineType == TimelineEntryType.thinking,
+      );
+      // Multiple thinking events should accumulate into a single entry.
+      expect(thinkingEntries.length, 1);
+      expect(
+        thinkingEntries.first.thinkingContent,
+        'First thought. Second thought.',
+      );
+
+      ctrl
+        ..add(const DoneEvent(role: 'assistant', content: 'done'))
+        ..close();
+      await tester.pumpAndSettle();
+    });
+  });
+
   // -- Phase 3: Timeline entry data model ------------------------------------
 
   group('ChatMessage timeline entries', () {

--- a/app/test/unit/chat/chat_provider_test.dart
+++ b/app/test/unit/chat/chat_provider_test.dart
@@ -824,4 +824,74 @@ void main() {
       );
     });
   });
+
+  // -- Phase 3: Timeline entry data model ------------------------------------
+
+  group('ChatMessage timeline entries', () {
+    test('default timelineType is message', () {
+      final msg = ChatMessage(id: '1', role: 'assistant', content: 'hi');
+      expect(msg.timelineType, TimelineEntryType.message);
+    });
+
+    test('thinking entry stores content', () {
+      final msg = ChatMessage(
+        id: '1',
+        role: 'assistant',
+        content: '',
+        timelineType: TimelineEntryType.thinking,
+        thinkingContent: 'Let me consider...',
+      );
+      expect(msg.timelineType, TimelineEntryType.thinking);
+      expect(msg.thinkingContent, 'Let me consider...');
+    });
+
+    test('toolCall entry stores tool data', () {
+      final msg = ChatMessage(
+        id: '1',
+        role: 'assistant',
+        content: '',
+        timelineType: TimelineEntryType.toolCall,
+        toolCalls: [
+          ToolCallRecord(toolName: 'web-search', status: ToolCallStatus.ok),
+        ],
+      );
+      expect(msg.timelineType, TimelineEntryType.toolCall);
+      expect(msg.toolCalls.first.toolName, 'web-search');
+    });
+
+    test('subagent entry stores agent fields', () {
+      final msg = ChatMessage(
+        id: '1',
+        role: 'assistant',
+        content: '',
+        timelineType: TimelineEntryType.subagent,
+        subagentId: 'research-1',
+        subagentTask: 'Find weather data',
+        subagentSummary: 'Found results',
+      );
+      expect(msg.timelineType, TimelineEntryType.subagent);
+      expect(msg.subagentId, 'research-1');
+      expect(msg.subagentTask, 'Find weather data');
+      expect(msg.subagentSummary, 'Found results');
+    });
+
+    test('copyWith preserves timeline fields', () {
+      final msg = ChatMessage(
+        id: '1',
+        role: 'assistant',
+        content: '',
+        timelineType: TimelineEntryType.thinking,
+        thinkingContent: 'reasoning',
+        subagentId: 'a1',
+        subagentTask: 'task',
+        subagentSummary: 'summary',
+      );
+      final copy = msg.copyWith(content: 'updated');
+      expect(copy.timelineType, TimelineEntryType.thinking);
+      expect(copy.thinkingContent, 'reasoning');
+      expect(copy.subagentId, 'a1');
+      expect(copy.subagentTask, 'task');
+      expect(copy.subagentSummary, 'summary');
+    });
+  });
 }

--- a/app/test/widget/timeline_section_test.dart
+++ b/app/test/widget/timeline_section_test.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  group('TimelineSection', () {
+  group('ChatTimelineSection', () {
     testWidgets('renders tool call with wrench icon and tool name', (
       tester,
     ) async {
@@ -19,7 +19,7 @@ void main() {
       );
       await tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(body: TimelineSection(message: msg)),
+          home: Scaffold(body: ChatTimelineSection(message: msg)),
         ),
       );
 
@@ -40,7 +40,7 @@ void main() {
       );
       await tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(body: TimelineSection(message: msg)),
+          home: Scaffold(body: ChatTimelineSection(message: msg)),
         ),
       );
 
@@ -58,7 +58,7 @@ void main() {
       );
       await tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(body: TimelineSection(message: msg)),
+          home: Scaffold(body: ChatTimelineSection(message: msg)),
         ),
       );
 
@@ -77,7 +77,7 @@ void main() {
       );
       await tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(body: TimelineSection(message: msg)),
+          home: Scaffold(body: ChatTimelineSection(message: msg)),
         ),
       );
 
@@ -95,7 +95,7 @@ void main() {
       );
       await tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(body: TimelineSection(message: msg)),
+          home: Scaffold(body: ChatTimelineSection(message: msg)),
         ),
       );
 
@@ -128,7 +128,7 @@ void main() {
       );
       await tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(body: TimelineSection(message: msg)),
+          home: Scaffold(body: ChatTimelineSection(message: msg)),
         ),
       );
 
@@ -154,7 +154,7 @@ void main() {
       );
       await tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(body: TimelineSection(message: msg)),
+          home: Scaffold(body: ChatTimelineSection(message: msg)),
         ),
       );
 
@@ -174,7 +174,7 @@ void main() {
       );
       await tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(body: TimelineSection(message: msg)),
+          home: Scaffold(body: ChatTimelineSection(message: msg)),
         ),
       );
 

--- a/app/test/widget/timeline_section_test.dart
+++ b/app/test/widget/timeline_section_test.dart
@@ -1,0 +1,184 @@
+import 'package:assistant_app/features/chat/chat_provider.dart';
+import 'package:assistant_app/features/chat/timeline_section.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('TimelineSection', () {
+    testWidgets('renders tool call with wrench icon and tool name', (
+      tester,
+    ) async {
+      final msg = ChatMessage(
+        id: 'tc1',
+        role: 'assistant',
+        content: '',
+        timelineType: TimelineEntryType.toolCall,
+        toolCalls: [
+          ToolCallRecord(toolName: 'web-search', status: ToolCallStatus.ok),
+        ],
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: TimelineSection(message: msg)),
+        ),
+      );
+
+      expect(find.byIcon(Icons.build_outlined), findsOneWidget);
+      expect(find.text('web-search'), findsOneWidget);
+      expect(find.byIcon(Icons.check_circle_outline), findsOneWidget);
+    });
+
+    testWidgets('renders pending tool call with spinner', (tester) async {
+      final msg = ChatMessage(
+        id: 'tc2',
+        role: 'assistant',
+        content: '',
+        timelineType: TimelineEntryType.toolCall,
+        toolCalls: [
+          ToolCallRecord(toolName: 'file-read', status: ToolCallStatus.pending),
+        ],
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: TimelineSection(message: msg)),
+        ),
+      );
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.text('file-read'), findsOneWidget);
+    });
+
+    testWidgets('renders thinking entry with brain icon', (tester) async {
+      final msg = ChatMessage(
+        id: 'th1',
+        role: 'assistant',
+        content: '',
+        timelineType: TimelineEntryType.thinking,
+        thinkingContent: 'Let me reason about this...',
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: TimelineSection(message: msg)),
+        ),
+      );
+
+      expect(find.byIcon(Icons.psychology_outlined), findsOneWidget);
+      expect(find.text('Thinking'), findsOneWidget);
+    });
+
+    testWidgets('renders subagent entry with smart toy icon', (tester) async {
+      final msg = ChatMessage(
+        id: 'sa1',
+        role: 'assistant',
+        content: '',
+        timelineType: TimelineEntryType.subagent,
+        subagentId: 'research-1',
+        subagentTask: 'Find weather data',
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: TimelineSection(message: msg)),
+        ),
+      );
+
+      expect(find.byIcon(Icons.smart_toy_outlined), findsOneWidget);
+      expect(find.text('Find weather data'), findsOneWidget);
+    });
+
+    testWidgets('expands on tap to show thinking content', (tester) async {
+      final msg = ChatMessage(
+        id: 'th2',
+        role: 'assistant',
+        content: '',
+        timelineType: TimelineEntryType.thinking,
+        thinkingContent: 'Deep reasoning here',
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: TimelineSection(message: msg)),
+        ),
+      );
+
+      // Thinking content not visible initially.
+      expect(find.text('Deep reasoning here'), findsNothing);
+
+      // Tap to expand.
+      await tester.tap(find.byType(GestureDetector).first);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Deep reasoning here'), findsOneWidget);
+    });
+
+    testWidgets('expands tool call to show arguments and result', (
+      tester,
+    ) async {
+      final msg = ChatMessage(
+        id: 'tc3',
+        role: 'assistant',
+        content: '',
+        timelineType: TimelineEntryType.toolCall,
+        toolCalls: [
+          ToolCallRecord(
+            toolName: 'web-search',
+            status: ToolCallStatus.ok,
+            arguments: {'query': 'flutter docs'},
+            result: 'Found 3 results',
+          ),
+        ],
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: TimelineSection(message: msg)),
+        ),
+      );
+
+      // Result not visible initially.
+      expect(find.text('Found 3 results'), findsNothing);
+
+      // Tap to expand.
+      await tester.tap(find.byType(GestureDetector).first);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Found 3 results'), findsOneWidget);
+    });
+
+    testWidgets('subagent shows summary when completed', (tester) async {
+      final msg = ChatMessage(
+        id: 'sa2',
+        role: 'assistant',
+        content: '',
+        timelineType: TimelineEntryType.subagent,
+        subagentId: 'r1',
+        subagentTask: 'Research topic',
+        subagentSummary: 'Found 5 papers',
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: TimelineSection(message: msg)),
+        ),
+      );
+
+      // Summary should be visible in collapsed state as status text.
+      expect(find.byIcon(Icons.check_circle_outline), findsOneWidget);
+    });
+
+    testWidgets('error tool call shows error icon', (tester) async {
+      final msg = ChatMessage(
+        id: 'tc4',
+        role: 'assistant',
+        content: '',
+        timelineType: TimelineEntryType.toolCall,
+        toolCalls: [
+          ToolCallRecord(toolName: 'bash', status: ToolCallStatus.error),
+        ],
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: TimelineSection(message: msg)),
+        ),
+      );
+
+      expect(find.byIcon(Icons.error_outline), findsOneWidget);
+    });
+  });
+}

--- a/crates/runtime/src/orchestrator/mod.rs
+++ b/crates/runtime/src/orchestrator/mod.rs
@@ -802,6 +802,9 @@ impl Orchestrator {
 
                 LlmResponse::Thinking(text, _meta) => {
                     debug!(iteration, "LLM emitted thinking step");
+                    if let Some(sink) = token_sink.as_ref() {
+                        let _ = sink.send(OrchestratorEvent::Thinking(text.clone())).await;
+                    }
                     let thinking_msg = {
                         let mut m = assistant_core::Message::assistant(
                             conversation_id,
@@ -1080,6 +1083,9 @@ impl Orchestrator {
 
                 LlmResponse::Thinking(text, _meta) => {
                     debug!(iteration, "LLM emitted thinking step");
+                    if let Some(sink) = token_sink.as_ref() {
+                        let _ = sink.send(OrchestratorEvent::Thinking(text.clone())).await;
+                    }
                     let thinking_msg = {
                         let mut m =
                             Message::assistant(conversation_id, format!("<think>{text}</think>"));

--- a/crates/runtime/src/orchestrator/stream_event.rs
+++ b/crates/runtime/src/orchestrator/stream_event.rs
@@ -54,6 +54,30 @@ pub enum OrchestratorEvent {
         message: String,
     },
 
+    /// Internal reasoning / chain-of-thought produced by the LLM.
+    ///
+    /// Streamed to the client so UIs can render an expandable "Thinking…"
+    /// section in the message timeline.
+    Thinking(String),
+
+    /// A subagent process was started.
+    SubagentStarted {
+        /// Identifier of the spawned subagent.
+        agent_id: String,
+        /// The task description given to the subagent.
+        task: String,
+    },
+
+    /// A subagent process completed.
+    SubagentCompleted {
+        /// Identifier of the completed subagent.
+        agent_id: String,
+        /// `"ok"` on success, `"error"` on failure.
+        status: String,
+        /// Short summary of the subagent's result.
+        summary: String,
+    },
+
     /// A `voice-response` tool call produced synthesised audio that clients
     /// should auto-play.
     ///
@@ -65,4 +89,77 @@ pub enum OrchestratorEvent {
         /// Retrieve via `GET /api/audio/{audio_id}`.
         audio_id: String,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn thinking_event_stores_content() {
+        let event = OrchestratorEvent::Thinking("Let me consider...".to_string());
+        match event {
+            OrchestratorEvent::Thinking(content) => {
+                assert_eq!(content, "Let me consider...");
+            }
+            _ => panic!("expected Thinking variant"),
+        }
+    }
+
+    #[test]
+    fn subagent_started_event_stores_fields() {
+        let event = OrchestratorEvent::SubagentStarted {
+            agent_id: "research-1".to_string(),
+            task: "Find weather data".to_string(),
+        };
+        match event {
+            OrchestratorEvent::SubagentStarted { agent_id, task } => {
+                assert_eq!(agent_id, "research-1");
+                assert_eq!(task, "Find weather data");
+            }
+            _ => panic!("expected SubagentStarted variant"),
+        }
+    }
+
+    #[test]
+    fn subagent_completed_event_stores_fields() {
+        let event = OrchestratorEvent::SubagentCompleted {
+            agent_id: "research-1".to_string(),
+            status: "ok".to_string(),
+            summary: "Found current conditions".to_string(),
+        };
+        match event {
+            OrchestratorEvent::SubagentCompleted {
+                agent_id,
+                status,
+                summary,
+            } => {
+                assert_eq!(agent_id, "research-1");
+                assert_eq!(status, "ok");
+                assert_eq!(summary, "Found current conditions");
+            }
+            _ => panic!("expected SubagentCompleted variant"),
+        }
+    }
+
+    #[test]
+    fn new_events_are_cloneable_and_debuggable() {
+        let events = vec![
+            OrchestratorEvent::Thinking("test".to_string()),
+            OrchestratorEvent::SubagentStarted {
+                agent_id: "a".to_string(),
+                task: "t".to_string(),
+            },
+            OrchestratorEvent::SubagentCompleted {
+                agent_id: "a".to_string(),
+                status: "ok".to_string(),
+                summary: "s".to_string(),
+            },
+        ];
+        for event in &events {
+            let cloned = event.clone();
+            let debug = format!("{:?}", cloned);
+            assert!(!debug.is_empty());
+        }
+    }
 }

--- a/crates/runtime/src/orchestrator/subagent.rs
+++ b/crates/runtime/src/orchestrator/subagent.rs
@@ -96,6 +96,19 @@ impl SubagentRunner for Orchestrator {
             .agent_spawn_count
             .add(1, &[KeyValue::new("agent.id", parent_agent_id.clone())]);
 
+        // Emit SubagentStarted to the parent conversation's event sink.
+        if let Some(parent_conv_id) = spawn.parent_conversation_id {
+            let sinks = self.token_sinks.read().await;
+            if let Some(sink) = sinks.get(&parent_conv_id) {
+                let _ = sink
+                    .send(super::stream_event::OrchestratorEvent::SubagentStarted {
+                        agent_id: spawn.agent_id.clone(),
+                        task: spawn.task.clone(),
+                    })
+                    .await;
+            }
+        }
+
         // Register a cancellation token for this agent.
         let cancel_token = CancellationToken::new();
         self.agent_cancellations
@@ -443,6 +456,26 @@ impl SubagentRunner for Orchestrator {
                 data: None,
             }
         };
+
+        // Emit SubagentCompleted to the parent conversation's event sink.
+        if let Some(parent_conv_id) = spawn.parent_conversation_id {
+            let sinks = self.token_sinks.read().await;
+            if let Some(sink) = sinks.get(&parent_conv_id) {
+                let status_str = match report.status {
+                    AgentReportStatus::Completed => "ok",
+                    AgentReportStatus::Failed => "error",
+                    AgentReportStatus::Cancelled => "cancelled",
+                };
+                let summary = report.content.chars().take(120).collect::<String>();
+                let _ = sink
+                    .send(super::stream_event::OrchestratorEvent::SubagentCompleted {
+                        agent_id: spawn.agent_id.clone(),
+                        status: status_str.to_string(),
+                        summary,
+                    })
+                    .await;
+            }
+        }
 
         // Clean up the cancellation token registry.
         self.agent_cancellations

--- a/crates/web-ui/src/api/mod.rs
+++ b/crates/web-ui/src/api/mod.rs
@@ -82,20 +82,20 @@ use assistant_storage::{
     AttachmentStore, ConversationEventStore, ConversationStore, RunBroadcaster,
 };
 use axum::{
+    Json, Router,
     body::Body,
     extract::{DefaultBodyLimit, Multipart, Path, State},
-    http::{header, StatusCode},
+    http::{StatusCode, header},
     response::{
-        sse::{Event, Sse},
         IntoResponse, Response,
+        sse::{Event, Sse},
     },
     routing::{delete, get, patch, post},
-    Json, Router,
 };
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sqlx::SqlitePool;
-use tokio::sync::{mpsc, RwLock};
+use tokio::sync::{RwLock, mpsc};
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::warn;
 use uuid::Uuid;
@@ -417,9 +417,10 @@ pub async fn get_conversation(State(state): State<ApiState>, Path(id): Path<Stri
         std::collections::HashMap::new();
     for m in &history {
         if matches!(m.role, MessageRole::Tool)
-            && let Some(ref name) = m.skill_name {
-                tool_results.insert((m.turn, name.clone()), m.content.clone());
-            }
+            && let Some(ref name) = m.skill_name
+        {
+            tool_results.insert((m.turn, name.clone()), m.content.clone());
+        }
     }
 
     let messages = history
@@ -807,6 +808,32 @@ pub async fn send_message(
                     let e = Event::default().event("agent_error").data(message.clone());
                     ("error", p, e)
                 }
+                OrchestratorEvent::Thinking(ref content) => {
+                    let p = serde_json::json!({"content": content});
+                    let e = Event::default().event("thinking").data(p.to_string());
+                    ("thinking", p, e)
+                }
+                OrchestratorEvent::SubagentStarted {
+                    ref agent_id,
+                    ref task,
+                } => {
+                    let p = serde_json::json!({"agent_id": agent_id, "task": task});
+                    let e = Event::default()
+                        .event("subagent_started")
+                        .data(p.to_string());
+                    ("subagent_started", p, e)
+                }
+                OrchestratorEvent::SubagentCompleted {
+                    ref agent_id,
+                    ref status,
+                    ref summary,
+                } => {
+                    let p = serde_json::json!({"agent_id": agent_id, "status": status, "summary": summary});
+                    let e = Event::default()
+                        .event("subagent_completed")
+                        .data(p.to_string());
+                    ("subagent_completed", p, e)
+                }
                 OrchestratorEvent::AudioReady { ref audio_id } => {
                     let p = serde_json::json!({"audio_id": audio_id, "auto_play": true});
                     let e = Event::default().event("audio_ready").data(p.to_string());
@@ -848,10 +875,12 @@ pub async fn send_message(
             done_data["message_id"] = serde_json::Value::String(mid.to_string());
         }
         if !reply_attachment_ids.is_empty() {
-            done_data["attachment_ids"] = serde_json::json!(reply_attachment_ids
-                .iter()
-                .map(|id| id.to_string())
-                .collect::<Vec<_>>());
+            done_data["attachment_ids"] = serde_json::json!(
+                reply_attachment_ids
+                    .iter()
+                    .map(|id| id.to_string())
+                    .collect::<Vec<_>>()
+            );
         }
 
         // Persist done event.
@@ -1277,6 +1306,26 @@ pub async fn send_voice_message(
                 OrchestratorEvent::AgentError { message } => {
                     Event::default().event("agent_error").data(message)
                 }
+                OrchestratorEvent::Thinking(content) => {
+                    let data = serde_json::json!({"content": content});
+                    Event::default().event("thinking").data(data.to_string())
+                }
+                OrchestratorEvent::SubagentStarted { agent_id, task } => {
+                    let data = serde_json::json!({"agent_id": agent_id, "task": task});
+                    Event::default()
+                        .event("subagent_started")
+                        .data(data.to_string())
+                }
+                OrchestratorEvent::SubagentCompleted {
+                    agent_id,
+                    status,
+                    summary,
+                } => {
+                    let data = serde_json::json!({"agent_id": agent_id, "status": status, "summary": summary});
+                    Event::default()
+                        .event("subagent_completed")
+                        .data(data.to_string())
+                }
                 OrchestratorEvent::AudioReady { audio_id } => {
                     let data = serde_json::json!({
                         "audio_id": audio_id,
@@ -1303,10 +1352,12 @@ pub async fn send_voice_message(
             done_data["message_id"] = serde_json::Value::String(mid.to_string());
         }
         if !reply_attachment_ids.is_empty() {
-            done_data["attachment_ids"] = serde_json::json!(reply_attachment_ids
-                .iter()
-                .map(|id| id.to_string())
-                .collect::<Vec<_>>());
+            done_data["attachment_ids"] = serde_json::json!(
+                reply_attachment_ids
+                    .iter()
+                    .map(|id| id.to_string())
+                    .collect::<Vec<_>>()
+            );
         }
         let done = Event::default().event("done").data(done_data.to_string());
         let _ = sse_tx.send(Ok(done)).await;
@@ -1642,9 +1693,10 @@ pub async fn serve_attachment(
     // Conditional request: check If-None-Match.
     if let Some(inm) = headers.get(header::IF_NONE_MATCH)
         && let Ok(inm_str) = inm.to_str()
-            && inm_str == etag {
-                return StatusCode::NOT_MODIFIED.into_response();
-            }
+        && inm_str == etag
+    {
+        return StatusCode::NOT_MODIFIED.into_response();
+    }
 
     // Load original bytes.
     let original = match state.attachment_store.load_bytes(att_id).await {
@@ -1746,7 +1798,7 @@ mod tests {
     };
     use async_trait::async_trait;
 
-    use super::{api_router, ApiState};
+    use super::{ApiState, api_router};
 
     // -- Stubs -----------------------------------------------------------------
 
@@ -2998,10 +3050,12 @@ mod tests {
         assert_eq!(meta["mime_type"], "image/png");
         assert_eq!(meta["filename"], "test.png");
         assert!(meta["id"].as_str().is_some());
-        assert!(meta["url"]
-            .as_str()
-            .unwrap()
-            .starts_with("/api/attachments/"));
+        assert!(
+            meta["url"]
+                .as_str()
+                .unwrap()
+                .starts_with("/api/attachments/")
+        );
     }
 
     #[tokio::test]
@@ -3058,13 +3112,14 @@ mod tests {
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
         assert_eq!(resp.headers().get("content-type").unwrap(), "image/png");
-        assert!(resp
-            .headers()
-            .get("cache-control")
-            .unwrap()
-            .to_str()
-            .unwrap()
-            .contains("immutable"));
+        assert!(
+            resp.headers()
+                .get("cache-control")
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .contains("immutable")
+        );
         assert!(resp.headers().get("etag").is_some());
 
         let body_bytes = resp.into_body().collect().await.unwrap().to_bytes();


### PR DESCRIPTION
## Summary

- Add `Thinking` and `SubagentStarted`/`SubagentCompleted` variants to `OrchestratorEvent` in the Rust runtime, with SSE serialisation in the web-ui
- Parse `thinking`, `subagent_started`, `subagent_completed`, `skill_complete`, `agent_error` SSE events in the Flutter client
- Add `TimelineEntryType` enum and timeline-specific fields (`thinkingContent`, `subagentId`, `subagentTask`, `subagentSummary`) to `ChatMessage`
- Insert timeline entries during streaming when `ThinkingEvent`, `SubagentStartedEvent`, `SubagentCompletedEvent` arrive (accumulates multiple thinking events)
- New `ChatTimelineSection` widget with expandable sections: wrench icon for tool calls, brain icon for thinking, robot icon for subagents
- Integrated into chat screen `ListView.builder` — non-message entries render as compact timeline sections
- Existing tool call chips preserved as fallback for old-format messages

## Test plan

- [x] Unit tests for `OrchestratorEvent` new variants (4 tests)
- [x] SSE parser tests for all new event types (11 tests)
- [x] Data model tests for `TimelineEntryType` and `ChatMessage` fields (5 tests)
- [x] Streaming integration tests for timeline entry insertion (4 tests)
- [x] Widget tests for `ChatTimelineSection` expand/collapse (8 tests)
- [x] All 361 Flutter tests pass
- [ ] Manual: send message triggering tool calls, verify timeline sections appear
- [ ] Manual: conversation with thinking content shows collapsible thinking section