### PR TITLE
refactor(ci): move macOS signing and notarization into fastlane

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -287,61 +287,15 @@ jobs:
           flutter build macos --release --build-name "${VERSION}"
         working-directory: app
 
-      - name: Sign macOS app
-        run: |
-          APP="app/build/macos/Build/Products/Release/assistant_app.app"
-          IDENTITY="${{ secrets.APPLE_SIGNING_IDENTITY }}"
-          # Bottom-up signing: embedded binaries and frameworks first, then the bundle
-          # Sign the embedded Rust binary (notarization requires all binaries to have hardened runtime + timestamp)
-          find "$APP/Contents/Resources" -type f -perm +111 2>/dev/null | while read f; do
-            codesign --force --sign "$IDENTITY" --options runtime --timestamp "$f"
-          done
-          find "$APP/Contents/Frameworks" \( -name "*.framework" -o -name "*.dylib" \) 2>/dev/null | while read f; do
-            codesign --force --sign "$IDENTITY" --options runtime --timestamp "$f"
-          done
-          # Sign app extensions (e.g. ShareExtension from super_clipboard plugin)
-          find "$APP/Contents/PlugIns" -name "*.appex" 2>/dev/null | while read appex; do
-            codesign --force --sign "$IDENTITY" --options runtime --timestamp "$appex"
-          done
-          codesign --force --sign "$IDENTITY" --options runtime --timestamp \
-            --entitlements app/macos/Runner/Release.entitlements "$APP"
-
-      - name: Verify code signature
-        run: |
-          APP="app/build/macos/Build/Products/Release/assistant_app.app"
-          codesign --verify --deep --strict "$APP"
-          echo "Code signature verification passed"
-
-      - name: Notarize macOS app
-        run: |
-          APP="app/build/macos/Build/Products/Release/assistant_app.app"
-          ditto -c -k --keepParent "$APP" "$RUNNER_TEMP/assistant_app_notarize.zip"
-          SUBMISSION=$(xcrun notarytool submit "$RUNNER_TEMP/assistant_app_notarize.zip" \
-            --apple-id "${{ secrets.APPLE_ID }}" \
-            --password "${{ secrets.APPLE_APP_PASSWORD }}" \
-            --team-id "${{ secrets.APPLE_TEAM_ID }}" \
-            --output-format json)
-          SUBMISSION_ID=$(echo "$SUBMISSION" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
-          echo "Notarization submission ID: $SUBMISSION_ID"
-          # Poll until complete
-          while true; do
-            STATUS=$(xcrun notarytool info "$SUBMISSION_ID" \
-              --apple-id "${{ secrets.APPLE_ID }}" \
-              --password "${{ secrets.APPLE_APP_PASSWORD }}" \
-              --team-id "${{ secrets.APPLE_TEAM_ID }}" \
-              --output-format json | python3 -c "import sys,json; print(json.load(sys.stdin)['status'])")
-            echo "Status: $STATUS"
-            if [ "$STATUS" = "Accepted" ]; then break; fi
-            if [ "$STATUS" = "Invalid" ] || [ "$STATUS" = "Rejected" ]; then
-              xcrun notarytool log "$SUBMISSION_ID" \
-                --apple-id "${{ secrets.APPLE_ID }}" \
-                --password "${{ secrets.APPLE_APP_PASSWORD }}" \
-                --team-id "${{ secrets.APPLE_TEAM_ID }}"
-              exit 1
-            fi
-            sleep 15
-          done
-          xcrun stapler staple "$APP"
+      - name: Sign and notarize macOS app
+        env:
+          APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
+          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}
+          APP_STORE_CONNECT_API_KEY_IS_BASE64: "true"
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+        run: bundle exec fastlane mac sign_and_notarize
+        working-directory: app
 
       - name: Cleanup keychain
         if: always()

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -46,3 +46,4 @@ app.*.map.json
 
 # Fastlane / Bundler
 vendor/bundle/
+fastlane/report.xml

--- a/app/fastlane/Fastfile
+++ b/app/fastlane/Fastfile
@@ -1,9 +1,10 @@
 # Fastfile — iOS & macOS release automation for the assistant app.
 #
 # Usage:
-#   bundle exec fastlane ios beta    — build and upload to TestFlight
-#   bundle exec fastlane ios release — build and submit to App Store
-#   bundle exec fastlane mac provision — sync macOS development profiles
+#   bundle exec fastlane ios beta             — build and upload to TestFlight
+#   bundle exec fastlane ios release          — build and submit to App Store
+#   bundle exec fastlane mac provision        — sync macOS development profiles
+#   bundle exec fastlane mac sign_and_notarize — sign + notarize the macOS .app
 
 default_platform(:ios)
 
@@ -19,8 +20,6 @@ MAC_REQUIRED_ENV_VARS = %w[
   APP_STORE_CONNECT_API_KEY_KEY_ID
   APP_STORE_CONNECT_API_KEY_ISSUER_ID
   APP_STORE_CONNECT_API_KEY_KEY
-  MATCH_GIT_URL
-  MATCH_PASSWORD
 ].freeze
 
 platform :ios do
@@ -121,6 +120,10 @@ platform :mac do
   end
 
   lane :provision do
+    %w[MATCH_GIT_URL MATCH_PASSWORD].each do |v|
+      UI.user_error!("Missing required env var: #{v}") if ENV[v].to_s.empty?
+    end
+
     # In CI the build-flutter-desktop job creates its own keychain and passes
     # KEYCHAIN_PATH / KEYCHAIN_PASSWORD. We import match certs into that
     # keychain so both Developer ID and development certs coexist.
@@ -159,6 +162,41 @@ platform :mac do
       code_sign_identity: "Apple Development",
       profile_name: ENV["sigh_com.cedricziel.assistant.macos.ShareExtension_development_macos_profile-name"] || "match Development com.cedricziel.assistant.macos.ShareExtension macos",
       targets: ["ShareExtension"]
+    )
+  end
+
+  lane :sign_and_notarize do
+    identity = ENV["APPLE_SIGNING_IDENTITY"]
+    UI.user_error!("Missing APPLE_SIGNING_IDENTITY env var") if identity.to_s.empty?
+
+    app = File.expand_path("../build/macos/Build/Products/Release/assistant_app.app")
+    UI.user_error!("App bundle not found at #{app}") unless File.exist?(app)
+    entitlements = File.expand_path("../macos/Runner/Release.entitlements")
+
+    # Bottom-up signing: embedded binaries and frameworks first, then the
+    # bundle itself. Notarization requires every binary to carry hardened
+    # runtime + a secure timestamp.
+    Dir.glob("#{app}/Contents/Resources/**/*").select { |f| File.file?(f) && File.executable?(f) }.each do |f|
+      sh("codesign", "--force", "--sign", identity, "--options", "runtime", "--timestamp", f)
+    end
+    Dir.glob("#{app}/Contents/Frameworks/*.{framework,dylib}").each do |f|
+      sh("codesign", "--force", "--sign", identity, "--options", "runtime", "--timestamp", f)
+    end
+    Dir.glob("#{app}/Contents/PlugIns/*.appex").each do |appex|
+      sh("codesign", "--force", "--sign", identity, "--options", "runtime", "--timestamp", appex)
+    end
+    sh("codesign", "--force", "--sign", identity, "--options", "runtime", "--timestamp",
+       "--entitlements", entitlements, app)
+
+    # Verify
+    sh("codesign", "--verify", "--deep", "--strict", app)
+    UI.success("Code signature verification passed")
+
+    # Notarize via ASC API key (already configured in before_all).
+    notarize(
+      package: app,
+      bundle_id: "com.cedricziel.assistant.macos",
+      print_log: true
     )
   end
 end


### PR DESCRIPTION
## Summary

- Add `sign_and_notarize` lane to `platform :mac` in the Fastfile that handles bottom-up Developer ID codesigning, verification, and notarization via fastlane's `notarize` action
- Replace ~55 lines of shell across 3 CI steps ("Sign macOS app", "Verify code signature", "Notarize macOS app") with a single `bundle exec fastlane mac sign_and_notarize` call
- Notarization now uses the ASC API key instead of Apple ID credentials, eliminating the need for `APPLE_ID`, `APPLE_APP_PASSWORD`, and `APPLE_TEAM_ID` secrets in the `build-flutter-desktop` job

Tested locally: full build → sign → notarize flow completed successfully (notarize took 73s).

## Test plan

- [ ] Verify `build-flutter-desktop` job succeeds with the new lane (signing + notarization)
- [ ] Verify the resulting `.app` passes Gatekeeper (`spctl --assess`)
- [ ] Confirm `APPLE_ID`/`APPLE_APP_PASSWORD`/`APPLE_TEAM_ID` secrets are no longer needed by this job