### PR TITLE
fix(app): add MaterialLocalizations to CupertinoApp shell

### DIFF
--- a/app/lib/shared/platform/adaptive_app.dart
+++ b/app/lib/shared/platform/adaptive_app.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:go_router/go_router.dart';
 
 import 'platform.dart';
@@ -13,6 +14,10 @@ import 'platform.dart';
 /// - Bouncing scroll physics
 /// - iOS text selection handles
 /// - SF Pro system font
+///
+/// The Cupertino path includes [GlobalMaterialLocalizations] and a
+/// [Material] + [Theme] wrapper so that Material widgets (TextField,
+/// Scaffold, SnackBar, etc.) continue to work inside the Cupertino shell.
 class AdaptiveApp extends StatelessWidget {
   const AdaptiveApp({
     super.key,
@@ -30,6 +35,15 @@ class AdaptiveApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (isAppleTouch) {
+      final brightness = MediaQuery.platformBrightnessOf(context);
+      final materialTheme = ThemeData(
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: _seedColor,
+          brightness: brightness,
+        ),
+        useMaterial3: true,
+      );
+
       return CupertinoApp.router(
         title: title,
         theme: const CupertinoThemeData(
@@ -37,6 +51,20 @@ class AdaptiveApp extends StatelessWidget {
         ),
         routerConfig: routerConfig,
         debugShowCheckedModeBanner: false,
+        localizationsDelegates: const [
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        builder: (context, child) {
+          return Theme(
+            data: materialTheme,
+            child: Material(
+              type: MaterialType.transparency,
+              child: child ?? const SizedBox.shrink(),
+            ),
+          );
+        },
       );
     }
 

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -421,6 +421,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_math_fork:
     dependency: transitive
     description:
@@ -615,6 +620,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.7.1+4"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.2"
   io:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -7,6 +7,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
   flutter_web_plugins:
     sdk: flutter
   cupertino_icons: ^1.0.9
@@ -50,8 +52,8 @@ flutter_launcher_icons:
   web:
     generate: true
     image_path: macos/Runner/Assets.xcassets/AppIcon.appiconset/app_icon_1024.png
-    background_color: '#080C1A'
-    theme_color: '#080C1A'
+    background_color: "#080C1A"
+    theme_color: "#080C1A"
 flutter:
   uses-material-design: true
   assets:


### PR DESCRIPTION
## Summary

- Fixes crash on iOS when any screen with a `TextField` is rendered — `CupertinoApp` doesn't provide `MaterialLocalizations` but Material widgets require them
- Adds `flutter_localizations` SDK dependency
- Injects `GlobalMaterialLocalizations`, `GlobalWidgetsLocalizations`, and `GlobalCupertinoLocalizations` delegates into the Cupertino path
- Wraps routed content in a `Theme` + `Material` widget so `colorScheme` tokens resolve correctly under the Cupertino shell
- Theme brightness tracks system dark/light mode

## Test plan

- [x] `flutter analyze --fatal-infos` — 0 issues
- [x] `flutter test` — 384/384 pass
- [x] `flutter build ios --no-codesign` — succeeds
- [x] `flutter build macos` — succeeds
- [x] `flutter build web` — succeeds
- [ ] Manual: launch on iPhone simulator — verify TextField renders without crash