### PR TITLE
fix(ci): configure manual code signing for iOS archive in CI

### DIFF
--- a/app/fastlane/Fastfile
+++ b/app/fastlane/Fastfile
@@ -36,6 +36,19 @@ platform :ios do
     # Sync certificates and provisioning profiles (readonly in CI).
     match(type: "appstore")
 
+    # Switch Runner target to manual signing with the App Store profile
+    # installed by match. Without this, xcodebuild uses the project's default
+    # signing identity ("iPhone Developer") and fails to find a matching
+    # provisioning profile in CI.
+    update_code_signing_settings(
+      use_automatic_signing: false,
+      path: "ios/Runner.xcodeproj",
+      team_id: "WPW3QSLZ2F",
+      code_sign_identity: "iPhone Distribution",
+      profile_name: ENV["sigh_com.cedricziel.assistant.ios_appstore_profile-name"] || "match AppStore com.cedricziel.assistant.ios",
+      targets: ["Runner"]
+    )
+
     # Set build number from CI environment (or local fallback).
     build_number = ENV["BUILD_NUMBER"] || number_of_commits.to_s
     increment_build_number(


### PR DESCRIPTION
## Summary
- Fixes the iOS TestFlight build failure where `gym` (xcodebuild archive) fails with "No profiles for 'com.cedricziel.assistant.ios' were found: Xcode couldn't find any iOS App Development provisioning profiles"
- Root cause: `match(type: "appstore")` installs an App Store distribution profile, but the Xcode project's default `CODE_SIGN_IDENTITY` is `"iPhone Developer"` — so xcodebuild looks for a development profile that doesn't exist
- Adds `update_code_signing_settings` after `match` to explicitly switch the Runner target to manual signing with `"iPhone Distribution"` and the correct App Store profile

## Test plan
- [ ] Merge and verify the `Build & Upload iOS to TestFlight` job passes on the next release