### PR TITLE
fix(flutter): surface clear error on 401 in conversation stream

### DIFF
--- a/app/lib/api/api_client.dart
+++ b/app/lib/api/api_client.dart
@@ -13,6 +13,21 @@ import 'package:dio/dio.dart';
 import 'models/server_capabilities.dart';
 import 'models/stream_event.dart';
 
+/// Thrown when the server rejects an API request with HTTP 401.
+///
+/// Callers can catch this to trigger re-authentication flows or surface a
+/// targeted error message rather than a generic "request failed" banner.
+class ApiAuthException implements Exception {
+  const ApiAuthException([
+    this.message = 'Authentication failed — verify your token',
+  ]);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
 /// Configured client bundle: generated API instances + SSE streaming helper.
 class ApiClient {
   ApiClient({required String baseUrl, required String token}) : _token = token {
@@ -249,6 +264,9 @@ class ApiClient {
         ),
       );
     } on DioException catch (e) {
+      if (e.response?.statusCode == 401) {
+        throw const ApiAuthException();
+      }
       throw Exception('Failed to connect to conversation stream: ${e.message}');
     }
 

--- a/app/lib/features/chat/chat_provider.dart
+++ b/app/lib/features/chat/chat_provider.dart
@@ -83,7 +83,10 @@ class ConversationListNotifier extends AsyncNotifier<ConversationListState> {
     _subscription = api.streamConversations().listen(
       _onEvent,
       onError: (Object e) {
-        state = AsyncData(ConversationListState(error: e.toString()));
+        final message = e is ApiAuthException
+            ? e.message
+            : 'Connection error: $e';
+        state = AsyncData(ConversationListState(error: message));
       },
       cancelOnError: false,
     );

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -592,10 +592,10 @@ packages:
     dependency: transitive
     description:
       name: hooks
-      sha256: e79ed1e8e1929bc6ecb6ec85f0cb519c887aa5b423705ded0d0f2d9226def388
+      sha256: "025f060e86d2d4c3c47b56e33caf7f93bf9283340f26d23424ebcfccf34f621e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   http:
     dependency: "direct main"
     description:
@@ -1068,6 +1068,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  record_use:
+    dependency: transitive
+    description:
+      name: record_use
+      sha256: "2551bd8eecfe95d14ae75f6021ad0248be5c27f138c2ec12fcb52b500b3ba1ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0"
   record_web:
     dependency: transitive
     description:

--- a/app/test/unit/chat/conversation_list_provider_test.dart
+++ b/app/test/unit/chat/conversation_list_provider_test.dart
@@ -303,6 +303,30 @@ void main() {
       expect(state.conversations, isEmpty);
     });
 
+    test('surfaces auth-specific message on ApiAuthException', () async {
+      final controller = StreamController<ConversationListEvent>.broadcast();
+      final client = _FakeApiClient(streamController: controller);
+      final container = _makeContainer(client: client);
+      addTearDown(container.dispose);
+      addTearDown(controller.close);
+      final sub = _keepAlive(container);
+      addTearDown(sub.close);
+
+      await container.read(conversationListProvider.future);
+
+      controller.addError(const ApiAuthException());
+      await Future<void>.delayed(Duration.zero);
+
+      final state = container.read(conversationListProvider).value!;
+      expect(state.error, isNotNull);
+      expect(
+        state.error,
+        contains('Authentication failed'),
+        reason: 'ApiAuthException should produce a clear auth error message',
+      );
+      expect(state.conversations, isEmpty);
+    });
+
     // -----------------------------------------------------------------------
     // REGRESSION: race condition — null → non-null rebuild
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Added `ApiAuthException` class to distinguish HTTP 401 errors from generic connection failures
- `streamConversations()` now throws `ApiAuthException` on 401 instead of wrapping DioException in a generic `Exception` with a verbose, unhelpful message
- `ConversationListNotifier` detects `ApiAuthException` and surfaces `"Authentication failed — verify your token"` instead of dumping the raw exception string

## Test plan

- [x] New unit test: `surfaces auth-specific message on ApiAuthException`
- [x] All 535 existing Flutter tests pass
- [x] `dart analyze --fatal-infos` clean
- [x] Pre-commit hooks pass (clippy, fmt, dart_pre_commit, flutter test)