### PR TITLE
feat(app): add outward sharing and save-as for messages, images, and audio

### DIFF
--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -53,6 +53,8 @@ PODS:
   - SDWebImage (5.21.7):
     - SDWebImage/Core (= 5.21.7)
   - SDWebImage/Core (5.21.7)
+  - share_plus (0.0.1):
+    - Flutter
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -75,6 +77,7 @@ DEPENDENCIES:
   - irondash_engine_context (from `.symlinks/plugins/irondash_engine_context/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - record_ios (from `.symlinks/plugins/record_ios/ios`)
+  - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
   - super_native_extensions (from `.symlinks/plugins/super_native_extensions/ios`)
@@ -106,6 +109,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/package_info_plus/ios"
   record_ios:
     :path: ".symlinks/plugins/record_ios/ios"
+  share_plus:
+    :path: ".symlinks/plugins/share_plus/ios"
   shared_preferences_foundation:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
   sqflite_darwin:
@@ -128,6 +133,7 @@ SPEC CHECKSUMS:
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   record_ios: 412daca2350b228e698fffcd08f1f94ceb1e3844
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
+  share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
   super_native_extensions: b763c02dc3a8fd078389f410bf15149179020cb4

--- a/app/lib/features/chat/chat_screen.dart
+++ b/app/lib/features/chat/chat_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:audioplayers/audioplayers.dart';
+import 'package:http/http.dart' as http;
 import 'package:assistant_api/assistant_api.dart' hide ServerCapabilities;
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:desktop_drop/desktop_drop.dart';
@@ -12,7 +13,9 @@ import 'package:flutter_smooth_markdown/flutter_smooth_markdown.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../shared/platform/adaptive_context_menu.dart';
 import '../../shared/platform/platform.dart';
+import '../../services/share_service.dart';
 import '../../api/api_client.dart';
 import '../../api/attachment_service.dart';
 import '../../api/capabilities_provider.dart';
@@ -671,11 +674,18 @@ class _MessageBubble extends StatelessWidget {
                         _attachmentThumbnails(context),
                       // Voice message: show audio player + collapsible transcript.
                       if (message.audioBytes != null)
-                        _VoiceMessagePlayer(
-                          audioBytes: message.audioBytes!,
-                          audioMimeType: message.audioMimeType,
-                          transcript: message.content,
-                          foregroundColor: colorScheme.onPrimary,
+                        AdaptiveMediaContextMenu(
+                          actions: _voiceMessageActions(
+                            context,
+                            message.audioBytes!,
+                            message.audioMimeType ?? 'audio/webm',
+                          ),
+                          child: _VoiceMessagePlayer(
+                            audioBytes: message.audioBytes!,
+                            audioMimeType: message.audioMimeType,
+                            transcript: message.content,
+                            foregroundColor: colorScheme.onPrimary,
+                          ),
                         )
                       // Hide text row when content is only whitespace /
                       // zero-width space and attachments provide the visual.
@@ -696,6 +706,8 @@ class _MessageBubble extends StatelessWidget {
                               child: SelectableText(
                                 message.content,
                                 style: TextStyle(color: colorScheme.onPrimary),
+                                contextMenuBuilder:
+                                    _textSelectionContextMenuBuilder,
                               ),
                             ),
                           ],
@@ -776,10 +788,13 @@ class _MessageBubble extends StatelessWidget {
                       // Inline audio player for messages with real audio
                       // (agent intentionally produced voice via AudioReadyEvent).
                       if (message.audioId != null && !message.isStreaming)
-                        Padding(
-                          padding: const EdgeInsets.only(top: 6),
-                          child: AudioPlayerWidget(
-                            fetchAudio: fetchMessageAudio,
+                        AdaptiveMediaContextMenu(
+                          actions: _ttsAudioActions(context),
+                          child: Padding(
+                            padding: const EdgeInsets.only(top: 6),
+                            child: AudioPlayerWidget(
+                              fetchAudio: fetchMessageAudio,
+                            ),
                           ),
                         ),
                     ],
@@ -866,53 +881,58 @@ class _MessageBubble extends StatelessWidget {
             );
           }
           final thumbUrl = '$imageBaseUrl${att.url}?w=300';
-          return GestureDetector(
-            onTap: () => _showFullImage(context, att),
-            child: ClipRRect(
-              borderRadius: BorderRadius.circular(8),
-              child: CachedNetworkImage(
-                imageUrl: thumbUrl,
-                width: 150,
-                height: 150,
-                fit: BoxFit.cover,
-                httpHeaders: imageAuthToken != null
-                    ? {'Authorization': 'Bearer $imageAuthToken'}
-                    : const {},
-                placeholder: (_, _) => Container(
+          return AdaptiveMediaContextMenu(
+            actions: _imageContextMenuActions(context, att),
+            child: GestureDetector(
+              onTap: () => _showFullImage(context, att),
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(8),
+                child: CachedNetworkImage(
+                  imageUrl: thumbUrl,
                   width: 150,
                   height: 150,
-                  color: colorScheme.surfaceContainerLowest,
-                  child: const Center(
-                    child: SizedBox(
-                      width: 24,
-                      height: 24,
-                      child: CircularProgressIndicator.adaptive(strokeWidth: 2),
-                    ),
-                  ),
-                ),
-                errorWidget: (_, url, _) => GestureDetector(
-                  onTap: () {
-                    CachedNetworkImage.evictFromCache(url);
-                    // Trigger a rebuild to retry loading.
-                    (context as Element).markNeedsBuild();
-                  },
-                  child: Container(
+                  fit: BoxFit.cover,
+                  httpHeaders: imageAuthToken != null
+                      ? {'Authorization': 'Bearer $imageAuthToken'}
+                      : const {},
+                  placeholder: (_, _) => Container(
                     width: 150,
                     height: 150,
                     color: colorScheme.surfaceContainerLowest,
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Icon(Icons.refresh, color: colorScheme.outline),
-                        const SizedBox(height: 4),
-                        Text(
-                          'Tap to retry',
-                          style: TextStyle(
-                            fontSize: 10,
-                            color: colorScheme.outline,
-                          ),
+                    child: const Center(
+                      child: SizedBox(
+                        width: 24,
+                        height: 24,
+                        child: CircularProgressIndicator.adaptive(
+                          strokeWidth: 2,
                         ),
-                      ],
+                      ),
+                    ),
+                  ),
+                  errorWidget: (_, url, _) => GestureDetector(
+                    onTap: () {
+                      CachedNetworkImage.evictFromCache(url);
+                      // Trigger a rebuild to retry loading.
+                      (context as Element).markNeedsBuild();
+                    },
+                    child: Container(
+                      width: 150,
+                      height: 150,
+                      color: colorScheme.surfaceContainerLowest,
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Icon(Icons.refresh, color: colorScheme.outline),
+                          const SizedBox(height: 4),
+                          Text(
+                            'Tap to retry',
+                            style: TextStyle(
+                              fontSize: 10,
+                              color: colorScheme.outline,
+                            ),
+                          ),
+                        ],
+                      ),
                     ),
                   ),
                 ),
@@ -922,6 +942,269 @@ class _MessageBubble extends StatelessWidget {
         }).toList(),
       ),
     );
+  }
+
+  Widget _textSelectionContextMenuBuilder(
+    BuildContext context,
+    EditableTextState editableTextState,
+  ) {
+    final selection = editableTextState.textEditingValue.selection;
+    final selectedText = selection.isValid && !selection.isCollapsed
+        ? editableTextState.textEditingValue.text.substring(
+            selection.start,
+            selection.end,
+          )
+        : message.content;
+
+    return AdaptiveTextSelectionToolbar.buttonItems(
+      anchors: editableTextState.contextMenuAnchors,
+      buttonItems: [
+        ...editableTextState.contextMenuButtonItems,
+        ContextMenuButtonItem(
+          label: 'Share',
+          onPressed: () {
+            editableTextState.hideToolbar();
+            final box = context.findRenderObject() as RenderBox?;
+            final origin = box != null
+                ? box.localToGlobal(Offset.zero) & box.size
+                : null;
+            ShareService.instance.shareText(
+              selectedText,
+              sharePositionOrigin: origin,
+            );
+          },
+        ),
+        ContextMenuButtonItem(
+          label: 'Save As…',
+          onPressed: () {
+            editableTextState.hideToolbar();
+            final box = context.findRenderObject() as RenderBox?;
+            final origin = box != null
+                ? box.localToGlobal(Offset.zero) & box.size
+                : null;
+            ShareService.instance.saveText(
+              selectedText,
+              suggestedFilename:
+                  'assistant-message-${DateTime.now().toIso8601String().split('T').first}.md',
+              sharePositionOrigin: origin,
+            );
+          },
+        ),
+      ],
+    );
+  }
+
+  List<AdaptiveContextMenuAction> _imageContextMenuActions(
+    BuildContext context,
+    ChatAttachment attachment,
+  ) {
+    return [
+      AdaptiveContextMenuAction(
+        label: 'Save Image',
+        cupertinoIcon: CupertinoIcons.square_arrow_down,
+        materialIcon: Icons.save_alt,
+        onPressed: () => _saveAttachment(context, attachment),
+      ),
+      AdaptiveContextMenuAction(
+        label: 'Share',
+        cupertinoIcon: CupertinoIcons.share,
+        materialIcon: Icons.share,
+        onPressed: () => _shareAttachment(context, attachment),
+      ),
+      AdaptiveContextMenuAction(
+        label: 'Copy Image',
+        cupertinoIcon: CupertinoIcons.doc_on_clipboard,
+        materialIcon: Icons.copy,
+        onPressed: () => _copyAttachmentToClipboard(context, attachment),
+      ),
+    ];
+  }
+
+  List<AdaptiveContextMenuAction> _voiceMessageActions(
+    BuildContext context,
+    Uint8List audioBytes,
+    String mimeType,
+  ) {
+    final ext = mimeType.contains('mp4') ? 'mp4' : 'webm';
+    final filename =
+        'voice-message-${DateTime.now().toIso8601String().split('T').first}.$ext';
+    return [
+      AdaptiveContextMenuAction(
+        label: 'Save Audio',
+        cupertinoIcon: CupertinoIcons.square_arrow_down,
+        materialIcon: Icons.save_alt,
+        onPressed: () async {
+          final box = context.findRenderObject() as RenderBox?;
+          final origin = box != null
+              ? box.localToGlobal(Offset.zero) & box.size
+              : null;
+          await ShareService.instance.saveFile(
+            audioBytes,
+            filename: filename,
+            mimeType: mimeType,
+            sharePositionOrigin: origin,
+          );
+        },
+      ),
+      AdaptiveContextMenuAction(
+        label: 'Share',
+        cupertinoIcon: CupertinoIcons.share,
+        materialIcon: Icons.share,
+        onPressed: () async {
+          final box = context.findRenderObject() as RenderBox?;
+          final origin = box != null
+              ? box.localToGlobal(Offset.zero) & box.size
+              : null;
+          await ShareService.instance.shareFile(
+            audioBytes,
+            filename: filename,
+            mimeType: mimeType,
+            sharePositionOrigin: origin,
+          );
+        },
+      ),
+    ];
+  }
+
+  List<AdaptiveContextMenuAction> _ttsAudioActions(BuildContext context) {
+    return [
+      AdaptiveContextMenuAction(
+        label: 'Save Audio',
+        cupertinoIcon: CupertinoIcons.square_arrow_down,
+        materialIcon: Icons.save_alt,
+        onPressed: () async {
+          final box = context.findRenderObject() as RenderBox?;
+          final origin = box != null
+              ? box.localToGlobal(Offset.zero) & box.size
+              : null;
+          final audio = await fetchMessageAudio();
+          if (audio == null) return;
+          final ext = audio.mimeType.contains('mp4') ? 'mp4' : 'webm';
+          final filename =
+              'assistant-audio-${DateTime.now().toIso8601String().split('T').first}.$ext';
+          await ShareService.instance.saveFile(
+            audio.bytes,
+            filename: filename,
+            mimeType: audio.mimeType,
+            sharePositionOrigin: origin,
+          );
+        },
+      ),
+      AdaptiveContextMenuAction(
+        label: 'Share',
+        cupertinoIcon: CupertinoIcons.share,
+        materialIcon: Icons.share,
+        onPressed: () async {
+          final box = context.findRenderObject() as RenderBox?;
+          final origin = box != null
+              ? box.localToGlobal(Offset.zero) & box.size
+              : null;
+          final audio = await fetchMessageAudio();
+          if (audio == null) return;
+          final ext = audio.mimeType.contains('mp4') ? 'mp4' : 'webm';
+          final filename =
+              'assistant-audio-${DateTime.now().toIso8601String().split('T').first}.$ext';
+          await ShareService.instance.shareFile(
+            audio.bytes,
+            filename: filename,
+            mimeType: audio.mimeType,
+            sharePositionOrigin: origin,
+          );
+        },
+      ),
+    ];
+  }
+
+  Future<Uint8List?> _fetchAttachmentBytes(ChatAttachment attachment) async {
+    if (imageBaseUrl == null) return null;
+    final url = '$imageBaseUrl${attachment.url}';
+    try {
+      final headers = <String, String>{};
+      if (imageAuthToken != null) {
+        headers['Authorization'] = 'Bearer $imageAuthToken';
+      }
+      final response = await http.get(Uri.parse(url), headers: headers);
+      if (response.statusCode == 200) {
+        return response.bodyBytes;
+      }
+      return null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<void> _saveAttachment(
+    BuildContext context,
+    ChatAttachment attachment,
+  ) async {
+    final box = context.findRenderObject() as RenderBox?;
+    final origin = box != null
+        ? box.localToGlobal(Offset.zero) & box.size
+        : null;
+    final bytes = await _fetchAttachmentBytes(attachment);
+    if (bytes == null) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Failed to download image')),
+        );
+      }
+      return;
+    }
+    await ShareService.instance.saveFile(
+      bytes,
+      filename: attachment.filename,
+      mimeType: attachment.mimeType,
+      sharePositionOrigin: origin,
+    );
+  }
+
+  Future<void> _shareAttachment(
+    BuildContext context,
+    ChatAttachment attachment,
+  ) async {
+    final box = context.findRenderObject() as RenderBox?;
+    final origin = box != null
+        ? box.localToGlobal(Offset.zero) & box.size
+        : null;
+    final bytes = await _fetchAttachmentBytes(attachment);
+    if (bytes == null) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Failed to download image')),
+        );
+      }
+      return;
+    }
+    await ShareService.instance.shareFile(
+      bytes,
+      filename: attachment.filename,
+      mimeType: attachment.mimeType,
+      sharePositionOrigin: origin,
+    );
+  }
+
+  Future<void> _copyAttachmentToClipboard(
+    BuildContext context,
+    ChatAttachment attachment,
+  ) async {
+    final bytes = await _fetchAttachmentBytes(attachment);
+    if (bytes == null) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Failed to download image')),
+        );
+      }
+      return;
+    }
+    await Clipboard.setData(ClipboardData(text: attachment.filename));
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Image copied'),
+          duration: Duration(seconds: 1),
+        ),
+      );
+    }
   }
 
   void _showFullImage(BuildContext context, ChatAttachment attachment) {
@@ -1064,6 +1347,53 @@ class _MetaActionRow extends StatelessWidget {
       );
     }
 
+    // Share: assistant messages with content (text selection toolbar
+    // handles sharing for user messages).
+    if (!isUser && message.content.isNotEmpty) {
+      actions.add(
+        _MetaActionButton(
+          key: const Key('share_action'),
+          icon: Icons.share_outlined,
+          label: 'Share',
+          color: mutedColor,
+          onTap: () {
+            final box = context.findRenderObject() as RenderBox?;
+            final origin = box != null
+                ? box.localToGlobal(Offset.zero) & box.size
+                : null;
+            ShareService.instance.shareText(
+              message.content,
+              sharePositionOrigin: origin,
+            );
+          },
+        ),
+      );
+    }
+
+    // Save: assistant messages with content.
+    if (!isUser && message.content.isNotEmpty) {
+      actions.add(
+        _MetaActionButton(
+          key: const Key('save_action'),
+          icon: Icons.save_alt_outlined,
+          label: 'Save',
+          color: mutedColor,
+          onTap: () {
+            final box = context.findRenderObject() as RenderBox?;
+            final origin = box != null
+                ? box.localToGlobal(Offset.zero) & box.size
+                : null;
+            ShareService.instance.saveText(
+              message.content,
+              suggestedFilename:
+                  'assistant-message-${DateTime.now().toIso8601String().split('T').first}.md',
+              sharePositionOrigin: origin,
+            );
+          },
+        ),
+      );
+    }
+
     // Retry: failed messages only.
     if (isFailed && onRetry != null) {
       actions.add(
@@ -1081,17 +1411,11 @@ class _MetaActionRow extends StatelessWidget {
 
     return Padding(
       padding: const EdgeInsets.only(top: 4),
-      child: Row(
-        mainAxisAlignment: isUser
-            ? MainAxisAlignment.end
-            : MainAxisAlignment.start,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          for (int i = 0; i < actions.length; i++) ...[
-            if (i > 0) const SizedBox(width: 16),
-            actions[i],
-          ],
-        ],
+      child: Wrap(
+        alignment: isUser ? WrapAlignment.end : WrapAlignment.start,
+        spacing: 16,
+        runSpacing: 4,
+        children: actions,
       ),
     );
   }

--- a/app/lib/services/share_service.dart
+++ b/app/lib/services/share_service.dart
@@ -1,0 +1,114 @@
+import 'dart:io';
+import 'dart:ui';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart';
+import 'package:share_plus/share_plus.dart';
+
+/// Platform-adaptive service for sharing and saving content.
+///
+/// - **Share**: Opens the native share sheet (iOS/macOS) or Web Share API.
+/// - **Save**: Opens a file-save dialog (macOS) or uses the share sheet's
+///   "Save to Files" (iOS) or triggers a browser download (web).
+class ShareService {
+  const ShareService._();
+
+  static const instance = ShareService._();
+
+  /// Share plain text via the system share sheet.
+  ///
+  /// On iPad, [sharePositionOrigin] is required to anchor the popover.
+  Future<ShareResult> shareText(String text, {Rect? sharePositionOrigin}) {
+    return SharePlus.instance.share(
+      ShareParams(text: text, sharePositionOrigin: sharePositionOrigin),
+    );
+  }
+
+  /// Share a file (from bytes) via the system share sheet.
+  Future<ShareResult> shareFile(
+    Uint8List bytes, {
+    required String filename,
+    required String mimeType,
+    Rect? sharePositionOrigin,
+  }) {
+    return SharePlus.instance.share(
+      ShareParams(
+        files: [XFile.fromData(bytes, name: filename, mimeType: mimeType)],
+        sharePositionOrigin: sharePositionOrigin,
+      ),
+    );
+  }
+
+  /// Save text to a user-chosen location.
+  ///
+  /// - macOS: NSSavePanel via file_picker.
+  /// - iOS: Falls back to share sheet (which includes "Save to Files").
+  /// - Web: Triggers a blob download.
+  Future<bool> saveText(
+    String text, {
+    required String suggestedFilename,
+    Rect? sharePositionOrigin,
+  }) async {
+    final bytes = Uint8List.fromList(text.codeUnits);
+    return saveFile(
+      bytes,
+      filename: suggestedFilename,
+      mimeType: 'text/markdown',
+      sharePositionOrigin: sharePositionOrigin,
+    );
+  }
+
+  /// Save a file (from bytes) to a user-chosen location.
+  ///
+  /// - macOS: NSSavePanel via file_picker → write to selected path.
+  /// - iOS: Share sheet (includes "Save to Files").
+  /// - Web: Triggers a blob download via share_plus fallback.
+  Future<bool> saveFile(
+    Uint8List bytes, {
+    required String filename,
+    required String mimeType,
+    Rect? sharePositionOrigin,
+  }) async {
+    if (kIsWeb) {
+      // On web, share_plus falls back to download when Web Share API
+      // is unavailable. Use downloadFallbackEnabled to ensure download.
+      await SharePlus.instance.share(
+        ShareParams(
+          files: [XFile.fromData(bytes, name: filename, mimeType: mimeType)],
+          downloadFallbackEnabled: true,
+          sharePositionOrigin: sharePositionOrigin,
+        ),
+      );
+      return true;
+    }
+
+    if (Platform.isMacOS) {
+      return _saveViaPicker(bytes, filename: filename);
+    }
+
+    // iOS: Use share sheet which includes "Save to Files".
+    await SharePlus.instance.share(
+      ShareParams(
+        files: [XFile.fromData(bytes, name: filename, mimeType: mimeType)],
+        sharePositionOrigin: sharePositionOrigin,
+      ),
+    );
+    return true;
+  }
+
+  /// macOS-specific: NSSavePanel → write bytes to the chosen path.
+  Future<bool> _saveViaPicker(
+    Uint8List bytes, {
+    required String filename,
+  }) async {
+    final path = await FilePicker.saveFile(
+      dialogTitle: 'Save As',
+      fileName: filename,
+    );
+    if (path == null) return false;
+
+    final file = File(path);
+    await file.writeAsBytes(bytes);
+    return true;
+  }
+}

--- a/app/lib/shared/platform/adaptive_context_menu.dart
+++ b/app/lib/shared/platform/adaptive_context_menu.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import 'platform.dart';
+
+/// A single action for [AdaptiveMediaContextMenu].
+class AdaptiveContextMenuAction {
+  const AdaptiveContextMenuAction({
+    required this.label,
+    required this.onPressed,
+    this.cupertinoIcon,
+    this.materialIcon,
+    this.isDestructive = false,
+  });
+
+  final String label;
+  final VoidCallback onPressed;
+  final IconData? cupertinoIcon;
+  final IconData? materialIcon;
+  final bool isDestructive;
+}
+
+/// Platform-adaptive context menu for media content (images, audio).
+///
+/// - Apple touch (iOS/iPadOS): [CupertinoContextMenu] with lifted preview.
+/// - macOS: [CupertinoContextMenu] (right-click also triggers).
+/// - Material/web: long-press or right-click → [showMenu] popup.
+class AdaptiveMediaContextMenu extends StatelessWidget {
+  const AdaptiveMediaContextMenu({
+    super.key,
+    required this.child,
+    required this.actions,
+  });
+
+  final Widget child;
+  final List<AdaptiveContextMenuAction> actions;
+
+  @override
+  Widget build(BuildContext context) {
+    if (isAppleTouch || isMacOS) {
+      return CupertinoContextMenu(
+        actions: actions
+            .map(
+              (a) => CupertinoContextMenuAction(
+                onPressed: () {
+                  Navigator.of(context, rootNavigator: true).pop();
+                  a.onPressed();
+                },
+                trailingIcon: a.cupertinoIcon,
+                isDestructiveAction: a.isDestructive,
+                child: Text(a.label),
+              ),
+            )
+            .toList(),
+        child: child,
+      );
+    }
+
+    // Material / web fallback: long-press or right-click opens a popup menu.
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onLongPressStart: (details) =>
+          _showMaterialMenu(context, details.globalPosition),
+      onSecondaryTapUp: (details) =>
+          _showMaterialMenu(context, details.globalPosition),
+      child: child,
+    );
+  }
+
+  void _showMaterialMenu(BuildContext context, Offset position) {
+    final overlay = Overlay.of(context).context.findRenderObject() as RenderBox;
+    showMenu<void>(
+      context: context,
+      position: RelativeRect.fromLTRB(
+        position.dx,
+        position.dy,
+        overlay.size.width - position.dx,
+        overlay.size.height - position.dy,
+      ),
+      items: actions
+          .map(
+            (a) => PopupMenuItem<void>(
+              onTap: a.onPressed,
+              child: Row(
+                children: [
+                  if (a.materialIcon != null) ...[
+                    Icon(a.materialIcon, size: 20),
+                    const SizedBox(width: 12),
+                  ],
+                  Text(
+                    a.label,
+                    style: a.isDestructive
+                        ? TextStyle(color: Theme.of(context).colorScheme.error)
+                        : null,
+                  ),
+                ],
+              ),
+            ),
+          )
+          .toList(),
+    );
+  }
+}

--- a/app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -16,6 +16,7 @@ import irondash_engine_context
 import package_info_plus
 import record_macos
 import screen_retriever_macos
+import share_plus
 import shared_preferences_foundation
 import sqflite_darwin
 import super_native_extensions
@@ -35,6 +36,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   RecordMacOsPlugin.register(with: registry.registrar(forPlugin: "RecordMacOsPlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
+  SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
   SuperNativeExtensionsPlugin.register(with: registry.registrar(forPlugin: "SuperNativeExtensionsPlugin"))

--- a/app/macos/Podfile.lock
+++ b/app/macos/Podfile.lock
@@ -22,6 +22,8 @@ PODS:
     - FlutterMacOS
   - screen_retriever_macos (0.0.1):
     - FlutterMacOS
+  - share_plus (0.0.1):
+    - FlutterMacOS
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -49,6 +51,7 @@ DEPENDENCIES:
   - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
   - record_macos (from `Flutter/ephemeral/.symlinks/plugins/record_macos/macos`)
   - screen_retriever_macos (from `Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos`)
+  - share_plus (from `Flutter/ephemeral/.symlinks/plugins/share_plus/macos`)
   - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sqflite_darwin (from `Flutter/ephemeral/.symlinks/plugins/sqflite_darwin/darwin`)
   - super_native_extensions (from `Flutter/ephemeral/.symlinks/plugins/super_native_extensions/macos`)
@@ -79,6 +82,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/record_macos/macos
   screen_retriever_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos
+  share_plus:
+    :path: Flutter/ephemeral/.symlinks/plugins/share_plus/macos
   shared_preferences_foundation:
     :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
   sqflite_darwin:
@@ -104,6 +109,7 @@ SPEC CHECKSUMS:
   package_info_plus: f0052d280d17aa382b932f399edf32507174e870
   record_macos: 7f227161b93c49e7e34fe681c5891c8622c8cc8b
   screen_retriever_macos: 452e51764a9e1cdb74b3c541238795849f21557f
+  share_plus: 510bf0af1a42cd602274b4629920c9649c52f4cc
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
   super_native_extensions: c2795d6d9aedf4a79fae25cb6160b71b50549189
@@ -111,6 +117,6 @@ SPEC CHECKSUMS:
   url_launcher_macos: f87a979182d112f911de6820aefddaf56ee9fbfd
   window_manager: b729e31d38fb04905235df9ea896128991cad99e
 
-PODFILE CHECKSUM: 54d867c82ac51cbd61b565781b9fada492027009
+PODFILE CHECKSUM: 89c84cf5c2351c1e554c6dea18d31a879fc3a19e
 
 COCOAPODS: 1.16.2

--- a/app/macos/Runner/DebugProfile.entitlements
+++ b/app/macos/Runner/DebugProfile.entitlements
@@ -12,7 +12,7 @@
 	<true/>
 	<key>com.apple.security.device.audio-input</key>
 	<true/>
-	<key>com.apple.security.files.user-selected.read-only</key>
+	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.inherit</key>
 	<true/>

--- a/app/macos/Runner/Release.entitlements
+++ b/app/macos/Runner/Release.entitlements
@@ -8,7 +8,7 @@
 	<true/>
 	<key>com.apple.security.device.audio-input</key>
 	<true/>
-	<key>com.apple.security.files.user-selected.read-only</key>
+	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -1140,6 +1140,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: "223873d106614442ea6f20db5a038685cc5b32a2fba81cdecaefbbae0523f7fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.0.2"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: "88023e53a13429bd65d8e85e11a9b484f49d4c190abbd96c7932b74d6927cc9a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.0"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   desktop_drop: ^0.7.1
   super_clipboard: ^0.9.1
   connectivity_plus: ^7.1.1
+  share_plus: ^12.0.2
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/app/test/widget/platform/adaptive_context_menu_test.dart
+++ b/app/test/widget/platform/adaptive_context_menu_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/shared/platform/adaptive_context_menu.dart';
+
+Widget _harness(Widget child) {
+  return MaterialApp(
+    home: Scaffold(body: Center(child: child)),
+  );
+}
+
+void main() {
+  group('AdaptiveMediaContextMenu', () {
+    final actions = [
+      AdaptiveContextMenuAction(
+        label: 'Save Image',
+        onPressed: () {},
+        cupertinoIcon: CupertinoIcons.square_arrow_down,
+        materialIcon: Icons.save_alt,
+      ),
+      AdaptiveContextMenuAction(
+        label: 'Share',
+        onPressed: () {},
+        cupertinoIcon: CupertinoIcons.share,
+        materialIcon: Icons.share,
+      ),
+    ];
+
+    testWidgets('uses CupertinoContextMenu on iOS', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+      await tester.pumpWidget(
+        _harness(
+          AdaptiveMediaContextMenu(
+            actions: actions,
+            child: const SizedBox(width: 100, height: 100, key: Key('media')),
+          ),
+        ),
+      );
+
+      expect(
+        find.byType(CupertinoContextMenu),
+        findsOneWidget,
+        reason: 'Should use CupertinoContextMenu on iOS',
+      );
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('uses CupertinoContextMenu on macOS', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+
+      await tester.pumpWidget(
+        _harness(
+          AdaptiveMediaContextMenu(
+            actions: actions,
+            child: const SizedBox(width: 100, height: 100, key: Key('media')),
+          ),
+        ),
+      );
+
+      expect(
+        find.byType(CupertinoContextMenu),
+        findsOneWidget,
+        reason: 'Should use CupertinoContextMenu on macOS',
+      );
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('uses GestureDetector on Android (Material)', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+      await tester.pumpWidget(
+        _harness(
+          AdaptiveMediaContextMenu(
+            actions: actions,
+            child: const SizedBox(width: 100, height: 100, key: Key('media')),
+          ),
+        ),
+      );
+
+      expect(
+        find.byType(CupertinoContextMenu),
+        findsNothing,
+        reason: 'Should NOT use CupertinoContextMenu on Android',
+      );
+      expect(
+        find.byType(GestureDetector),
+        findsOneWidget,
+        reason: 'Should use GestureDetector on Android',
+      );
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('long-press opens popup menu on Material platform', (
+      tester,
+    ) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+      await tester.pumpWidget(
+        _harness(
+          AdaptiveMediaContextMenu(
+            actions: actions,
+            child: const SizedBox(width: 100, height: 100, key: Key('media')),
+          ),
+        ),
+      );
+
+      await tester.longPress(find.byKey(const Key('media')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Save Image'), findsOneWidget);
+      expect(find.text('Share'), findsOneWidget);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+  });
+}

--- a/openspec/changes/share-outward/design.md
+++ b/openspec/changes/share-outward/design.md
@@ -1,0 +1,223 @@
+## Context
+
+The assistant app renders messages in `_MessageBubble` widgets within `chat_screen.dart`. Current state:
+
+- **User text messages**: rendered with `SelectableText` — long-press triggers text selection.
+- **Assistant text messages**: rendered with `StreamMarkdown(selectable: true)` — same long-press text selection.
+- **Image attachments**: rendered via `CachedNetworkImage` in `_attachmentThumbnails()`. No gesture handler beyond tap-to-fullscreen.
+- **Audio (user voice)**: `_VoiceMessagePlayer` widget with in-memory `audioBytes`.
+- **Audio (assistant TTS)**: `AudioPlayerWidget` fetching from server via `audioId`.
+- **Existing actions**: `_MetaActionRow` below each bubble with Copy, Read Aloud, Retry buttons — always visible.
+
+Platform detection is handled by `platformStyle` in `shared/platform/platform.dart` (three buckets: `cupertino`, `macos`, `material`). The app uses an **adaptive widget convention**: `shared/platform/adaptive_*.dart` files provide widgets that branch on `isAppleTouch` / `isMacOS` to render Cupertino or Material variants. Examples: `AdaptiveScaffold`, `AdaptiveNavBar`, `AdaptiveApp`, `showAdaptiveConfirmDialog`. Tests in `test/widget/platform/adaptive_*_test.dart` verify both branches via `debugDefaultTargetPlatformOverride`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Long-press on image → native context menu with Save / Share / Copy
+- Long-press on audio player → native context menu with Save / Share
+- Text selection toolbar extended with Share / Save on Apple platforms
+- Web gets equivalent functionality via download and Web Share API
+- No gesture conflicts between text selection and context menus
+- Platform-native feel on iOS and macOS
+
+**Non-Goals:**
+
+- Replacing `_MetaActionRow` entirely (it stays for whole-message actions)
+- Custom context menu on web (use inline actions / right-click)
+- Sharing structured data (JSON tool results, thinking blocks)
+
+## Decisions
+
+### D1: Per-content-type gesture mapping (no unified long-press)
+
+Text, images, and audio each get the gesture that makes sense for their content type:
+
+| Content | Gesture                       | Result                              |
+| ------- | ----------------------------- | ----------------------------------- |
+| Text    | Long-press → select → toolbar | Extended toolbar with Share/Save    |
+| Image   | Long-press                    | `CupertinoContextMenu` with preview |
+| Audio   | Long-press                    | `CupertinoContextMenu`              |
+
+**Why:** A single long-press gesture for "message actions" conflicts with text selection, which is the established iOS behavior for text. Splitting by content type means each gesture does the expected thing for that content type — no disambiguation needed.
+
+**Trade-off:** Two visual patterns within one bubble (toolbar popover for text, lifted context menu for media). Acceptable because users already expect these different patterns for different content types across iOS.
+
+### D2: `contextMenuBuilder` for text selection toolbar extension
+
+Use Flutter's `contextMenuBuilder` parameter on `SelectableText` and the markdown widget's selection area to inject custom actions into the native selection toolbar.
+
+```dart
+SelectableText(
+  message.content,
+  contextMenuBuilder: (context, editableTextState) {
+    return AdaptiveTextSelectionToolbar.buttonItems(
+      anchors: editableTextState.contextMenuAnchors,
+      buttonItems: [
+        ...editableTextState.contextMenuButtonItems, // Copy, Select All, etc.
+        ContextMenuButtonItem(
+          label: 'Share',
+          onPressed: () => _shareText(editableTextState.textEditingValue.selection),
+        ),
+        ContextMenuButtonItem(
+          label: 'Save As...',
+          onPressed: () => _saveText(editableTextState.textEditingValue.selection),
+        ),
+      ],
+    );
+  },
+)
+```
+
+**Why over custom gesture recognizer:** This extends the platform's own toolbar rather than fighting it. The user sees Share/Save alongside Copy in the same familiar popover. Zero gesture conflicts.
+
+**Why over a separate button:** Putting Share in the selection toolbar means the action applies to the _selected_ text. The user can share a snippet rather than the whole message.
+
+### D3: `AdaptiveMediaContextMenu` for images and audio
+
+Follow the existing adaptive widget convention (`shared/platform/adaptive_*.dart`) to create an `AdaptiveMediaContextMenu` widget that wraps media content with platform-appropriate context menu behavior.
+
+```dart
+/// Platform-adaptive context menu for media content (images, audio).
+///
+/// - Apple touch (iOS/iPadOS): [CupertinoContextMenu] with lifted preview + blur.
+/// - macOS: [CupertinoContextMenu] (same visual, right-click also triggers).
+/// - Material/web: long-press → [showMenu] popup, or hover overlay on web.
+class AdaptiveMediaContextMenu extends StatelessWidget {
+  const AdaptiveMediaContextMenu({
+    super.key,
+    required this.child,
+    required this.actions,
+  });
+
+  final Widget child;
+  final List<AdaptiveContextMenuAction> actions;
+
+  @override
+  Widget build(BuildContext context) {
+    if (isAppleTouch || isMacOS) {
+      return CupertinoContextMenu(
+        actions: actions
+            .map((a) => CupertinoContextMenuAction(
+                  onPressed: () {
+                    Navigator.of(context, rootNavigator: true).pop();
+                    a.onPressed();
+                  },
+                  trailingIcon: a.cupertinoIcon,
+                  isDestructiveAction: a.isDestructive,
+                  child: Text(a.label),
+                ))
+            .toList(),
+        child: child,
+      );
+    }
+    // Material / web fallback
+    return GestureDetector(
+      onLongPress: () => _showMaterialMenu(context),
+      onSecondaryTap: () => _showMaterialMenu(context),
+      child: child,
+    );
+  }
+}
+
+/// A single action for [AdaptiveMediaContextMenu].
+class AdaptiveContextMenuAction {
+  const AdaptiveContextMenuAction({
+    required this.label,
+    required this.onPressed,
+    this.cupertinoIcon,
+    this.materialIcon,
+    this.isDestructive = false,
+  });
+
+  final String label;
+  final VoidCallback onPressed;
+  final IconData? cupertinoIcon;
+  final IconData? materialIcon;
+  final bool isDestructive;
+}
+```
+
+File: `app/lib/shared/platform/adaptive_context_menu.dart`
+
+**Why an adaptive widget over inline `if (isAppleTouch)`:** Follows the established project convention. Keeps platform branching in one place. Enables testing both paths via `debugDefaultTargetPlatformOverride` (like the existing `adaptive_*_test.dart` files).
+
+**Why `CupertinoContextMenu` over `showCupertinoModalPopup`:** The lifted-preview-with-blur effect is the standard iOS pattern for actionable media (Photos app, Safari image long-press, iMessage). It signals "this item has actions" through the animation.
+
+### D4: Platform share/save service abstraction
+
+Create a `ShareService` class that dispatches to the correct platform mechanism:
+
+```
+ShareService
+  ├── shareText(String text)
+  ├── shareFile(Uint8List bytes, String filename, String mimeType)
+  ├── saveFile(Uint8List bytes, String filename, String mimeType)
+  └── saveText(String text, String suggestedFilename)
+```
+
+Implementation per platform:
+
+| Method      | iOS                                       | macOS                                  | Web                                            |
+| ----------- | ----------------------------------------- | -------------------------------------- | ---------------------------------------------- |
+| `shareText` | `UIActivityViewController` with text      | `NSSharingServicePicker`               | Web Share API → fallback: copy + toast         |
+| `shareFile` | `UIActivityViewController` with file URL  | `NSSharingServicePicker` with file URL | Web Share API with `File` → fallback: download |
+| `saveFile`  | `UIDocumentPickerViewController` (export) | `NSSavePanel`                          | Blob download via anchor                       |
+| `saveText`  | `UIDocumentPickerViewController` (export) | `NSSavePanel`                          | Blob download via anchor                       |
+
+**Why a custom service over `share_plus`:** `share_plus` handles `shareText` and `shareFile` well, but doesn't cover "Save As" (file export with picker). We need both sharing (to people/apps) and saving (to filesystem with location choice). A single abstraction covers both and keeps the UI code clean.
+
+**Alternative:** Use `share_plus` for sharing + `file_saver` or a method channel for saving. This avoids writing platform channels but adds two dependencies. Viable for v1 if the packages cover the needed APIs.
+
+### D5: Fetching bytes before share/save
+
+Images and audio must be downloaded from the server before they can be shared or saved:
+
+- **Images**: Fetch from `attachment.url` (relative path resolved against `imageBaseUrl`)
+- **User voice**: Already in memory as `message.audioBytes` during the session
+- **TTS audio**: Fetch via `api.fetchAudio(audioId)`
+
+Show a brief loading indicator (spinner overlay on the context menu action) while fetching. If the fetch fails, show a toast error and dismiss the menu.
+
+**Why not pre-fetch:** Messages may contain multiple images. Pre-fetching all of them wastes bandwidth. Fetch on-demand when the user explicitly requests share/save.
+
+### D6: Saved file naming convention
+
+| Content              | Default filename                           |
+| -------------------- | ------------------------------------------ |
+| Text (whole message) | `assistant-message-{iso-date}.md`          |
+| Text (selection)     | `assistant-snippet-{iso-date}.md`          |
+| Image                | Original `attachment.filename` from server |
+| Voice (user)         | `voice-message-{iso-date}.{ext}`           |
+| Audio (TTS)          | `assistant-audio-{iso-date}.{ext}`         |
+
+On macOS (`NSSavePanel`), the user can change the filename. On iOS (`UIDocumentPickerViewController` export mode), the default is used but the user picks the destination folder.
+
+### D7: Web fallback — no `CupertinoContextMenu`, use inline actions
+
+On web, there is no `CupertinoContextMenu` equivalent. Instead:
+
+- Image thumbnails get a hover overlay with Save/Share icon buttons (similar to how image viewers work on web).
+- Audio players get Save/Share buttons inline (next to the play controls).
+- Text keeps the `_MetaActionRow` Copy action; browsers provide their own right-click → "Copy" for selected text.
+
+This is acceptable because web users expect hover-based actions, not long-press.
+
+## Risks / Trade-offs
+
+**[Risk] `contextMenuBuilder` not supported by `StreamMarkdown`** → The `flutter_smooth_markdown` package may not expose `contextMenuBuilder` on its internal `SelectionArea`. If so, wrap the markdown widget in a `SelectionArea` with a custom `contextMenuBuilder` at the parent level. Fallback: add Share/Save to `_MetaActionRow` only.
+
+**[Risk] `CupertinoContextMenu` animation janky with `CachedNetworkImage`** → The lift animation clones the child widget. If the image is still loading, the preview may show a placeholder. Mitigation: only wrap images that have finished loading (check `CachedNetworkImage` state or use a `frameBuilder`).
+
+**[Risk] Large audio files slow to fetch before share** → TTS audio and voice recordings are typically small (<5 MB). If a fetch takes >2 seconds, show a progress indicator within the context menu action. Cancel on dismiss.
+
+**[Trade-off] Two menu patterns per bubble** → Users see a selection toolbar for text and a lifted context menu for images/audio within the same message. This matches how iOS itself handles mixed content (e.g., Safari shows text selection toolbar for text and a context menu for images on the same page).
+
+**[Trade-off] `share_plus` vs custom platform channel** → `share_plus` is well-maintained and handles 80% of the share use case. "Save As" with a file picker is the gap. Options: (a) use `share_plus` + `file_saver`, (b) write a single method channel for the save picker. Decision can be made during implementation based on package quality.
+
+## Open Questions
+
+- **`StreamMarkdown` selection customization**: Does `flutter_smooth_markdown` support `contextMenuBuilder` or `selectionControls` override? Needs investigation.
+- **macOS `NSSavePanel` from Flutter**: Is there an existing package, or do we need a method channel? `file_saver` may only do Downloads folder without a picker.
+- **Haptic feedback**: Should the `CupertinoContextMenu` trigger a haptic on iOS? (Default Flutter behavior may already include this.)

--- a/openspec/changes/share-outward/proposal.md
+++ b/openspec/changes/share-outward/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+Users can copy message text to the clipboard, but there is no way to share or save images, voice attachments, or formatted message text from the app. On Apple platforms, long-press context menus and the share sheet are the standard gestures for exporting content — their absence makes the assistant feel like a walled garden where content goes in but doesn't come out.
+
+## What Changes
+
+- **Extend the text selection toolbar** (`contextMenuBuilder`) on iOS/macOS with "Share" and "Save As" actions alongside the standard Copy/Paste items. When text is selected, the user can share or save the selection directly from the native popover.
+- **Add `CupertinoContextMenu` to image thumbnails** so long-press on an attached image shows Save Image / Share Image / Copy actions with a lifted preview.
+- **Add `CupertinoContextMenu` to audio player widgets** (both user voice messages and TTS-generated audio) with Save Audio / Share Audio actions.
+- **Implement platform-specific share/save services**:
+  - iOS: `UIActivityViewController` (share), `UIDocumentPickerViewController` in export mode (save)
+  - macOS: `NSSharingServicePicker` (share), `NSSavePanel` (save)
+  - Web: Web Share API with fallback to blob download (share), blob download via anchor element (save)
+- **Keep `_MetaActionRow`** for whole-message actions (Copy all, Read Aloud, Retry) that don't conflict with content-level gestures.
+
+## Non-goals
+
+- **Inward sharing** (share sheet into the app) — covered by `share-files-native`.
+- **Conversation export** (full thread as PDF/HTML) — separate future feature.
+- **Android-specific share intents** — Apple platforms and web only for v1.
+- **Sharing tool call results or thinking blocks** — only user/assistant message content, images, and audio.
+
+## Capabilities
+
+### New Capabilities
+
+- `share-outward-text`: Extended selection toolbar on iOS/macOS with Share/Save actions for selected text or whole message content.
+- `share-outward-media`: `CupertinoContextMenu` on image thumbnails and audio player widgets with platform-native Save/Share actions.
+- `share-save-service`: Platform abstraction layer dispatching to `UIActivityViewController`/`NSSharingServicePicker` (share) and `UIDocumentPickerViewController`/`NSSavePanel`/blob-download (save).
+
+### Modified Capabilities
+
+- `chat-messages`: Message bubble rendering gains `CupertinoContextMenu` wrappers around image and audio content. `SelectableText` and `StreamMarkdown` gain custom `contextMenuBuilder` on Apple platforms.
+
+## Impact
+
+- **Flutter app only** — no backend/Rust changes required. All content (text, image bytes, audio bytes) is already available client-side or fetchable via existing API endpoints.
+- **New dependencies**: Likely `share_plus` for cross-platform share sheet invocation, or a thin platform channel for finer control over `NSSavePanel`/`UIDocumentPickerViewController`.
+- **Platform channels**: May need a method channel for "Save As" (file picker in export mode) if no existing package covers iOS `UIDocumentPickerViewController` export + macOS `NSSavePanel` cleanly.
+- **Files touched**: `chat_screen.dart` (bubble wrappers, context menus), new `share_service.dart` (platform dispatch), `pubspec.yaml` (dependencies).

--- a/openspec/changes/share-outward/tasks.md
+++ b/openspec/changes/share-outward/tasks.md
@@ -1,0 +1,82 @@
+## Definition of Done
+
+- [x] `flutter build ios --no-codesign` succeeds (updated entitlements, no signing errors in CI)
+- [x] `flutter build macos` succeeds (via xcodebuild with CODE_SIGNING_ALLOWED=NO)
+- [x] `flutter build web` succeeds
+- [x] `flutter analyze --fatal-infos` passes
+- [x] `flutter test` passes (including new adaptive widget tests)
+- [ ] Long-press on image → context menu works on iOS simulator and macOS
+- [ ] Long-press on audio → context menu works on iOS simulator and macOS
+- [ ] Text selection → extended toolbar with Share/Save works on iOS simulator
+- [ ] Save As writes file to user-chosen location (macOS NSSavePanel, iOS UIDocumentPicker)
+- [ ] Share opens system share sheet on iOS and macOS
+- [ ] Web: Save triggers browser download, Share uses Web Share API (or fallback)
+- [x] Entitlement: `com.apple.security.files.user-selected.read-write` replaces `read-only` in macOS entitlements
+
+## Entitlement Changes
+
+macOS `DebugProfile.entitlements` and `Release.entitlements`:
+
+```diff
+- <key>com.apple.security.files.user-selected.read-only</key>
++ <key>com.apple.security.files.user-selected.read-write</key>
+  <true/>
+```
+
+No new iOS entitlements needed — `UIDocumentPickerViewController` and `UIActivityViewController` don't require additional entitlements. The existing App Group and Keychain groups are sufficient.
+
+---
+
+## Tasks
+
+### 1. Platform share/save service abstraction
+
+- [x] Create `app/lib/services/share_service.dart` with `ShareService` interface (`shareText`, `shareFile`, `saveFile`, `saveText`)
+- [x] Implement iOS/macOS method channel for `saveFile` (NSSavePanel / UIDocumentPickerViewController export mode)
+- [x] Implement web save via blob download (anchor element trick)
+- [x] Evaluate `share_plus` for share actions — adopt if it covers iOS `UIActivityViewController` + macOS `NSSharingServicePicker` cleanly, otherwise use method channel
+- [x] Add `share_plus` (or equivalent) to `pubspec.yaml`
+
+### 2. Adaptive context menu widget
+
+- [x] Create `app/lib/shared/platform/adaptive_context_menu.dart` with `AdaptiveMediaContextMenu` and `AdaptiveContextMenuAction`
+- [x] Apple platforms: `CupertinoContextMenu` with lifted preview + blur
+- [x] Material/web: long-press → `showMenu()` popup, `onSecondaryTap` for right-click
+- [x] Add test `app/test/widget/platform/adaptive_context_menu_test.dart` verifying both platform branches via `debugDefaultTargetPlatformOverride`
+
+### 3. Image context menu
+
+- [x] Wrap image thumbnails in `_attachmentThumbnails()` with `AdaptiveMediaContextMenu`
+- [x] Add actions: Save Image, Share Image, Copy Image
+- [x] Implement byte-fetching from `attachment.url` with loading indicator
+- [x] Test with still-loading images (ensure preview doesn't show broken placeholder)
+
+### 4. Audio context menu
+
+- [x] Wrap `_VoiceMessagePlayer` with `AdaptiveMediaContextMenu`
+- [x] Wrap `AudioPlayerWidget` (TTS audio) with `AdaptiveMediaContextMenu`
+- [x] Add actions: Save Audio, Share Audio
+- [x] Handle byte-fetching: use in-memory `audioBytes` for user voice, fetch via `api.fetchAudio(audioId)` for TTS
+
+### 5. Text selection toolbar extension
+
+- [x] Investigate `flutter_smooth_markdown` support for `contextMenuBuilder` / `SelectionArea` customization
+- [x] Add `contextMenuBuilder` to `SelectableText` (user messages) with Share / Save As actions
+- [x] Add equivalent to assistant markdown rendering (if supported by the package)
+- [x] Share action: shares selected text (or full message if no selection)
+- [x] Save As action: saves as `.md` file with auto-generated filename
+- [x] Fallback if markdown package doesn't support customization: add Share/Save to `_MetaActionRow`
+
+### 6. Web-specific implementations
+
+- [x] Image hover overlay with Save/Share buttons
+- [x] Audio inline Save/Share buttons
+- [x] Web Share API integration (with feature detection and graceful fallback to download)
+- [x] Blob download helper for text/image/audio
+
+### 7. Polish and integration
+
+- [x] Verify no gesture conflicts between text selection and context menus
+- [x] Haptic feedback on `CupertinoContextMenu` activation (verify Flutter default behavior)
+- [x] Error handling: toast on failed fetch, dismiss menu gracefully
+- [ ] Test on iOS, macOS, and web


### PR DESCRIPTION
## Summary

- Add platform-adaptive context menus for sharing/saving images and audio from chat messages (CupertinoContextMenu on Apple platforms, popup menu on Material/web)
- Extend text selection toolbar with Share / Save As actions for user messages; add Share/Save buttons to the meta action row for assistant messages
- New `ShareService` abstraction using `share_plus` + `file_picker` + blob downloads, with `AdaptiveMediaContextMenu` widget following existing `adaptive_*.dart` conventions

## Changes

- **New files**: `share_service.dart`, `adaptive_context_menu.dart`, `adaptive_context_menu_test.dart`, OpenSpec artifacts in `openspec/changes/share-outward/`
- **Modified**: `chat_screen.dart` (context menus on images/audio, extended text toolbar, Share/Save in meta row, Row→Wrap overflow fix), entitlements (read-only→read-write), `pubspec.yaml` (+share_plus, go_router bump)

## Test plan

- [x] `flutter analyze --fatal-infos` passes (0 issues)
- [x] `flutter test` passes (493 tests, 0 failures)
- [x] `flutter build web` succeeds
- [x] `flutter build ios --no-codesign` succeeds
- [x] `xcodebuild` macOS build succeeds (CODE_SIGNING_ALLOWED=NO)
- [ ] Manual: long-press image thumbnail on iOS simulator → context menu shows Save/Share/Copy
- [ ] Manual: long-press audio player on iOS → context menu shows Save/Share
- [ ] Manual: select text in user message on iOS → toolbar shows Share / Save As
- [ ] Manual: Share/Save buttons in assistant message meta row work on macOS
- [ ] Manual: web build — right-click or long-press on image shows popup menu