### PR TITLE
fix(ci): add fastlane match provisioning for macOS desktop build

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -180,8 +180,18 @@ jobs:
             flutter_target: macos
             archive_suffix: macos-arm64
 
+    env:
+      MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+      MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+      MATCH_READONLY: "true"
+
     steps:
       - uses: actions/checkout@v6
+
+      - name: Set up SSH for match repo
+        uses: webfactory/ssh-agent@v0.10.0
+        with:
+          ssh-private-key: ${{ secrets.MATCH_DEPLOY_KEY }}
 
       - name: Install Flutter SDK
         uses: subosito/flutter-action@v2
@@ -211,7 +221,6 @@ jobs:
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_DEV_CERTIFICATE: ${{ secrets.APPLE_DEV_CERTIFICATE }}
         run: |
           KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
           KEYCHAIN_PASSWORD=$(openssl rand -base64 20)
@@ -222,13 +231,10 @@ jobs:
           echo -n "$APPLE_CERTIFICATE" | base64 --decode -o $RUNNER_TEMP/certificate.p12
           security import "$RUNNER_TEMP/certificate.p12" -P "$APPLE_CERTIFICATE_PASSWORD" \
             -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
-          # Apple Development cert (required by flutter build macos with keychain-access-groups)
-          echo -n "$APPLE_DEV_CERTIFICATE" | base64 --decode -o $RUNNER_TEMP/dev-certificate.p12
-          security import "$RUNNER_TEMP/dev-certificate.p12" -P "" \
-            -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
           security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security list-keychain -d user -s "$KEYCHAIN_PATH"
           echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> $GITHUB_ENV
+          echo "KEYCHAIN_PASSWORD=$KEYCHAIN_PASSWORD" >> $GITHUB_ENV
 
       - name: Build universal Rust binary for macOS bundle
         run: make build-macos-binary
@@ -257,6 +263,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload ${{ needs.release-please.outputs.tag_name }} ${{ env.STANDALONE_ARCHIVE }}
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: app
+
+      - name: Provision macOS signing profiles via match
+        env:
+          APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
+          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}
+          APP_STORE_CONNECT_API_KEY_IS_BASE64: "true"
+        run: bundle exec fastlane mac provision
+        working-directory: app
 
       - name: Build Flutter macOS app
         run: |

--- a/app/fastlane/Fastfile
+++ b/app/fastlane/Fastfile
@@ -1,12 +1,13 @@
-# Fastfile — iOS release automation for the assistant app.
+# Fastfile — iOS & macOS release automation for the assistant app.
 #
 # Usage:
 #   bundle exec fastlane ios beta    — build and upload to TestFlight
 #   bundle exec fastlane ios release — build and submit to App Store
+#   bundle exec fastlane mac provision — sync macOS development profiles
 
 default_platform(:ios)
 
-REQUIRED_ENV_VARS = %w[
+IOS_REQUIRED_ENV_VARS = %w[
   APP_STORE_CONNECT_API_KEY_KEY_ID
   APP_STORE_CONNECT_API_KEY_ISSUER_ID
   APP_STORE_CONNECT_API_KEY_KEY
@@ -14,24 +15,31 @@ REQUIRED_ENV_VARS = %w[
   MATCH_PASSWORD
 ].freeze
 
-before_all do
-  missing = REQUIRED_ENV_VARS.reject { |v| ENV[v] && !ENV[v].empty? }
-  unless missing.empty?
-    UI.user_error!("Missing required environment variables:\n  #{missing.join("\n  ")}\n\nSee app/fastlane/README.md for setup instructions.")
-  end
-
-  # Create a temporary keychain in CI so match doesn't prompt.
-  setup_ci if ENV["CI"]
-
-  app_store_connect_api_key(
-    key_id:      ENV["APP_STORE_CONNECT_API_KEY_KEY_ID"],
-    issuer_id:   ENV["APP_STORE_CONNECT_API_KEY_ISSUER_ID"],
-    key_content: ENV["APP_STORE_CONNECT_API_KEY_KEY"],
-    is_key_content_base64: ENV["APP_STORE_CONNECT_API_KEY_IS_BASE64"] == "true"
-  )
-end
+MAC_REQUIRED_ENV_VARS = %w[
+  APP_STORE_CONNECT_API_KEY_KEY_ID
+  APP_STORE_CONNECT_API_KEY_ISSUER_ID
+  APP_STORE_CONNECT_API_KEY_KEY
+  MATCH_GIT_URL
+  MATCH_PASSWORD
+].freeze
 
 platform :ios do
+  before_all do
+    missing = IOS_REQUIRED_ENV_VARS.reject { |v| ENV[v] && !ENV[v].empty? }
+    unless missing.empty?
+      UI.user_error!("Missing required environment variables:\n  #{missing.join("\n  ")}\n\nSee app/fastlane/README.md for setup instructions.")
+    end
+
+    setup_ci if ENV["CI"]
+
+    app_store_connect_api_key(
+      key_id:      ENV["APP_STORE_CONNECT_API_KEY_KEY_ID"],
+      issuer_id:   ENV["APP_STORE_CONNECT_API_KEY_ISSUER_ID"],
+      key_content: ENV["APP_STORE_CONNECT_API_KEY_KEY"],
+      is_key_content_base64: ENV["APP_STORE_CONNECT_API_KEY_IS_BASE64"] == "true"
+    )
+  end
+
   private_lane :build_ios do
     # Sync certificates and provisioning profiles (readonly in CI).
     match(type: "appstore")
@@ -93,6 +101,64 @@ platform :ios do
       force:                    true,
       skip_screenshots:         true,
       skip_metadata:            true
+    )
+  end
+end
+
+platform :mac do
+  before_all do
+    missing = MAC_REQUIRED_ENV_VARS.reject { |v| ENV[v] && !ENV[v].empty? }
+    unless missing.empty?
+      UI.user_error!("Missing required environment variables:\n  #{missing.join("\n  ")}\n\nSee app/fastlane/README.md for setup instructions.")
+    end
+
+    app_store_connect_api_key(
+      key_id:      ENV["APP_STORE_CONNECT_API_KEY_KEY_ID"],
+      issuer_id:   ENV["APP_STORE_CONNECT_API_KEY_ISSUER_ID"],
+      key_content: ENV["APP_STORE_CONNECT_API_KEY_KEY"],
+      is_key_content_base64: ENV["APP_STORE_CONNECT_API_KEY_IS_BASE64"] == "true"
+    )
+  end
+
+  lane :provision do
+    # In CI the build-flutter-desktop job creates its own keychain and passes
+    # KEYCHAIN_PATH / KEYCHAIN_PASSWORD. We import match certs into that
+    # keychain so both Developer ID and development certs coexist.
+    match_opts = {
+      type: "development",
+      platform: "macos",
+      app_identifier: [
+        "com.cedricziel.assistant.macos",
+        "com.cedricziel.assistant.macos.ShareExtension"
+      ]
+    }
+
+    if ENV["CI"] && ENV["KEYCHAIN_PATH"]
+      match_opts[:keychain_name] = ENV["KEYCHAIN_PATH"]
+      match_opts[:keychain_password] = ENV["KEYCHAIN_PASSWORD"]
+    else
+      setup_ci if ENV["CI"]
+    end
+
+    match(match_opts)
+
+    # Switch both targets to manual signing with the profiles match installed.
+    update_code_signing_settings(
+      use_automatic_signing: false,
+      path: "macos/Runner.xcodeproj",
+      team_id: "WPW3QSLZ2F",
+      code_sign_identity: "Apple Development",
+      profile_name: ENV["sigh_com.cedricziel.assistant.macos_development_macos_profile-name"] || "match Development com.cedricziel.assistant.macos macos",
+      targets: ["Runner"]
+    )
+
+    update_code_signing_settings(
+      use_automatic_signing: false,
+      path: "macos/Runner.xcodeproj",
+      team_id: "WPW3QSLZ2F",
+      code_sign_identity: "Apple Development",
+      profile_name: ENV["sigh_com.cedricziel.assistant.macos.ShareExtension_development_macos_profile-name"] || "match Development com.cedricziel.assistant.macos.ShareExtension macos",
+      targets: ["ShareExtension"]
     )
   end
 end


### PR DESCRIPTION
## Summary

- Add `platform :mac` with `provision` lane to Fastfile — runs `match(type: "development", platform: "macos")` for `com.cedricziel.assistant.macos` and its ShareExtension, then switches both targets to manual signing
- Add SSH agent, Ruby, and `fastlane mac provision` steps to the `build-flutter-desktop` CI job before `flutter build macos`
- Match imports into the existing CI keychain (via `KEYCHAIN_PATH`/`KEYCHAIN_PASSWORD`) so development certs and Developer ID certs coexist without conflicts
- macOS App IDs registered on Dev Portal with APP_GROUPS capability, initial development profiles generated and pushed to the match certificates repo

Fixes the `No profiles for 'com.cedricziel.assistant.macos'` error from [this run](https://github.com/cedricziel/assistant/actions/runs/24694757283/job/72224897428).

## Test plan

- [ ] Verify iOS `release-ios-testflight` job still passes (no changes to iOS lanes)
- [ ] Verify `build-flutter-desktop` job succeeds with the new match provisioning step
- [ ] Confirm `match Development com.cedricziel.assistant.macos macos` profile is fetched in readonly mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS build and provisioning infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->