### PR TITLE
chore(release): bump openapi.json version via release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -19,6 +19,11 @@
           "type": "yaml",
           "path": "app/pubspec.yaml",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "openapi.json",
+          "jsonpath": "$.info.version"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- Adds `openapi.json` to `release-please-config.json` extra-files so the spec version (`$.info.version`) is bumped automatically on each release.

## Test plan
- [ ] Verify next release-please PR includes a version bump in `openapi.json`