### PR TITLE
chore(deps): bump arrow and parquet from 57.1 to 57.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,11 @@ updates:
       reqwest:
         patterns:
           - "reqwest*"
+      arrow-iceberg:
+        patterns:
+          - "arrow*"
+          - "parquet"
+          - "iceberg*"
 
   - package-ecosystem: pub
     directory: /app

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,9 +171,9 @@ urlencoding = "2"
 # Apache Iceberg
 iceberg = "0.9"
 iceberg-catalog-rest = "0.9"
-arrow-array = "57.1"
-arrow-schema = "57.1"
-parquet = { version = "57.1", default-features = false, features = ["arrow", "async"] }
+arrow-array = "57.3"
+arrow-schema = "57.3"
+parquet = { version = "57.3", default-features = false, features = ["arrow", "async"] }
 # Internal crates
 opentelemetry-exporter-sqlite = { path = "crates/opentelemetry-exporter-sqlite" }
 opentelemetry-exporter-iceberg = { path = "crates/opentelemetry-exporter-iceberg" }


### PR DESCRIPTION
## Summary
- Bumps `arrow-array`, `arrow-schema`, and `parquet` workspace dependencies from 57.1 to 57.3 (latest patch in the 57.x series)
- Cannot upgrade to 58.x yet — `iceberg 0.9.x` requires arrow 57. Arrow 58 support is on iceberg's `main` branch but not released.

## Test plan
- [x] `cargo check --workspace` passes
- [x] `make lint` passes
- [x] `cargo machete --with-metadata` reports no unused deps
- [x] Pre-commit hooks pass (fmt, clippy, machete, flutter)