### PR TITLE
fix(app): convert HEIC images to PNG before upload on iOS

### DIFF
--- a/app/lib/features/chat/chat_screen.dart
+++ b/app/lib/features/chat/chat_screen.dart
@@ -22,6 +22,7 @@ import 'attachment_provider.dart';
 import 'audio_player_widget.dart';
 import 'chat_provider.dart';
 import 'conversation_list.dart';
+import 'image_utils.dart';
 import 'timeline_section.dart';
 import 'tool_call_chip.dart';
 import 'voice_recorder_button.dart';
@@ -190,7 +191,9 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
               ),
             );
           } catch (e) {
-            // Skip failed uploads — don't block sending the message.
+            // Log but don't block — the message will still be sent without
+            // the failed attachment.
+            debugPrint('Attachment upload failed for ${p.filename}: $e');
           }
         }
       }
@@ -224,26 +227,16 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     final notifier = ref.read(pendingAttachmentsProvider.notifier);
     for (final file in result.files) {
       if (file.bytes != null) {
-        final mime = _mimeFromExtension(file.extension);
+        final (bytes, filename, mime) = await normalizeImage(
+          file.bytes!,
+          file.name,
+          file.extension,
+        );
         notifier.add(
-          PendingAttachment(
-            bytes: file.bytes!,
-            filename: file.name,
-            mimeType: mime,
-          ),
+          PendingAttachment(bytes: bytes, filename: filename, mimeType: mime),
         );
       }
     }
-  }
-
-  static String _mimeFromExtension(String? ext) {
-    return switch (ext?.toLowerCase()) {
-      'png' => 'image/png',
-      'jpg' || 'jpeg' => 'image/jpeg',
-      'gif' => 'image/gif',
-      'webp' => 'image/webp',
-      _ => 'application/octet-stream',
-    };
   }
 
   @override
@@ -362,7 +355,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                   for (final file in details.files) {
                     file.readAsBytes().then((bytes) {
                       final ext = file.name.split('.').last;
-                      final mime = _mimeFromExtension(ext);
+                      final mime = mimeFromExtension(ext);
                       if (mime.startsWith('image/')) {
                         notifier.add(
                           PendingAttachment(

--- a/app/lib/features/chat/image_utils.dart
+++ b/app/lib/features/chat/image_utils.dart
@@ -1,0 +1,72 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+/// Maps a file extension to a MIME type for image formats.
+///
+/// Returns `'application/octet-stream'` for unrecognised extensions.
+String mimeFromExtension(String? ext) {
+  return switch (ext?.toLowerCase()) {
+    'png' => 'image/png',
+    'jpg' || 'jpeg' => 'image/jpeg',
+    'gif' => 'image/gif',
+    'webp' => 'image/webp',
+    'heic' || 'heif' => 'image/heic',
+    _ => 'application/octet-stream',
+  };
+}
+
+/// Returns `true` if [ext] is a format that the server does not accept and
+/// must be converted client-side (e.g. HEIC from iOS cameras).
+bool needsConversion(String? ext) {
+  final lower = ext?.toLowerCase();
+  return lower == 'heic' || lower == 'heif';
+}
+
+/// Converts [bytes] from an unsupported image format (HEIC/HEIF) to PNG using
+/// the platform's native image decoder.
+///
+/// On iOS the platform decoder handles HEIC natively via Image I/O.
+/// Returns `null` if the conversion fails (e.g. unsupported platform).
+Future<Uint8List?> convertToPng(Uint8List bytes) async {
+  try {
+    final codec = await ui.instantiateImageCodec(bytes);
+    final frame = await codec.getNextFrame();
+    final image = frame.image;
+    final byteData = await image.toByteData(format: ui.ImageByteFormat.png);
+    codec.dispose();
+    image.dispose();
+    return byteData?.buffer.asUint8List();
+  } catch (_) {
+    return null;
+  }
+}
+
+/// Normalises an image picked from the file system.
+///
+/// If the file is in a format the server does not accept (HEIC/HEIF), it is
+/// converted to PNG.  Otherwise the original bytes, filename and MIME type are
+/// returned unchanged.
+///
+/// Returns `(bytes, filename, mimeType)`.
+Future<(Uint8List, String, String)> normalizeImage(
+  Uint8List bytes,
+  String filename,
+  String? ext,
+) async {
+  if (!needsConversion(ext)) {
+    return (bytes, filename, mimeFromExtension(ext));
+  }
+
+  final pngBytes = await convertToPng(bytes);
+  if (pngBytes != null) {
+    final newFilename = filename.replaceAll(
+      RegExp(r'\.(heic|heif)$', caseSensitive: false),
+      '.png',
+    );
+    return (pngBytes, newFilename, 'image/png');
+  }
+
+  // Conversion failed — return original with correct MIME so the server can
+  // give a clear rejection message.
+  return (bytes, filename, 'image/heic');
+}

--- a/app/test/unit/chat/image_utils_test.dart
+++ b/app/test/unit/chat/image_utils_test.dart
@@ -1,0 +1,66 @@
+import 'package:assistant_app/features/chat/image_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('mimeFromExtension', () {
+    test('maps png', () {
+      expect(mimeFromExtension('png'), 'image/png');
+    });
+
+    test('maps jpg and jpeg', () {
+      expect(mimeFromExtension('jpg'), 'image/jpeg');
+      expect(mimeFromExtension('jpeg'), 'image/jpeg');
+    });
+
+    test('maps gif', () {
+      expect(mimeFromExtension('gif'), 'image/gif');
+    });
+
+    test('maps webp', () {
+      expect(mimeFromExtension('webp'), 'image/webp');
+    });
+
+    test('maps heic and heif to image/heic', () {
+      expect(mimeFromExtension('heic'), 'image/heic');
+      expect(mimeFromExtension('heif'), 'image/heic');
+    });
+
+    test('is case insensitive', () {
+      expect(mimeFromExtension('HEIC'), 'image/heic');
+      expect(mimeFromExtension('PNG'), 'image/png');
+      expect(mimeFromExtension('Jpg'), 'image/jpeg');
+    });
+
+    test('unknown extension returns application/octet-stream', () {
+      expect(mimeFromExtension('xyz'), 'application/octet-stream');
+      expect(mimeFromExtension(null), 'application/octet-stream');
+    });
+  });
+
+  group('needsConversion', () {
+    test('heic needs conversion', () {
+      expect(needsConversion('heic'), true);
+    });
+
+    test('heif needs conversion', () {
+      expect(needsConversion('heif'), true);
+    });
+
+    test('case insensitive', () {
+      expect(needsConversion('HEIC'), true);
+      expect(needsConversion('Heif'), true);
+    });
+
+    test('supported formats do not need conversion', () {
+      expect(needsConversion('png'), false);
+      expect(needsConversion('jpg'), false);
+      expect(needsConversion('jpeg'), false);
+      expect(needsConversion('gif'), false);
+      expect(needsConversion('webp'), false);
+    });
+
+    test('null does not need conversion', () {
+      expect(needsConversion(null), false);
+    });
+  });
+}

--- a/crates/web-ui/src/api/mod.rs
+++ b/crates/web-ui/src/api/mod.rs
@@ -1703,6 +1703,11 @@ pub async fn upload_attachment(
 
     // Validate MIME type.
     if !assistant_core::is_supported_mime_type(&mime_type) {
+        warn!(
+            mime_type = %mime_type,
+            filename = %filename,
+            "Attachment upload rejected: unsupported MIME type"
+        );
         return (
             StatusCode::BAD_REQUEST,
             format!(


### PR DESCRIPTION
## Summary

- iOS cameras capture photos as HEIC, which the server doesn't accept (only PNG/JPEG/GIF/WebP). The Flutter app mapped unknown extensions to `application/octet-stream` and silently swallowed the upload 400 error, so images never reached the conversation.
- Adds client-side HEIC→PNG conversion using `dart:ui` (delegates to iOS's native Image I/O decoder) before upload.
- Logs upload failures via `debugPrint` instead of silently swallowing them.
- Adds `warn!` on the server for MIME type rejections to aid future debugging.

## Test plan

- [x] 12 new unit tests for MIME mapping and HEIC detection (`image_utils_test.dart`)
- [x] All 402 existing Flutter tests pass
- [x] `make lint` / `make format` / `flutter analyze` clean
- [ ] Manual: upload a HEIC photo from iOS camera roll → should convert to PNG and appear in conversation
- [ ] Manual: upload PNG/JPEG from iOS → should work as before (no conversion)
- [ ] Manual: upload from web/PWA → should work as before