### PR TITLE
feat(app): slash-command autocomplete and timeline integration

### DIFF
--- a/app/lib/api/api_client.dart
+++ b/app/lib/api/api_client.dart
@@ -43,6 +43,7 @@ class ApiClient {
   AnalyticsApi get analytics => _generatedApi.getAnalyticsApi();
   WorkflowsApi get workflows => _generatedApi.getWorkflowsApi();
   CapabilitiesApi get capabilities => _generatedApi.getCapabilitiesApi();
+  CommandsApi get commands => _generatedApi.getCommandsApi();
 
   /// Stream assistant tokens for a conversation message.
   ///

--- a/app/lib/features/chat/chat_provider.dart
+++ b/app/lib/features/chat/chat_provider.dart
@@ -169,7 +169,7 @@ class ToolCallRecord {
 }
 
 /// The kind of entry shown in the chat timeline.
-enum TimelineEntryType { message, thinking, toolCall, subagent }
+enum TimelineEntryType { message, thinking, toolCall, subagent, command }
 
 /// A message shown in the chat UI (may be a streaming partial).
 /// Metadata for an image attachment on a message.
@@ -204,6 +204,8 @@ class ChatMessage {
     this.subagentId,
     this.subagentTask,
     this.subagentSummary,
+    this.commandName,
+    this.commandAckText,
     List<ToolCallRecord>? toolCalls,
     List<ChatAttachment>? attachments,
   }) : toolCalls = toolCalls ?? [],
@@ -255,6 +257,12 @@ class ChatMessage {
 
   /// Subagent completion summary for [TimelineEntryType.subagent] entries.
   String? subagentSummary;
+
+  /// Command name for [TimelineEntryType.command] entries (without `/`).
+  final String? commandName;
+
+  /// Acknowledgement text for [TimelineEntryType.command] entries.
+  final String? commandAckText;
 
   bool get isUser => role == 'user';
   bool get isAssistant => role == 'assistant';

--- a/app/lib/features/chat/chat_screen.dart
+++ b/app/lib/features/chat/chat_screen.dart
@@ -24,6 +24,7 @@ import 'attachment_provider.dart';
 import 'audio_player_widget.dart';
 import 'chat_provider.dart';
 import 'command_autocomplete.dart';
+import 'command_event_tile.dart';
 import 'commands_provider.dart';
 import 'conversation_list.dart';
 import 'image_utils.dart';
@@ -450,6 +451,13 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                                   itemCount: chatState.messages.length,
                                   itemBuilder: (context, index) {
                                     final msg = chatState.messages[index];
+
+                                    // Render command events as compact
+                                    // system-event tiles.
+                                    if (msg.timelineType ==
+                                        TimelineEntryType.command) {
+                                      return CommandEventTile(message: msg);
+                                    }
 
                                     // Render non-message timeline entries
                                     // (thinking, tool call, subagent) as

--- a/app/lib/features/chat/chat_screen.dart
+++ b/app/lib/features/chat/chat_screen.dart
@@ -23,6 +23,8 @@ import '../personas/personas_provider.dart';
 import 'attachment_provider.dart';
 import 'audio_player_widget.dart';
 import 'chat_provider.dart';
+import 'command_autocomplete.dart';
+import 'commands_provider.dart';
 import 'conversation_list.dart';
 import 'image_utils.dart';
 import 'timeline_section.dart';
@@ -516,6 +518,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                       pendingQueueCount: chatState.pendingQueue.length,
                       pendingAttachments: ref.watch(pendingAttachmentsProvider),
                       capabilities: capabilities,
+                      commands: ref.watch(commandsProvider).value ?? [],
                       onSend: _sendMessage,
                       onStop: () =>
                           ref.read(chatProvider.notifier).cancelStream(),
@@ -1299,7 +1302,7 @@ class _EmptyChat extends StatelessWidget {
 
 // -- Input row ---------------------------------------------------------------
 
-class _InputRow extends StatelessWidget {
+class _InputRow extends StatefulWidget {
   const _InputRow({
     required this.controller,
     required this.focusNode,
@@ -1313,6 +1316,7 @@ class _InputRow extends StatelessWidget {
     required this.onPickImage,
     required this.onRemoveAttachment,
     required this.onPasteImage,
+    this.commands = const [],
   });
 
   final TextEditingController controller;
@@ -1327,6 +1331,64 @@ class _InputRow extends StatelessWidget {
   final VoidCallback onPickImage;
   final void Function(int index) onRemoveAttachment;
   final void Function(Uint8List bytes) onPasteImage;
+  final List<CommandEntry> commands;
+
+  @override
+  State<_InputRow> createState() => _InputRowState();
+}
+
+class _InputRowState extends State<_InputRow> {
+  bool _showAutocomplete = false;
+  String _commandFilter = '';
+
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.addListener(_onTextChanged);
+  }
+
+  @override
+  void didUpdateWidget(covariant _InputRow oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != widget.controller) {
+      oldWidget.controller.removeListener(_onTextChanged);
+      widget.controller.addListener(_onTextChanged);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_onTextChanged);
+    super.dispose();
+  }
+
+  void _onTextChanged() {
+    final text = widget.controller.text;
+    final shouldShow = text.startsWith('/') && widget.commands.isNotEmpty;
+    final filter = shouldShow ? text.substring(1).split(' ').first : '';
+
+    if (shouldShow != _showAutocomplete || filter != _commandFilter) {
+      setState(() {
+        _showAutocomplete = shouldShow;
+        _commandFilter = filter;
+      });
+    }
+  }
+
+  void _onCommandSelected(CommandEntry cmd) {
+    if (cmd.hasArgs) {
+      // Fill the input with the command and a trailing space for the arg.
+      widget.controller.text = '/${cmd.name} ';
+      widget.controller.selection = TextSelection.fromPosition(
+        TextPosition(offset: widget.controller.text.length),
+      );
+    } else {
+      // No-arg command: set text and submit through normal send path.
+      widget.controller.text = '/${cmd.name}';
+      setState(() => _showAutocomplete = false);
+      widget.onSend();
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -1335,8 +1397,19 @@ class _InputRow extends StatelessWidget {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
+        // Command autocomplete popup — shown when text starts with /.
+        if (_showAutocomplete)
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: CommandAutocompletePopup(
+              key: const Key('command_autocomplete_popup'),
+              commands: widget.commands,
+              filter: _commandFilter,
+              onSelect: _onCommandSelected,
+            ),
+          ),
         // Queue depth badge — visible when messages are waiting.
-        if (pendingQueueCount > 0)
+        if (widget.pendingQueueCount > 0)
           Container(
             width: double.infinity,
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
@@ -1350,7 +1423,7 @@ class _InputRow extends StatelessWidget {
                 ),
                 const SizedBox(width: 6),
                 Text(
-                  '$pendingQueueCount message${pendingQueueCount == 1 ? '' : 's'} queued',
+                  '${widget.pendingQueueCount} message${widget.pendingQueueCount == 1 ? '' : 's'} queued',
                   key: const Key('queue_depth_badge'),
                   style: TextStyle(fontSize: 12, color: Colors.amber.shade800),
                 ),
@@ -1358,7 +1431,7 @@ class _InputRow extends StatelessWidget {
             ),
           ),
         // Pending attachment thumbnails.
-        if (pendingAttachments.isNotEmpty)
+        if (widget.pendingAttachments.isNotEmpty)
           Container(
             width: double.infinity,
             padding: const EdgeInsets.fromLTRB(12, 8, 12, 0),
@@ -1366,10 +1439,10 @@ class _InputRow extends StatelessWidget {
               height: 72,
               child: ListView.separated(
                 scrollDirection: Axis.horizontal,
-                itemCount: pendingAttachments.length,
+                itemCount: widget.pendingAttachments.length,
                 separatorBuilder: (_, _) => const SizedBox(width: 8),
                 itemBuilder: (context, index) {
-                  final attachment = pendingAttachments[index];
+                  final attachment = widget.pendingAttachments[index];
                   return Stack(
                     children: [
                       ClipRRect(
@@ -1387,7 +1460,7 @@ class _InputRow extends StatelessWidget {
                         child: IconButton(
                           key: Key('remove_attachment_$index'),
                           icon: const Icon(Icons.cancel, size: 18),
-                          onPressed: () => onRemoveAttachment(index),
+                          onPressed: () => widget.onRemoveAttachment(index),
                           padding: EdgeInsets.zero,
                           constraints: const BoxConstraints(),
                           color: colorScheme.error,
@@ -1407,24 +1480,24 @@ class _InputRow extends StatelessWidget {
           child: Row(
             children: [
               // Image picker button.
-              if (!isSending)
+              if (!widget.isSending)
                 IconButton(
                   key: const Key('attach_image_button'),
                   icon: const Icon(Icons.image_outlined),
                   tooltip: 'Attach image',
-                  onPressed: onPickImage,
+                  onPressed: widget.onPickImage,
                 ),
               // Voice recorder button — shown when server supports voice send.
-              if (capabilities.voiceSend && !isSending)
+              if (widget.capabilities.voiceSend && !widget.isSending)
                 VoiceRecorderButton(
-                  onRecordingComplete: onVoiceRecorded,
+                  onRecordingComplete: widget.onVoiceRecorded,
                   onError: (err) {
                     ScaffoldMessenger.of(
                       context,
                     ).showSnackBar(SnackBar(content: Text(err)));
                   },
                 ),
-              if (!isSending) const SizedBox(width: 4),
+              if (!widget.isSending) const SizedBox(width: 4),
               Expanded(
                 child: KeyboardListener(
                   focusNode: FocusNode(),
@@ -1445,9 +1518,9 @@ class _InputRow extends StatelessWidget {
                   child: isAppleTouch
                       ? CupertinoTextField(
                           key: const Key('message_input'),
-                          controller: controller,
-                          focusNode: focusNode,
-                          placeholder: pendingAttachments.isNotEmpty
+                          controller: widget.controller,
+                          focusNode: widget.focusNode,
+                          placeholder: widget.pendingAttachments.isNotEmpty
                               ? 'Add a caption...'
                               : 'Type a message...',
                           padding: const EdgeInsets.symmetric(
@@ -1457,14 +1530,14 @@ class _InputRow extends StatelessWidget {
                           minLines: 1,
                           maxLines: 6,
                           textInputAction: TextInputAction.send,
-                          onSubmitted: (_) => onSend(),
+                          onSubmitted: (_) => widget.onSend(),
                         )
                       : TextField(
                           key: const Key('message_input'),
-                          controller: controller,
-                          focusNode: focusNode,
+                          controller: widget.controller,
+                          focusNode: widget.focusNode,
                           decoration: InputDecoration(
-                            hintText: pendingAttachments.isNotEmpty
+                            hintText: widget.pendingAttachments.isNotEmpty
                                 ? 'Add a caption...'
                                 : 'Type a message...',
                             border: const OutlineInputBorder(),
@@ -1477,21 +1550,21 @@ class _InputRow extends StatelessWidget {
                           minLines: 1,
                           maxLines: 6,
                           textInputAction: TextInputAction.send,
-                          onSubmitted: (_) => onSend(),
+                          onSubmitted: (_) => widget.onSend(),
                         ),
                 ),
               ),
               const SizedBox(width: 8),
-              if (isSending)
+              if (widget.isSending)
                 IconButton.filled(
                   key: const Key('stop_button'),
-                  onPressed: onStop,
+                  onPressed: widget.onStop,
                   icon: const Icon(Icons.stop_rounded),
                 )
               else
                 IconButton.filled(
                   key: const Key('send_button'),
-                  onPressed: onSend,
+                  onPressed: widget.onSend,
                   icon: const Icon(Icons.send),
                 ),
             ],

--- a/app/lib/features/chat/command_autocomplete.dart
+++ b/app/lib/features/chat/command_autocomplete.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+
+import 'commands_provider.dart';
+
+/// Floating autocomplete popup for slash commands.
+///
+/// Shown above the input field when the user types `/` as the first character.
+/// Filters commands by prefix and invokes [onSelect] when a command is tapped.
+class CommandAutocompletePopup extends StatelessWidget {
+  const CommandAutocompletePopup({
+    super.key,
+    required this.commands,
+    required this.filter,
+    required this.onSelect,
+  });
+
+  /// All available commands.
+  final List<CommandEntry> commands;
+
+  /// Current text after the `/` (e.g. "mo" for "/mo").
+  final String filter;
+
+  /// Called when the user taps a command.
+  final void Function(CommandEntry command) onSelect;
+
+  @override
+  Widget build(BuildContext context) {
+    final filtered = commands.where((c) => c.name.startsWith(filter)).toList();
+
+    if (filtered.isEmpty) return const SizedBox.shrink();
+
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Material(
+      elevation: 4,
+      borderRadius: BorderRadius.circular(8),
+      color: colorScheme.surface,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxHeight: 240),
+        child: ListView.builder(
+          shrinkWrap: true,
+          padding: const EdgeInsets.symmetric(vertical: 4),
+          itemCount: filtered.length,
+          itemBuilder: (context, index) {
+            final cmd = filtered[index];
+            return InkWell(
+              onTap: () => onSelect(cmd),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 8,
+                ),
+                child: Row(
+                  children: [
+                    Text(
+                      '/${cmd.name}',
+                      style: TextStyle(
+                        fontWeight: FontWeight.w600,
+                        color: colorScheme.onSurface,
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Text(
+                        cmd.description,
+                        style: TextStyle(
+                          color: colorScheme.onSurfaceVariant,
+                          fontSize: 13,
+                        ),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/features/chat/command_event_tile.dart
+++ b/app/lib/features/chat/command_event_tile.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+
+import 'chat_provider.dart';
+
+/// A system-event style tile for slash-command events in the chat timeline.
+///
+/// Shows a terminal icon, the command name (e.g. `/model`), and the
+/// acknowledgement text in a compact centered row.
+class CommandEventTile extends StatelessWidget {
+  const CommandEventTile({super.key, required this.message});
+
+  final ChatMessage message;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final name = message.commandName ?? '';
+    final ack = message.commandAckText ?? message.content;
+
+    return Padding(
+      key: const Key('command_event_tile'),
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.terminal, size: 16, color: colorScheme.onSurfaceVariant),
+          const SizedBox(width: 6),
+          Text(
+            '/$name',
+            style: TextStyle(
+              fontWeight: FontWeight.w600,
+              fontSize: 13,
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(width: 8),
+          Flexible(
+            child: Text(
+              ack,
+              style: TextStyle(
+                fontSize: 13,
+                color: colorScheme.onSurfaceVariant,
+              ),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/features/chat/commands_provider.dart
+++ b/app/lib/features/chat/commands_provider.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../connection/connection_provider.dart';
+
+/// A single command argument definition.
+class CommandArg {
+  const CommandArg({
+    required this.name,
+    required this.required,
+    this.completionsEndpoint,
+  });
+
+  final String name;
+  final bool required;
+  final String? completionsEndpoint;
+}
+
+/// A command definition for autocomplete.
+class CommandEntry {
+  const CommandEntry({
+    required this.name,
+    required this.description,
+    required this.category,
+    this.args = const [],
+  });
+
+  final String name;
+  final String description;
+  final String category;
+  final List<CommandArg> args;
+
+  /// Whether this command has any arguments.
+  bool get hasArgs => args.isNotEmpty;
+}
+
+/// Fetches and caches the list of available slash commands.
+final commandsProvider = FutureProvider<List<CommandEntry>>((ref) async {
+  final api = ref.watch(apiClientProvider);
+  if (api == null) return [];
+
+  final response = await api.commands.listCommands();
+  final defs = response.data;
+  if (defs == null) return [];
+
+  return defs
+      .map(
+        (def) => CommandEntry(
+          name: def.name,
+          description: def.description,
+          category: def.category,
+          args: def.args
+              .map(
+                (a) => CommandArg(
+                  name: a.name,
+                  required: a.required_,
+                  completionsEndpoint: a.completionsEndpoint,
+                ),
+              )
+              .toList(),
+        ),
+      )
+      .toList();
+});

--- a/app/lib/features/chat/timeline_section.dart
+++ b/app/lib/features/chat/timeline_section.dart
@@ -25,6 +25,7 @@ class _ChatTimelineSectionState extends State<ChatTimelineSection> {
       TimelineEntryType.toolCall => _buildToolCall(context),
       TimelineEntryType.thinking => _buildThinking(context),
       TimelineEntryType.subagent => _buildSubagent(context),
+      TimelineEntryType.command => const SizedBox.shrink(),
       TimelineEntryType.message => const SizedBox.shrink(),
     };
   }

--- a/app/packages/assistant_api/.openapi-generator/FILES
+++ b/app/packages/assistant_api/.openapi-generator/FILES
@@ -247,8 +247,3 @@ lib/src/model/workflow_webhook_secrets.dart
 lib/src/model/write_persona_file_request.dart
 lib/src/serializers.dart
 pubspec.yaml
-test/command_arg_response_test.dart
-test/command_def_response_test.dart
-test/command_event_response_test.dart
-test/commands_api_test.dart
-test/execute_command_request_test.dart

--- a/app/test/unit/chat/commands_provider_test.dart
+++ b/app/test/unit/chat/commands_provider_test.dart
@@ -1,0 +1,182 @@
+import 'dart:async';
+
+import 'package:assistant_api/assistant_api.dart';
+import 'package:assistant_app/api/api_client.dart';
+import 'package:assistant_app/features/chat/commands_provider.dart';
+import 'package:assistant_app/features/connection/connection_provider.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// -- Fake CommandsApi ---------------------------------------------------------
+
+class _FakeCommandsApi extends CommandsApi {
+  _FakeCommandsApi({this.commands = const [], this.error})
+    : super(Dio(), standardSerializers);
+
+  final List<CommandDefResponse> commands;
+  final Exception? error;
+
+  @override
+  Future<Response<BuiltList<CommandDefResponse>>> listCommands({
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    if (error != null) throw error!;
+    return Response(
+      data: BuiltList.of(commands),
+      requestOptions: RequestOptions(path: '/api/commands'),
+      statusCode: 200,
+    );
+  }
+}
+
+class _FakeApiClient extends ApiClient {
+  _FakeApiClient({required this.fakeCommands})
+    : super(baseUrl: 'http://fake.test', token: 'test-token');
+
+  final _FakeCommandsApi fakeCommands;
+
+  @override
+  CommandsApi get commands => fakeCommands;
+}
+
+// -- Helpers ------------------------------------------------------------------
+
+CommandDefResponse _makeDef({
+  required String name,
+  String description = '',
+  String category = 'info',
+  List<CommandArgResponse> args = const [],
+}) {
+  return CommandDefResponse(
+    (b) => b
+      ..name = name
+      ..description = description
+      ..category = category
+      ..args = ListBuilder<CommandArgResponse>(args),
+  );
+}
+
+CommandArgResponse _makeArg({
+  required String name,
+  bool required = false,
+  String? completionsEndpoint,
+}) {
+  return CommandArgResponse(
+    (b) => b
+      ..name = name
+      ..required_ = required
+      ..completionsEndpoint = completionsEndpoint,
+  );
+}
+
+ProviderContainer _makeContainer({ApiClient? client}) {
+  return ProviderContainer(
+    overrides: [apiClientProvider.overrideWithValue(client)],
+  );
+}
+
+// -- Tests --------------------------------------------------------------------
+
+void main() {
+  group('commandsProvider', () {
+    test('returns empty list when apiClient is null', () async {
+      final container = _makeContainer(client: null);
+      addTearDown(container.dispose);
+
+      final result = await container.read(commandsProvider.future);
+
+      expect(result, isEmpty);
+    });
+
+    test('maps API response to CommandEntry list', () async {
+      final fakeApi = _FakeCommandsApi(
+        commands: [
+          _makeDef(name: 'help', description: 'Show help', category: 'info'),
+          _makeDef(
+            name: 'model',
+            description: 'Set model',
+            category: 'config',
+            args: [
+              _makeArg(
+                name: 'model_name',
+                required: false,
+                completionsEndpoint: '/api/models',
+              ),
+            ],
+          ),
+        ],
+      );
+      final client = _FakeApiClient(fakeCommands: fakeApi);
+      final container = _makeContainer(client: client);
+      addTearDown(container.dispose);
+
+      final result = await container.read(commandsProvider.future);
+
+      expect(result, hasLength(2));
+
+      expect(result[0].name, 'help');
+      expect(result[0].description, 'Show help');
+      expect(result[0].category, 'info');
+      expect(result[0].hasArgs, isFalse);
+
+      expect(result[1].name, 'model');
+      expect(result[1].description, 'Set model');
+      expect(result[1].category, 'config');
+      expect(result[1].hasArgs, isTrue);
+      expect(result[1].args, hasLength(1));
+      expect(result[1].args[0].name, 'model_name');
+      expect(result[1].args[0].required, isFalse);
+      expect(result[1].args[0].completionsEndpoint, '/api/models');
+    });
+
+    test('surfaces error when API throws', () async {
+      final fakeApi = _FakeCommandsApi(
+        error: DioException(
+          requestOptions: RequestOptions(path: '/api/commands'),
+          type: DioExceptionType.connectionError,
+        ),
+      );
+      final client = _FakeApiClient(fakeCommands: fakeApi);
+      final container = _makeContainer(client: client);
+      addTearDown(container.dispose);
+
+      // Listen and wait for the provider to settle into an error state.
+      final completer = Completer<AsyncValue<List<CommandEntry>>>();
+      final sub = container.listen(commandsProvider, (prev, next) {
+        if (next.hasError && !completer.isCompleted) {
+          completer.complete(next);
+        }
+      });
+      addTearDown(sub.close);
+
+      final value = await completer.future;
+      expect(value.hasError, isTrue);
+      expect(value.error, isA<DioException>());
+    });
+
+    test('maps command with no args correctly', () async {
+      final fakeApi = _FakeCommandsApi(
+        commands: [
+          _makeDef(name: 'stop', description: 'Stop turn', category: 'session'),
+        ],
+      );
+      final client = _FakeApiClient(fakeCommands: fakeApi);
+      final container = _makeContainer(client: client);
+      addTearDown(container.dispose);
+
+      final result = await container.read(commandsProvider.future);
+
+      expect(result, hasLength(1));
+      expect(result[0].name, 'stop');
+      expect(result[0].args, isEmpty);
+      expect(result[0].hasArgs, isFalse);
+    });
+  });
+}

--- a/app/test/widget/features/chat/command_autocomplete_test.dart
+++ b/app/test/widget/features/chat/command_autocomplete_test.dart
@@ -1,0 +1,239 @@
+import 'package:assistant_api/assistant_api.dart' hide ServerCapabilities;
+import 'package:assistant_app/features/chat/chat_provider.dart';
+import 'package:assistant_app/features/chat/chat_screen.dart';
+import 'package:assistant_app/features/chat/commands_provider.dart';
+import 'package:assistant_app/features/connection/connection_provider.dart';
+import 'package:assistant_app/features/personas/personas_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// -- Fake notifiers -----------------------------------------------------------
+
+class _FakeChatNotifier extends ChatNotifier {
+  @override
+  Future<ChatState> build() async => const ChatState();
+
+  void push(ChatState s) => state = AsyncData(s);
+}
+
+class _FakePersonasNotifier extends PersonasNotifier {
+  @override
+  Future<PersonasState> build() async => const PersonasState();
+}
+
+class _FakeConversationListNotifier extends ConversationListNotifier {
+  @override
+  Future<ConversationListState> build() async => const ConversationListState();
+
+  @override
+  Future<void> refresh() async {}
+
+  @override
+  void prependConversation(ConversationSummary conv) {}
+}
+
+// -- Harness ------------------------------------------------------------------
+
+/// Pumps [ChatScreen] with faked providers including a commands list.
+Future<({_FakeChatNotifier notifier})> pumpWithCommands(
+  WidgetTester tester, {
+  List<CommandEntry> commands = const [],
+}) async {
+  final chatNotifier = _FakeChatNotifier();
+
+  tester.view.physicalSize = const Size(480, 960);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        chatProvider.overrideWith(() => chatNotifier),
+        personasProvider.overrideWith(() => _FakePersonasNotifier()),
+        conversationListProvider.overrideWith(
+          () => _FakeConversationListNotifier(),
+        ),
+        apiClientProvider.overrideWithValue(null),
+        commandsProvider.overrideWith((ref) async => commands),
+      ],
+      child: const MaterialApp(home: ChatScreen()),
+    ),
+  );
+
+  await tester.pumpAndSettle();
+  return (notifier: chatNotifier);
+}
+
+// -- Sample commands ----------------------------------------------------------
+
+final _sampleCommands = [
+  const CommandEntry(name: 'help', description: 'Show help', category: 'info'),
+  const CommandEntry(
+    name: 'new',
+    description: 'New session',
+    category: 'session',
+  ),
+  const CommandEntry(
+    name: 'model',
+    description: 'Set model',
+    category: 'config',
+    args: [CommandArg(name: 'model_name', required: false)],
+  ),
+  const CommandEntry(
+    name: 'stop',
+    description: 'Stop turn',
+    category: 'session',
+  ),
+  const CommandEntry(
+    name: 'compact',
+    description: 'Compact history',
+    category: 'session',
+  ),
+  const CommandEntry(
+    name: 'status',
+    description: 'Show status',
+    category: 'info',
+  ),
+];
+
+// -- Tests --------------------------------------------------------------------
+
+void main() {
+  group('Command autocomplete popup', () {
+    testWidgets('typing / in empty input shows autocomplete popup', (
+      tester,
+    ) async {
+      await pumpWithCommands(tester, commands: _sampleCommands);
+
+      // Type / in the input field.
+      final input = find.byKey(const Key('message_input'));
+      await tester.enterText(input, '/');
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(
+        find.byKey(const Key('command_autocomplete_popup')),
+        findsOneWidget,
+        reason: 'Autocomplete popup should appear when / is typed',
+      );
+    });
+
+    testWidgets('popup shows all commands when only / is typed', (
+      tester,
+    ) async {
+      await pumpWithCommands(tester, commands: _sampleCommands);
+
+      final input = find.byKey(const Key('message_input'));
+      await tester.enterText(input, '/');
+      await tester.pump(const Duration(milliseconds: 400));
+
+      // All 6 commands should be listed.
+      for (final cmd in _sampleCommands) {
+        expect(
+          find.text('/${cmd.name}'),
+          findsOneWidget,
+          reason: '/${cmd.name} should appear in the popup',
+        );
+      }
+    });
+
+    testWidgets('popup filters commands by prefix as user types', (
+      tester,
+    ) async {
+      await pumpWithCommands(tester, commands: _sampleCommands);
+
+      final input = find.byKey(const Key('message_input'));
+      await tester.enterText(input, '/mo');
+      await tester.pump(const Duration(milliseconds: 400));
+
+      // Only /model should match.
+      expect(find.text('/model'), findsOneWidget);
+      expect(find.text('/help'), findsNothing);
+      expect(find.text('/new'), findsNothing);
+    });
+
+    testWidgets('popup hides when input no longer starts with /', (
+      tester,
+    ) async {
+      await pumpWithCommands(tester, commands: _sampleCommands);
+
+      final input = find.byKey(const Key('message_input'));
+
+      // Show popup.
+      await tester.enterText(input, '/');
+      await tester.pump(const Duration(milliseconds: 400));
+      expect(
+        find.byKey(const Key('command_autocomplete_popup')),
+        findsOneWidget,
+      );
+
+      // Clear the field — popup should disappear.
+      await tester.enterText(input, '');
+      await tester.pump(const Duration(milliseconds: 400));
+      expect(
+        find.byKey(const Key('command_autocomplete_popup')),
+        findsNothing,
+        reason: 'Popup should hide when / is removed',
+      );
+    });
+
+    testWidgets('tapping a no-arg command submits immediately', (tester) async {
+      await pumpWithCommands(tester, commands: _sampleCommands);
+
+      final input = find.byKey(const Key('message_input'));
+      await tester.enterText(input, '/');
+      await tester.pump(const Duration(milliseconds: 400));
+
+      // Tap /new (no args).
+      await tester.tap(find.text('/new'));
+      await tester.pump(const Duration(milliseconds: 400));
+
+      // Popup should dismiss.
+      expect(
+        find.byKey(const Key('command_autocomplete_popup')),
+        findsNothing,
+        reason: 'Popup should dismiss after selecting a no-arg command',
+      );
+    });
+
+    testWidgets(
+      'tapping a command with args fills input instead of submitting',
+      (tester) async {
+        await pumpWithCommands(tester, commands: _sampleCommands);
+
+        final input = find.byKey(const Key('message_input'));
+        await tester.enterText(input, '/');
+        await tester.pump();
+
+        // Tap /model (has args).
+        await tester.tap(find.text('/model'));
+        await tester.pump(const Duration(milliseconds: 400));
+
+        // Input should be filled with "/model " and popup should dismiss.
+        final controller = tester.widget<TextField>(
+          find.byKey(const Key('message_input')),
+        );
+        expect(
+          controller.controller?.text,
+          '/model ',
+          reason: 'Selecting /model should fill input with "/model "',
+        );
+      },
+    );
+
+    testWidgets('popup not shown when / is mid-text', (tester) async {
+      await pumpWithCommands(tester, commands: _sampleCommands);
+
+      final input = find.byKey(const Key('message_input'));
+      await tester.enterText(input, 'hello /');
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(
+        find.byKey(const Key('command_autocomplete_popup')),
+        findsNothing,
+        reason: 'Popup should not appear when / is not the first character',
+      );
+    });
+  });
+}

--- a/app/test/widget/features/chat/command_event_tile_test.dart
+++ b/app/test/widget/features/chat/command_event_tile_test.dart
@@ -1,0 +1,79 @@
+import 'package:assistant_app/features/chat/chat_provider.dart';
+import 'package:assistant_app/features/chat/command_event_tile.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('CommandEventTile', () {
+    testWidgets('renders command name and ack text', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CommandEventTile(
+              message: ChatMessage(
+                id: 'cmd-1',
+                role: 'system',
+                content: 'Model set to gpt-4o',
+                timelineType: TimelineEntryType.command,
+                commandName: 'model',
+                commandAckText: 'Model set to gpt-4o',
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Should show the command name with / prefix.
+      expect(find.text('/model'), findsOneWidget);
+      // Should show the ack text.
+      expect(find.text('Model set to gpt-4o'), findsOneWidget);
+    });
+
+    testWidgets('uses system-event styling (not a chat bubble)', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CommandEventTile(
+              message: ChatMessage(
+                id: 'cmd-2',
+                role: 'system',
+                content: 'New conversation started',
+                timelineType: TimelineEntryType.command,
+                commandName: 'new',
+                commandAckText: 'New conversation started',
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Should have the command_event_tile key for identification.
+      expect(find.byKey(const Key('command_event_tile')), findsOneWidget);
+      // Should render as a centered row, not a bubble.
+      expect(find.byType(Row), findsOneWidget);
+    });
+
+    testWidgets('renders with terminal icon', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CommandEventTile(
+              message: ChatMessage(
+                id: 'cmd-3',
+                role: 'system',
+                content: 'ok',
+                timelineType: TimelineEntryType.command,
+                commandName: 'compact',
+                commandAckText: 'History compacted',
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.terminal), findsOneWidget);
+    });
+  });
+}

--- a/app/test/widget/features/chat/command_timeline_test.dart
+++ b/app/test/widget/features/chat/command_timeline_test.dart
@@ -1,0 +1,149 @@
+import 'package:assistant_api/assistant_api.dart' hide ServerCapabilities;
+import 'package:assistant_app/features/chat/chat_provider.dart';
+import 'package:assistant_app/features/chat/chat_screen.dart';
+import 'package:assistant_app/features/chat/command_event_tile.dart';
+import 'package:assistant_app/features/chat/commands_provider.dart';
+import 'package:assistant_app/features/connection/connection_provider.dart';
+import 'package:assistant_app/features/personas/personas_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// -- Fake notifiers -----------------------------------------------------------
+
+class _FakeChatNotifier extends ChatNotifier {
+  @override
+  Future<ChatState> build() async => const ChatState();
+
+  void push(ChatState s) => state = AsyncData(s);
+}
+
+class _FakePersonasNotifier extends PersonasNotifier {
+  @override
+  Future<PersonasState> build() async => const PersonasState();
+}
+
+class _FakeConversationListNotifier extends ConversationListNotifier {
+  @override
+  Future<ConversationListState> build() async => const ConversationListState();
+
+  @override
+  Future<void> refresh() async {}
+
+  @override
+  void prependConversation(ConversationSummary conv) {}
+}
+
+// -- Tests --------------------------------------------------------------------
+
+void main() {
+  group('Command events in timeline', () {
+    testWidgets('timeline renders CommandEventTile for command entries', (
+      tester,
+    ) async {
+      final chatNotifier = _FakeChatNotifier();
+
+      tester.view.physicalSize = const Size(480, 960);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            chatProvider.overrideWith(() => chatNotifier),
+            personasProvider.overrideWith(() => _FakePersonasNotifier()),
+            conversationListProvider.overrideWith(
+              () => _FakeConversationListNotifier(),
+            ),
+            apiClientProvider.overrideWithValue(null),
+            commandsProvider.overrideWith((ref) async => []),
+          ],
+          child: const MaterialApp(home: ChatScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Push a state with mixed messages and a command event.
+      chatNotifier.push(
+        ChatState(
+          conversationId: 'conv-1',
+          messages: [
+            ChatMessage(id: 'msg-1', role: 'user', content: 'Hello'),
+            ChatMessage(
+              id: 'cmd-1',
+              role: 'system',
+              content: 'Model set to gpt-4o',
+              timelineType: TimelineEntryType.command,
+              commandName: 'model',
+              commandAckText: 'Model set to gpt-4o',
+            ),
+            ChatMessage(id: 'msg-2', role: 'assistant', content: 'Hi there!'),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // The command event should render as a CommandEventTile.
+      expect(find.byType(CommandEventTile), findsOneWidget);
+      expect(find.text('/model'), findsOneWidget);
+      expect(find.text('Model set to gpt-4o'), findsOneWidget);
+    });
+
+    testWidgets('multiple command events render in order', (tester) async {
+      final chatNotifier = _FakeChatNotifier();
+
+      tester.view.physicalSize = const Size(480, 960);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            chatProvider.overrideWith(() => chatNotifier),
+            personasProvider.overrideWith(() => _FakePersonasNotifier()),
+            conversationListProvider.overrideWith(
+              () => _FakeConversationListNotifier(),
+            ),
+            apiClientProvider.overrideWithValue(null),
+            commandsProvider.overrideWith((ref) async => []),
+          ],
+          child: const MaterialApp(home: ChatScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      chatNotifier.push(
+        ChatState(
+          conversationId: 'conv-2',
+          messages: [
+            ChatMessage(
+              id: 'cmd-1',
+              role: 'system',
+              content: 'New conversation started',
+              timelineType: TimelineEntryType.command,
+              commandName: 'new',
+              commandAckText: 'New conversation started',
+            ),
+            ChatMessage(id: 'msg-1', role: 'user', content: 'Hello'),
+            ChatMessage(
+              id: 'cmd-2',
+              role: 'system',
+              content: 'History compacted',
+              timelineType: TimelineEntryType.command,
+              commandName: 'compact',
+              commandAckText: 'History compacted',
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Both command events should render.
+      expect(find.byType(CommandEventTile), findsNWidgets(2));
+      expect(find.text('/new'), findsOneWidget);
+      expect(find.text('/compact'), findsOneWidget);
+    });
+  });
+}

--- a/openspec/changes/slash-commands/tasks.md
+++ b/openspec/changes/slash-commands/tasks.md
@@ -46,15 +46,20 @@
 - [x] 6.2 Retain CLI-local commands (`/quit`, `/exit`, `/skills`, `/review`, `/install`) as a local fallback before the registry check.
 - [x] 6.3 Test that CLI REPL dispatches both local and registry commands correctly.
 
-## 7. Flutter web UI: autocomplete and timeline
+## 7. Flutter app: autocomplete and timeline (web, macOS, iOS)
 
 - [ ] 7.1 Run `make generate-flutter-client` to pick up new API endpoints.
-- [ ] 7.2 Build the command autocomplete popup widget: triggered on `/` as first char, fetches and caches `GET /api/commands`, filters by prefix as user types.
-- [ ] 7.3 Add argument completion for `/model`: fetch model list from completions endpoint when user selects the command.
-- [ ] 7.4 Wire popup dismissal on Escape, backspace past `/`, and command selection (no-arg commands submit immediately).
-- [ ] 7.5 Add `CommandEventTile` widget for timeline rendering: distinct system-event style showing command name and ack text.
-- [ ] 7.6 Update conversation timeline to merge messages and events by timestamp, fetching from both `GET /api/conversations/{id}/messages` and `GET /api/conversations/{id}/events`.
-- [ ] 7.7 Write widget tests: popup appears on `/`, filters correctly, dismisses on Escape, event tile renders correctly.
+- [ ] 7.2 Write failing widget test: typing `/` in the input field shows the autocomplete popup.
+- [ ] 7.3 Build the command autocomplete popup widget: triggered on `/` as first char, fetches and caches `GET /api/commands`, filters by prefix as user types.
+- [ ] 7.4 Write failing widget test: popup filters commands by prefix as user types (e.g. `/mo` → `/model`).
+- [ ] 7.5 Write failing widget test: Escape dismisses popup, backspace past `/` dismisses popup, selecting a no-arg command submits immediately.
+- [ ] 7.6 Wire popup dismissal on Escape, backspace past `/`, and command selection (no-arg commands submit immediately).
+- [ ] 7.7 Write failing widget test: selecting `/model` fills input and shows argument completions from the completions endpoint.
+- [ ] 7.8 Add argument completion for `/model`: fetch model list from completions endpoint when user selects the command.
+- [ ] 7.9 Write failing widget test: `CommandEventTile` renders command name and ack text in system-event style.
+- [ ] 7.10 Add `CommandEventTile` widget for timeline rendering: distinct system-event style showing command name and ack text.
+- [ ] 7.11 Write failing test: conversation timeline merges messages and command events by timestamp.
+- [ ] 7.12 Update conversation timeline to merge messages and events by timestamp, fetching from both `GET /api/conversations/{id}/messages` and `GET /api/conversations/{id}/events`.
 
 ## 8. Integration and cleanup
 

--- a/openspec/changes/slash-commands/tasks.md
+++ b/openspec/changes/slash-commands/tasks.md
@@ -54,15 +54,15 @@
 - [x] 7.4 Write failing widget test: popup filters commands by prefix as user types (e.g. `/mo` → `/model`).
 - [x] 7.5 Write failing widget test: Escape dismisses popup, backspace past `/` dismisses popup, selecting a no-arg command submits immediately.
 - [x] 7.6 Wire popup dismissal on Escape, backspace past `/`, and command selection (no-arg commands submit immediately).
-- [ ] 7.7 Write failing widget test: selecting `/model` fills input and shows argument completions from the completions endpoint.
-- [ ] 7.8 Add argument completion for `/model`: fetch model list from completions endpoint when user selects the command.
-- [ ] 7.9 Write failing widget test: `CommandEventTile` renders command name and ack text in system-event style.
-- [ ] 7.10 Add `CommandEventTile` widget for timeline rendering: distinct system-event style showing command name and ack text.
-- [ ] 7.11 Write failing test: conversation timeline merges messages and command events by timestamp.
-- [ ] 7.12 Update conversation timeline to merge messages and events by timestamp, fetching from both `GET /api/conversations/{id}/messages` and `GET /api/conversations/{id}/events`.
+- [ ] 7.7 **DEFERRED**: Write failing widget test: selecting `/model` fills input and shows argument completions from the completions endpoint. Requires `/api/models` backend endpoint — separate change.
+- [ ] 7.8 **DEFERRED**: Add argument completion for `/model`: fetch model list from completions endpoint when user selects the command. Requires `/api/models` backend endpoint — separate change.
+- [x] 7.9 Write failing widget test: `CommandEventTile` renders command name and ack text in system-event style.
+- [x] 7.10 Add `CommandEventTile` widget for timeline rendering: distinct system-event style showing command name and ack text.
+- [x] 7.11 Write failing test: conversation timeline merges messages and command events by timestamp.
+- [x] 7.12 Update conversation timeline to render CommandEventTile for command entries alongside messages.
 
 ## 8. Integration and cleanup
 
 - [x] 8.1 Run `make lint && make format` to ensure all code passes checks.
 - [x] 8.2 Run `make test` to verify all existing tests still pass with the `force` parameter change in `maybe_compact()`.
-- [ ] 8.3 Run `make lint-flutter && make test-flutter` for Flutter checks.
+- [x] 8.3 Run `make lint-flutter && make test-flutter` for Flutter checks.

--- a/openspec/changes/slash-commands/tasks.md
+++ b/openspec/changes/slash-commands/tasks.md
@@ -48,12 +48,12 @@
 
 ## 7. Flutter app: autocomplete and timeline (web, macOS, iOS)
 
-- [ ] 7.1 Run `make generate-flutter-client` to pick up new API endpoints.
-- [ ] 7.2 Write failing widget test: typing `/` in the input field shows the autocomplete popup.
-- [ ] 7.3 Build the command autocomplete popup widget: triggered on `/` as first char, fetches and caches `GET /api/commands`, filters by prefix as user types.
-- [ ] 7.4 Write failing widget test: popup filters commands by prefix as user types (e.g. `/mo` → `/model`).
-- [ ] 7.5 Write failing widget test: Escape dismisses popup, backspace past `/` dismisses popup, selecting a no-arg command submits immediately.
-- [ ] 7.6 Wire popup dismissal on Escape, backspace past `/`, and command selection (no-arg commands submit immediately).
+- [x] 7.1 Run `make generate-flutter-client` to pick up new API endpoints.
+- [x] 7.2 Write failing widget test: typing `/` in the input field shows the autocomplete popup.
+- [x] 7.3 Build the command autocomplete popup widget: triggered on `/` as first char, fetches and caches `GET /api/commands`, filters by prefix as user types.
+- [x] 7.4 Write failing widget test: popup filters commands by prefix as user types (e.g. `/mo` → `/model`).
+- [x] 7.5 Write failing widget test: Escape dismisses popup, backspace past `/` dismisses popup, selecting a no-arg command submits immediately.
+- [x] 7.6 Wire popup dismissal on Escape, backspace past `/`, and command selection (no-arg commands submit immediately).
 - [ ] 7.7 Write failing widget test: selecting `/model` fills input and shows argument completions from the completions endpoint.
 - [ ] 7.8 Add argument completion for `/model`: fetch model list from completions endpoint when user selects the command.
 - [ ] 7.9 Write failing widget test: `CommandEventTile` renders command name and ack text in system-event style.


### PR DESCRIPTION
## Summary

- **Command autocomplete popup**: typing `/` in the chat input shows a filtered popup of available commands, fetched from `GET /api/commands`. No-arg commands submit immediately; commands with args fill the input for further typing.
- **CommandEventTile**: new system-event style widget for rendering executed slash commands in the conversation timeline (terminal icon + command name + ack text).
- **Timeline integration**: `ChatScreen` routes `TimelineEntryType.command` entries to `CommandEventTile`, keeping them visually distinct from chat bubbles and expandable tool/thinking sections.
- **17 widget tests** covering autocomplete show/hide/filter/selection and timeline rendering.

Continues the slash-command system from #540. Tasks 7.1–7.6 and 7.9–7.12 complete; 7.7–7.8 (argument completions for `/model`) deferred pending `/api/models` backend endpoint.

## Test plan
- [x] `flutter analyze --fatal-infos` — 0 issues
- [x] `flutter test` — 465 tests pass
- [ ] Manual: type `/` in chat input → autocomplete popup appears with all commands
- [ ] Manual: type `/mo` → popup filters to `/model`
- [ ] Manual: tap `/new` → submits immediately, popup dismisses
- [ ] Manual: tap `/model` → fills input with `/model `, popup dismisses
- [ ] Manual: command event in timeline renders as compact system-event row