### PR TITLE
feat(runtime): enable skill learning for subagent turns

### DIFF
--- a/crates/runtime/src/orchestrator/subagent.rs
+++ b/crates/runtime/src/orchestrator/subagent.rs
@@ -176,6 +176,10 @@ impl SubagentRunner for Orchestrator {
             warn!(agent_id = %spawn.agent_id, %e, "Failed to persist agent record");
         }
 
+        // Track tool usage for post-turn skill learning.
+        let mut subagent_tool_count: usize = 0;
+        let mut subagent_had_errors = false;
+
         // Tool-calling loop (same structure as run_turn, but with restricted context).
         let report = 'outer: {
             for iteration in 0..self.max_iterations {
@@ -346,6 +350,26 @@ impl SubagentRunner for Orchestrator {
                         ));
                         span.end();
 
+                        // Spawn post-turn skill evaluation for this subagent (fire-and-forget).
+                        // Subagents don't inherit active_skill from the parent, so the
+                        // heuristic gate evaluates them as standalone turns.
+                        if self.learning_config.enabled && self.learning_config.auto_create_skills {
+                            crate::skill_learner::spawn_post_turn_eval(
+                                crate::skill_learner::TurnContext {
+                                    conversation_id,
+                                    agent_id: spawn.agent_id.clone(),
+                                    tool_count: subagent_tool_count,
+                                    had_errors: subagent_had_errors,
+                                    active_skill: None,
+                                    history: history.clone(),
+                                },
+                                self.learning_config.clone(),
+                                std::sync::Arc::clone(&self.storage),
+                                std::sync::Arc::clone(&self.registry),
+                                std::sync::Arc::clone(&self.llm),
+                            );
+                        }
+
                         break 'outer AgentReport {
                             status: AgentReportStatus::Completed,
                             content: text,
@@ -433,6 +457,10 @@ impl SubagentRunner for Orchestrator {
                                 .await;
                             let elapsed = start.elapsed();
 
+                            if exec_result.is_err() {
+                                subagent_had_errors = true;
+                            }
+
                             // Subagent does not surface attachments to
                             // the parent — pass scratch vectors.
                             let mut scratch_attachments = Vec::new();
@@ -476,6 +504,8 @@ impl SubagentRunner for Orchestrator {
                                 child_event_sink.as_ref(),
                             )
                             .await;
+
+                            subagent_tool_count += 1;
                         }
                     }
 

--- a/crates/runtime/src/skill_learner.rs
+++ b/crates/runtime/src/skill_learner.rs
@@ -309,4 +309,113 @@ mod tests {
         let name = resolve_name_collision(&registry, "new-skill").await;
         assert_eq!(name, "new-skill");
     }
+
+    #[test]
+    fn test_heuristic_gate_passes_subagent_turn() {
+        let config = LearningConfig::default();
+        // Subagent turns have no active_skill (they don't inherit from parent).
+        let ctx = TurnContext {
+            conversation_id: Uuid::new_v4(),
+            agent_id: "subagent-abc123".to_string(),
+            tool_count: 10,
+            had_errors: false,
+            active_skill: None,
+            history: vec![],
+        };
+        assert!(
+            passes_heuristic_gate(&ctx, &config),
+            "Subagent turns with enough tool calls should pass the heuristic gate"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_evaluate_and_create_from_subagent_turn() {
+        use assistant_llm::{
+            Capabilities, ChatHistoryMessage as CHM, LlmResponse, LlmResponseMeta, StreamChunk,
+            ToolSupport, tool_spec::ToolSpec,
+        };
+        use async_trait::async_trait;
+        use tokio::sync::mpsc;
+
+        struct MockJudgeLlm;
+
+        #[async_trait]
+        impl LlmProvider for MockJudgeLlm {
+            fn capabilities(&self) -> Capabilities {
+                Capabilities {
+                    tools: ToolSupport::None,
+                    streaming: false,
+                    vision: false,
+                    hosted_tools: vec![],
+                }
+            }
+            async fn chat(
+                &self,
+                _system: &str,
+                _history: &[CHM],
+                _tools: &[ToolSpec],
+            ) -> anyhow::Result<LlmResponse> {
+                Ok(LlmResponse::FinalAnswer(
+                    "{\"create\": true, \"name\": \"codebase-search\", \"description\": \"Search and summarize codebase patterns\", \"body\": \"# Codebase Search\\n\\n1. Glob for files\\n2. Grep for patterns\\n3. Summarize\"}".to_string(),
+                    LlmResponseMeta {
+                        model: None,
+                        input_tokens: None,
+                        output_tokens: None,
+                        finish_reason: None,
+                        response_id: None,
+                    },
+                ))
+            }
+            async fn chat_streaming(
+                &self,
+                _system: &str,
+                _history: &[CHM],
+                _tools: &[ToolSpec],
+                _sink: Option<mpsc::Sender<StreamChunk>>,
+            ) -> anyhow::Result<LlmResponse> {
+                unimplemented!()
+            }
+        }
+
+        let storage = Arc::new(
+            assistant_storage::StorageLayer::new_in_memory()
+                .await
+                .unwrap(),
+        );
+        let registry = Arc::new(SkillRegistry::new(storage.pool.clone()).await.unwrap());
+        let llm: Arc<dyn LlmProvider> = Arc::new(MockJudgeLlm);
+
+        // Simulate a subagent turn with rich tool-call history.
+        let ctx = TurnContext {
+            conversation_id: Uuid::new_v4(),
+            agent_id: "subagent-test-abc".to_string(),
+            tool_count: 5,
+            had_errors: false,
+            active_skill: None,
+            history: vec![
+                ChatHistoryMessage::Text {
+                    role: assistant_llm::ChatRole::User,
+                    content: "Search the codebase for sidebar components".to_string(),
+                },
+                ChatHistoryMessage::Text {
+                    role: assistant_llm::ChatRole::Assistant,
+                    content: "Found 5 sidebar-related files across the project.".to_string(),
+                },
+            ],
+        };
+
+        let config = LearningConfig::default();
+        evaluate_and_create(ctx, &config, storage.clone(), registry.clone(), llm)
+            .await
+            .unwrap();
+
+        // Verify the skill was created.
+        let skill = registry.get("codebase-search").await;
+        assert!(
+            skill.is_some(),
+            "Skill should have been auto-created from subagent turn"
+        );
+        let skill = skill.unwrap();
+        assert_eq!(skill.description, "Search and summarize codebase patterns");
+    }
 }


### PR DESCRIPTION
## Summary

- The skill learner now evaluates subagent turns for skill creation, not just parent turns
- Previously, multi-step work delegated to subagents was invisible to the learner because the parent turn only had 1 tool call (`agent-spawn`)
- The subagent runner now tracks its own `tool_count` and `had_errors`, and calls `spawn_post_turn_eval` on successful completion with the subagent's own conversation history

## Test plan

- [x] `test_heuristic_gate_passes_subagent_turn` — verifies subagent contexts pass the heuristic gate
- [x] `test_evaluate_and_create_from_subagent_turn` — end-to-end with mock LLM: subagent context → judge approves → skill created
- [x] All existing `skill_learner` and `skill_improver` tests pass
- [x] `make lint`, `make format`, `make test` all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic skill evaluation and creation following subagent tool usage, triggered based on execution metrics and error detection.

* **Tests**
  * Added tests for subagent turn processing and automated skill generation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->