### PR TITLE
fix(app): remove dart:io Platform crash on web, add error screen

### DIFF
--- a/app/lib/features/chat/chat_provider.dart
+++ b/app/lib/features/chat/chat_provider.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:assistant_api/assistant_api.dart' hide ServerCapabilities;
@@ -1418,13 +1417,13 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
   /// Returns `true` if [error] looks like a transient connection failure
   /// (iOS backgrounding, network blip) rather than a permanent server error.
   static bool _isTransientError(Object error) {
-    if (error is HttpException) return true;
     if (error is DioException &&
         error.type == DioExceptionType.connectionError) {
       return true;
     }
     final msg = error.toString();
-    return msg.contains('Connection closed') ||
+    return msg.contains('HttpException') ||
+        msg.contains('Connection closed') ||
         msg.contains('Connection reset') ||
         msg.contains('SocketException');
   }

--- a/app/lib/features/updater/update_banner.dart
+++ b/app/lib/features/updater/update_banner.dart
@@ -1,6 +1,5 @@
-import 'dart:io';
-
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -17,8 +16,8 @@ class UpdateBannerWrapper extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // Self-update is not supported on iOS - skip banner entirely
-    if (Platform.isIOS) return child;
+    // Self-update is not supported on web or iOS — skip banner entirely.
+    if (kIsWeb || defaultTargetPlatform == TargetPlatform.iOS) return child;
 
     final updateAsync = ref.watch(updateCheckProvider);
 

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -8,6 +10,7 @@ import 'features/embedded_server/embedded_server_provider.dart';
 import 'features/notifications/notification_badge_notifier.dart';
 import 'features/pwa/pwa_update_service.dart';
 import 'router/app_router.dart';
+import 'shared/error_screen.dart';
 import 'shared/platform/adaptive_app.dart';
 import 'tray/platform_init.dart';
 import 'tray/tray_platform.dart';
@@ -19,6 +22,21 @@ final _scaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  // -- Global error handling --------------------------------------------------
+  // Replace the default red/grey error widget with a styled error screen that
+  // shows crash details visibly instead of only logging to the console.
+  ErrorWidget.builder = (details) => ErrorScreen(details: details);
+
+  // Catch async errors that escape the Flutter framework (e.g. unhandled
+  // Future rejections). Log them so they appear in the browser console /
+  // device log rather than being silently swallowed.
+  PlatformDispatcher.instance.onError = (error, stack) {
+    FlutterError.reportError(
+      FlutterErrorDetails(exception: error, stack: stack),
+    );
+    return true;
+  };
 
   // Use /path URLs instead of /#/path. The Rust server's SPA handler serves
   // index.html for every unmatched path, so deep-linking works correctly.

--- a/app/lib/shared/error_screen.dart
+++ b/app/lib/shared/error_screen.dart
@@ -1,0 +1,213 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import 'platform/platform.dart';
+
+/// A visible error screen shown when an unhandled Flutter framework error
+/// occurs during widget build, layout, or rendering.
+///
+/// On Apple touch platforms (iOS / iPadOS / Catalyst) this renders a
+/// Cupertino-styled page; on Material platforms (web, Android, macOS desktop)
+/// it uses Material 3 widgets — matching the project's adaptive pattern via
+/// [isAppleTouch].
+///
+/// In debug/profile mode the full error details are shown so developers can
+/// diagnose the issue. In release mode a friendlier message is displayed.
+///
+/// Wire this up via [ErrorWidget.builder] in `main()` so that broken widgets
+/// render this screen instead of the default red/grey error box.
+class ErrorScreen extends StatelessWidget {
+  const ErrorScreen({super.key, required this.details});
+
+  final FlutterErrorDetails details;
+
+  @override
+  Widget build(BuildContext context) {
+    final content = _ErrorContent(details: details);
+
+    if (isAppleTouch) {
+      return CupertinoPageScaffold(
+        navigationBar: const CupertinoNavigationBar(
+          middle: Text('Something went wrong'),
+          automaticBackgroundVisibility: false,
+        ),
+        child: content,
+      );
+    }
+
+    return Material(
+      color: Theme.of(context).colorScheme.surface,
+      child: content,
+    );
+  }
+}
+
+/// Shared body content used by both Cupertino and Material paths.
+class _ErrorContent extends StatelessWidget {
+  const _ErrorContent({required this.details});
+
+  final FlutterErrorDetails details;
+
+  @override
+  Widget build(BuildContext context) {
+    // Resolve colors via the Material theme — Cupertino path inherits a
+    // Material Theme wrapper from AdaptiveApp, so this works on both.
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return SafeArea(
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (!isAppleTouch) ...[
+              Row(
+                children: [
+                  Icon(Icons.error_outline, color: colorScheme.error, size: 32),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text(
+                      'Something went wrong',
+                      style: Theme.of(context).textTheme.headlineSmall
+                          ?.copyWith(
+                            color: colorScheme.error,
+                            fontWeight: FontWeight.w600,
+                          ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+            ],
+            Text(
+              _userMessage(details),
+              style: Theme.of(
+                context,
+              ).textTheme.bodyLarge?.copyWith(color: colorScheme.onSurface),
+            ),
+            if (kDebugMode || kProfileMode) ...[
+              const SizedBox(height: 24),
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  color: colorScheme.errorContainer.withValues(alpha: 0.3),
+                  borderRadius: BorderRadius.circular(12),
+                  border: Border.all(
+                    color: colorScheme.error.withValues(alpha: 0.3),
+                  ),
+                ),
+                child: SelectableText(
+                  details.exceptionAsString(),
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    fontFamily: 'monospace',
+                    color: colorScheme.onErrorContainer,
+                  ),
+                ),
+              ),
+              if (details.stack != null) ...[
+                const SizedBox(height: 16),
+                _StackTraceSection(
+                  stack: details.stack!,
+                  colorScheme: colorScheme,
+                ),
+              ],
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  static String _userMessage(FlutterErrorDetails details) {
+    if (kReleaseMode) {
+      return 'An unexpected error occurred. '
+          'Try refreshing the page or restarting the app.';
+    }
+
+    final buffer = StringBuffer();
+    if (details.context != null) {
+      buffer.writeln('Error caught by: ${details.context}');
+    }
+    if (details.library != null) {
+      buffer.writeln('Library: ${details.library}');
+    }
+    return buffer.isEmpty
+        ? details.exceptionAsString()
+        : buffer.toString().trimRight();
+  }
+}
+
+/// Expandable stack trace section.
+///
+/// Uses [ExpansionTile] on Material and a tap-to-expand pattern on Cupertino
+/// (since ExpansionTile uses Material ink effects that look out of place on
+/// iOS).
+class _StackTraceSection extends StatefulWidget {
+  const _StackTraceSection({required this.stack, required this.colorScheme});
+
+  final StackTrace stack;
+  final ColorScheme colorScheme;
+
+  @override
+  State<_StackTraceSection> createState() => _StackTraceSectionState();
+}
+
+class _StackTraceSectionState extends State<_StackTraceSection> {
+  bool _expanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final traceBox = Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: widget.colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: SelectableText(
+        widget.stack.toString(),
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+          fontFamily: 'monospace',
+          fontSize: 11,
+          color: widget.colorScheme.onSurfaceVariant,
+        ),
+      ),
+    );
+
+    if (isAppleTouch) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          CupertinoButton(
+            padding: EdgeInsets.zero,
+            onPressed: () => setState(() => _expanded = !_expanded),
+            child: Row(
+              children: [
+                Icon(
+                  _expanded
+                      ? CupertinoIcons.chevron_down
+                      : CupertinoIcons.chevron_right,
+                  size: 16,
+                  color: widget.colorScheme.onSurfaceVariant,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  'Stack trace',
+                  style: Theme.of(context).textTheme.titleSmall,
+                ),
+              ],
+            ),
+          ),
+          if (_expanded) ...[const SizedBox(height: 8), traceBox],
+        ],
+      );
+    }
+
+    return ExpansionTile(
+      title: Text('Stack trace', style: Theme.of(context).textTheme.titleSmall),
+      children: [traceBox],
+    );
+  }
+}

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -1333,10 +1333,10 @@ packages:
     dependency: transitive
     description:
       name: synchronized
-      sha256: c254ade258ec8282947a0acbbc90b9575b4f19673533ee46f2f6e9b3aeefd7c0
+      sha256: "63896c27e81b28f8cb4e69ead0d3e8f03f1d1e5fc531a3e579cabed6a2c7c9e5"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.0"
+    version: "3.4.0+1"
   term_glyph:
     dependency: transitive
     description:

--- a/app/test/unit/shared/error_screen_test.dart
+++ b/app/test/unit/shared/error_screen_test.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/shared/error_screen.dart';
+
+void main() {
+  group('ErrorScreen', () {
+    final details = FlutterErrorDetails(
+      exception: UnsupportedError('Platform._operatingSystem'),
+      library: 'dart:io',
+      context: ErrorDescription('during build'),
+      stack: StackTrace.current,
+    );
+
+    // -- Material (default platform) ------------------------------------------
+
+    testWidgets('Material: renders error icon and heading', (tester) async {
+      await tester.pumpWidget(MaterialApp(home: ErrorScreen(details: details)));
+
+      expect(find.byIcon(Icons.error_outline), findsOneWidget);
+      expect(find.text('Something went wrong'), findsOneWidget);
+    });
+
+    testWidgets('Material: shows exception text in debug mode', (tester) async {
+      await tester.pumpWidget(MaterialApp(home: ErrorScreen(details: details)));
+
+      expect(find.textContaining('Platform._operatingSystem'), findsWidgets);
+    });
+
+    testWidgets('Material: shows library and context info', (tester) async {
+      await tester.pumpWidget(MaterialApp(home: ErrorScreen(details: details)));
+
+      expect(find.textContaining('dart:io'), findsOneWidget);
+      expect(find.textContaining('during build'), findsOneWidget);
+    });
+
+    testWidgets('Material: has ExpansionTile stack trace', (tester) async {
+      await tester.pumpWidget(MaterialApp(home: ErrorScreen(details: details)));
+
+      expect(find.text('Stack trace'), findsOneWidget);
+      expect(find.byType(ExpansionTile), findsOneWidget);
+    });
+
+    testWidgets('Material: is scrollable', (tester) async {
+      await tester.pumpWidget(MaterialApp(home: ErrorScreen(details: details)));
+
+      expect(find.byType(SingleChildScrollView), findsOneWidget);
+    });
+
+    testWidgets('renders without stack trace when absent', (tester) async {
+      final noStack = FlutterErrorDetails(exception: StateError('test error'));
+
+      await tester.pumpWidget(MaterialApp(home: ErrorScreen(details: noStack)));
+
+      expect(find.text('Something went wrong'), findsOneWidget);
+      expect(find.text('Stack trace'), findsNothing);
+    });
+
+    // -- Cupertino (iOS) ------------------------------------------------------
+
+    testWidgets('iOS: uses CupertinoNavigationBar', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Theme(
+            data: ThemeData(
+              colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+            ),
+            child: Material(
+              type: MaterialType.transparency,
+              child: ErrorScreen(details: details),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(CupertinoNavigationBar), findsOneWidget);
+      // The heading text is in the nav bar, not a Material icon row.
+      expect(find.byIcon(Icons.error_outline), findsNothing);
+      expect(find.text('Something went wrong'), findsOneWidget);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('iOS: uses chevron toggle instead of ExpansionTile', (
+      tester,
+    ) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Theme(
+            data: ThemeData(
+              colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+            ),
+            child: Material(
+              type: MaterialType.transparency,
+              child: ErrorScreen(details: details),
+            ),
+          ),
+        ),
+      );
+
+      // Should use a CupertinoButton with chevron, not an ExpansionTile.
+      expect(find.byType(ExpansionTile), findsNothing);
+      expect(find.byType(CupertinoButton), findsOneWidget);
+      expect(find.text('Stack trace'), findsOneWidget);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    // -- ErrorWidget.builder wiring -------------------------------------------
+
+    testWidgets('ErrorWidget.builder wiring shows ErrorScreen', (tester) async {
+      final originalBuilder = ErrorWidget.builder;
+      ErrorWidget.builder = (details) => ErrorScreen(details: details);
+
+      final errors = <FlutterErrorDetails>[];
+      final originalOnError = FlutterError.onError;
+      FlutterError.onError = (d) => errors.add(d);
+
+      try {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Builder(
+              builder: (context) {
+                throw UnsupportedError('Platform._operatingSystem');
+              },
+            ),
+          ),
+        );
+
+        expect(find.text('Something went wrong'), findsOneWidget);
+        expect(find.textContaining('Platform._operatingSystem'), findsWidgets);
+
+        expect(errors, hasLength(1));
+        expect(
+          errors.first.exceptionAsString(),
+          contains('Platform._operatingSystem'),
+        );
+      } finally {
+        ErrorWidget.builder = originalBuilder;
+        FlutterError.onError = originalOnError;
+      }
+    });
+  });
+}

--- a/crates/web-ui/e2e/tests/platform-io-web.spec.ts
+++ b/crates/web-ui/e2e/tests/platform-io-web.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect, Page } from "@playwright/test";
+
+/**
+ * Regression test for dart:io Platform usage on web.
+ *
+ * Flutter's `Platform` from `dart:io` throws `UnsupportedError` when accessed
+ * in a browser environment. Several files (e.g. update_banner.dart) call
+ * `Platform.isIOS` directly in `build()` without a `kIsWeb` guard, causing:
+ *
+ *   Unsupported operation: Platform._operatingSystem
+ *
+ * This test navigates through the app and asserts that no such error appears
+ * in the browser console. It should FAIL (red) until the offending code is
+ * fixed to use `kIsWeb` / `defaultTargetPlatform` instead of `dart:io`.
+ */
+
+const AUTH_TOKEN = "test-token";
+const FLUTTER_SETTLE_MS = 3000;
+
+// Pattern that matches the fatal dart:io error on web.
+const PLATFORM_ERROR_PATTERN = /Platform\._operatingSystem/;
+
+async function loginFlutter(page: Page) {
+  await page.goto(`/setup?_token=${AUTH_TOKEN}`, { waitUntil: "networkidle" });
+  await page.waitForTimeout(FLUTTER_SETTLE_MS);
+  await page.waitForURL((url) => !url.pathname.includes("/setup"), {
+    timeout: 15_000,
+  });
+  await page.waitForTimeout(FLUTTER_SETTLE_MS);
+}
+
+test.describe("dart:io Platform must not be used on web", () => {
+  test("no Platform._operatingSystem errors after login and navigation", async ({
+    page,
+  }) => {
+    const consoleErrors: string[] = [];
+
+    // Collect all console messages that mention the Platform error.
+    page.on("console", (msg) => {
+      const text = msg.text();
+      if (PLATFORM_ERROR_PATTERN.test(text)) {
+        consoleErrors.push(text);
+      }
+    });
+
+    // Also catch unhandled page errors (thrown as exceptions).
+    page.on("pageerror", (error) => {
+      if (PLATFORM_ERROR_PATTERN.test(error.message)) {
+        consoleErrors.push(error.message);
+      }
+    });
+
+    // 1. Login — this loads the full Flutter app and triggers provider init.
+    await loginFlutter(page);
+
+    // 2. Navigate to /chat — UpdateBannerWrapper wraps every page and calls
+    //    Platform.isIOS in its build() method, which crashes on web.
+    await page.goto("/chat", { waitUntil: "networkidle" });
+    await page.waitForTimeout(FLUTTER_SETTLE_MS);
+
+    expect(
+      consoleErrors,
+      `Expected no Platform._operatingSystem errors in the browser console, ` +
+        `but found ${consoleErrors.length}:\n${consoleErrors.join("\n")}`,
+    ).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- **Fix `Platform._operatingSystem` crash on web**: `UpdateBannerWrapper.build()` called `Platform.isIOS` from `dart:io` unconditionally, which throws on web. Replaced with `kIsWeb || defaultTargetPlatform == TargetPlatform.iOS`. Also removed unused `dart:io` import from `chat_provider.dart` and converted `HttpException` type check to a web-safe string match.
- **Add adaptive `ErrorScreen`**: Wired via `ErrorWidget.builder` + `PlatformDispatcher.instance.onError` in `main()` so unhandled framework errors render a visible crash page instead of silently logging to the browser console. Uses `CupertinoPageScaffold` on iOS, `Material` surface elsewhere — following the project's `isAppleTouch` / `platformStyle` adaptive pattern.

## Test plan

- [x] Playwright e2e test (`platform-io-web.spec.ts`) asserts zero `Platform._operatingSystem` console errors after login — was red before fix, green after
- [x] 9 widget tests for `ErrorScreen` covering both Material and Cupertino paths, stack trace rendering, absent stack trace, and `ErrorWidget.builder` wiring
- [x] All 478 Flutter tests pass
- [x] `flutter analyze --fatal-infos` clean
- [x] Pre-commit hooks pass (fmt, clippy, machete, dart_pre_commit)