### PR TITLE
fix(app): pass MIME type to audioplayers BytesSource on iOS

### DIFF
--- a/app/lib/api/api_client.dart
+++ b/app/lib/api/api_client.dart
@@ -181,7 +181,9 @@ class ApiClient {
   }
 
   /// Fetch the audio bytes for a message (GET /api/messages/{id}/audio).
-  Future<Uint8List?> fetchMessageAudio(String messageId) async {
+  Future<({Uint8List bytes, String mimeType})?> fetchMessageAudio(
+    String messageId,
+  ) async {
     try {
       final response = await _dio.get<List<int>>(
         '/api/messages/$messageId/audio',
@@ -191,7 +193,8 @@ class ApiClient {
         ),
       );
       if (response.statusCode == 200 && response.data != null) {
-        return Uint8List.fromList(response.data!);
+        final mime = response.headers.value('content-type') ?? 'audio/mpeg';
+        return (bytes: Uint8List.fromList(response.data!), mimeType: mime);
       }
     } catch (_) {
       // ignore
@@ -200,7 +203,9 @@ class ApiClient {
   }
 
   /// Fetch audio bytes by audio ID (GET /api/audio/{id}).
-  Future<Uint8List?> fetchAudio(String audioId) async {
+  Future<({Uint8List bytes, String mimeType})?> fetchAudio(
+    String audioId,
+  ) async {
     try {
       final response = await _dio.get<List<int>>(
         '/api/audio/$audioId',
@@ -210,7 +215,8 @@ class ApiClient {
         ),
       );
       if (response.statusCode == 200 && response.data != null) {
-        return Uint8List.fromList(response.data!);
+        final mime = response.headers.value('content-type') ?? 'audio/mpeg';
+        return (bytes: Uint8List.fromList(response.data!), mimeType: mime);
       }
     } catch (_) {
       // ignore

--- a/app/lib/features/chat/audio_player_widget.dart
+++ b/app/lib/features/chat/audio_player_widget.dart
@@ -10,8 +10,8 @@ import 'package:flutter/material.dart';
 class AudioPlayerWidget extends StatefulWidget {
   const AudioPlayerWidget({super.key, required this.fetchAudio});
 
-  /// Called once to obtain the audio bytes.  Returns `null` on failure.
-  final Future<Uint8List?> Function() fetchAudio;
+  /// Called once to obtain the audio bytes and MIME type.  Returns `null` on failure.
+  final Future<({Uint8List bytes, String mimeType})?> Function() fetchAudio;
 
   @override
   State<AudioPlayerWidget> createState() => _AudioPlayerWidgetState();
@@ -22,7 +22,7 @@ class _AudioPlayerWidgetState extends State<AudioPlayerWidget> {
   bool _isPlaying = false;
   bool _isLoading = false;
   bool _hasError = false;
-  Uint8List? _cachedBytes;
+  ({Uint8List bytes, String mimeType})? _cachedAudio;
 
   @override
   void initState() {
@@ -50,9 +50,9 @@ class _AudioPlayerWidgetState extends State<AudioPlayerWidget> {
       _hasError = false;
     });
     try {
-      _cachedBytes ??= await widget.fetchAudio();
-      final bytes = _cachedBytes;
-      if (bytes == null || !mounted) {
+      _cachedAudio ??= await widget.fetchAudio();
+      final audio = _cachedAudio;
+      if (audio == null || !mounted) {
         if (mounted) {
           setState(() {
             _isLoading = false;
@@ -62,7 +62,7 @@ class _AudioPlayerWidgetState extends State<AudioPlayerWidget> {
         return;
       }
 
-      await _player.play(BytesSource(bytes));
+      await _player.play(BytesSource(audio.bytes, mimeType: audio.mimeType));
       if (mounted) {
         setState(() {
           _isPlaying = true;
@@ -70,7 +70,7 @@ class _AudioPlayerWidgetState extends State<AudioPlayerWidget> {
         });
       }
     } catch (_) {
-      _cachedBytes = null; // clear so retry re-fetches
+      _cachedAudio = null; // clear so retry re-fetches
       if (mounted) {
         setState(() {
           _isLoading = false;

--- a/app/lib/features/chat/chat_screen.dart
+++ b/app/lib/features/chat/chat_screen.dart
@@ -556,7 +556,8 @@ class _MessageBubble extends StatelessWidget {
   final VoidCallback? onRetry;
   final VoidCallback? onStop;
   final ServerCapabilities capabilities;
-  final Future<Uint8List?> Function() fetchMessageAudio;
+  final Future<({Uint8List bytes, String mimeType})?> Function()
+  fetchMessageAudio;
   final String? imageBaseUrl;
   final String? imageAuthToken;
 
@@ -608,6 +609,7 @@ class _MessageBubble extends StatelessWidget {
                       if (message.audioBytes != null)
                         _VoiceMessagePlayer(
                           audioBytes: message.audioBytes!,
+                          audioMimeType: message.audioMimeType,
                           transcript: message.content,
                           foregroundColor: colorScheme.onPrimary,
                         )
@@ -900,7 +902,8 @@ class _MetaActionRow extends StatelessWidget {
 
   final ChatMessage message;
   final ServerCapabilities capabilities;
-  final Future<Uint8List?> Function() fetchMessageAudio;
+  final Future<({Uint8List bytes, String mimeType})?> Function()
+  fetchMessageAudio;
   final VoidCallback? onRetry;
   final VoidCallback? onStop;
 
@@ -1043,7 +1046,7 @@ class _ReadAloudAction extends StatefulWidget {
     required this.color,
   });
 
-  final Future<Uint8List?> Function() fetchAudio;
+  final Future<({Uint8List bytes, String mimeType})?> Function() fetchAudio;
   final Color color;
 
   @override
@@ -1053,7 +1056,7 @@ class _ReadAloudAction extends StatefulWidget {
 class _ReadAloudActionState extends State<_ReadAloudAction> {
   final _player = AudioPlayer();
   _ReadAloudState _state = _ReadAloudState.idle;
-  Uint8List? _cachedBytes;
+  ({Uint8List bytes, String mimeType})? _cachedAudio;
   Timer? _errorTimer;
 
   @override
@@ -1080,13 +1083,15 @@ class _ReadAloudActionState extends State<_ReadAloudAction> {
       case _ReadAloudState.error:
         setState(() => _state = _ReadAloudState.loading);
         try {
-          _cachedBytes ??= await widget.fetchAudio();
-          final bytes = _cachedBytes;
-          if (bytes == null || !mounted) {
+          _cachedAudio ??= await widget.fetchAudio();
+          final audio = _cachedAudio;
+          if (audio == null || !mounted) {
             _showError();
             return;
           }
-          await _player.play(BytesSource(bytes));
+          await _player.play(
+            BytesSource(audio.bytes, mimeType: audio.mimeType),
+          );
           if (mounted) setState(() => _state = _ReadAloudState.playing);
         } catch (_) {
           _showError();
@@ -1479,11 +1484,13 @@ class _VoiceMessagePlayer extends StatefulWidget {
     required this.audioBytes,
     required this.transcript,
     required this.foregroundColor,
+    this.audioMimeType,
   });
 
   final Uint8List audioBytes;
   final String transcript;
   final Color foregroundColor;
+  final String? audioMimeType;
 
   @override
   State<_VoiceMessagePlayer> createState() => _VoiceMessagePlayerState();
@@ -1527,7 +1534,9 @@ class _VoiceMessagePlayerState extends State<_VoiceMessagePlayer> {
       setState(() => _isPlaying = false);
     } else {
       if (_position == Duration.zero) {
-        await _player.play(BytesSource(widget.audioBytes));
+        await _player.play(
+          BytesSource(widget.audioBytes, mimeType: widget.audioMimeType),
+        );
       } else {
         await _player.resume();
       }

--- a/app/test/widget/features/voice_widgets_test.dart
+++ b/app/test/widget/features/voice_widgets_test.dart
@@ -211,7 +211,10 @@ void main() {
         MaterialApp(
           home: Scaffold(
             body: AudioPlayerWidget(
-              fetchAudio: () async => Uint8List.fromList([1, 2, 3]),
+              fetchAudio: () async => (
+                bytes: Uint8List.fromList([1, 2, 3]),
+                mimeType: 'audio/mpeg',
+              ),
             ),
           ),
         ),
@@ -224,7 +227,7 @@ void main() {
 
     testWidgets('shows spinner while audio is being fetched', (tester) async {
       // Use a Completer that never completes so the fetch stays in-flight.
-      final completer = Completer<Uint8List?>();
+      final completer = Completer<({Uint8List bytes, String mimeType})?>();
 
       await tester.pumpWidget(
         MaterialApp(
@@ -305,7 +308,10 @@ void main() {
               fetchAudio: () async {
                 callCount++;
                 if (callCount == 1) return null; // first call fails
-                return Uint8List.fromList([1, 2, 3]); // retry succeeds
+                return (
+                  bytes: Uint8List.fromList([1, 2, 3]),
+                  mimeType: 'audio/mpeg',
+                ); // retry succeeds
               },
             ),
           ),
@@ -345,7 +351,10 @@ void main() {
             body: AudioPlayerWidget(
               fetchAudio: () async {
                 callCount++;
-                return Uint8List.fromList([1, 2, 3]);
+                return (
+                  bytes: Uint8List.fromList([1, 2, 3]),
+                  mimeType: 'audio/mpeg',
+                );
               },
             ),
           ),


### PR DESCRIPTION
## Summary

- Fixes iOS audio playback crash (`AVPlayerItem.Status.failed`) caused by `audioplayers` writing `BytesSource` bytes to a temp cache file without a file extension
- Extracts `Content-Type` header from server audio responses and passes it as `mimeType` to `BytesSource` across all three playback paths: TTS audio, read-aloud, and user voice messages

## Root cause

On iOS, `audioplayers` internally writes `BytesSource` bytes to a temporary file in the Caches directory (e.g. `/Library/Caches/6df0a`) with no extension. Without a `mimeType` hint, AVPlayer cannot determine the codec and fails with `AVPlayerItem.Status.failed`.

## Changes

- `api_client.dart`: `fetchAudio` and `fetchMessageAudio` now return `({Uint8List bytes, String mimeType})?` instead of `Uint8List?`, extracting `Content-Type` from the Dio response
- `audio_player_widget.dart`: passes `mimeType` to `BytesSource`
- `chat_screen.dart`: `_ReadAloudAction` and `_VoiceMessagePlayer` updated to propagate MIME type to `BytesSource`
- Updated tests to match new return types

## Test plan

- [x] `flutter analyze` — 0 issues
- [x] `flutter test` — all 384 tests pass
- [x] Pre-commit hooks pass (format, clippy, machete, dart checks)
- [ ] Manual verification: play TTS audio on iOS device