### PR TITLE
feat(app): Cupertino page chrome — large titles and adaptive nav bars

### DIFF
--- a/app/lib/features/agents/agents_screen.dart
+++ b/app/lib/features/agents/agents_screen.dart
@@ -1,8 +1,10 @@
 import 'package:assistant_api/assistant_api.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../shared/platform/platform.dart';
 import 'agents_provider.dart';
 
 /// Screen that lists all registered agents.
@@ -12,6 +14,56 @@ class AgentsScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final agentsAsync = ref.watch(agentsProvider);
+
+    if (isAppleTouch) {
+      return Scaffold(
+        body: CustomScrollView(
+          slivers: [
+            CupertinoSliverNavigationBar(
+              largeTitle: const Text('Agents'),
+              trailing: CupertinoButton(
+                padding: EdgeInsets.zero,
+                child: const Icon(CupertinoIcons.refresh),
+                onPressed: () => ref.read(agentsProvider.notifier).refresh(),
+              ),
+            ),
+            agentsAsync.when(
+              loading: () => const SliverFillRemaining(
+                child: Center(child: CircularProgressIndicator()),
+              ),
+              error: (err, _) => SliverFillRemaining(
+                child: _ErrorView(
+                  error: err.toString(),
+                  onRetry: () => ref.read(agentsProvider.notifier).refresh(),
+                ),
+              ),
+              data: (state) {
+                if (state.error != null) {
+                  return SliverFillRemaining(
+                    child: _ErrorView(
+                      error: state.error!,
+                      onRetry: () =>
+                          ref.read(agentsProvider.notifier).refresh(),
+                    ),
+                  );
+                }
+                if (state.agents.isEmpty) {
+                  return const SliverFillRemaining(child: _EmptyView());
+                }
+                return SliverList(
+                  delegate: SliverChildBuilderDelegate((context, index) {
+                    if (index.isOdd) {
+                      return const Divider(height: 1, indent: 72);
+                    }
+                    return _AgentRow(agent: state.agents[index ~/ 2]);
+                  }, childCount: state.agents.length * 2 - 1),
+                );
+              },
+            ),
+          ],
+        ),
+      );
+    }
 
     return Scaffold(
       appBar: AppBar(

--- a/app/lib/features/analytics/analytics_screen.dart
+++ b/app/lib/features/analytics/analytics_screen.dart
@@ -1,7 +1,9 @@
 import 'package:assistant_api/assistant_api.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../shared/platform/platform.dart';
 import 'analytics_provider.dart';
 
 /// Screen showing aggregated assistant usage analytics.
@@ -11,6 +13,46 @@ class AnalyticsScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final analyticsAsync = ref.watch(analyticsProvider);
+
+    if (isAppleTouch) {
+      return Scaffold(
+        body: CustomScrollView(
+          slivers: [
+            CupertinoSliverNavigationBar(
+              largeTitle: const Text('Analytics'),
+              trailing: CupertinoButton(
+                padding: EdgeInsets.zero,
+                child: const Icon(CupertinoIcons.refresh),
+                onPressed: () => ref.read(analyticsProvider.notifier).refresh(),
+              ),
+            ),
+            analyticsAsync.when(
+              loading: () => const SliverFillRemaining(
+                child: Center(child: CircularProgressIndicator()),
+              ),
+              error: (err, _) => SliverFillRemaining(
+                child: _ErrorView(
+                  error: err.toString(),
+                  onRetry: () => ref.read(analyticsProvider.notifier).refresh(),
+                ),
+              ),
+              data: (state) {
+                if (state.error != null) {
+                  return SliverFillRemaining(
+                    child: _ErrorView(
+                      error: state.error!,
+                      onRetry: () =>
+                          ref.read(analyticsProvider.notifier).refresh(),
+                    ),
+                  );
+                }
+                return SliverFillRemaining(child: _AnalyticsBody(state: state));
+              },
+            ),
+          ],
+        ),
+      );
+    }
 
     return Scaffold(
       appBar: AppBar(

--- a/app/lib/features/chat/chat_screen.dart
+++ b/app/lib/features/chat/chat_screen.dart
@@ -5,12 +5,14 @@ import 'package:assistant_api/assistant_api.dart' hide ServerCapabilities;
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:desktop_drop/desktop_drop.dart';
 import 'package:file_picker/file_picker.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_smooth_markdown/flutter_smooth_markdown.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../shared/platform/platform.dart';
 import '../../api/api_client.dart';
 import '../../api/attachment_service.dart';
 import '../../api/capabilities_provider.dart';
@@ -281,45 +283,59 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     final imageBaseUrl = activeProfile?.baseUrl;
     final imageAuthToken = activeProfile?.token;
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(activePersonaName),
-        leading: isWide
-            ? null
-            : Builder(
-                builder: (ctx) => IconButton(
-                  icon: const Icon(Icons.menu),
-                  onPressed: () => Scaffold.of(ctx).openDrawer(),
-                ),
-              ),
-        actions: [
-          // Persona picker button.
-          IconButton(
-            key: const Key('persona_picker_button'),
-            icon: const Icon(Icons.switch_account_outlined),
-            tooltip: 'Switch persona',
-            onPressed: () => showPersonaPicker(context),
-          ),
-          // Navigate to traces.
-          IconButton(
-            icon: const Icon(Icons.timeline_outlined),
-            tooltip: 'Traces',
-            onPressed: () => context.go('/traces'),
-          ),
-          // Navigate to logs.
-          IconButton(
-            icon: const Icon(Icons.article_outlined),
-            tooltip: 'Logs',
-            onPressed: () => context.go('/logs'),
-          ),
-          // Navigate to skills.
-          IconButton(
-            icon: const Icon(Icons.extension_outlined),
-            tooltip: 'Skills',
-            onPressed: () => context.go('/skills'),
-          ),
-        ],
+    final chatActions = [
+      IconButton(
+        key: const Key('persona_picker_button'),
+        icon: const Icon(Icons.switch_account_outlined),
+        tooltip: 'Switch persona',
+        onPressed: () => showPersonaPicker(context),
       ),
+      IconButton(
+        icon: const Icon(Icons.timeline_outlined),
+        tooltip: 'Traces',
+        onPressed: () => context.go('/traces'),
+      ),
+      IconButton(
+        icon: const Icon(Icons.article_outlined),
+        tooltip: 'Logs',
+        onPressed: () => context.go('/logs'),
+      ),
+      IconButton(
+        icon: const Icon(Icons.extension_outlined),
+        tooltip: 'Skills',
+        onPressed: () => context.go('/skills'),
+      ),
+    ];
+
+    return Scaffold(
+      appBar: isAppleTouch
+          ? CupertinoNavigationBar(
+              middle: Text(activePersonaName),
+              leading: isWide
+                  ? null
+                  : Builder(
+                      builder: (ctx) => GestureDetector(
+                        onTap: () => Scaffold.of(ctx).openDrawer(),
+                        child: const Icon(CupertinoIcons.line_horizontal_3),
+                      ),
+                    ),
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: chatActions,
+              ),
+            )
+          : AppBar(
+              title: Text(activePersonaName),
+              leading: isWide
+                  ? null
+                  : Builder(
+                      builder: (ctx) => IconButton(
+                        icon: const Icon(Icons.menu),
+                        onPressed: () => Scaffold.of(ctx).openDrawer(),
+                      ),
+                    ),
+              actions: chatActions,
+            ),
 
       // Drawer on narrow screens.
       drawer: isWide

--- a/app/lib/features/contexts/screens/context_switcher_screen.dart
+++ b/app/lib/features/contexts/screens/context_switcher_screen.dart
@@ -1,7 +1,9 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../shared/platform/platform.dart';
 import '../models/context_model.dart';
 import '../providers/context_providers.dart';
 import 'edit_context_screen.dart';
@@ -18,6 +20,48 @@ class ContextSwitcherScreen extends ConsumerWidget {
     final contextsAsync = ref.watch(contextsProvider);
     final activeAsync = ref.watch(activeContextProvider);
     final activeContext = activeAsync.value;
+
+    final fab = FloatingActionButton(
+      tooltip: 'Add context',
+      onPressed: () => _openCreate(context, ref),
+      child: const Icon(Icons.add),
+    );
+
+    if (isAppleTouch) {
+      return Scaffold(
+        floatingActionButton: fab,
+        body: CustomScrollView(
+          slivers: [
+            const CupertinoSliverNavigationBar(largeTitle: Text('Contexts')),
+            contextsAsync.when(
+              loading: () => const SliverFillRemaining(
+                child: Center(child: CircularProgressIndicator()),
+              ),
+              error: (e, _) =>
+                  SliverFillRemaining(child: Center(child: Text('Error: $e'))),
+              data: (contexts) {
+                if (contexts.isEmpty) {
+                  return const SliverFillRemaining(child: _EmptyState());
+                }
+                return SliverList(
+                  delegate: SliverChildBuilderDelegate((ctx, i) {
+                    final item = contexts[i];
+                    final isActive = activeContext?.id == item.id;
+                    return _ContextTile(
+                      context: item,
+                      isActive: isActive,
+                      onTap: () => _activateAndNavigate(ctx, ref, item),
+                      onEdit: () => _openEdit(ctx, item),
+                      onDelete: () => _confirmDelete(ctx, ref, item),
+                    );
+                  }, childCount: contexts.length),
+                );
+              },
+            ),
+          ],
+        ),
+      );
+    }
 
     return Scaffold(
       appBar: AppBar(title: const Text('Contexts')),
@@ -44,11 +88,7 @@ class ContextSwitcherScreen extends ConsumerWidget {
           );
         },
       ),
-      floatingActionButton: FloatingActionButton(
-        tooltip: 'Add context',
-        onPressed: () => _openCreate(context, ref),
-        child: const Icon(Icons.add),
-      ),
+      floatingActionButton: fab,
     );
   }
 

--- a/app/lib/features/logs/logs_screen.dart
+++ b/app/lib/features/logs/logs_screen.dart
@@ -1,11 +1,13 @@
 import 'dart:async';
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:assistant_api/assistant_api.dart';
 
+import '../../shared/platform/platform.dart';
 import 'logs_provider.dart';
 
 /// Observability screen that lists recent structured log entries.
@@ -44,6 +46,108 @@ class _LogsScreenState extends ConsumerState<LogsScreen> {
   Widget build(BuildContext context) {
     final logsAsync = ref.watch(logsProvider);
 
+    final searchField = Padding(
+      padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
+      child: TextField(
+        key: const Key('log_search_field'),
+        controller: _searchController,
+        decoration: InputDecoration(
+          hintText: 'Filter by keyword...',
+          prefixIcon: const Icon(Icons.search, size: 20),
+          suffixIcon: _searching
+              ? const Padding(
+                  padding: EdgeInsets.all(12),
+                  child: SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                )
+              : null,
+          border: const OutlineInputBorder(),
+          contentPadding: const EdgeInsets.symmetric(vertical: 8),
+          isDense: true,
+        ),
+        onChanged: _onSearchChanged,
+      ),
+    );
+
+    if (isAppleTouch) {
+      return Scaffold(
+        body: GestureDetector(
+          onTap: () => FocusScope.of(context).unfocus(),
+          child: CustomScrollView(
+            slivers: [
+              CupertinoSliverNavigationBar(
+                largeTitle: const Text('Logs'),
+                trailing: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    IconButton(
+                      icon: const Icon(Icons.refresh),
+                      onPressed: () =>
+                          ref.read(logsProvider.notifier).refresh(),
+                    ),
+                  ],
+                ),
+              ),
+              SliverToBoxAdapter(child: searchField),
+              logsAsync.when(
+                loading: () => const SliverFillRemaining(
+                  child: Center(child: CircularProgressIndicator()),
+                ),
+                error: (err, _) => SliverFillRemaining(
+                  child: _ErrorView(
+                    error: err.toString(),
+                    onRetry: () => ref.read(logsProvider.notifier).refresh(),
+                  ),
+                ),
+                data: (state) {
+                  if (state.error != null) {
+                    return SliverFillRemaining(
+                      child: _ErrorView(
+                        error: state.error!,
+                        onRetry: () =>
+                            ref.read(logsProvider.notifier).refresh(),
+                      ),
+                    );
+                  }
+                  if (state.logs.isEmpty) {
+                    return SliverFillRemaining(
+                      child: Center(
+                        child: state.searchQuery.isNotEmpty
+                            ? Text(
+                                'No logs matching "${state.searchQuery}"',
+                                style: TextStyle(
+                                  color: Theme.of(
+                                    context,
+                                  ).colorScheme.onSurfaceVariant,
+                                ),
+                              )
+                            : const _EmptyView(),
+                      ),
+                    );
+                  }
+                  return SliverList(
+                    delegate: SliverChildBuilderDelegate((context, index) {
+                      if (index.isOdd) {
+                        return const Divider(
+                          height: 1,
+                          indent: 12,
+                          endIndent: 12,
+                        );
+                      }
+                      return _LogRow(entry: state.logs[index ~/ 2]);
+                    }, childCount: state.logs.length * 2 - 1),
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('Logs'),
@@ -62,33 +166,7 @@ class _LogsScreenState extends ConsumerState<LogsScreen> {
         onTap: () => FocusScope.of(context).unfocus(),
         child: Column(
           children: [
-            // Keyword filter
-            Padding(
-              padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
-              child: TextField(
-                key: const Key('log_search_field'),
-                controller: _searchController,
-                decoration: InputDecoration(
-                  hintText: 'Filter by keyword...',
-                  prefixIcon: const Icon(Icons.search, size: 20),
-                  suffixIcon: _searching
-                      ? const Padding(
-                          padding: EdgeInsets.all(12),
-                          child: SizedBox(
-                            width: 16,
-                            height: 16,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          ),
-                        )
-                      : null,
-                  border: const OutlineInputBorder(),
-                  contentPadding: const EdgeInsets.symmetric(vertical: 8),
-                  isDense: true,
-                ),
-                onChanged: _onSearchChanged,
-              ),
-            ),
-
+            searchField,
             // Log list
             Expanded(
               child: logsAsync.when(

--- a/app/lib/features/personas/personas_screen.dart
+++ b/app/lib/features/personas/personas_screen.dart
@@ -1,9 +1,11 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:assistant_api/assistant_api.dart';
 
+import '../../shared/platform/platform.dart';
 import 'personas_provider.dart';
 
 /// Screen that lists all personas.
@@ -32,6 +34,93 @@ class _PersonasScreenState extends ConsumerState<PersonasScreen> {
   Widget build(BuildContext context) {
     final personasAsync = ref.watch(personasProvider);
 
+    final fab = FloatingActionButton(
+      onPressed: () => context.go('/personas/new'),
+      child: const Icon(Icons.add),
+    );
+
+    final searchField = Padding(
+      padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
+      child: TextField(
+        controller: _searchController,
+        decoration: const InputDecoration(
+          hintText: 'Search personas...',
+          prefixIcon: Icon(Icons.search, size: 20),
+          border: OutlineInputBorder(),
+          contentPadding: EdgeInsets.symmetric(vertical: 8),
+          isDense: true,
+        ),
+        onChanged: (v) => setState(() => _query = v.toLowerCase()),
+      ),
+    );
+
+    if (isAppleTouch) {
+      return Scaffold(
+        floatingActionButton: fab,
+        body: CustomScrollView(
+          slivers: [
+            CupertinoSliverNavigationBar(
+              largeTitle: const Text('Personas'),
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.refresh),
+                    onPressed: () =>
+                        ref.read(personasProvider.notifier).refresh(),
+                  ),
+                ],
+              ),
+            ),
+            SliverToBoxAdapter(child: searchField),
+            personasAsync.when(
+              loading: () => const SliverFillRemaining(
+                child: Center(child: CircularProgressIndicator()),
+              ),
+              error: (err, _) => SliverFillRemaining(
+                child: _ErrorView(
+                  error: err.toString(),
+                  onRetry: () => ref.read(personasProvider.notifier).refresh(),
+                ),
+              ),
+              data: (state) {
+                if (state.error != null) {
+                  return SliverFillRemaining(
+                    child: _ErrorView(
+                      error: state.error!,
+                      onRetry: () =>
+                          ref.read(personasProvider.notifier).refresh(),
+                    ),
+                  );
+                }
+                final filtered = _query.isEmpty
+                    ? state.personas
+                    : state.personas
+                          .where(
+                            (p) =>
+                                p.name.toLowerCase().contains(_query) ||
+                                p.id.toLowerCase().contains(_query),
+                          )
+                          .toList();
+
+                if (filtered.isEmpty) {
+                  return const SliverFillRemaining(child: _EmptyView());
+                }
+                return SliverList(
+                  delegate: SliverChildBuilderDelegate((context, index) {
+                    if (index.isOdd) {
+                      return const Divider(height: 1, indent: 72);
+                    }
+                    return _PersonaRow(persona: filtered[index ~/ 2]);
+                  }, childCount: filtered.length * 2 - 1),
+                );
+              },
+            ),
+          ],
+        ),
+      );
+    }
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('Personas'),
@@ -42,10 +131,7 @@ class _PersonasScreenState extends ConsumerState<PersonasScreen> {
           ),
         ],
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () => context.go('/personas/new'),
-        child: const Icon(Icons.add),
-      ),
+      floatingActionButton: fab,
       body: personasAsync.when(
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (err, _) => _ErrorView(
@@ -71,20 +157,7 @@ class _PersonasScreenState extends ConsumerState<PersonasScreen> {
 
           return Column(
             children: [
-              Padding(
-                padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
-                child: TextField(
-                  controller: _searchController,
-                  decoration: const InputDecoration(
-                    hintText: 'Search personas...',
-                    prefixIcon: Icon(Icons.search, size: 20),
-                    border: OutlineInputBorder(),
-                    contentPadding: EdgeInsets.symmetric(vertical: 8),
-                    isDense: true,
-                  ),
-                  onChanged: (v) => setState(() => _query = v.toLowerCase()),
-                ),
-              ),
+              searchField,
               Expanded(
                 child: filtered.isEmpty
                     ? const _EmptyView()

--- a/app/lib/features/settings/settings_screen.dart
+++ b/app/lib/features/settings/settings_screen.dart
@@ -1,6 +1,8 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../shared/platform/platform.dart';
 import '../notifications/notification_preferences.dart';
 import '../notifications/notification_service.dart';
 
@@ -12,75 +14,81 @@ class SettingsScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final prefsAsync = ref.watch(notificationPreferencesProvider);
 
+    final bodyChildren = [
+      // -- Notifications -----------------------------------------------
+      const _SectionHeader('Notifications'),
+      prefsAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => ListTile(
+          leading: const Icon(Icons.error_outline),
+          title: Text('Failed to load preferences: $e'),
+        ),
+        data: (prefs) => Column(
+          children: [
+            SwitchListTile(
+              secondary: const Icon(Icons.chat_bubble_outline),
+              title: const Text('New chat messages'),
+              subtitle: const Text(
+                'Notify when the assistant sends a new message',
+              ),
+              value: prefs.notifyChatMessages,
+              onChanged: (value) async {
+                await prefs.setNotifyChatMessages(value);
+                // Refresh provider so UI stays in sync.
+                ref.invalidate(notificationPreferencesProvider);
+              },
+            ),
+            SwitchListTile(
+              secondary: const Icon(Icons.extension_outlined),
+              title: const Text('Skill completions'),
+              subtitle: const Text('Notify when a skill run succeeds or fails'),
+              value: prefs.notifySkillComplete,
+              onChanged: (value) async {
+                await prefs.setNotifySkillComplete(value);
+                ref.invalidate(notificationPreferencesProvider);
+              },
+            ),
+            SwitchListTile(
+              secondary: const Icon(Icons.warning_amber_outlined),
+              title: const Text('Agent errors'),
+              subtitle: const Text('Notify on critical assistant errors'),
+              value: prefs.notifyAgentErrors,
+              onChanged: (value) async {
+                await prefs.setNotifyAgentErrors(value);
+                ref.invalidate(notificationPreferencesProvider);
+              },
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: OutlinedButton.icon(
+                icon: const Icon(Icons.notifications_outlined),
+                label: const Text('Request notification permission'),
+                onPressed: () async {
+                  final ns = ref.read(notificationServiceProvider);
+                  await ns.initialize();
+                  await ns.requestPermission();
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    ];
+
+    if (isAppleTouch) {
+      return Scaffold(
+        body: CustomScrollView(
+          slivers: [
+            const CupertinoSliverNavigationBar(largeTitle: Text('Settings')),
+            SliverList(delegate: SliverChildListDelegate(bodyChildren)),
+          ],
+        ),
+      );
+    }
+
     return Scaffold(
       appBar: AppBar(title: const Text('Settings')),
-      body: ListView(
-        children: [
-          // -- Notifications -----------------------------------------------
-          const _SectionHeader('Notifications'),
-          prefsAsync.when(
-            loading: () => const Center(child: CircularProgressIndicator()),
-            error: (e, _) => ListTile(
-              leading: const Icon(Icons.error_outline),
-              title: Text('Failed to load preferences: $e'),
-            ),
-            data: (prefs) => Column(
-              children: [
-                SwitchListTile(
-                  secondary: const Icon(Icons.chat_bubble_outline),
-                  title: const Text('New chat messages'),
-                  subtitle: const Text(
-                    'Notify when the assistant sends a new message',
-                  ),
-                  value: prefs.notifyChatMessages,
-                  onChanged: (value) async {
-                    await prefs.setNotifyChatMessages(value);
-                    // Refresh provider so UI stays in sync.
-                    ref.invalidate(notificationPreferencesProvider);
-                  },
-                ),
-                SwitchListTile(
-                  secondary: const Icon(Icons.extension_outlined),
-                  title: const Text('Skill completions'),
-                  subtitle: const Text(
-                    'Notify when a skill run succeeds or fails',
-                  ),
-                  value: prefs.notifySkillComplete,
-                  onChanged: (value) async {
-                    await prefs.setNotifySkillComplete(value);
-                    ref.invalidate(notificationPreferencesProvider);
-                  },
-                ),
-                SwitchListTile(
-                  secondary: const Icon(Icons.warning_amber_outlined),
-                  title: const Text('Agent errors'),
-                  subtitle: const Text('Notify on critical assistant errors'),
-                  value: prefs.notifyAgentErrors,
-                  onChanged: (value) async {
-                    await prefs.setNotifyAgentErrors(value);
-                    ref.invalidate(notificationPreferencesProvider);
-                  },
-                ),
-                Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 16,
-                    vertical: 8,
-                  ),
-                  child: OutlinedButton.icon(
-                    icon: const Icon(Icons.notifications_outlined),
-                    label: const Text('Request notification permission'),
-                    onPressed: () async {
-                      final ns = ref.read(notificationServiceProvider);
-                      await ns.initialize();
-                      await ns.requestPermission();
-                    },
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ],
-      ),
+      body: ListView(children: bodyChildren),
     );
   }
 }

--- a/app/lib/features/skills/skills_screen.dart
+++ b/app/lib/features/skills/skills_screen.dart
@@ -1,9 +1,11 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:assistant_api/assistant_api.dart';
 
+import '../../shared/platform/platform.dart';
 import '../personas/personas_provider.dart';
 import 'skills_provider.dart';
 
@@ -21,6 +23,70 @@ class SkillsScreen extends ConsumerWidget {
     final activePersonaName =
         personasAsync.value?.activePersona?.name ?? 'Active Persona';
 
+    final fab = FloatingActionButton(
+      onPressed: () => context.go('/skills/new'),
+      tooltip: 'New skill',
+      child: const Icon(Icons.add),
+    );
+
+    if (isAppleTouch) {
+      return Scaffold(
+        floatingActionButton: fab,
+        body: CustomScrollView(
+          slivers: [
+            CupertinoSliverNavigationBar(
+              largeTitle: Text('Skills — $activePersonaName'),
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.refresh),
+                    onPressed: () =>
+                        ref.read(skillsProvider.notifier).refresh(),
+                  ),
+                ],
+              ),
+            ),
+            skillsAsync.when(
+              loading: () => const SliverFillRemaining(
+                child: Center(child: CircularProgressIndicator()),
+              ),
+              error: (err, _) => SliverFillRemaining(
+                child: _ErrorView(
+                  error: err.toString(),
+                  onRetry: () => ref.read(skillsProvider.notifier).refresh(),
+                ),
+              ),
+              data: (state) {
+                if (state.error != null) {
+                  return SliverFillRemaining(
+                    child: _ErrorView(
+                      error: state.error!,
+                      onRetry: () =>
+                          ref.read(skillsProvider.notifier).refresh(),
+                    ),
+                  );
+                }
+                if (state.skills.isEmpty) {
+                  return SliverFillRemaining(
+                    child: _EmptyView(personaName: activePersonaName),
+                  );
+                }
+                return SliverList(
+                  delegate: SliverChildBuilderDelegate((context, index) {
+                    if (index.isOdd) {
+                      return const Divider(height: 1, indent: 72);
+                    }
+                    return _SkillRow(skill: state.skills[index ~/ 2]);
+                  }, childCount: state.skills.length * 2 - 1),
+                );
+              },
+            ),
+          ],
+        ),
+      );
+    }
+
     return Scaffold(
       appBar: AppBar(
         title: Text('Skills — $activePersonaName'),
@@ -35,11 +101,7 @@ class SkillsScreen extends ConsumerWidget {
           ),
         ],
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () => context.go('/skills/new'),
-        tooltip: 'New skill',
-        child: const Icon(Icons.add),
-      ),
+      floatingActionButton: fab,
       body: skillsAsync.when(
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (err, _) => _ErrorView(

--- a/app/lib/features/traces/traces_screen.dart
+++ b/app/lib/features/traces/traces_screen.dart
@@ -1,9 +1,11 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:assistant_api/assistant_api.dart';
 
+import '../../shared/platform/platform.dart';
 import 'traces_provider.dart';
 
 /// Observability screen that lists recent assistant traces.
@@ -16,6 +18,58 @@ class TracesScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final tracesAsync = ref.watch(tracesProvider);
+
+    if (isAppleTouch) {
+      return Scaffold(
+        body: CustomScrollView(
+          slivers: [
+            CupertinoSliverNavigationBar(
+              largeTitle: const Text('Traces'),
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.refresh),
+                    onPressed: () =>
+                        ref.read(tracesProvider.notifier).refresh(),
+                  ),
+                ],
+              ),
+            ),
+            tracesAsync.when(
+              loading: () => const SliverFillRemaining(
+                child: Center(child: CircularProgressIndicator()),
+              ),
+              error: (err, _) => SliverFillRemaining(
+                child: _ErrorView(
+                  error: err.toString(),
+                  onRetry: () => ref.read(tracesProvider.notifier).refresh(),
+                ),
+              ),
+              data: (state) {
+                if (state.error != null) {
+                  return SliverFillRemaining(
+                    child: _ErrorView(
+                      error: state.error!,
+                      onRetry: () =>
+                          ref.read(tracesProvider.notifier).refresh(),
+                    ),
+                  );
+                }
+                if (state.traces.isEmpty) {
+                  return const SliverFillRemaining(child: _EmptyView());
+                }
+                return SliverList(
+                  delegate: SliverChildBuilderDelegate((context, index) {
+                    return _TraceRow(trace: state.traces[index]);
+                  }, childCount: state.traces.length),
+                );
+              },
+            ),
+          ],
+        ),
+      );
+    }
 
     return Scaffold(
       appBar: AppBar(

--- a/app/lib/features/webhooks/webhooks_screen.dart
+++ b/app/lib/features/webhooks/webhooks_screen.dart
@@ -1,8 +1,10 @@
 import 'package:assistant_api/assistant_api.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../shared/platform/platform.dart';
 import 'webhooks_provider.dart';
 
 /// Screen that lists all registered webhooks.
@@ -12,6 +14,56 @@ class WebhooksScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final webhooksAsync = ref.watch(webhooksProvider);
+
+    if (isAppleTouch) {
+      return Scaffold(
+        body: CustomScrollView(
+          slivers: [
+            CupertinoSliverNavigationBar(
+              largeTitle: const Text('Webhooks'),
+              trailing: CupertinoButton(
+                padding: EdgeInsets.zero,
+                child: const Icon(CupertinoIcons.refresh),
+                onPressed: () => ref.read(webhooksProvider.notifier).refresh(),
+              ),
+            ),
+            webhooksAsync.when(
+              loading: () => const SliverFillRemaining(
+                child: Center(child: CircularProgressIndicator()),
+              ),
+              error: (err, _) => SliverFillRemaining(
+                child: _ErrorView(
+                  error: err.toString(),
+                  onRetry: () => ref.read(webhooksProvider.notifier).refresh(),
+                ),
+              ),
+              data: (state) {
+                if (state.error != null) {
+                  return SliverFillRemaining(
+                    child: _ErrorView(
+                      error: state.error!,
+                      onRetry: () =>
+                          ref.read(webhooksProvider.notifier).refresh(),
+                    ),
+                  );
+                }
+                if (state.webhooks.isEmpty) {
+                  return const SliverFillRemaining(child: _EmptyView());
+                }
+                return SliverList(
+                  delegate: SliverChildBuilderDelegate((context, index) {
+                    if (index.isOdd) {
+                      return const Divider(height: 1, indent: 72);
+                    }
+                    return _WebhookRow(webhook: state.webhooks[index ~/ 2]);
+                  }, childCount: state.webhooks.length * 2 - 1),
+                );
+              },
+            ),
+          ],
+        ),
+      );
+    }
 
     return Scaffold(
       appBar: AppBar(

--- a/app/lib/features/workflows/workflows_screen.dart
+++ b/app/lib/features/workflows/workflows_screen.dart
@@ -1,8 +1,10 @@
 import 'package:assistant_api/assistant_api.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../shared/platform/platform.dart';
 import 'workflows_provider.dart';
 
 /// Screen that lists all workflows.
@@ -12,6 +14,54 @@ class WorkflowsScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final workflowsAsync = ref.watch(workflowsProvider);
+
+    final fab = FloatingActionButton(
+      onPressed: () => context.go('/workflows/new'),
+      tooltip: 'New workflow',
+      child: const Icon(Icons.add),
+    );
+
+    if (isAppleTouch) {
+      return Scaffold(
+        floatingActionButton: fab,
+        body: CustomScrollView(
+          slivers: [
+            CupertinoSliverNavigationBar(
+              largeTitle: const Text('Workflows'),
+              trailing: CupertinoButton(
+                padding: EdgeInsets.zero,
+                child: const Icon(CupertinoIcons.refresh),
+                onPressed: () => ref.read(workflowsProvider.notifier).refresh(),
+              ),
+            ),
+            workflowsAsync.when(
+              loading: () => const SliverFillRemaining(
+                child: Center(child: CircularProgressIndicator()),
+              ),
+              error: (err, _) => SliverFillRemaining(
+                child: _ErrorView(
+                  error: err.toString(),
+                  onRetry: () => ref.read(workflowsProvider.notifier).refresh(),
+                ),
+              ),
+              data: (workflows) {
+                if (workflows.isEmpty) {
+                  return const SliverFillRemaining(child: _EmptyView());
+                }
+                return SliverList(
+                  delegate: SliverChildBuilderDelegate((context, index) {
+                    if (index.isOdd) {
+                      return const Divider(height: 1, indent: 72);
+                    }
+                    return _WorkflowRow(workflow: workflows[index ~/ 2]);
+                  }, childCount: workflows.length * 2 - 1),
+                );
+              },
+            ),
+          ],
+        ),
+      );
+    }
 
     return Scaffold(
       appBar: AppBar(
@@ -23,11 +73,7 @@ class WorkflowsScreen extends ConsumerWidget {
           ),
         ],
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () => context.go('/workflows/new'),
-        tooltip: 'New workflow',
-        child: const Icon(Icons.add),
-      ),
+      floatingActionButton: fab,
       body: workflowsAsync.when(
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (err, _) => _ErrorView(

--- a/app/lib/shared/platform/adaptive_nav_bar.dart
+++ b/app/lib/shared/platform/adaptive_nav_bar.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import 'platform.dart';
+
+/// Navigation bar that renders [CupertinoNavigationBar] on Apple touch
+/// platforms and [AppBar] on Material platforms.
+///
+/// Implements [ObstructingPreferredSizeWidget] so it can be used as both
+/// [Scaffold.appBar] and [CupertinoPageScaffold.navigationBar].
+class AdaptiveNavBar extends StatelessWidget
+    implements ObstructingPreferredSizeWidget {
+  const AdaptiveNavBar({
+    super.key,
+    required this.title,
+    this.actions,
+    this.leading,
+    this.previousPageTitle,
+  });
+
+  final String title;
+  final List<Widget>? actions;
+  final Widget? leading;
+  final String? previousPageTitle;
+
+  @override
+  Size get preferredSize => isAppleTouch
+      ? const Size.fromHeight(44)
+      : const Size.fromHeight(kToolbarHeight);
+
+  @override
+  bool shouldFullyObstruct(BuildContext context) => true;
+
+  @override
+  Widget build(BuildContext context) {
+    if (isAppleTouch) {
+      return CupertinoNavigationBar(
+        middle: Text(title),
+        leading: leading,
+        previousPageTitle: previousPageTitle,
+        trailing: actions != null && actions!.isNotEmpty
+            ? Row(mainAxisSize: MainAxisSize.min, children: actions!)
+            : null,
+      );
+    }
+    return AppBar(title: Text(title), leading: leading, actions: actions);
+  }
+}

--- a/app/lib/shared/platform/adaptive_scaffold.dart
+++ b/app/lib/shared/platform/adaptive_scaffold.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import 'platform.dart';
+
+/// Scaffold that renders [CupertinoPageScaffold] on Apple touch platforms
+/// and [Scaffold] on Material platforms.
+///
+/// Pass [navigationBar] for the Cupertino path and [appBar] for the
+/// Material path. When using [AdaptiveNavBar], it implements
+/// [ObstructingPreferredSizeWidget] and can serve as both.
+class AdaptiveScaffold extends StatelessWidget {
+  const AdaptiveScaffold({
+    super.key,
+    this.navigationBar,
+    this.appBar,
+    required this.body,
+    this.floatingActionButton,
+  });
+
+  /// Navigation bar for the Cupertino path.
+  final ObstructingPreferredSizeWidget? navigationBar;
+
+  /// App bar for the Material path.
+  final PreferredSizeWidget? appBar;
+
+  /// The primary content of the scaffold.
+  final Widget body;
+
+  /// Floating action button (Material only).
+  final Widget? floatingActionButton;
+
+  @override
+  Widget build(BuildContext context) {
+    if (isAppleTouch) {
+      if (navigationBar != null) {
+        return CupertinoPageScaffold(
+          navigationBar: navigationBar!,
+          child: body,
+        );
+      }
+      return CupertinoPageScaffold(child: body);
+    }
+    return Scaffold(
+      appBar: appBar,
+      body: body,
+      floatingActionButton: floatingActionButton,
+    );
+  }
+}

--- a/app/test/widget/platform/adaptive_large_title_test.dart
+++ b/app/test/widget/platform/adaptive_large_title_test.dart
@@ -1,0 +1,172 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:assistant_app/features/connection/connection_provider.dart';
+import 'package:assistant_app/features/pwa/pwa_provider.dart';
+import 'package:assistant_app/features/settings/settings_screen.dart';
+import 'package:assistant_app/features/skills/skills_screen.dart';
+import 'package:assistant_app/features/personas/personas_screen.dart';
+import 'package:assistant_app/features/traces/traces_screen.dart';
+import 'package:assistant_app/features/logs/logs_screen.dart';
+import 'package:assistant_app/features/contexts/screens/context_switcher_screen.dart';
+import 'package:assistant_app/features/webhooks/webhooks_screen.dart';
+import 'package:assistant_app/features/agents/agents_screen.dart';
+import 'package:assistant_app/features/analytics/analytics_screen.dart';
+import 'package:assistant_app/features/workflows/workflows_screen.dart';
+import 'package:assistant_app/features/chat/chat_screen.dart';
+
+class _FakePwaNotifier extends PwaInstallNotifier {
+  @override
+  bool build() => false;
+}
+
+/// Pump a screen with common provider overrides that prevent API calls.
+Widget _harness(Widget screen) {
+  return ProviderScope(
+    overrides: [
+      apiClientProvider.overrideWithValue(null),
+      pwaInstallProvider.overrideWith(_FakePwaNotifier.new),
+    ],
+    child: MaterialApp(home: Material(child: screen)),
+  );
+}
+
+void main() {
+  // 3.2.1 — Settings screen
+  group('Large title — Settings', () {
+    testWidgets('CupertinoSliverNavigationBar on iOS', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      SharedPreferences.setMockInitialValues({});
+      tester.view.physicalSize = const Size(375, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(_harness(const SettingsScreen()));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CupertinoSliverNavigationBar), findsOneWidget);
+      expect(find.text('Settings'), findsWidgets); // largeTitle + collapsed
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('AppBar on macOS', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      SharedPreferences.setMockInitialValues({});
+      tester.view.physicalSize = const Size(375, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(_harness(const SettingsScreen()));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AppBar), findsOneWidget);
+      expect(find.byType(CupertinoSliverNavigationBar), findsNothing);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+  });
+
+  // 3.2.3 — Parameterized test for remaining list screens
+  final screenMatrix = <String, Widget>{
+    'Skills': const SkillsScreen(),
+    'Personas': const PersonasScreen(),
+    'Traces': const TracesScreen(),
+    'Logs': const LogsScreen(),
+    'Contexts': const ContextSwitcherScreen(),
+    'Webhooks': const WebhooksScreen(),
+    'Agents': const AgentsScreen(),
+    'Analytics': const AnalyticsScreen(),
+    'Workflows': const WorkflowsScreen(),
+  };
+
+  for (final entry in screenMatrix.entries) {
+    group('Large title — ${entry.key}', () {
+      testWidgets('CupertinoSliverNavigationBar on iOS', (tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+        SharedPreferences.setMockInitialValues({});
+        tester.view.physicalSize = const Size(375, 800);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.reset);
+
+        await tester.pumpWidget(_harness(entry.value));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.byType(CupertinoSliverNavigationBar),
+          findsOneWidget,
+          reason:
+              '${entry.key} should show CupertinoSliverNavigationBar on iOS',
+        );
+
+        debugDefaultTargetPlatformOverride = null;
+      });
+
+      testWidgets('AppBar on macOS', (tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+        SharedPreferences.setMockInitialValues({});
+        tester.view.physicalSize = const Size(375, 800);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.reset);
+
+        await tester.pumpWidget(_harness(entry.value));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.byType(AppBar),
+          findsOneWidget,
+          reason: '${entry.key} should show AppBar on macOS',
+        );
+        expect(
+          find.byType(CupertinoSliverNavigationBar),
+          findsNothing,
+          reason:
+              '${entry.key} should not show CupertinoSliverNavigationBar on macOS',
+        );
+
+        debugDefaultTargetPlatformOverride = null;
+      });
+    });
+  }
+
+  // 3.3 — Chat screen chrome (compact nav bar, no large title)
+  group('Chat screen chrome', () {
+    testWidgets('3.3.1 CupertinoNavigationBar on iOS', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      SharedPreferences.setMockInitialValues({});
+      tester.view.physicalSize = const Size(375, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(_harness(const ChatScreen()));
+      await tester.pump();
+
+      expect(find.byType(CupertinoNavigationBar), findsOneWidget);
+      expect(find.byType(AppBar), findsNothing);
+      // No large title on chat
+      expect(find.byType(CupertinoSliverNavigationBar), findsNothing);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('3.3.3 AppBar on macOS (non-regression)', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      SharedPreferences.setMockInitialValues({});
+      tester.view.physicalSize = const Size(375, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(_harness(const ChatScreen()));
+      await tester.pump();
+
+      expect(find.byType(AppBar), findsOneWidget);
+      expect(find.byType(CupertinoNavigationBar), findsNothing);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+  });
+}

--- a/app/test/widget/platform/adaptive_nav_bar_test.dart
+++ b/app/test/widget/platform/adaptive_nav_bar_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/shared/platform/adaptive_nav_bar.dart';
+
+void main() {
+  group('AdaptiveNavBar', () {
+    testWidgets('renders CupertinoNavigationBar on iOS', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+      await tester.pumpWidget(
+        const CupertinoApp(
+          home: CupertinoPageScaffold(
+            navigationBar: AdaptiveNavBar(title: 'Test Title'),
+            child: Text('body'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CupertinoNavigationBar), findsOneWidget);
+      expect(find.byType(AppBar), findsNothing);
+      expect(find.text('Test Title'), findsOneWidget);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('renders AppBar on macOS', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            appBar: const AdaptiveNavBar(title: 'Test Title'),
+            body: const Text('body'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AppBar), findsOneWidget);
+      expect(find.byType(CupertinoNavigationBar), findsNothing);
+      expect(find.text('Test Title'), findsOneWidget);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('passes actions to AppBar on Material', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            appBar: AdaptiveNavBar(
+              title: 'With Actions',
+              actions: [
+                IconButton(icon: const Icon(Icons.add), onPressed: () {}),
+              ],
+            ),
+            body: const Text('body'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.add), findsOneWidget);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('passes trailing to CupertinoNavigationBar on iOS', (
+      tester,
+    ) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: CupertinoPageScaffold(
+            navigationBar: AdaptiveNavBar(
+              title: 'With Actions',
+              actions: [
+                CupertinoButton(
+                  padding: EdgeInsets.zero,
+                  onPressed: () {},
+                  child: const Icon(CupertinoIcons.add),
+                ),
+              ],
+            ),
+            child: const Text('body'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(CupertinoIcons.add), findsOneWidget);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+  });
+}

--- a/app/test/widget/platform/adaptive_scaffold_test.dart
+++ b/app/test/widget/platform/adaptive_scaffold_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/shared/platform/adaptive_scaffold.dart';
+
+void main() {
+  group('AdaptiveScaffold', () {
+    testWidgets('renders CupertinoPageScaffold on iOS', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: AdaptiveScaffold(
+            navigationBar: CupertinoNavigationBar(middle: Text('Test')),
+            appBar: null,
+            body: Text('body'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CupertinoPageScaffold), findsOneWidget);
+      // No Material Scaffold on iOS path
+      expect(find.byType(Scaffold), findsNothing);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('renders Scaffold on macOS', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AdaptiveScaffold(
+            appBar: AppBar(title: const Text('Test')),
+            body: const Text('body'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(Scaffold), findsOneWidget);
+      expect(find.byType(CupertinoPageScaffold), findsNothing);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+  });
+}

--- a/openspec/changes/apple-native-ux/tasks.md
+++ b/openspec/changes/apple-native-ux/tasks.md
@@ -121,30 +121,30 @@ Capture the current state on each matrix entry before any changes. These screens
 
 ### 3.1 Adaptive Scaffold & Nav Bar
 
-- [ ] 3.1.1 🔴 Write widget test `app/test/widget/platform/adaptive_scaffold_test.dart`: pump `AdaptiveScaffold` with iOS platform override — assert `CupertinoPageScaffold` found. Pump with macOS override — assert `Scaffold` found. Confirm tests fail.
-- [ ] 3.1.2 🔴 Write widget test `app/test/widget/platform/adaptive_nav_bar_test.dart`: pump `AdaptiveNavBar` with iOS override — assert `CupertinoNavigationBar` found. Pump with macOS override — assert `AppBar` found. Confirm tests fail.
-- [ ] 3.1.3 🟢 Create `app/lib/shared/platform/adaptive_scaffold.dart` and `adaptive_nav_bar.dart`. Make tests green.
+- [x] 3.1.1 🔴 Write widget test `app/test/widget/platform/adaptive_scaffold_test.dart`: pump `AdaptiveScaffold` with iOS platform override — assert `CupertinoPageScaffold` found. Pump with macOS override — assert `Scaffold` found. Confirm tests fail.
+- [x] 3.1.2 🔴 Write widget test `app/test/widget/platform/adaptive_nav_bar_test.dart`: pump `AdaptiveNavBar` with iOS override — assert `CupertinoNavigationBar` found. Pump with macOS override — assert `AppBar` found. Confirm tests fail.
+- [x] 3.1.3 🟢 Create `app/lib/shared/platform/adaptive_scaffold.dart` and `adaptive_nav_bar.dart`. Make tests green.
 
 ### 3.2 Large Title Screens
 
-- [ ] 3.2.1 🔴 Write widget test: pump `SettingsScreen` with iOS platform override inside a `CustomScrollView`-compatible ancestor. Assert `CupertinoSliverNavigationBar` is found with `largeTitle` text "Settings". Confirm test fails.
-- [ ] 3.2.2 🟢 Convert Settings screen to use `CupertinoSliverNavigationBar` on Apple touch. Make test green.
-- [ ] 3.2.3 🔴 Write parameterized widget test for remaining list screens (Skills, Personas, Traces, Logs, Contexts, Webhooks, Agents, Analytics, Workflows): for each, assert `CupertinoSliverNavigationBar` found on iOS and `AppBar` found on macOS/web. Confirm tests fail.
-- [ ] 3.2.4 🟢 Convert Skills screen to use large title. Make its test green.
-- [ ] 3.2.5 🟢 Convert Personas screen. Green.
-- [ ] 3.2.6 🟢 Convert Traces screen. Green.
-- [ ] 3.2.7 🟢 Convert Logs screen. Green.
-- [ ] 3.2.8 🟢 Convert Contexts screen. Green.
-- [ ] 3.2.9 🟢 Convert Webhooks screen. Green.
-- [ ] 3.2.10 🟢 Convert Agents screen. Green.
-- [ ] 3.2.11 🟢 Convert Analytics screen. Green.
-- [ ] 3.2.12 🟢 Convert Workflows screen. Green.
+- [x] 3.2.1 🔴 Write widget test: pump `SettingsScreen` with iOS platform override inside a `CustomScrollView`-compatible ancestor. Assert `CupertinoSliverNavigationBar` is found with `largeTitle` text "Settings". Confirm test fails.
+- [x] 3.2.2 🟢 Convert Settings screen to use `CupertinoSliverNavigationBar` on Apple touch. Make test green.
+- [x] 3.2.3 🔴 Write parameterized widget test for remaining list screens (Skills, Personas, Traces, Logs, Contexts, Webhooks, Agents, Analytics, Workflows): for each, assert `CupertinoSliverNavigationBar` found on iOS and `AppBar` found on macOS/web. Confirm tests fail.
+- [x] 3.2.4 🟢 Convert Skills screen to use large title. Make its test green.
+- [x] 3.2.5 🟢 Convert Personas screen. Green.
+- [x] 3.2.6 🟢 Convert Traces screen. Green.
+- [x] 3.2.7 🟢 Convert Logs screen. Green.
+- [x] 3.2.8 🟢 Convert Contexts screen. Green.
+- [x] 3.2.9 🟢 Convert Webhooks screen. Green.
+- [x] 3.2.10 🟢 Convert Agents screen. Green.
+- [x] 3.2.11 🟢 Convert Analytics screen. Green.
+- [x] 3.2.12 🟢 Convert Workflows screen. Green.
 
 ### 3.3 Chat Screen Chrome
 
-- [ ] 3.3.1 🔴 Write widget test: pump `ChatScreen` with iOS override. Assert `CupertinoNavigationBar` found (not `CupertinoSliverNavigationBar` — no large title). Assert `AppBar` is NOT found. Confirm test fails.
-- [ ] 3.3.2 🟢 Update Chat screen to use `CupertinoNavigationBar` on Apple touch. Make test green.
-- [ ] 3.3.3 🔴 Write widget test: pump `ChatScreen` with macOS override. Assert `AppBar` found (Material, unchanged). Confirm test passes immediately (non-regression).
+- [x] 3.3.1 🔴 Write widget test: pump `ChatScreen` with iOS override. Assert `CupertinoNavigationBar` found (not `CupertinoSliverNavigationBar` — no large title). Assert `AppBar` is NOT found. Confirm test fails.
+- [x] 3.3.2 🟢 Update Chat screen to use `CupertinoNavigationBar` on Apple touch. Make test green.
+- [x] 3.3.3 🔴 Write widget test: pump `ChatScreen` with macOS override. Assert `AppBar` found (Material, unchanged). Confirm test passes immediately (non-regression).
 
 ### 3.4 Phase 3 Verification — Per Matrix Entry
 
@@ -155,8 +155,8 @@ Capture the current state on each matrix entry before any changes. These screens
 - [ ] 3.4.5 **M4 Mac Catalyst**: Large titles work. Edge-swipe-to-go-back works (if trackpad gesture supported).
 - [ ] 3.4.6 **M5 macOS native**: All screens use Scaffold + AppBar unchanged. No visual regression from baseline.
 - [ ] 3.4.7 **M6 Web**: All screens use Scaffold + AppBar unchanged. No visual regression from baseline.
-- [ ] 3.4.8 Run `flutter analyze --fatal-infos` — zero issues
-- [ ] 3.4.9 Run `flutter test` — all tests pass
+- [x] 3.4.8 Run `flutter analyze --fatal-infos` — zero issues
+- [x] 3.4.9 Run `flutter test` — all tests pass (418/418)
 
 ---
 


### PR DESCRIPTION
## Summary
- **AdaptiveScaffold** — renders `CupertinoPageScaffold` on iOS/iPadOS or `Scaffold` elsewhere
- **AdaptiveNavBar** — renders `CupertinoNavigationBar` on iOS/iPadOS or `AppBar` elsewhere, implements `ObstructingPreferredSizeWidget` so it works in both scaffold types
- **10 list screens** converted to `CupertinoSliverNavigationBar` on iOS for collapsing large-title headers (Settings, Skills, Personas, Traces, Logs, Contexts, Webhooks, Agents, Analytics, Workflows)
- **ChatScreen** converted to compact `CupertinoNavigationBar` on iOS (no large title, appropriate for a conversation view)
- All screens fall back to standard `AppBar` on macOS/web — zero visual regression on non-Apple-touch platforms

Phase 3 of the Apple-native UX change (`openspec/changes/apple-native-ux`).

## Test plan
- [x] 28 new widget tests covering platform-specific chrome behavior (418/418 pass)
- [x] `flutter analyze --fatal-infos` — zero issues
- [ ] Manual: verify large title collapse on scroll on iPhone/iPad
- [ ] Manual: verify compact nav bar on ChatScreen
- [ ] Manual: verify macOS and web are unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added native iOS user interface support with Apple-specific navigation styling across agents, analytics, chat, contexts, logs, personas, settings, skills, traces, webhooks, and workflows screens.
  * Implemented adaptive layout components for automatic platform-appropriate rendering based on device type.

* **Tests**
  * Added comprehensive widget tests verifying platform-specific UI rendering across iOS and non-iOS platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->