### PR TITLE
feat(app): silent SSE stream reconnection on iOS background/resume

### DIFF
--- a/app/lib/features/chat/chat_provider.dart
+++ b/app/lib/features/chat/chat_provider.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:assistant_api/assistant_api.dart' hide ServerCapabilities;
@@ -566,6 +567,20 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
   /// Used as the `since` cursor when requesting event-log replay.
   int _lastSeq = 0;
 
+  /// When `true`, a transient connection error occurred and silent recovery
+  /// should be attempted on app resume (via [attemptReconnect]).
+  bool _needsReconnect = false;
+
+  /// User message ID from the interrupted stream (for replay status updates).
+  String? _disconnectedUserMsgId;
+
+  /// Conversation ID at the time the stream was interrupted.
+  String? _disconnectedConversationId;
+
+  /// Whether a transient stream interruption occurred that should be retried
+  /// on app resume.
+  bool get needsReconnect => _needsReconnect;
+
   @override
   Future<ChatState> build() async {
     return const ChatState();
@@ -594,6 +609,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
 
   /// Load an existing conversation by ID.
   Future<void> loadConversation(String conversationId) async {
+    _resetReconnectState();
     state = AsyncData(
       (state.value ?? const ChatState()).copyWith(
         isLoadingHistory: true,
@@ -658,6 +674,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
 
   /// Start a fresh conversation (no conversation ID set).
   void clearConversation() {
+    _resetReconnectState();
     state = const AsyncData(ChatState());
   }
 
@@ -1102,6 +1119,27 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
       }
     } catch (e) {
       unawaited(tokenController.close());
+
+      // Transient error with a run ID: defer recovery to app resume.
+      if (_isTransientError(e) && _currentRunId != null) {
+        _needsReconnect = true;
+        _disconnectedUserMsgId = userMsgId;
+        _disconnectedConversationId = conversationId;
+
+        final chatState = state.value ?? const ChatState();
+        final msgs = List<ChatMessage>.from(chatState.messages)
+          ..removeWhere((m) => m.id == 'assistant-streaming');
+        state = AsyncData(
+          chatState.copyWith(
+            messages: msgs,
+            isSending: false,
+            streamingContent: '',
+            clearStatusMessage: true,
+          ),
+        );
+        return;
+      }
+
       final chatState = state.value ?? const ChatState();
       final msgs = List<ChatMessage>.from(chatState.messages)
         ..removeWhere((m) => m.id == 'assistant-streaming');
@@ -1114,7 +1152,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
           messages: msgs,
           isSending: false,
           streamingContent: '',
-          error: 'Voice stream error: $e',
+          error: _friendlyErrorMessage(e),
         ),
       );
     }
@@ -1133,6 +1171,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
     _cancelled = false;
     _currentRunId = null;
     _lastSeq = 0;
+    _resetReconnectState();
     final current = state.value ?? const ChatState();
 
     // Create a broadcast stream controller for token-by-token rendering.
@@ -1316,7 +1355,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
       }
     } catch (e) {
       unawaited(tokenController.close());
-      // If we have a run ID, attempt replay before marking as failed.
+      // Attempt immediate replay (works for brief network blips).
       if (_currentRunId != null) {
         final replayed = await _replayRun(
           api,
@@ -1328,10 +1367,31 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
         if (replayed) return;
       }
 
+      // Transient error with a run ID: defer recovery to app resume
+      // instead of showing an error banner.
+      if (_isTransientError(e) && _currentRunId != null) {
+        _needsReconnect = true;
+        _disconnectedUserMsgId = userMsgId;
+        _disconnectedConversationId = conversationId;
+
+        final chatState = state.value ?? const ChatState();
+        final msgs = List<ChatMessage>.from(chatState.messages)
+          ..removeWhere((m) => m.id == 'assistant-streaming');
+        state = AsyncData(
+          chatState.copyWith(
+            messages: msgs,
+            isSending: false,
+            streamingContent: '',
+            clearStatusMessage: true,
+          ),
+        );
+        return;
+      }
+
+      // Non-transient error or no run ID: show error immediately.
       final chatState = state.value ?? const ChatState();
       final msgs = List<ChatMessage>.from(chatState.messages)
         ..removeWhere((m) => m.id == 'assistant-streaming');
-      // Mark user message as failed.
       final userIdx = msgs.indexWhere((m) => m.id == userMsgId);
       if (userIdx != -1) {
         msgs[userIdx] = msgs[userIdx].copyWith(status: MessageStatus.failed);
@@ -1341,10 +1401,101 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
           messages: msgs,
           isSending: false,
           streamingContent: '',
-          error: 'Stream error: $e',
+          error: _friendlyErrorMessage(e),
         ),
       );
     }
+  }
+
+  /// Returns `true` if [error] looks like a transient connection failure
+  /// (iOS backgrounding, network blip) rather than a permanent server error.
+  static bool _isTransientError(Object error) {
+    if (error is HttpException) return true;
+    if (error is DioException &&
+        error.type == DioExceptionType.connectionError) {
+      return true;
+    }
+    final msg = error.toString();
+    return msg.contains('Connection closed') ||
+        msg.contains('Connection reset') ||
+        msg.contains('SocketException');
+  }
+
+  /// Returns a user-friendly error message for stream exceptions.
+  static String _friendlyErrorMessage(Object error) {
+    if (_isTransientError(error)) {
+      return 'Connection lost — tap retry to resend';
+    }
+    return 'Stream error: $error';
+  }
+
+  /// Attempt to silently recover from a transient stream interruption.
+  ///
+  /// Called from the app lifecycle observer on [AppLifecycleState.resumed].
+  /// Tries: 1) replay from last sequence, 2) fetch full conversation history,
+  /// 3) show error only if both fail.
+  Future<void> attemptReconnect() async {
+    if (!_needsReconnect) return;
+
+    // Clear immediately to prevent re-entrant calls.
+    _needsReconnect = false;
+
+    final api = _api;
+    final conversationId = _disconnectedConversationId;
+    final userMsgId = _disconnectedUserMsgId;
+    final runId = _currentRunId;
+
+    _disconnectedUserMsgId = null;
+    _disconnectedConversationId = null;
+
+    if (api == null || conversationId == null) return;
+
+    // Strategy 1: Replay from last event sequence.
+    if (runId != null && userMsgId != null) {
+      try {
+        final replayed = await _replayRun(
+          api,
+          conversationId,
+          userMsgId,
+          runId,
+          _lastSeq,
+        );
+        if (replayed) return;
+      } catch (_) {
+        // Replay failed — fall through to history fetch.
+      }
+    }
+
+    // Strategy 2: Fetch full conversation history.
+    // Save current messages in case loadConversation fails and wipes them.
+    final preLoadMessages = List<ChatMessage>.from(state.value?.messages ?? []);
+    await loadConversation(conversationId);
+    // loadConversation catches errors internally — check if it succeeded.
+    final afterLoad = state.value;
+    if (afterLoad != null && afterLoad.error == null) return;
+
+    // Both strategies failed: restore messages and show friendly error.
+    final msgs = List<ChatMessage>.from(preLoadMessages);
+    if (userMsgId != null) {
+      final userIdx = msgs.indexWhere((m) => m.id == userMsgId);
+      if (userIdx != -1) {
+        msgs[userIdx] = msgs[userIdx].copyWith(status: MessageStatus.failed);
+      }
+    }
+    state = AsyncData(
+      ChatState(
+        conversationId: conversationId,
+        messages: msgs,
+        error: 'Connection lost — tap retry to resend',
+      ),
+    );
+  }
+
+  /// Clears deferred reconnection state.
+  void _resetReconnectState() {
+    _needsReconnect = false;
+    _disconnectedUserMsgId = null;
+    _disconnectedConversationId = null;
   }
 }
 

--- a/app/lib/features/notifications/agent_event_listener.dart
+++ b/app/lib/features/notifications/agent_event_listener.dart
@@ -44,6 +44,10 @@ class _AgentEventListenerState extends ConsumerState<AgentEventListener>
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     _lifecycleState = state;
+    if (state == AppLifecycleState.resumed) {
+      // Silently recover any stream interrupted by iOS backgrounding.
+      ref.read(chatProvider.notifier).attemptReconnect();
+    }
   }
 
   bool get _isResumed =>

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -276,10 +276,10 @@ packages:
     dependency: "direct main"
     description:
       name: desktop_drop
-      sha256: e70b46b2d61f1af7a81a40d1f79b43c28a879e30a4ef31e87e9c27bea4d784e8
+      sha256: aa1e797255bfbc76f9eb5aa4f61e5b68dbf69962ab1be6495816d2f251bc0d1f
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.1"
   device_info_plus:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   audioplayers: ^6.6.0
   file_picker: ^11.0.2
   cached_network_image: ^3.4.1
-  desktop_drop: ^0.7.0
+  desktop_drop: ^0.7.1
   super_clipboard: ^0.9.1
 dev_dependencies:
   flutter_test:
@@ -52,8 +52,8 @@ flutter_launcher_icons:
   web:
     generate: true
     image_path: macos/Runner/Assets.xcassets/AppIcon.appiconset/app_icon_1024.png
-    background_color: '#080C1A'
-    theme_color: '#080C1A'
+    background_color: "#080C1A"
+    theme_color: "#080C1A"
 flutter:
   uses-material-design: true
   assets:

--- a/app/test/unit/chat/chat_provider_test.dart
+++ b/app/test/unit/chat/chat_provider_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:assistant_api/assistant_api.dart';
@@ -1056,6 +1057,361 @@ void main() {
       expect(copy.subagentId, 'a1');
       expect(copy.subagentTask, 'task');
       expect(copy.subagentSummary, 'summary');
+    });
+  });
+
+  // -- Deferred reconnection on transient errors --------------------------------
+
+  group('ChatNotifier — deferred reconnection', () {
+    testWidgets(
+      'transient error without run ID shows friendly error immediately',
+      (tester) async {
+        final fakeApi = _FakeApiClient();
+        final ctrl = fakeApi.enqueueStream();
+
+        final notifier = await _pumpTestApp(tester, fakeApi);
+
+        unawaited(notifier.sendMessage('hello'));
+        await tester.pump();
+
+        // Connection closed before RunStartedEvent — no run ID available.
+        await tester.runAsync(() async {
+          ctrl.addError(
+            const HttpException('Connection closed while receiving data'),
+          );
+          await ctrl.close();
+          await Future<void>.delayed(Duration.zero);
+          await Future<void>.delayed(Duration.zero);
+        });
+        await tester.pumpAndSettle();
+
+        final chatState = notifier.state.value!;
+        // No run ID → can't defer → show friendly error immediately.
+        expect(chatState.error, isNotNull, reason: 'should have an error set');
+        expect(
+          chatState.error,
+          isNot(contains('HttpException')),
+          reason: 'should not expose raw exception type to user',
+        );
+        expect(
+          chatState.error!.toLowerCase(),
+          contains('connection lost'),
+          reason: 'should show a friendly connection-lost message',
+        );
+        expect(
+          notifier.needsReconnect,
+          isFalse,
+          reason: 'cannot defer without a run ID',
+        );
+      },
+    );
+
+    testWidgets(
+      'transient error with run ID defers reconnection (no error shown)',
+      (tester) async {
+        final fakeApi = _FakeApiClient();
+        final ctrl = fakeApi.enqueueStream();
+
+        final notifier = await _pumpTestApp(tester, fakeApi);
+
+        unawaited(notifier.sendMessage('hello'));
+        await tester.pump();
+
+        await tester.runAsync(() async {
+          // Emit run ID so deferred reconnect is possible.
+          ctrl.add(const RunStartedEvent('run-defer'));
+          await Future<void>.delayed(Duration.zero);
+          // Connection closed (iOS backgrounding).
+          ctrl.addError(
+            const HttpException('Connection closed while receiving data'),
+          );
+          await ctrl.close();
+          await Future<void>.delayed(Duration.zero);
+          await Future<void>.delayed(Duration.zero);
+          await Future<void>.delayed(Duration.zero);
+        });
+        await tester.pumpAndSettle();
+
+        final chatState = notifier.state.value!;
+        expect(
+          chatState.error,
+          isNull,
+          reason: 'transient error with run ID should NOT show error',
+        );
+        expect(
+          notifier.needsReconnect,
+          isTrue,
+          reason: 'should flag for reconnection on resume',
+        );
+        expect(
+          chatState.isSending,
+          isFalse,
+          reason: 'should clear sending state',
+        );
+        // User message should still be in sending status, not failed.
+        final userMsg = chatState.messages.firstWhere((m) => m.isUser);
+        expect(
+          userMsg.status,
+          MessageStatus.sending,
+          reason:
+              'user message stays in sending status until reconnect resolves',
+        );
+      },
+    );
+
+    testWidgets('immediate replay succeeds — no deferred reconnect needed', (
+      tester,
+    ) async {
+      final fakeApi = _FakeApiClient();
+      final ctrl = fakeApi.enqueueStream();
+      // Replay stream succeeds immediately.
+      fakeApi.enqueueReplayStream()
+        ..add(const TokenEvent('recovered'))
+        ..add(const DoneEvent(role: 'assistant', content: 'recovered'))
+        ..close();
+
+      final notifier = await _pumpTestApp(tester, fakeApi);
+
+      unawaited(notifier.sendMessage('hello'));
+      await tester.pump();
+
+      await tester.runAsync(() async {
+        ctrl.add(const RunStartedEvent('run-replay'));
+        await Future<void>.delayed(Duration.zero);
+        ctrl.addError(
+          const HttpException('Connection closed while receiving data'),
+        );
+        await ctrl.close();
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+      });
+      await tester.pumpAndSettle();
+
+      final chatState = notifier.state.value!;
+      expect(
+        chatState.error,
+        isNull,
+        reason: 'successful immediate replay should clear the error',
+      );
+      expect(
+        notifier.needsReconnect,
+        isFalse,
+        reason: 'no deferred reconnect needed when immediate replay works',
+      );
+      final userMsg = chatState.messages.firstWhere((m) => m.isUser);
+      expect(
+        userMsg.status,
+        MessageStatus.ok,
+        reason: 'user message should be ok after successful replay',
+      );
+    });
+
+    testWidgets('attemptReconnect replays successfully on resume', (
+      tester,
+    ) async {
+      final fakeApi = _FakeApiClient();
+      final ctrl = fakeApi.enqueueStream();
+      // First replay (in catch block) fails.
+      fakeApi.enqueueReplayError(404);
+      // Second replay (in attemptReconnect) succeeds.
+      fakeApi.enqueueReplayStream()
+        ..add(const TokenEvent('resumed'))
+        ..add(const DoneEvent(role: 'assistant', content: 'resumed'))
+        ..close();
+
+      final notifier = await _pumpTestApp(tester, fakeApi);
+
+      unawaited(notifier.sendMessage('hello'));
+      await tester.pump();
+
+      await tester.runAsync(() async {
+        ctrl.add(const RunStartedEvent('run-resume'));
+        await Future<void>.delayed(Duration.zero);
+        ctrl.addError(
+          const HttpException('Connection closed while receiving data'),
+        );
+        await ctrl.close();
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+      });
+      await tester.pumpAndSettle();
+
+      expect(notifier.needsReconnect, isTrue);
+
+      // Simulate app resume → attemptReconnect.
+      await tester.runAsync(() async {
+        await notifier.attemptReconnect();
+      });
+      await tester.pumpAndSettle();
+
+      final chatState = notifier.state.value!;
+      expect(
+        chatState.error,
+        isNull,
+        reason: 'replay on resume should succeed silently',
+      );
+      expect(
+        notifier.needsReconnect,
+        isFalse,
+        reason: 'reconnect flag should be cleared after attempt',
+      );
+      final userMsg = chatState.messages.firstWhere((m) => m.isUser);
+      expect(
+        userMsg.status,
+        MessageStatus.ok,
+        reason: 'user message should be ok after replay on resume',
+      );
+    });
+
+    testWidgets(
+      'attemptReconnect shows error when both replay and history fail',
+      (tester) async {
+        final fakeApi = _FakeApiClient();
+        final ctrl = fakeApi.enqueueStream();
+        // First replay (in catch block) fails.
+        fakeApi.enqueueReplayError(404);
+        // Second replay (in attemptReconnect) also fails.
+        fakeApi.enqueueReplayError(404);
+        // loadConversation will also fail (fake API has no real server).
+
+        final notifier = await _pumpTestApp(tester, fakeApi);
+
+        unawaited(notifier.sendMessage('hello'));
+        await tester.pump();
+
+        await tester.runAsync(() async {
+          ctrl.add(const RunStartedEvent('run-fail'));
+          await Future<void>.delayed(Duration.zero);
+          ctrl.addError(
+            const HttpException('Connection closed while receiving data'),
+          );
+          await ctrl.close();
+          await Future<void>.delayed(Duration.zero);
+          await Future<void>.delayed(Duration.zero);
+          await Future<void>.delayed(Duration.zero);
+        });
+        await tester.pumpAndSettle();
+
+        expect(notifier.needsReconnect, isTrue);
+
+        // attemptReconnect: replay fails, loadConversation fails.
+        await tester.runAsync(() async {
+          await notifier.attemptReconnect();
+        });
+        await tester.pumpAndSettle();
+
+        final chatState = notifier.state.value!;
+        expect(
+          chatState.error,
+          isNotNull,
+          reason: 'should show error when all recovery strategies fail',
+        );
+        expect(
+          chatState.error!.toLowerCase(),
+          contains('connection lost'),
+          reason: 'should show friendly error message',
+        );
+        expect(
+          notifier.needsReconnect,
+          isFalse,
+          reason: 'reconnect flag cleared even on failure',
+        );
+        final userMsg = chatState.messages.firstWhere((m) => m.isUser);
+        expect(
+          userMsg.status,
+          MessageStatus.failed,
+          reason: 'user message should be marked failed when all retries fail',
+        );
+      },
+    );
+
+    testWidgets(
+      'non-transient error shows immediately (no deferred reconnect)',
+      (tester) async {
+        final fakeApi = _FakeApiClient();
+        final ctrl = fakeApi.enqueueStream();
+
+        final notifier = await _pumpTestApp(tester, fakeApi);
+
+        unawaited(notifier.sendMessage('hello'));
+        await tester.pump();
+
+        await tester.runAsync(() async {
+          ctrl.add(const RunStartedEvent('run-nontransient'));
+          await Future<void>.delayed(Duration.zero);
+          ctrl.addError(const FormatException('malformed response'));
+          await ctrl.close();
+          await Future<void>.delayed(Duration.zero);
+          await Future<void>.delayed(Duration.zero);
+        });
+        await tester.pumpAndSettle();
+
+        final chatState = notifier.state.value!;
+        expect(
+          chatState.error,
+          isNotNull,
+          reason: 'non-transient errors should show immediately',
+        );
+        expect(
+          notifier.needsReconnect,
+          isFalse,
+          reason: 'should not defer non-transient errors',
+        );
+      },
+    );
+
+    testWidgets('attemptReconnect is no-op when not needed', (tester) async {
+      final fakeApi = _FakeApiClient();
+
+      final notifier = await _pumpTestApp(tester, fakeApi);
+
+      final stateBefore = notifier.state.value;
+      await tester.runAsync(() async {
+        await notifier.attemptReconnect();
+      });
+      await tester.pumpAndSettle();
+
+      expect(
+        notifier.state.value,
+        same(stateBefore),
+        reason: 'state should be unchanged when no reconnect is needed',
+      );
+    });
+
+    testWidgets('clearConversation resets reconnect state', (tester) async {
+      final fakeApi = _FakeApiClient();
+      final ctrl = fakeApi.enqueueStream();
+      // Replay fails in catch so deferred reconnect is set.
+      fakeApi.enqueueReplayError(404);
+
+      final notifier = await _pumpTestApp(tester, fakeApi);
+
+      unawaited(notifier.sendMessage('hello'));
+      await tester.pump();
+
+      await tester.runAsync(() async {
+        ctrl.add(const RunStartedEvent('run-clear'));
+        await Future<void>.delayed(Duration.zero);
+        ctrl.addError(
+          const HttpException('Connection closed while receiving data'),
+        );
+        await ctrl.close();
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+      });
+      await tester.pumpAndSettle();
+
+      expect(notifier.needsReconnect, isTrue);
+
+      notifier.clearConversation();
+
+      expect(
+        notifier.needsReconnect,
+        isFalse,
+        reason: 'clearConversation should reset reconnect state',
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary

- When iOS kills the SSE connection (screen off/backgrounding), the app now silently defers recovery instead of showing an error banner
- On app resume, tries event-log replay first, falls back to fetching full conversation history, and only shows an error if both fail
- Transient connection errors (HttpException, SocketException) get friendly messages; non-transient errors still show immediately

## How it works

1. **Stream interrupted** → detect transient error → stash reconnect intent (no error shown)
2. **App resumes** → `AgentEventListener.didChangeAppLifecycleState` calls `attemptReconnect()`
3. **Replay** → tries `streamEventsFrom()` with last sequence number
4. **History fallback** → if replay fails, `loadConversation()` fetches final server state
5. **Error** → only if both strategies fail

## Test plan

- [x] 8 new unit tests covering all reconnection paths (453 total, all passing)
- [x] `flutter analyze` — zero issues
- [ ] Manual: run on iOS, start conversation, lock screen mid-stream, unlock — should see completed response without error