### PR TITLE
feat(openspec): propose llm-wiki skill for structured knowledge

### DIFF
--- a/openspec/changes/llm-wiki-skill/.openspec.yaml
+++ b/openspec/changes/llm-wiki-skill/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-19

--- a/openspec/changes/llm-wiki-skill/design.md
+++ b/openspec/changes/llm-wiki-skill/design.md
@@ -1,0 +1,90 @@
+## Context
+
+The assistant has a memory system with six flat files (SOUL.md, IDENTITY.md, USER.md, TOOLS.md, MEMORY.md, AGENTS.md) and date-keyed daily notes. These are read/written via `memory-get` and `memory-append` builtin tools, with `memory-search` providing hybrid FTS+vector retrieval. The system works well for ephemeral observations but lacks structured, cross-referenced knowledge that persists and evolves across conversations.
+
+Karpathy's "LLM Wiki" pattern proposes that an LLM incrementally builds and maintains a structured markdown wiki — synthesizing knowledge once rather than rediscovering it every query. This design adds wiki capabilities as a pure skill — no new tools, just instructions that teach the agent how to organize a wiki using its existing file I/O capabilities.
+
+Skills are pure knowledge packages: a `SKILL.md` with YAML frontmatter and markdown instructions. They teach the agent how to behave but don't register tools or require Rust code changes.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Ship a builtin skill (`llm-wiki`) that teaches the agent the ingest/query/lint workflows
+- Define conventions for wiki page format, directory layout, index, and activity log
+- Store wiki pages as plain markdown in the agent's workspace directory (`wiki/` subdirectory)
+- Keep the wiki fully optional — agents without the skill loaded behave identically to today
+- Zero Rust code changes — the skill uses existing tools (`bash`, `memory-append`, file I/O)
+
+**Non-Goals:**
+
+- New builtin tools — the agent already has file read/write capabilities
+- Embedding/vector indexing of wiki pages (future work — `memory-search` stays separate)
+- UI for browsing or editing the wiki (agent-internal only)
+- Multi-agent wiki sharing or federation
+- Automatic ingestion triggers (the agent decides when to ingest based on skill instructions)
+
+## Decisions
+
+### D1: Pure skill, no new tools
+
+**Decision:** The entire wiki system is implemented as a SKILL.md that teaches the agent conventions and workflows. The agent uses its existing tools (`bash` for file operations, `memory-search` for finding related content) to maintain the wiki.
+
+**Rationale:** The agent already has all the capabilities needed to read, write, and list files. Adding dedicated wiki tools would duplicate existing functionality and add Rust code to maintain. A skill-only approach is simpler, faster to ship, and follows the project's philosophy that skills are knowledge packages. If tool-level guarantees (e.g., atomic index updates) prove necessary later, tools can be added incrementally.
+
+**Alternatives considered:**
+
+- _Three dedicated tools (`wiki-read`, `wiki-write`, `wiki-list`)_ — Would enforce conventions at the tool layer (e.g., auto-updating index on write). But this rigidity isn't needed at v1 — the LLM can follow conventions from instructions, and the lint workflow catches drift. Rejected as premature.
+
+### D2: Wiki storage as flat markdown files in `wiki/` subdirectory
+
+**Decision:** Wiki pages live at `<agent_workspace>/wiki/<page-name>.md`. The `wiki/` directory sits alongside existing memory files.
+
+**Rationale:** Matches the project's existing approach (memory files are plain markdown on disk). No database schema changes, no migrations. Pages are human-readable and debuggable.
+
+**Alternatives considered:**
+
+- _SQLite table for wiki pages_ — Rejected; wiki should be inspectable by users.
+- _Nested subdirectories by topic_ — Adds complexity without clear benefit at early scale.
+
+### D3: Page format — YAML frontmatter + markdown body + cross-references
+
+**Decision:** The skill instructs the agent to follow this page structure:
+
+```markdown
+---
+title: Page Title
+created: 2026-04-19T12:00:00Z
+updated: 2026-04-19T12:00:00Z
+tags: [topic-a, topic-b]
+---
+
+Content here...
+
+## See Also
+
+- [[related-page]]
+- [[another-page]]
+```
+
+**Rationale:** Frontmatter gives structured metadata for future indexing. `[[wikilink]]` syntax is a well-known convention. Timestamps enable staleness detection during lint. This is a convention enforced by the skill's instructions, not by code.
+
+### D4: Two index files maintained by convention
+
+**Decision:** `wiki/index.md` is a topic catalog with one-line summaries per page. `wiki/log.md` is an append-only activity journal. The skill instructs the agent to update both whenever it modifies wiki pages.
+
+**Rationale:** The index enables page discovery without listing the directory. The log provides an audit trail. Both are maintained by the agent following skill instructions — no tooling enforcement needed.
+
+### D5: Skill includes reference examples and scripts
+
+**Decision:** The skill directory includes a `references/` subdirectory with example wiki pages and index format, so the agent has concrete templates to follow.
+
+**Rationale:** LLMs follow conventions better when given concrete examples rather than abstract rules. Reference files are discovered and served by the skill system automatically.
+
+## Risks / Trade-offs
+
+- **[Convention drift]** → The agent may deviate from wiki conventions over time since nothing enforces them programmatically. Mitigated by the lint workflow and clear examples in the skill's reference files. If drift becomes a problem, dedicated tools can be added later.
+- **[Wiki page sprawl]** → The lint workflow instructs the agent to identify orphan and stale pages. The agent can delete files via bash when cleanup is needed.
+- **[Index desync]** → If wiki files are edited outside the agent, index.md may drift. The lint workflow can rebuild the index by scanning the directory.
+- **[System prompt bloat]** → The skill body is subject to the 20,000 char cap. The skill should be concise; reference files provide detail without inflating the main body.
+- **[No search integration]** → Wiki pages are not indexed by `memory-search`. The agent discovers pages via the index and reads them with file tools. Vector indexing can be added later.

--- a/openspec/changes/llm-wiki-skill/proposal.md
+++ b/openspec/changes/llm-wiki-skill/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+The assistant's memory system stores facts as append-only notes and flat markdown files (SOUL.md, MEMORY.md, daily notes). This works for short-lived context but breaks down for building structured, interconnected knowledge over time — there's no synthesis, no cross-referencing, and no way to organize knowledge by topic or entity. Inspired by Karpathy's "LLM Wiki" concept, a builtin skill can teach the agent to incrementally build and maintain a personal wiki alongside (not replacing) the existing memory files, turning raw observations into a curated, navigable knowledge base.
+
+## What Changes
+
+- **New builtin skill `llm-wiki`** — A SKILL.md that instructs the agent how to maintain a wiki directory structure inside its agent workspace (`~/.assistant/agents/<id>/wiki/`) using the tools it already has (`memory-append`, `bash`, file I/O tools).
+- **Wiki conventions** — The skill defines a page format (YAML frontmatter + markdown body + cross-references), two index files (`wiki/index.md` catalog and `wiki/log.md` activity journal), and `[[wikilink]]` syntax for cross-referencing.
+- **Three core workflows** — The skill teaches the agent:
+  - **Ingest**: When the agent learns new information, it creates/updates wiki pages, maintains cross-references, and logs the activity.
+  - **Query**: When answering questions, the agent checks the wiki for structured context before responding.
+  - **Lint**: Periodic self-check to find stale pages, contradictions, orphans, and missing links.
+- **No new tools** — The agent uses existing file I/O capabilities to read, write, and list wiki pages. The skill is purely instructional.
+
+## Non-goals
+
+- **Not replacing the memory system** — The wiki augments MEMORY.md and daily notes; it does not replace SOUL.md, IDENTITY.md, or the core memory files.
+- **Not a RAG pipeline** — No embedding-based retrieval for wiki pages in this change. The existing `memory-search` vector search remains separate.
+- **Not user-facing UI** — No Flutter screens for browsing/editing the wiki. The wiki is an agent-internal knowledge structure.
+- **Not multi-agent shared wikis** — Each agent has its own wiki directory; no cross-agent wiki federation.
+- **Not new builtin tools** — No new Rust tool handlers. The agent operates on wiki files using its existing tool set.
+
+## Capabilities
+
+### New Capabilities
+
+- `wiki-skill`: The builtin SKILL.md that teaches the agent wiki conventions and maintenance workflows (ingest, query, lint) using existing tools.
+
+### Modified Capabilities
+
+_(none)_
+
+## Impact
+
+- **Crates affected**: `assistant-skills` only (new embedded skill via `include_dir!`)
+- **Storage**: New `wiki/` directory inside agent workspace; no schema/migration changes (plain markdown files on disk)
+- **System prompt**: When the skill is loaded, wiki instructions are injected into context
+- **Existing tools**: No changes — the agent uses `bash`, `memory-append`, and file tools it already has

--- a/openspec/changes/llm-wiki-skill/specs/wiki-skill/spec.md
+++ b/openspec/changes/llm-wiki-skill/specs/wiki-skill/spec.md
@@ -1,0 +1,86 @@
+## ADDED Requirements
+
+### Requirement: Builtin llm-wiki skill exists with valid frontmatter
+
+The system SHALL include a builtin skill at `skills/llm-wiki/SKILL.md` with valid YAML frontmatter containing `name: llm-wiki`, a `description`, and `allowed-tools` listing the existing tools the agent uses for wiki operations (e.g., `bash`, `memory-search`). The skill body SHALL contain markdown instructions for the agent.
+
+#### Scenario: Skill is discovered and parseable
+
+- **WHEN** the skill discovery process scans the builtin skills directory
+- **THEN** it finds `skills/llm-wiki/SKILL.md` and parses it as a valid `SkillDef` with name `llm-wiki`
+
+#### Scenario: Skill is synced to disk
+
+- **WHEN** `sync_builtins_to_disk()` runs
+- **THEN** the `llm-wiki` skill is written to the user's skills directory if not already present or outdated
+
+### Requirement: Skill defines wiki directory layout and page format conventions
+
+The skill body SHALL define the wiki directory structure: pages stored as `<agent_workspace>/wiki/<page-name>.md` with kebab-case names, an `index.md` catalog file, and a `log.md` activity journal. The skill SHALL specify the page format: YAML frontmatter (`title`, `created`, `updated`, `tags`) followed by a markdown body and an optional `## See Also` section using `[[page-name]]` wikilink syntax for cross-references.
+
+#### Scenario: Agent creates a well-formed wiki page
+
+- **WHEN** the agent follows the skill's instructions to create a wiki page
+- **THEN** the resulting file has YAML frontmatter with title, created timestamp, updated timestamp, and tags, followed by markdown content and a See Also section with wikilinks
+
+#### Scenario: Agent maintains the index
+
+- **WHEN** the agent creates or updates a wiki page
+- **THEN** it also updates `wiki/index.md` with a one-line entry for the page (name + summary), following the skill's instructions
+
+#### Scenario: Agent maintains the activity log
+
+- **WHEN** the agent creates or updates a wiki page
+- **THEN** it appends a timestamped entry to `wiki/log.md` recording the action type (created/updated) and page name
+
+### Requirement: Skill defines the ingest workflow
+
+The skill body SHALL instruct the agent on the **ingest** workflow: when the agent acquires new knowledge (from conversation, documents, or tool output), it SHOULD determine whether the information is wiki-worthy (durable, structured knowledge vs. ephemeral observation), and if so, check the wiki index for existing related pages, then create a new page or update an existing one with synthesized knowledge, including cross-references in the `## See Also` section and reciprocal links on related pages.
+
+#### Scenario: Agent ingests new knowledge
+
+- **WHEN** the agent learns a significant new concept or durable fact during conversation
+- **THEN** the skill instructs the agent to check the wiki index, decide whether to create or update a page, write the page with appropriate cross-references, update the index, and log the activity
+
+#### Scenario: Agent adds reciprocal cross-references
+
+- **WHEN** the agent creates or updates a wiki page that relates to existing pages
+- **THEN** the skill instructs the agent to add `[[related-page]]` links in the See Also section and update related pages' See Also sections to link back
+
+### Requirement: Skill defines the query workflow
+
+The skill body SHALL instruct the agent on the **query** workflow: when answering a user question, the agent SHOULD first check the wiki index for relevant pages, read them, and use the structured wiki knowledge to provide a more informed answer. Optionally, valuable Q&A synthesis can be filed back into the wiki.
+
+#### Scenario: Agent queries wiki before answering
+
+- **WHEN** the agent receives a question that may be covered by wiki knowledge
+- **THEN** the skill instructs the agent to check the wiki index, read relevant pages, and incorporate that knowledge into its response
+
+### Requirement: Skill defines the lint workflow
+
+The skill body SHALL instruct the agent on the **lint** workflow: a periodic self-check where the agent reviews the wiki for quality issues including stale pages (not updated recently), orphan pages (no incoming cross-references), missing cross-references between related pages, and contradictions across pages. The agent SHOULD fix issues it finds.
+
+#### Scenario: Agent performs lint check
+
+- **WHEN** the agent is asked to lint the wiki or performs a periodic check
+- **THEN** the skill instructs the agent to read the index and log, identify stale/orphan pages, check for contradictions, and fix issues by updating pages
+
+### Requirement: Skill distinguishes wiki from daily notes and memory files
+
+The skill body SHALL explicitly state that the wiki is complementary to the existing memory system. Daily notes (`memory-append`) are for transient observations. Core memory files (SOUL.md, IDENTITY.md, etc.) are for identity and configuration. The wiki is for synthesized, structured, long-lived, cross-referenced knowledge.
+
+#### Scenario: Agent distinguishes wiki from daily notes
+
+- **WHEN** the agent encounters a transient observation (e.g., "user is debugging auth today")
+- **THEN** the skill instructs the agent to use daily notes rather than the wiki
+- **WHEN** the agent encounters a durable concept (e.g., "the project uses OAuth2 with PKCE flow")
+- **THEN** the skill instructs the agent to write or update a wiki page
+
+### Requirement: Skill includes reference examples
+
+The skill directory SHALL include a `references/` subdirectory with example files demonstrating the expected wiki page format, index format, and log format, giving the agent concrete templates to follow.
+
+#### Scenario: Reference files are available
+
+- **WHEN** the skill is loaded
+- **THEN** the `references/` directory contains at least an example wiki page, an example index.md, and an example log.md

--- a/openspec/changes/llm-wiki-skill/tasks.md
+++ b/openspec/changes/llm-wiki-skill/tasks.md
@@ -1,0 +1,20 @@
+## 1. Skill file
+
+- [ ] 1.1 Create `skills/llm-wiki/SKILL.md` with YAML frontmatter (`name: llm-wiki`, `description`, `allowed-tools: bash memory-search`)
+- [ ] 1.2 Write the wiki conventions section: directory layout (`wiki/`), page format (YAML frontmatter + body + See Also), index.md format, log.md format, kebab-case page naming
+- [ ] 1.3 Write the ingest workflow section: when/how to create or update wiki pages from new knowledge, cross-reference maintenance with `[[wikilink]]` syntax, index and log updates
+- [ ] 1.4 Write the query workflow section: checking the wiki index before answering questions, reading relevant pages, incorporating wiki knowledge
+- [ ] 1.5 Write the lint workflow section: periodic quality checks (stale pages, orphans, contradictions, missing links), how to fix issues
+- [ ] 1.6 Write the disambiguation section: when to use wiki vs daily notes vs MEMORY.md vs core memory files
+
+## 2. Reference examples
+
+- [ ] 2.1 Create `skills/llm-wiki/references/example-page.md` showing the expected wiki page format with frontmatter, content, and See Also section
+- [ ] 2.2 Create `skills/llm-wiki/references/example-index.md` showing the expected index.md format with page entries and summaries
+- [ ] 2.3 Create `skills/llm-wiki/references/example-log.md` showing the expected log.md format with timestamped activity entries
+
+## 3. Verification
+
+- [ ] 3.1 Run `make lint` and `make format` — fix any issues
+- [ ] 3.2 Run `make test` — ensure all existing tests pass (no Rust changes, but verify skill discovery still works)
+- [ ] 3.3 Verify the skill is discovered by the embedded skills system (`include_dir!("skills")` picks up the new directory)


### PR DESCRIPTION
## Summary

- Proposes a new builtin `llm-wiki` skill inspired by [Karpathy's LLM Wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)
- Pure skill approach — no new Rust tools; teaches the agent to maintain a personal wiki using existing file I/O and memory tools
- Defines conventions for wiki pages (YAML frontmatter + markdown + cross-references), index, and activity log
- Three agent workflows: **ingest** (synthesize new knowledge into pages), **query** (consult wiki before answering), **lint** (periodic quality checks)

## Artifacts

| File | Purpose |
|------|---------|
| `proposal.md` | Motivation and scope |
| `design.md` | Technical decisions (especially D1: pure-skill, no new tools) |
| `specs/wiki-skill/spec.md` | Requirements with testable scenarios |
| `tasks.md` | 11 implementation tasks across 3 groups |

## Test plan

- [ ] Review proposal for scope and non-goals
- [ ] Review design decisions (D1: pure skill with no new tools)
- [ ] Review spec scenarios for completeness
- [ ] Review task breakdown for implementability
- [ ] Run `/opsx:apply` to implement when approved