### PR TITLE
fix(web-ui): vendor swagger-ui assets to avoid CI download failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6969,8 +6969,15 @@ dependencies = [
  "serde_json",
  "url",
  "utoipa",
+ "utoipa-swagger-ui-vendored",
  "zip",
 ]
+
+[[package]]
+name = "utoipa-swagger-ui-vendored"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ async-nats = "0.47"
 testcontainers = "0.27"
 # OpenAPI spec generation
 utoipa = { version = "5.4", features = ["chrono", "uuid"] }
-utoipa-swagger-ui = { version = "9.0", features = ["axum"] }
+utoipa-swagger-ui = { version = "9.0", features = ["axum", "vendored"] }
 testcontainers-modules = { version = "0.15", features = ["nats"] }
 wiremock = "0.6"
 tempfile = "3"


### PR DESCRIPTION
## Summary
- Adds the `vendored` feature to `utoipa-swagger-ui`, which bundles Swagger UI assets via `utoipa-swagger-ui-vendored` instead of downloading a zip from GitHub at compile time
- Fixes transient CI failures caused by network issues during the build script download (e.g. rate limits, corrupt archives: `"Could not find EOCD"`)

## Test plan
- [x] `cargo check -p assistant-web-ui` passes
- [x] `make lint` passes
- [x] `make format` passes
- [x] Pre-commit hooks pass (clippy, machete, Flutter tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency configuration to optimize build and distribution setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->