### PR TITLE
fix(release): sign PlugIns/*.appex for macOS notarization

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -277,6 +277,10 @@ jobs:
           find "$APP/Contents/Frameworks" \( -name "*.framework" -o -name "*.dylib" \) 2>/dev/null | while read f; do
             codesign --force --sign "$IDENTITY" --options runtime --timestamp "$f"
           done
+          # Sign app extensions (e.g. ShareExtension from super_clipboard plugin)
+          find "$APP/Contents/PlugIns" -name "*.appex" 2>/dev/null | while read appex; do
+            codesign --force --sign "$IDENTITY" --options runtime --timestamp "$appex"
+          done
           codesign --force --sign "$IDENTITY" --options runtime --timestamp \
             --entitlements app/macos/Runner/Release.entitlements "$APP"
 

--- a/app/ios/Runner/DebugProfile.entitlements
+++ b/app/ios/Runner/DebugProfile.entitlements
@@ -4,6 +4,10 @@
 <dict>
 	<key>com.apple.security.application-identifier</key>
 	<string>$(AppIdentifierPrefix)$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.cedricziel.assistant</string>
+	</array>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)$(PRODUCT_BUNDLE_IDENTIFIER)</string>

--- a/app/ios/Runner/Release.entitlements
+++ b/app/ios/Runner/Release.entitlements
@@ -4,6 +4,10 @@
 <dict>
 	<key>com.apple.security.application-identifier</key>
 	<string>$(AppIdentifierPrefix)$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.cedricziel.assistant</string>
+	</array>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)$(PRODUCT_BUNDLE_IDENTIFIER)</string>

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -560,10 +560,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: "5540e4a3f416dd4a93458257b908eb88353cbd0fb5b0a3d1bd7d849ba1e88735"
+      sha256: "08b742eef4f71c9df5af543751cd0b7f1c679c4088488f4223ecaddc1a813b79"
       url: "https://pub.dev"
     source: hosted
-    version: "17.2.1"
+    version: "17.2.2"
   highlight:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   cupertino_icons: ^1.0.9
   flutter_riverpod: ^3.3.1
-  go_router: ^17.2.1
+  go_router: ^17.2.2
   flutter_secure_storage: ^10.0.0
   http: ^1.6.0
   dio: ^5.9.2
@@ -52,8 +52,8 @@ flutter_launcher_icons:
   web:
     generate: true
     image_path: macos/Runner/Assets.xcassets/AppIcon.appiconset/app_icon_1024.png
-    background_color: '#080C1A'
-    theme_color: '#080C1A'
+    background_color: "#080C1A"
+    theme_color: "#080C1A"
 flutter:
   uses-material-design: true
   assets:


### PR DESCRIPTION
## Summary
- Sign app extensions in `Contents/PlugIns/` (e.g. `ShareExtension.appex` from `super_clipboard`) during the macOS release build
- Without this, Apple's notarization rejects the app because the appex binary lacks Developer ID signature, hardened runtime, and secure timestamp

## Context
Failed run: https://github.com/cedricziel/assistant/actions/runs/24672409593

The other two failures in that run are:
- **iOS TestFlight**: provisioning profile needs to be regenerated with App Groups capability (see below)
- **Docker Alpine**: transient GitHub CDN failure downloading `docker/metadata-action` — will self-resolve on retry

## Test plan
- [ ] Next release triggers the macOS desktop build and notarization succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved macOS build security by enhancing codesigning of app extension bundles in the release workflow, ensuring all embedded components are signed with consistent security standards and hardened runtime configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->