### PR TITLE
fix(runtime): prevent orphaned tool results from breaking Moonshot API

### DIFF
--- a/crates/provider-moonshot/src/provider.rs
+++ b/crates/provider-moonshot/src/provider.rs
@@ -698,7 +698,6 @@ fn build_chat_messages(
             }
 
             ChatHistoryMessage::AssistantToolCalls(calls) => {
-                pending_ids.clear();
                 let tc_enums: Vec<ChatCompletionMessageToolCalls> = calls
                     .iter()
                     .enumerate()
@@ -729,6 +728,7 @@ fn build_chat_messages(
                 let tool_call_id = if let Some(idx) = pos {
                     pending_ids.remove(idx).1
                 } else {
+                    warn!(tool = %name, "no pending tool-call ID for tool result, using fallback");
                     format!("call_unknown_{name}")
                 };
 
@@ -829,7 +829,6 @@ fn build_raw_messages(system_prompt: &str, history: &[ChatHistoryMessage]) -> Ve
             }
 
             ChatHistoryMessage::AssistantToolCalls(calls) => {
-                pending_ids.clear();
                 let tool_calls: Vec<Value> = calls
                     .iter()
                     .enumerate()
@@ -856,6 +855,7 @@ fn build_raw_messages(system_prompt: &str, history: &[ChatHistoryMessage]) -> Ve
                 let tool_call_id = if let Some(idx) = pos {
                     pending_ids.remove(idx).1
                 } else {
+                    warn!(tool = %name, "no pending tool-call ID for tool result, using fallback");
                     format!("call_unknown_{name}")
                 };
                 messages.push(json!({
@@ -927,6 +927,89 @@ mod tests {
         assert!(pending.is_empty());
     }
 
+    /// Two rounds of tool calls – the second `AssistantToolCalls` must not
+    /// lose the IDs established in the first round.
+    #[test]
+    fn build_chat_messages_multi_turn_tool_calls() {
+        let history = vec![
+            // Round 1
+            ChatHistoryMessage::AssistantToolCalls(vec![ToolCallItem {
+                name: "tool-a".to_string(),
+                params: json!({}),
+                id: Some("call_r1".to_string()),
+            }]),
+            ChatHistoryMessage::ToolResult {
+                name: "tool-a".to_string(),
+                content: "result-a".to_string(),
+            },
+            // Intermediate assistant text
+            ChatHistoryMessage::Text {
+                role: ChatRole::Assistant,
+                content: "thinking...".to_string(),
+            },
+            // Round 2
+            ChatHistoryMessage::AssistantToolCalls(vec![ToolCallItem {
+                name: "tool-b".to_string(),
+                params: json!({}),
+                id: Some("call_r2".to_string()),
+            }]),
+            ChatHistoryMessage::ToolResult {
+                name: "tool-b".to_string(),
+                content: "result-b".to_string(),
+            },
+        ];
+        let (msgs, pending) = build_chat_messages("sys", &history);
+        // system + 5 history entries
+        assert_eq!(msgs.len(), 6);
+        assert!(pending.is_empty(), "all tool results should be consumed");
+    }
+
+    /// When a `ToolResult` arrives after a *subsequent* `AssistantToolCalls`,
+    /// its ID must still be resolvable (regression for `pending_ids.clear()`).
+    #[test]
+    fn build_chat_messages_late_tool_result_preserves_id() {
+        // Simulate a history where a tool result for round-1 appears after
+        // round-2's tool calls (unusual ordering, but must not lose the ID).
+        let history = vec![
+            ChatHistoryMessage::AssistantToolCalls(vec![
+                ToolCallItem {
+                    name: "tool-a".to_string(),
+                    params: json!({}),
+                    id: Some("call_a".to_string()),
+                },
+                ToolCallItem {
+                    name: "tool-b".to_string(),
+                    params: json!({}),
+                    id: Some("call_b".to_string()),
+                },
+            ]),
+            // Only tool-a gets a result before the next assistant turn
+            ChatHistoryMessage::ToolResult {
+                name: "tool-a".to_string(),
+                content: "result-a".to_string(),
+            },
+            // Second round of tool calls
+            ChatHistoryMessage::AssistantToolCalls(vec![ToolCallItem {
+                name: "tool-c".to_string(),
+                params: json!({}),
+                id: Some("call_c".to_string()),
+            }]),
+            // Late result for tool-b from round 1
+            ChatHistoryMessage::ToolResult {
+                name: "tool-b".to_string(),
+                content: "result-b".to_string(),
+            },
+            ChatHistoryMessage::ToolResult {
+                name: "tool-c".to_string(),
+                content: "result-c".to_string(),
+            },
+        ];
+        let (msgs, pending) = build_chat_messages("", &history);
+        // 5 history entries, no system message (empty prompt)
+        assert_eq!(msgs.len(), 5);
+        assert!(pending.is_empty(), "all tool results should be consumed");
+    }
+
     // ── Raw-HTTP message builder tests ────────────────────────────────────
 
     #[test]
@@ -970,6 +1053,53 @@ mod tests {
         let msgs = build_raw_messages("", &history);
         assert_eq!(msgs.len(), 2);
         assert_eq!(msgs[1]["tool_call_id"], "call_123");
+    }
+
+    /// Raw-HTTP: late tool result after a second `AssistantToolCalls` must
+    /// still carry the correct `tool_call_id`.
+    #[test]
+    fn build_raw_messages_late_tool_result_preserves_id() {
+        let history = vec![
+            ChatHistoryMessage::AssistantToolCalls(vec![
+                ToolCallItem {
+                    name: "tool-a".to_string(),
+                    params: json!({}),
+                    id: Some("call_a".to_string()),
+                },
+                ToolCallItem {
+                    name: "tool-b".to_string(),
+                    params: json!({}),
+                    id: Some("call_b".to_string()),
+                },
+            ]),
+            ChatHistoryMessage::ToolResult {
+                name: "tool-a".to_string(),
+                content: "result-a".to_string(),
+            },
+            ChatHistoryMessage::AssistantToolCalls(vec![ToolCallItem {
+                name: "tool-c".to_string(),
+                params: json!({}),
+                id: Some("call_c".to_string()),
+            }]),
+            // Late result for tool-b from round 1
+            ChatHistoryMessage::ToolResult {
+                name: "tool-b".to_string(),
+                content: "result-b".to_string(),
+            },
+            ChatHistoryMessage::ToolResult {
+                name: "tool-c".to_string(),
+                content: "result-c".to_string(),
+            },
+        ];
+        let msgs = build_raw_messages("", &history);
+        // 5 history entries, no system message (empty prompt)
+        assert_eq!(msgs.len(), 5);
+        // tool-b result must carry its original ID, not a fallback
+        assert_eq!(
+            msgs[3]["tool_call_id"], "call_b",
+            "tool-b must keep its original call ID"
+        );
+        assert_eq!(msgs[4]["tool_call_id"], "call_c");
     }
 
     // ── Capabilities ──────────────────────────────────────────────────────

--- a/crates/runtime/src/history.rs
+++ b/crates/runtime/src/history.rs
@@ -89,7 +89,44 @@ pub(crate) fn sanitize_history(history: &mut Vec<ChatHistoryMessage>) {
         return;
     }
 
-    // --- Pass 1: fill in missing tool results for orphaned tool calls ------
+    // --- Pass 1: drop orphaned ToolResult messages -------------------------
+    //
+    // A ToolResult is valid only when it immediately follows an
+    // AssistantToolCalls (or another valid ToolResult within the same
+    // batch).  System-injected results (e.g. from skill-learner) that
+    // have no preceding AssistantToolCalls cause providers to reject the
+    // request because the tool_call_id has no matching tool call.
+    {
+        let mut i = 0;
+        let mut remaining_results: usize = 0; // results still expected from current batch
+        while i < history.len() {
+            match &history[i] {
+                ChatHistoryMessage::AssistantToolCalls(calls) => {
+                    remaining_results = calls.len();
+                    i += 1;
+                }
+                ChatHistoryMessage::ToolResult { name, .. } => {
+                    if remaining_results > 0 {
+                        remaining_results -= 1;
+                        i += 1;
+                    } else {
+                        debug!(
+                            tool = %name,
+                            "Sanitizing history: dropping orphaned ToolResult with no preceding tool call"
+                        );
+                        history.remove(i);
+                        // don't advance i; the next element slid into this position
+                    }
+                }
+                _ => {
+                    remaining_results = 0;
+                    i += 1;
+                }
+            }
+        }
+    }
+
+    // --- Pass 2: fill in missing tool results for orphaned tool calls ------
     //
     // Walk the history and, for every AssistantToolCalls, count how many
     // ToolResult messages follow (before the next non-ToolResult entry or

--- a/crates/runtime/src/orchestrator/tests.rs
+++ b/crates/runtime/src/orchestrator/tests.rs
@@ -1454,6 +1454,86 @@ fn sanitize_history_combined_orphaned_tools_and_trailing_user() {
     ));
 }
 
+#[test]
+fn sanitize_history_orphaned_tool_result_dropped() {
+    // Simulates: a system-injected tool result (e.g. skill-learner) appears
+    // at the start of history with no preceding AssistantToolCalls.
+    let mut history = vec![
+        ChatHistoryMessage::Text {
+            role: ChatRole::User,
+            content: "hello".into(),
+        },
+        ChatHistoryMessage::ToolResult {
+            name: "skill-learner".into(),
+            content: "Auto-created skill 'foo'".into(),
+        },
+        ChatHistoryMessage::Text {
+            role: ChatRole::Assistant,
+            content: "hi".into(),
+        },
+    ];
+    crate::history::sanitize_history(&mut history);
+    // The orphaned ToolResult should be dropped
+    assert_eq!(history.len(), 2);
+    assert!(matches!(
+        &history[0],
+        ChatHistoryMessage::Text {
+            role: ChatRole::User,
+            ..
+        }
+    ));
+    assert!(matches!(
+        &history[1],
+        ChatHistoryMessage::Text {
+            role: ChatRole::Assistant,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn sanitize_history_tool_result_after_matched_calls_dropped() {
+    // Extra ToolResult beyond what the tool calls declared should be dropped.
+    let mut history = vec![
+        ChatHistoryMessage::AssistantToolCalls(vec![ToolCallItem {
+            name: "my-tool".into(),
+            params: serde_json::json!({}),
+            id: Some("call_1".into()),
+        }]),
+        ChatHistoryMessage::ToolResult {
+            name: "my-tool".into(),
+            content: "result".into(),
+        },
+        // Spurious extra result with no matching call
+        ChatHistoryMessage::ToolResult {
+            name: "skill-learner".into(),
+            content: "injected".into(),
+        },
+        ChatHistoryMessage::Text {
+            role: ChatRole::Assistant,
+            content: "done".into(),
+        },
+    ];
+    crate::history::sanitize_history(&mut history);
+    // The extra ToolResult should be dropped
+    assert_eq!(history.len(), 3);
+    assert!(matches!(
+        &history[0],
+        ChatHistoryMessage::AssistantToolCalls(_)
+    ));
+    assert!(matches!(
+        &history[1],
+        ChatHistoryMessage::ToolResult { name, .. } if name == "my-tool"
+    ));
+    assert!(matches!(
+        &history[2],
+        ChatHistoryMessage::Text {
+            role: ChatRole::Assistant,
+            ..
+        }
+    ));
+}
+
 // ── Bus integration tests ────────────────────────────────────────────────
 
 #[test]

--- a/crates/runtime/src/skill_learner.rs
+++ b/crates/runtime/src/skill_learner.rs
@@ -169,12 +169,13 @@ async fn evaluate_and_create(
                 "Skill learner: created new skill from turn"
             );
             // Record in conversation store for observability.
-            let mut msg = assistant_core::Message::new(
+            // Use System role — Tool role requires a matching AssistantToolCalls
+            // message and would cause providers to reject the request.
+            let msg = assistant_core::Message::new(
                 ctx.conversation_id,
-                assistant_core::MessageRole::Tool,
+                assistant_core::MessageRole::System,
                 format!("Auto-created skill '{final_name}': {description}"),
             );
-            msg.skill_name = Some("skill-learner".to_string());
             let conv_store = storage.conversation_store();
             if let Err(e) = conv_store.save_message(&msg).await {
                 warn!(error = %e, "Failed to record skill creation message");


### PR DESCRIPTION
## Summary

- **Root cause**: skill-learner (PR #582) wrote a `role=tool` message into conversation history without a preceding `AssistantToolCalls`. The Moonshot API rejected requests with `"Invalid request: tool_call_id is not found"` because the generated fallback ID had no matching tool call.
- **skill_learner.rs**: Changed the observability message from `MessageRole::Tool` to `MessageRole::System`. System-role messages are filtered out by `messages_to_chat_history` and never reach any LLM provider.
- **history.rs**: Added a new sanitization pass that drops orphaned `ToolResult` messages not preceded by a matching `AssistantToolCalls` (defence in depth for any future source of orphaned results).
- **provider-moonshot**: Removed `pending_ids.clear()` in both message builders. The clear wiped tool-call ID mappings when a second `AssistantToolCalls` appeared before all results from the first batch were consumed.

Confirmed via Iceberg traces on schorschvm: conversation `8a024c57` (2026-04-21) shows the exact error triggered by an auto-created skill-learner tool result at turn 0.

## Test plan

- [x] New tests: `sanitize_history_orphaned_tool_result_dropped`, `sanitize_history_tool_result_after_matched_calls_dropped`
- [x] New tests: `build_chat_messages_multi_turn_tool_calls`, `build_chat_messages_late_tool_result_preserves_id`, `build_raw_messages_late_tool_result_preserves_id`
- [x] All 160 runtime tests pass, all 15 moonshot provider tests pass
- [x] `make lint` and `make format` clean
- [ ] Deploy to schorschvm and verify the conversation `8a024c57` can proceed without errors