### PR TITLE
feat(app): add connectivity_plus for network awareness

### DIFF
--- a/app/lib/api/connectivity_provider.dart
+++ b/app/lib/api/connectivity_provider.dart
@@ -1,0 +1,23 @@
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Streams real-time connectivity status changes from the OS.
+///
+/// Emits a list of active connection types (wifi, mobile, ethernet, etc.)
+/// or an empty list / [ConnectivityResult.none] when offline.
+final connectivityProvider =
+    StreamProvider.autoDispose<List<ConnectivityResult>>((ref) {
+      return Connectivity().onConnectivityChanged;
+    });
+
+/// Derived provider — `true` when at least one network transport is available.
+final isOnlineProvider = Provider.autoDispose<bool>((ref) {
+  final connectivity = ref.watch(connectivityProvider);
+  return connectivity.when(
+    data: (results) =>
+        results.isNotEmpty &&
+        !results.every((r) => r == ConnectivityResult.none),
+    loading: () => true, // Assume online until proven otherwise.
+    error: (_, _) => true, // Assume online on error (fail open).
+  );
+});

--- a/app/lib/features/chat/chat_screen.dart
+++ b/app/lib/features/chat/chat_screen.dart
@@ -16,6 +16,7 @@ import '../../shared/platform/platform.dart';
 import '../../api/api_client.dart';
 import '../../api/attachment_service.dart';
 import '../../api/capabilities_provider.dart';
+import '../../api/connectivity_provider.dart';
 import '../../api/models/server_capabilities.dart';
 import '../connection/connection_provider.dart';
 import '../personas/persona_picker.dart';
@@ -224,6 +225,17 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   }
 
   Future<void> _pickImages() async {
+    if (!ref.read(isOnlineProvider)) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('File upload requires an internet connection'),
+          ),
+        );
+      }
+      return;
+    }
+
     final result = await FilePicker.pickFiles(
       type: FileType.custom,
       allowedExtensions: [

--- a/app/lib/features/chat/voice_recorder_button.dart
+++ b/app/lib/features/chat/voice_recorder_button.dart
@@ -2,9 +2,11 @@ import 'dart:async' show Timer, unawaited;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:record/record.dart';
 
+import '../../api/connectivity_provider.dart';
 import 'recorder_bytes_io.dart'
     if (dart.library.js_interop) 'recorder_bytes_web.dart';
 
@@ -19,7 +21,7 @@ import 'recorder_bytes_io.dart'
 /// - **Web fallback**: PCM/WAV.
 /// - **Native (iOS, macOS, Android)**: AAC-LC → audio/aac.
 /// - **Native fallback**: Opus → audio/ogg, then WAV → audio/wav.
-class VoiceRecorderButton extends StatefulWidget {
+class VoiceRecorderButton extends ConsumerStatefulWidget {
   const VoiceRecorderButton({
     super.key,
     required this.onRecordingComplete,
@@ -35,10 +37,11 @@ class VoiceRecorderButton extends StatefulWidget {
   final AudioRecorder? audioRecorder;
 
   @override
-  State<VoiceRecorderButton> createState() => _VoiceRecorderButtonState();
+  ConsumerState<VoiceRecorderButton> createState() =>
+      _VoiceRecorderButtonState();
 }
 
-class _VoiceRecorderButtonState extends State<VoiceRecorderButton> {
+class _VoiceRecorderButtonState extends ConsumerState<VoiceRecorderButton> {
   late final AudioRecorder _recorder;
   bool _isRecording = false;
   int _secondsElapsed = 0;
@@ -112,6 +115,17 @@ class _VoiceRecorderButtonState extends State<VoiceRecorderButton> {
   }
 
   Future<void> _start() async {
+    if (!ref.read(isOnlineProvider)) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Voice recording requires an internet connection'),
+          ),
+        );
+      }
+      return;
+    }
+
     try {
       final hasPermission = await _recorder.hasPermission();
       if (!hasPermission) {

--- a/app/lib/features/notifications/agent_event_listener.dart
+++ b/app/lib/features/notifications/agent_event_listener.dart
@@ -1,6 +1,8 @@
+import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../api/connectivity_provider.dart';
 import '../chat/chat_provider.dart';
 import 'notification_preferences.dart';
 import 'notification_service.dart';
@@ -29,6 +31,10 @@ class _AgentEventListenerState extends ConsumerState<AgentEventListener>
     with WidgetsBindingObserver {
   AppLifecycleState? _lifecycleState;
 
+  /// Tracks whether the last known connectivity state was offline, so we can
+  /// detect none→connected transitions and trigger SSE reconnection.
+  bool _wasOffline = false;
+
   @override
   void initState() {
     super.initState();
@@ -56,6 +62,26 @@ class _AgentEventListenerState extends ConsumerState<AgentEventListener>
   @override
   Widget build(BuildContext context) {
     ref.listen<AsyncValue<ChatState>>(chatProvider, _onChatStateChanged);
+
+    // Watch connectivity and trigger reconnect on none→connected transitions.
+    ref.listen<AsyncValue<List<ConnectivityResult>>>(connectivityProvider, (
+      prev,
+      next,
+    ) {
+      final isNowOnline =
+          next.whenOrNull(
+            data: (results) =>
+                results.isNotEmpty &&
+                !results.every((r) => r == ConnectivityResult.none),
+          ) ??
+          true;
+
+      if (_wasOffline && isNowOnline) {
+        ref.read(chatProvider.notifier).attemptReconnect();
+      }
+      _wasOffline = !isNowOnline;
+    });
+
     return widget.child;
   }
 

--- a/app/lib/shared/nav_shell.dart
+++ b/app/lib/shared/nav_shell.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../api/connectivity_provider.dart';
 import '../features/contexts/providers/context_providers.dart';
 import '../features/notifications/agent_event_listener.dart';
 import '../features/pwa/pwa_provider.dart';
@@ -344,7 +345,9 @@ class NavShell extends ConsumerWidget {
                 const VerticalDivider(width: 1, thickness: 1),
                 Expanded(
                   child: AgentEventListener(
-                    child: UpdateBannerWrapper(child: child),
+                    child: _OfflineBanner(
+                      child: UpdateBannerWrapper(child: child),
+                    ),
                   ),
                 ),
               ],
@@ -356,7 +359,9 @@ class NavShell extends ConsumerWidget {
       // iOS compact: CupertinoTabBar with 5 items.
       final selected = _iosMobileSelectedIndex(context);
       return Scaffold(
-        body: AgentEventListener(child: UpdateBannerWrapper(child: child)),
+        body: AgentEventListener(
+          child: _OfflineBanner(child: UpdateBannerWrapper(child: child)),
+        ),
         bottomNavigationBar: CupertinoTabBar(
           currentIndex: selected,
           onTap: (i) {
@@ -478,7 +483,9 @@ class NavShell extends ConsumerWidget {
               const VerticalDivider(width: 1, thickness: 1),
               Expanded(
                 child: AgentEventListener(
-                  child: UpdateBannerWrapper(child: child),
+                  child: _OfflineBanner(
+                    child: UpdateBannerWrapper(child: child),
+                  ),
                 ),
               ),
             ],
@@ -492,7 +499,9 @@ class NavShell extends ConsumerWidget {
     // prompt is available.
     final selected = _mobileSelectedIndex(context);
     return Scaffold(
-      body: AgentEventListener(child: UpdateBannerWrapper(child: child)),
+      body: AgentEventListener(
+        child: _OfflineBanner(child: UpdateBannerWrapper(child: child)),
+      ),
       bottomNavigationBar: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
@@ -748,6 +757,63 @@ class _SafariStep extends StatelessWidget {
         Icon(icon, color: color),
         const SizedBox(width: 8),
         Expanded(child: Text(text)),
+      ],
+    );
+  }
+}
+
+/// Persistent banner shown when the device has no network connectivity.
+///
+/// Skipped on web — browsers provide their own offline indicators.
+/// Uses a Cupertino-style slim bar on iOS, MaterialBanner elsewhere.
+class _OfflineBanner extends ConsumerWidget {
+  const _OfflineBanner({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (kIsWeb) return child;
+
+    final isOnline = ref.watch(isOnlineProvider);
+    if (isOnline) return child;
+
+    return Column(
+      children: [
+        if (isAppleTouch)
+          Builder(
+            builder: (context) {
+              final fgColor = Theme.of(context).colorScheme.onInverseSurface;
+              return Container(
+                width: double.infinity,
+                color: CupertinoColors.systemOrange.resolveFrom(context),
+                padding: const EdgeInsets.symmetric(vertical: 4),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(CupertinoIcons.wifi_slash, size: 14, color: fgColor),
+                    const SizedBox(width: 6),
+                    Text(
+                      'No Connection',
+                      style: TextStyle(
+                        color: fgColor,
+                        fontSize: 13,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            },
+          )
+        else
+          MaterialBanner(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            leading: const Icon(Icons.wifi_off),
+            content: const Text('No internet connection'),
+            actions: const [SizedBox.shrink()],
+          ),
+        Expanded(child: child),
       ],
     );
   }

--- a/app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,6 +6,7 @@ import FlutterMacOS
 import Foundation
 
 import audioplayers_darwin
+import connectivity_plus
 import desktop_drop
 import device_info_plus
 import file_picker
@@ -24,6 +25,7 @@ import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioplayersDarwinPlugin.register(with: registry.registrar(forPlugin: "AudioplayersDarwinPlugin"))
+  ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   DesktopDropPlugin.register(with: registry.registrar(forPlugin: "DesktopDropPlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -208,6 +208,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  connectivity_plus:
+    dependency: "direct main"
+    description:
+      name: connectivity_plus
+      sha256: "62ffa266d9a23b79fb3fcbc206afc00bb979417ba57b1324c546b5aab95ba057"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.1.1"
+  connectivity_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: connectivity_plus_platform_interface
+      sha256: "3c09627c536d22fd24691a905cdd8b14520de69da52c7a97499c8be5284a32ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   console:
     dependency: transitive
     description:
@@ -560,10 +576,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: "5540e4a3f416dd4a93458257b908eb88353cbd0fb5b0a3d1bd7d849ba1e88735"
+      sha256: "08b742eef4f71c9df5af543751cd0b7f1c679c4088488f4223ecaddc1a813b79"
       url: "https://pub.dev"
     source: hosted
-    version: "17.2.1"
+    version: "17.2.2"
   highlight:
     dependency: transitive
     description:
@@ -780,6 +796,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  nm:
+    dependency: transitive
+    description:
+      name: nm
+      sha256: "2c9aae4127bdc8993206464fcc063611e0e36e72018696cd9631023a31b24254"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   node_preamble:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   cupertino_icons: ^1.0.9
   flutter_riverpod: ^3.3.1
-  go_router: ^17.2.1
+  go_router: ^17.2.2
   flutter_secure_storage: ^10.0.0
   http: ^1.6.0
   dio: ^5.9.2
@@ -40,6 +40,7 @@ dependencies:
   cached_network_image: ^3.4.1
   desktop_drop: ^0.7.1
   super_clipboard: ^0.9.1
+  connectivity_plus: ^7.1.1
 dev_dependencies:
   flutter_test:
     sdk: flutter
@@ -52,8 +53,8 @@ flutter_launcher_icons:
   web:
     generate: true
     image_path: macos/Runner/Assets.xcassets/AppIcon.appiconset/app_icon_1024.png
-    background_color: '#080C1A'
-    theme_color: '#080C1A'
+    background_color: "#080C1A"
+    theme_color: "#080C1A"
 flutter:
   uses-material-design: true
   assets:

--- a/app/test/unit/api/connectivity_provider_test.dart
+++ b/app/test/unit/api/connectivity_provider_test.dart
@@ -1,0 +1,142 @@
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/api/connectivity_provider.dart';
+
+void main() {
+  group('isOnlineProvider', () {
+    test('returns true when wifi is available', () async {
+      final container = ProviderContainer(
+        overrides: [
+          connectivityProvider.overrideWith(
+            (ref) => Stream.value([ConnectivityResult.wifi]),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      // Keep a listener alive so autoDispose doesn't kick in.
+      final sub = container.listen(isOnlineProvider, (_, _) {});
+      await container.read(connectivityProvider.future);
+
+      expect(container.read(isOnlineProvider), isTrue);
+      sub.close();
+    });
+
+    test('returns true when mobile is available', () async {
+      final container = ProviderContainer(
+        overrides: [
+          connectivityProvider.overrideWith(
+            (ref) => Stream.value([ConnectivityResult.mobile]),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final sub = container.listen(isOnlineProvider, (_, _) {});
+      await container.read(connectivityProvider.future);
+
+      expect(container.read(isOnlineProvider), isTrue);
+      sub.close();
+    });
+
+    test('returns false when connectivity is none', () async {
+      final container = ProviderContainer(
+        overrides: [
+          connectivityProvider.overrideWith(
+            (ref) => Stream.value([ConnectivityResult.none]),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final sub = container.listen(isOnlineProvider, (_, _) {});
+      await container.read(connectivityProvider.future);
+
+      expect(container.read(isOnlineProvider), isFalse);
+      sub.close();
+    });
+
+    test('returns false when result list is empty', () async {
+      final container = ProviderContainer(
+        overrides: [
+          connectivityProvider.overrideWith(
+            (ref) => Stream.value(<ConnectivityResult>[]),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final sub = container.listen(isOnlineProvider, (_, _) {});
+      await container.read(connectivityProvider.future);
+
+      expect(container.read(isOnlineProvider), isFalse);
+      sub.close();
+    });
+
+    test('returns true when loading (optimistic)', () {
+      final container = ProviderContainer(
+        overrides: [
+          connectivityProvider.overrideWith((ref) => const Stream.empty()),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final sub = container.listen(isOnlineProvider, (_, _) {});
+
+      // Stream hasn't emitted yet — loading state.
+      expect(container.read(isOnlineProvider), isTrue);
+      sub.close();
+    });
+
+    test('returns true with multiple results including wifi', () async {
+      final container = ProviderContainer(
+        overrides: [
+          connectivityProvider.overrideWith(
+            (ref) => Stream.value([
+              ConnectivityResult.wifi,
+              ConnectivityResult.ethernet,
+            ]),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final sub = container.listen(isOnlineProvider, (_, _) {});
+      await container.read(connectivityProvider.future);
+
+      expect(container.read(isOnlineProvider), isTrue);
+      sub.close();
+    });
+
+    test('transitions from online to offline', () async {
+      final controller = StreamController<List<ConnectivityResult>>();
+      addTearDown(controller.close);
+
+      final container = ProviderContainer(
+        overrides: [
+          connectivityProvider.overrideWith((ref) => controller.stream),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final values = <bool>[];
+      final sub = container.listen(isOnlineProvider, (_, next) {
+        values.add(next);
+      });
+
+      controller.add([ConnectivityResult.wifi]);
+      await Future.microtask(() {});
+      expect(container.read(isOnlineProvider), isTrue);
+
+      controller.add([ConnectivityResult.none]);
+      await Future.microtask(() {});
+      expect(container.read(isOnlineProvider), isFalse);
+
+      sub.close();
+    });
+  });
+}

--- a/app/test/unit/notifications/connectivity_reconnect_test.dart
+++ b/app/test/unit/notifications/connectivity_reconnect_test.dart
@@ -1,0 +1,145 @@
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/api/connectivity_provider.dart';
+import 'package:assistant_app/features/chat/chat_provider.dart';
+import 'package:assistant_app/features/notifications/agent_event_listener.dart';
+
+/// Tracks calls to attemptReconnect.
+class _MockChatNotifier extends AsyncNotifier<ChatState>
+    implements ChatNotifier {
+  int reconnectCallCount = 0;
+
+  @override
+  Future<ChatState> build() async => const ChatState();
+
+  @override
+  Future<void> attemptReconnect() async {
+    reconnectCallCount++;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+void main() {
+  group('AgentEventListener connectivity reconnect', () {
+    testWidgets('calls attemptReconnect on none→wifi transition', (
+      tester,
+    ) async {
+      final connectivityController =
+          StreamController<List<ConnectivityResult>>();
+      addTearDown(connectivityController.close);
+
+      final mockChat = _MockChatNotifier();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            connectivityProvider.overrideWith(
+              (ref) => connectivityController.stream,
+            ),
+            chatProvider.overrideWith(() => mockChat),
+          ],
+          child: const MaterialApp(
+            home: AgentEventListener(child: SizedBox.shrink()),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Emit offline state.
+      connectivityController.add([ConnectivityResult.none]);
+      await tester.pumpAndSettle();
+
+      // Emit online state — should trigger reconnect.
+      connectivityController.add([ConnectivityResult.wifi]);
+      await tester.pumpAndSettle();
+
+      expect(
+        mockChat.reconnectCallCount,
+        1,
+        reason: 'attemptReconnect should be called once on none→wifi',
+      );
+    });
+
+    testWidgets('does not call attemptReconnect on wifi→wifi transition', (
+      tester,
+    ) async {
+      final connectivityController =
+          StreamController<List<ConnectivityResult>>();
+      addTearDown(connectivityController.close);
+
+      final mockChat = _MockChatNotifier();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            connectivityProvider.overrideWith(
+              (ref) => connectivityController.stream,
+            ),
+            chatProvider.overrideWith(() => mockChat),
+          ],
+          child: const MaterialApp(
+            home: AgentEventListener(child: SizedBox.shrink()),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Emit online state.
+      connectivityController.add([ConnectivityResult.wifi]);
+      await tester.pumpAndSettle();
+
+      // Emit online state again.
+      connectivityController.add([ConnectivityResult.wifi]);
+      await tester.pumpAndSettle();
+
+      expect(
+        mockChat.reconnectCallCount,
+        0,
+        reason:
+            'attemptReconnect should not be called on wifi→wifi (no offline transition)',
+      );
+    });
+
+    testWidgets('does not call attemptReconnect when initial state is online', (
+      tester,
+    ) async {
+      final connectivityController =
+          StreamController<List<ConnectivityResult>>();
+      addTearDown(connectivityController.close);
+
+      final mockChat = _MockChatNotifier();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            connectivityProvider.overrideWith(
+              (ref) => connectivityController.stream,
+            ),
+            chatProvider.overrideWith(() => mockChat),
+          ],
+          child: const MaterialApp(
+            home: AgentEventListener(child: SizedBox.shrink()),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // First emission is online — _wasOffline starts as false.
+      connectivityController.add([ConnectivityResult.wifi]);
+      await tester.pumpAndSettle();
+
+      expect(
+        mockChat.reconnectCallCount,
+        0,
+        reason: 'attemptReconnect should not be called on initial online state',
+      );
+    });
+  });
+}

--- a/app/test/widget/features/voice_widgets_test.dart
+++ b/app/test/widget/features/voice_widgets_test.dart
@@ -4,8 +4,10 @@ import 'dart:io';
 import 'package:audioplayers_platform_interface/audioplayers_platform_interface.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:assistant_app/api/connectivity_provider.dart';
 import 'package:assistant_app/features/chat/audio_player_widget.dart';
 import 'package:assistant_app/features/chat/voice_recorder_button.dart';
 
@@ -394,16 +396,22 @@ void main() {
   // ---------------------------------------------------------------------------
 
   group('VoiceRecorderButton', () {
+    /// Wraps a VoiceRecorderButton in the required ProviderScope.
+    Widget wrapWithProviders(Widget child) {
+      return ProviderScope(
+        overrides: [isOnlineProvider.overrideWithValue(true)],
+        child: MaterialApp(home: Scaffold(body: child)),
+      );
+    }
+
     testWidgets('initially shows the mic icon and no stop icon', (
       tester,
     ) async {
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: VoiceRecorderButton(
-              onRecordingComplete: (bytes, mime) {},
-              onError: (_) {},
-            ),
+        wrapWithProviders(
+          VoiceRecorderButton(
+            onRecordingComplete: (bytes, mime) {},
+            onError: (_) {},
           ),
         ),
       );
@@ -420,12 +428,10 @@ void main() {
       String? capturedError;
 
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: VoiceRecorderButton(
-              onRecordingComplete: (bytes, mime) {},
-              onError: (e) => capturedError = e,
-            ),
+        wrapWithProviders(
+          VoiceRecorderButton(
+            onRecordingComplete: (bytes, mime) {},
+            onError: (e) => capturedError = e,
           ),
         ),
       );
@@ -460,13 +466,8 @@ void main() {
       _setPathProviderMock();
 
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: VoiceRecorderButton(
-              onRecordingComplete: (_, _) {},
-              onError: (_) {},
-            ),
-          ),
+        wrapWithProviders(
+          VoiceRecorderButton(onRecordingComplete: (_, _) {}, onError: (_) {}),
         ),
       );
 
@@ -506,15 +507,13 @@ void main() {
       String? capturedMime;
 
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: VoiceRecorderButton(
-              onRecordingComplete: (bytes, mime) {
-                capturedBytes = bytes;
-                capturedMime = mime;
-              },
-              onError: (_) {},
-            ),
+        wrapWithProviders(
+          VoiceRecorderButton(
+            onRecordingComplete: (bytes, mime) {
+              capturedBytes = bytes;
+              capturedMime = mime;
+            },
+            onError: (_) {},
           ),
         ),
       );

--- a/app/test/widget/offline_banner_test.dart
+++ b/app/test/widget/offline_banner_test.dart
@@ -1,0 +1,117 @@
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:assistant_app/api/connectivity_provider.dart';
+import 'package:assistant_app/features/pwa/pwa_provider.dart';
+import 'package:assistant_app/shared/nav_shell.dart';
+
+class _FakePwaNotifier extends PwaInstallNotifier {
+  @override
+  bool build() => false;
+}
+
+Widget _buildApp({
+  required Stream<List<ConnectivityResult>> connectivityStream,
+}) {
+  final router = GoRouter(
+    initialLocation: '/chat',
+    routes: [
+      ShellRoute(
+        builder: (ctx, state, child) => NavShell(child: child),
+        routes: [
+          GoRoute(
+            path: '/chat',
+            builder: (_, _) => const Scaffold(body: Text('Chat content')),
+          ),
+          GoRoute(
+            path: '/skills',
+            builder: (_, _) => const Scaffold(body: Text('Skills content')),
+          ),
+          GoRoute(
+            path: '/workflows',
+            builder: (_, _) => const Scaffold(body: Text('Workflows content')),
+          ),
+        ],
+      ),
+    ],
+  );
+  return ProviderScope(
+    overrides: [
+      pwaInstallProvider.overrideWith(_FakePwaNotifier.new),
+      connectivityProvider.overrideWith((ref) => connectivityStream),
+    ],
+    child: MaterialApp.router(routerConfig: router),
+  );
+}
+
+void main() {
+  group('Offline banner', () {
+    testWidgets('shows banner when connectivity is none', (tester) async {
+      tester.view.physicalSize = const Size(1280, 900);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      final controller = StreamController<List<ConnectivityResult>>();
+      addTearDown(controller.close);
+
+      await tester.pumpWidget(_buildApp(connectivityStream: controller.stream));
+      await tester.pumpAndSettle();
+
+      // Initially loading → no banner (optimistic online).
+      expect(find.text('No internet connection'), findsNothing);
+
+      // Emit offline.
+      controller.add([ConnectivityResult.none]);
+      await tester.pumpAndSettle();
+
+      expect(find.text('No internet connection'), findsOneWidget);
+      expect(find.byIcon(Icons.wifi_off), findsOneWidget);
+    });
+
+    testWidgets('hides banner when connectivity is restored', (tester) async {
+      tester.view.physicalSize = const Size(1280, 900);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      final controller = StreamController<List<ConnectivityResult>>();
+      addTearDown(controller.close);
+
+      await tester.pumpWidget(_buildApp(connectivityStream: controller.stream));
+      await tester.pumpAndSettle();
+
+      // Go offline.
+      controller.add([ConnectivityResult.none]);
+      await tester.pumpAndSettle();
+      expect(find.text('No internet connection'), findsOneWidget);
+
+      // Come back online.
+      controller.add([ConnectivityResult.wifi]);
+      await tester.pumpAndSettle();
+      expect(find.text('No internet connection'), findsNothing);
+    });
+
+    testWidgets('child content remains visible when offline', (tester) async {
+      tester.view.physicalSize = const Size(1280, 900);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      final controller = StreamController<List<ConnectivityResult>>();
+      addTearDown(controller.close);
+
+      await tester.pumpWidget(_buildApp(connectivityStream: controller.stream));
+      await tester.pumpAndSettle();
+
+      controller.add([ConnectivityResult.none]);
+      await tester.pumpAndSettle();
+
+      // Banner is shown AND content is still visible.
+      expect(find.text('No internet connection'), findsOneWidget);
+      expect(find.text('Chat content'), findsOneWidget);
+    });
+  });
+}

--- a/app/test/widget/voice_recorder_offline_test.dart
+++ b/app/test/widget/voice_recorder_offline_test.dart
@@ -1,0 +1,118 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:record/record.dart';
+
+import 'package:assistant_app/api/connectivity_provider.dart';
+import 'package:assistant_app/features/chat/voice_recorder_button.dart';
+
+/// Fake recorder that tracks whether start() was called.
+class _FakeAudioRecorder implements AudioRecorder {
+  bool startCalled = false;
+
+  @override
+  Future<bool> hasPermission({bool request = true}) async => true;
+
+  @override
+  Future<void> start(RecordConfig config, {required String path}) async {
+    startCalled = true;
+  }
+
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  Future<bool> isEncoderSupported(AudioEncoder encoder) async => true;
+
+  @override
+  Future<String?> stop() async => null;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    // Return appropriate futures for methods that return them.
+    final memberName = invocation.memberName.toString();
+    if (memberName.contains('cancel') || memberName.contains('pause')) {
+      return Future<void>.value();
+    }
+    return null;
+  }
+}
+
+void main() {
+  group('VoiceRecorderButton offline guard', () {
+    testWidgets('does not start recording when offline and shows SnackBar', (
+      tester,
+    ) async {
+      final recorder = _FakeAudioRecorder();
+      var completedCalled = false;
+      String? errorMsg;
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [isOnlineProvider.overrideWithValue(false)],
+          child: MaterialApp(
+            home: Scaffold(
+              body: VoiceRecorderButton(
+                audioRecorder: recorder,
+                onRecordingComplete: (Uint8List bytes, String mime) {
+                  completedCalled = true;
+                },
+                onError: (String error) {
+                  errorMsg = error;
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Tap the mic button.
+      await tester.tap(find.byIcon(Icons.mic_none_outlined));
+      await tester.pumpAndSettle();
+
+      // Recording should NOT have started.
+      expect(recorder.startCalled, isFalse);
+      expect(completedCalled, isFalse);
+      expect(errorMsg, isNull);
+
+      // SnackBar should appear with the offline message.
+      expect(
+        find.text('Voice recording requires an internet connection'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('does not show offline snackbar when online', (tester) async {
+      final recorder = _FakeAudioRecorder();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [isOnlineProvider.overrideWithValue(true)],
+          child: MaterialApp(
+            home: Scaffold(
+              body: VoiceRecorderButton(
+                audioRecorder: recorder,
+                onRecordingComplete: (_, _) {},
+                onError: (_) {},
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Tap the mic button.
+      await tester.tap(find.byIcon(Icons.mic_none_outlined));
+      await tester.pumpAndSettle();
+
+      // The offline guard snackbar should NOT appear.
+      expect(
+        find.text('Voice recording requires an internet connection'),
+        findsNothing,
+      );
+    });
+  });
+}

--- a/openspec/changes/archive/2026-04-20-connectivity-plus-integration/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-20-connectivity-plus-integration/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-20

--- a/openspec/changes/archive/2026-04-20-connectivity-plus-integration/design.md
+++ b/openspec/changes/archive/2026-04-20-connectivity-plus-integration/design.md
@@ -1,0 +1,72 @@
+## Context
+
+The Flutter app communicates with the assistant backend via HTTP (Dio) and SSE streaming. Currently, network failures are detected reactively — only when a request fails with a `DioException`. The app has reconnect logic in `ChatProvider.attemptReconnect()` but it's only triggered on `AppLifecycleState.resumed`. On macOS desktop, where the app stays in the foreground during Wi-Fi drops (lid close, network switch), this trigger never fires.
+
+The app already uses Riverpod for state management, has a `nav_shell.dart` wrapping all routes, and the chat provider tracks `_needsReconnect` state with a `_currentRunId` for SSE event-log replay.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Provide immediate visual feedback when network is unavailable
+- Automatically trigger SSE reconnection when connectivity is restored
+- Prevent user from initiating actions that will fail (voice recording, file upload) while offline
+- Work across all target platforms (macOS, iOS, web)
+
+**Non-Goals:**
+
+- Server reachability probing (captive portals, VPN tunnels)
+- Offline message queuing or draft persistence
+- Custom web implementation (browsers provide `navigator.onLine` natively, which `connectivity_plus` wraps)
+
+## Decisions
+
+### 1. Use `connectivity_plus` over raw platform channels
+
+**Choice**: `connectivity_plus` package (Flutter Favorites, maintained by the plus_plugins team)
+
+**Alternatives considered**:
+
+- Raw `NWPathMonitor` (macOS/iOS) + platform channel: More control, but requires native code in both platforms and ongoing maintenance. Not worth it for transport-level detection.
+- `internet_connection_checker`: Does active HTTP probing (pings Google DNS). Heavier, adds latency, requires an external endpoint. Overkill — our DioException path already handles server-unreachable cases.
+
+**Rationale**: `connectivity_plus` is lightweight, well-maintained, covers all our platforms, and only reports transport availability — which is exactly what we need as a fast signal.
+
+### 2. Riverpod StreamProvider for connectivity state
+
+**Choice**: A `connectivityProvider` (StreamProvider) wrapping `Connectivity().onConnectivityChanged`, with a derived `isOnlineProvider` (Provider<bool>).
+
+**Rationale**: Fits the existing Riverpod architecture. StreamProvider auto-disposes when nothing watches it. The derived boolean makes consumption trivial for guards.
+
+### 3. Offline banner in NavShell (not per-screen)
+
+**Choice**: A single `MaterialBanner` or slim bar at the top of `NavShell`, visible across all routes.
+
+**Alternatives considered**:
+
+- Per-screen banners: Duplicated logic, inconsistent placement.
+- SnackBar: Dismissible, can be missed, doesn't persist.
+
+**Rationale**: Consistent, always visible, single integration point. Disappears automatically when connectivity returns.
+
+### 4. Reconnect trigger: connectivity restoration + existing app-resume
+
+**Choice**: Watch `connectivityProvider` transitions from `none` → any connected state inside `AgentEventListener` (which already watches lifecycle) and call `chatProvider.attemptReconnect()`.
+
+**Rationale**: Reuses existing reconnect machinery. The `attemptReconnect()` method already handles the run-ID-based event replay. Adding a second trigger (connectivity change) alongside the existing lifecycle trigger covers both mobile (backgrounding) and desktop (network drop without backgrounding) scenarios.
+
+### 5. Guard pattern for voice/upload
+
+**Choice**: Read `isOnlineProvider` before starting voice recording or file upload. Show a brief toast/snackbar ("No internet connection") and abort. Don't disable the button permanently — just guard the action.
+
+**Rationale**: Disabling buttons confuses users who don't notice the offline banner. A guard with feedback is clearer and self-resolving.
+
+## Risks / Trade-offs
+
+- **[False positives on web]** `connectivity_plus` on web uses `navigator.onLine` which can report "online" behind captive portals. → Mitigation: This is a known limitation; our DioException path is the fallback. The banner is additive UX, not the only failure path.
+
+- **[Platform inconsistency]** iOS may report `ConnectivityResult.wifi` while actually on a captive portal with no internet. → Mitigation: Same as above — we treat this as transport awareness, not server reachability.
+
+- **[Stream disposal race]** If `connectivityProvider` triggers reconnect while `ChatProvider` is mid-dispose (route change), we could get a use-after-dispose. → Mitigation: Guard `attemptReconnect()` with a mounted/active check (already partially in place via `_needsReconnect` flag).
+
+- **[Battery on mobile]** `connectivity_plus` uses OS-level callbacks, not polling — negligible battery impact.

--- a/openspec/changes/archive/2026-04-20-connectivity-plus-integration/proposal.md
+++ b/openspec/changes/archive/2026-04-20-connectivity-plus-integration/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+The Flutter app has no proactive network-state awareness. When connectivity drops (laptop lid close, Wi-Fi switch, mobile data loss), the SSE chat stream dies silently and the user sees stale UI until they manually retry. On macOS desktop — where the app stays in the foreground for long sessions — the lifecycle-based reconnect (`AppLifecycleState.resumed`) never fires because the app isn't backgrounded. Users deserve immediate feedback when offline and automatic recovery when connectivity returns.
+
+## What Changes
+
+- Add `connectivity_plus` dependency to the Flutter app
+- Introduce a Riverpod `connectivityProvider` (StreamProvider) exposing real-time network state
+- Derive an `isOnlineProvider` boolean for simple consumption
+- Show a persistent offline banner in the navigation shell when connectivity is lost
+- Trigger `ChatProvider.attemptReconnect()` on connectivity restoration (none → connected transition) in addition to the existing app-resume path
+- Gate voice recording and file uploads behind connectivity check to prevent wasted work
+
+## Non-goals
+
+- Server-reachability probing (captive portals, VPN issues) — out of scope, existing DioException path handles this
+- Offline queue / message drafts — messages still fail when offline, but fail fast with clear UX
+- Web platform offline detection — browsers handle this natively via `navigator.onLine`
+
+## Capabilities
+
+### New Capabilities
+
+- `network-awareness`: Real-time connectivity monitoring, offline banner, and automatic SSE reconnection on network restoration
+
+### Modified Capabilities
+
+(none — no existing spec-level behavior changes)
+
+## Impact
+
+- **Dependencies**: adds `connectivity_plus` to `app/pubspec.yaml`
+- **Code**: new provider file, modifications to `nav_shell.dart`, `chat_provider.dart`, `voice_recorder_button.dart`, `attachment_provider.dart`
+- **Platforms**: iOS/macOS need no entitlement changes (connectivity_plus uses reachability APIs already permitted). Web uses `navigator.onLine` under the hood — no additional permissions.
+- **APIs**: no backend changes

--- a/openspec/changes/archive/2026-04-20-connectivity-plus-integration/specs/network-awareness/spec.md
+++ b/openspec/changes/archive/2026-04-20-connectivity-plus-integration/specs/network-awareness/spec.md
@@ -1,0 +1,81 @@
+## ADDED Requirements
+
+### Requirement: Real-time connectivity monitoring
+
+The system SHALL expose a reactive connectivity state stream that reports the current network transport status (wifi, mobile, ethernet, none) across all target platforms (macOS, iOS, web).
+
+#### Scenario: Connectivity state updates on network change
+
+- **WHEN** the device network transport changes (e.g., Wi-Fi disconnects)
+- **THEN** the connectivity provider SHALL emit the new connectivity result within 2 seconds of the OS reporting the change
+
+#### Scenario: Initial connectivity state on app launch
+
+- **WHEN** the app starts and the connectivity provider is first watched
+- **THEN** the provider SHALL emit the current connectivity state before any user interaction occurs
+
+### Requirement: Offline banner display
+
+The system SHALL display a persistent, non-dismissible banner when connectivity is lost, visible across all screens.
+
+#### Scenario: Banner appears when offline
+
+- **WHEN** connectivity state transitions to none (no network transport)
+- **THEN** a banner SHALL appear at the top of the navigation shell indicating "No internet connection"
+
+#### Scenario: Banner disappears when connectivity returns
+
+- **WHEN** connectivity state transitions from none to any connected state (wifi, mobile, ethernet)
+- **THEN** the offline banner SHALL be removed immediately
+
+#### Scenario: Banner is not shown on web platform
+
+- **WHEN** the app is running in a web browser
+- **THEN** the offline banner SHALL NOT be displayed (browsers provide native offline indicators)
+
+### Requirement: Automatic SSE reconnection on connectivity restoration
+
+The system SHALL automatically attempt to reconnect dropped SSE streams when network connectivity is restored, without requiring user interaction.
+
+#### Scenario: Reconnect after Wi-Fi restore on desktop
+
+- **WHEN** connectivity transitions from none to connected AND the chat provider has a pending reconnect (`_needsReconnect == true`)
+- **THEN** the system SHALL call `attemptReconnect()` to resume the SSE event stream using the stored run ID
+
+#### Scenario: No reconnect when no pending stream
+
+- **WHEN** connectivity transitions from none to connected AND there is no pending reconnect state
+- **THEN** the system SHALL NOT initiate any reconnection (no wasted requests)
+
+#### Scenario: Reconnect coexists with lifecycle-based trigger
+
+- **WHEN** connectivity is restored AND the app is subsequently resumed from background
+- **THEN** only one reconnection attempt SHALL be made (the first trigger clears the `_needsReconnect` flag)
+
+### Requirement: Offline guard for voice recording
+
+The system SHALL prevent voice recording from starting when the device is offline, since the recording cannot be uploaded.
+
+#### Scenario: Voice recording blocked while offline
+
+- **WHEN** the user taps the voice record button AND connectivity state is none
+- **THEN** the system SHALL NOT start recording AND SHALL display a brief message indicating that voice recording requires an internet connection
+
+#### Scenario: Voice recording allowed when online
+
+- **WHEN** the user taps the voice record button AND connectivity state is not none
+- **THEN** voice recording SHALL proceed normally
+
+### Requirement: Offline guard for file uploads
+
+The system SHALL prevent file upload initiation when the device is offline.
+
+#### Scenario: File upload blocked while offline
+
+- **WHEN** the user attempts to attach a file AND connectivity state is none
+- **THEN** the system SHALL NOT initiate the upload AND SHALL display a brief message indicating that file upload requires an internet connection
+
+#### Scenario: File upload allowed when online
+
+- **WHEN** the user attempts to attach a file AND connectivity state is not none
+- **THEN** file upload SHALL proceed normally

--- a/openspec/changes/archive/2026-04-20-connectivity-plus-integration/tasks.md
+++ b/openspec/changes/archive/2026-04-20-connectivity-plus-integration/tasks.md
@@ -1,0 +1,26 @@
+## 1. Dependency & Provider Setup
+
+- [x] 1.1 Add `connectivity_plus` to `app/pubspec.yaml` dependencies and run `flutter pub get`
+- [x] 1.2 Create `app/lib/api/connectivity_provider.dart` with a `connectivityProvider` (StreamProvider wrapping `Connectivity().onConnectivityChanged`) and a derived `isOnlineProvider` (Provider<bool> that returns `result != ConnectivityResult.none`)
+- [x] 1.3 Write unit test for `connectivity_provider.dart` verifying the derived `isOnlineProvider` maps connectivity results correctly
+
+## 2. Offline Banner
+
+- [x] 2.1 Add an offline banner widget to `app/lib/shared/nav_shell.dart` that watches `isOnlineProvider` and displays a persistent `MaterialBanner` when offline (skip on web platform using `kIsWeb` guard)
+- [x] 2.2 Write widget test for the offline banner: verify it appears when connectivity is none and disappears when restored
+
+## 3. Auto-Reconnect on Connectivity Restoration
+
+- [x] 3.1 In `app/lib/features/notifications/agent_event_listener.dart`, watch `connectivityProvider` for none→connected transitions and call `chatProvider.attemptReconnect()` (mirroring the existing lifecycle-based trigger)
+- [x] 3.2 Write unit test verifying that `attemptReconnect()` is called on connectivity restoration when `_needsReconnect` is true, and NOT called when there is no pending reconnect
+
+## 4. Offline Guards for Voice & Upload
+
+- [x] 4.1 In `app/lib/features/chat/voice_recorder_button.dart`, check `isOnlineProvider` before starting recording; show a SnackBar with "Voice recording requires an internet connection" and abort if offline
+- [x] 4.2 In `app/lib/features/chat/attachment_provider.dart` (guard in chat_screen.dart `_pickImages`), check `isOnlineProvider` before initiating file upload; show a SnackBar with "File upload requires an internet connection" and abort if offline
+- [x] 4.3 Write widget test for voice recorder offline guard: verify recording does not start and feedback is shown when offline
+
+## 5. Verification
+
+- [x] 5.1 Run `flutter analyze` and `flutter test` — all pass with zero issues
+- [ ] 5.2 Manual smoke test: toggle Wi-Fi off/on on macOS, verify banner appears/disappears and SSE reconnects automatically

--- a/openspec/specs/network-awareness/spec.md
+++ b/openspec/specs/network-awareness/spec.md
@@ -1,0 +1,81 @@
+## ADDED Requirements
+
+### Requirement: Real-time connectivity monitoring
+
+The system SHALL expose a reactive connectivity state stream that reports the current network transport status (wifi, mobile, ethernet, none) across all target platforms (macOS, iOS, web).
+
+#### Scenario: Connectivity state updates on network change
+
+- **WHEN** the device network transport changes (e.g., Wi-Fi disconnects)
+- **THEN** the connectivity provider SHALL emit the new connectivity result within 2 seconds of the OS reporting the change
+
+#### Scenario: Initial connectivity state on app launch
+
+- **WHEN** the app starts and the connectivity provider is first watched
+- **THEN** the provider SHALL emit the current connectivity state before any user interaction occurs
+
+### Requirement: Offline banner display
+
+The system SHALL display a persistent, non-dismissible banner when connectivity is lost, visible across all screens.
+
+#### Scenario: Banner appears when offline
+
+- **WHEN** connectivity state transitions to none (no network transport)
+- **THEN** a banner SHALL appear at the top of the navigation shell indicating "No internet connection"
+
+#### Scenario: Banner disappears when connectivity returns
+
+- **WHEN** connectivity state transitions from none to any connected state (wifi, mobile, ethernet)
+- **THEN** the offline banner SHALL be removed immediately
+
+#### Scenario: Banner is not shown on web platform
+
+- **WHEN** the app is running in a web browser
+- **THEN** the offline banner SHALL NOT be displayed (browsers provide native offline indicators)
+
+### Requirement: Automatic SSE reconnection on connectivity restoration
+
+The system SHALL automatically attempt to reconnect dropped SSE streams when network connectivity is restored, without requiring user interaction.
+
+#### Scenario: Reconnect after Wi-Fi restore on desktop
+
+- **WHEN** connectivity transitions from none to connected AND the chat provider has a pending reconnect (`_needsReconnect == true`)
+- **THEN** the system SHALL call `attemptReconnect()` to resume the SSE event stream using the stored run ID
+
+#### Scenario: No reconnect when no pending stream
+
+- **WHEN** connectivity transitions from none to connected AND there is no pending reconnect state
+- **THEN** the system SHALL NOT initiate any reconnection (no wasted requests)
+
+#### Scenario: Reconnect coexists with lifecycle-based trigger
+
+- **WHEN** connectivity is restored AND the app is subsequently resumed from background
+- **THEN** only one reconnection attempt SHALL be made (the first trigger clears the `_needsReconnect` flag)
+
+### Requirement: Offline guard for voice recording
+
+The system SHALL prevent voice recording from starting when the device is offline, since the recording cannot be uploaded.
+
+#### Scenario: Voice recording blocked while offline
+
+- **WHEN** the user taps the voice record button AND connectivity state is none
+- **THEN** the system SHALL NOT start recording AND SHALL display a brief message indicating that voice recording requires an internet connection
+
+#### Scenario: Voice recording allowed when online
+
+- **WHEN** the user taps the voice record button AND connectivity state is not none
+- **THEN** voice recording SHALL proceed normally
+
+### Requirement: Offline guard for file uploads
+
+The system SHALL prevent file upload initiation when the device is offline.
+
+#### Scenario: File upload blocked while offline
+
+- **WHEN** the user attempts to attach a file AND connectivity state is none
+- **THEN** the system SHALL NOT initiate the upload AND SHALL display a brief message indicating that file upload requires an internet connection
+
+#### Scenario: File upload allowed when online
+
+- **WHEN** the user attempts to attach a file AND connectivity state is not none
+- **THEN** file upload SHALL proceed normally


### PR DESCRIPTION
## Summary

- Adds `connectivity_plus` (^7.1.1) for real-time network state monitoring via Riverpod StreamProvider
- Shows an adaptive offline banner: Cupertino-style slim orange bar on iOS, MaterialBanner on macOS/Material
- Auto-reconnects SSE chat streams when connectivity is restored (none→connected transition), complementing the existing app-resume trigger
- Guards voice recording and file uploads behind a connectivity check to prevent wasted work when offline
- Skips banner on web (browsers provide native offline indicators)

## Test plan

- [x] Unit tests for `connectivityProvider` / `isOnlineProvider` (7 tests)
- [x] Widget tests for offline banner appearance/disappearance (3 tests)
- [x] Widget tests for auto-reconnect on connectivity restoration (3 tests)
- [x] Widget tests for voice recorder offline guard (2 tests)
- [x] Existing voice widget tests updated and passing (4 tests)
- [x] Full suite: `flutter analyze` (0 issues) + `flutter test` (504 passing)
- [ ] Manual: toggle Wi-Fi off/on on macOS, verify banner + SSE reconnect

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added persistent offline status banner displayed when no internet connection is available
  * File uploads now blocked when offline with notification to user
  * Voice recording now blocked when offline with notification to user
  * Chat connection automatically restores when internet connectivity returns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->