### PR TITLE
chore(app): declare export compliance for iOS and macOS

### DIFF
--- a/app/ios/Runner/Info.plist
+++ b/app/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>CFBundleDevelopmentRegion</key>

--- a/app/macos/Runner/Info.plist
+++ b/app/macos/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
## Summary
- Set `ITSAppUsesNonExemptEncryption` to `NO` in both iOS and macOS `Info.plist` files
- The app only uses standard OS-provided HTTPS encryption, so no export compliance documentation is required
- Prevents App Store Connect from prompting about export compliance on every upload

## Test plan
- [ ] Verify iOS archive uploads to App Store Connect without export compliance prompt
- [ ] Verify macOS archive uploads without export compliance prompt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS and macOS app configuration to include encryption settings declaration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->