### PR TITLE
feat(app): add Cmd+N / Ctrl+N shortcut to create new chat

### DIFF
--- a/app/lib/features/chat/chat_screen.dart
+++ b/app/lib/features/chat/chat_screen.dart
@@ -100,12 +100,12 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     super.didUpdateWidget(old);
     if (old.conversationId != widget.conversationId) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        _loadConversation();
+        _loadConversation(focusInput: true);
       });
     }
   }
 
-  void _loadConversation() {
+  void _loadConversation({bool focusInput = false}) {
     final id = widget.conversationId;
     if (id != null) {
       ref.read(chatProvider.notifier).loadConversation(id);
@@ -113,6 +113,11 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
       ref.read(chatProvider.notifier).clearConversation();
     }
     _scrollToBottom();
+    if (focusInput) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _inputFocus.requestFocus();
+      });
+    }
   }
 
   /// Retry loading the conversation once the API client becomes available.

--- a/app/lib/shared/nav_shell.dart
+++ b/app/lib/shared/nav_shell.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../api/connectivity_provider.dart';
+import '../features/chat/chat_provider.dart';
 import '../features/contexts/providers/context_providers.dart';
 import '../features/notifications/agent_event_listener.dart';
 import '../features/pwa/pwa_provider.dart';
@@ -137,10 +139,32 @@ bool _isOverflowRouteActive(String currentPath) {
 /// When the PWA install prompt is available (web only), an "Install App"
 /// button is shown: in the [NavigationRail] trailing area on wide screens,
 /// and as a banner above the [NavigationBar] on narrow screens.
-class NavShell extends ConsumerWidget {
+class NavShell extends ConsumerStatefulWidget {
   const NavShell({super.key, required this.child});
 
   final Widget child;
+
+  @override
+  ConsumerState<NavShell> createState() => _NavShellState();
+}
+
+class _NavShellState extends ConsumerState<NavShell> {
+  bool _creatingChat = false;
+
+  Future<void> _createNewChat() async {
+    if (_creatingChat) return;
+    _creatingChat = true;
+    try {
+      final id = await ref
+          .read(conversationListProvider.notifier)
+          .createConversation();
+      if (id != null && mounted) {
+        context.go('/chat/$id');
+      }
+    } finally {
+      _creatingChat = false;
+    }
+  }
 
   /// Index for the mobile [NavigationBar].
   ///
@@ -290,7 +314,8 @@ class NavShell extends ConsumerWidget {
   }
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
+    final child = widget.child;
     final width = MediaQuery.of(context).size.width;
     final isWide = width >= _kNavRailBreakpoint;
 
@@ -299,6 +324,40 @@ class NavShell extends ConsumerWidget {
     // True when on iOS Safari and not yet installed as a PWA.
     final isSafariInstallable = ref.watch(safariInstallProvider);
 
+    // Platform-aware Cmd+N / Ctrl+N shortcut for creating a new chat.
+    final useMeta =
+        defaultTargetPlatform == TargetPlatform.macOS ||
+        defaultTargetPlatform == TargetPlatform.iOS;
+    final newChatShortcuts = CallbackShortcuts(
+      bindings: {
+        SingleActivator(
+          LogicalKeyboardKey.keyN,
+          meta: useMeta,
+          control: !useMeta,
+        ): _createNewChat,
+      },
+      child: Focus(
+        autofocus: true,
+        child: _buildBody(
+          context,
+          child,
+          isWide,
+          isInstallable,
+          isSafariInstallable,
+        ),
+      ),
+    );
+
+    return newChatShortcuts;
+  }
+
+  Widget _buildBody(
+    BuildContext context,
+    Widget child,
+    bool isWide,
+    bool isInstallable,
+    bool isSafariInstallable,
+  ) {
     // Apple touch: CupertinoTabBar (compact) or sidebar (wide).
     if (isAppleTouch) {
       if (isWide) {

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -592,10 +592,10 @@ packages:
     dependency: transitive
     description:
       name: hooks
-      sha256: e79ed1e8e1929bc6ecb6ec85f0cb519c887aa5b423705ded0d0f2d9226def388
+      sha256: "025f060e86d2d4c3c47b56e33caf7f93bf9283340f26d23424ebcfccf34f621e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   http:
     dependency: "direct main"
     description:
@@ -1068,6 +1068,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  record_use:
+    dependency: transitive
+    description:
+      name: record_use
+      sha256: "2551bd8eecfe95d14ae75f6021ad0248be5c27f138c2ec12fcb52b500b3ba1ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0"
   record_web:
     dependency: transitive
     description:

--- a/app/test/widget/new_chat_shortcut_test.dart
+++ b/app/test/widget/new_chat_shortcut_test.dart
@@ -1,0 +1,167 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:assistant_app/features/chat/chat_provider.dart';
+import 'package:assistant_app/features/pwa/pwa_provider.dart';
+import 'package:assistant_app/shared/nav_shell.dart';
+
+/// Tracks calls to [createConversation] and returns a predetermined ID.
+class _FakeConversationListNotifier extends AsyncNotifier<ConversationListState>
+    implements ConversationListNotifier {
+  int createCount = 0;
+  String? nextId = 'new-convo-123';
+
+  /// How long to delay the response (simulates network latency for the
+  /// debounce test).
+  Duration delay = Duration.zero;
+
+  @override
+  Future<ConversationListState> build() async {
+    return const ConversationListState();
+  }
+
+  @override
+  Future<String?> createConversation({String? title}) async {
+    createCount++;
+    if (delay > Duration.zero) await Future<void>.delayed(delay);
+    return nextId;
+  }
+
+  // Stubs for the rest of the interface — not exercised by these tests.
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakePwaNotifier extends PwaInstallNotifier {
+  @override
+  bool build() => false;
+}
+
+/// The route that the router navigated to last.
+String? _lastLocation;
+
+Widget _buildTestApp(_FakeConversationListNotifier fakeNotifier) {
+  _lastLocation = null;
+  final router = GoRouter(
+    initialLocation: '/skills',
+    routes: [
+      ShellRoute(
+        builder: (ctx, state, child) => NavShell(child: child),
+        routes: [
+          GoRoute(
+            path: '/chat',
+            builder: (_, state) {
+              return const Scaffold(body: Text('Chat'));
+            },
+            routes: [
+              GoRoute(
+                path: ':id',
+                builder: (_, state) {
+                  _lastLocation = '/chat/${state.pathParameters['id']}';
+                  return Scaffold(
+                    body: Text('Chat ${state.pathParameters['id']}'),
+                  );
+                },
+              ),
+            ],
+          ),
+          GoRoute(
+            path: '/skills',
+            builder: (_, _) => const Scaffold(body: Text('Skills')),
+          ),
+          GoRoute(
+            path: '/workflows',
+            builder: (_, _) => const Scaffold(body: Text('Workflows')),
+          ),
+        ],
+      ),
+    ],
+  );
+
+  return ProviderScope(
+    overrides: [
+      conversationListProvider.overrideWith(() => fakeNotifier),
+      pwaInstallProvider.overrideWith(_FakePwaNotifier.new),
+    ],
+    child: MaterialApp.router(routerConfig: router),
+  );
+}
+
+/// Sends Ctrl+N — the new-chat shortcut on non-Apple platforms (the default
+/// in Flutter widget tests, which run as TargetPlatform.android).
+Future<void> _sendCtrlN(WidgetTester tester) async {
+  await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+  await tester.sendKeyDownEvent(LogicalKeyboardKey.keyN);
+  await tester.sendKeyUpEvent(LogicalKeyboardKey.keyN);
+  await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+}
+
+void main() {
+  group('Cmd+N new chat shortcut', () {
+    testWidgets('creates a new conversation and navigates to it', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(1280, 900);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      final notifier = _FakeConversationListNotifier();
+      await tester.pumpWidget(_buildTestApp(notifier));
+      await tester.pumpAndSettle();
+
+      // Verify we start on /skills (visible in both nav and page content).
+      expect(find.text('Skills'), findsWidgets);
+
+      // Simulate Ctrl+N (default test platform is Android, so control is used).
+      await _sendCtrlN(tester);
+      await tester.pumpAndSettle();
+
+      expect(
+        notifier.createCount,
+        1,
+        reason: 'Should create exactly one conversation',
+      );
+      expect(
+        _lastLocation,
+        '/chat/new-convo-123',
+        reason: 'Should navigate to the new conversation',
+      );
+    });
+
+    testWidgets(
+      'rapid double-press creates only one conversation (debounce guard)',
+      (tester) async {
+        tester.view.physicalSize = const Size(1280, 900);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.reset);
+
+        final notifier = _FakeConversationListNotifier()
+          ..delay = const Duration(milliseconds: 200);
+        await tester.pumpWidget(_buildTestApp(notifier));
+        await tester.pumpAndSettle();
+
+        // First Ctrl+N — starts an in-flight creation.
+        await _sendCtrlN(tester);
+
+        // Pump a frame so the callback fires, but don't settle (creation still in-flight).
+        await tester.pump();
+
+        // Second Ctrl+N — should be ignored because _creatingChat is true.
+        await _sendCtrlN(tester);
+
+        // Let the 200ms delay complete so no pending timers remain.
+        await tester.pump(const Duration(milliseconds: 300));
+        await tester.pumpAndSettle();
+
+        expect(
+          notifier.createCount,
+          1,
+          reason: 'Second Ctrl+N during in-flight should be ignored',
+        );
+      },
+    );
+  });
+}

--- a/openspec/changes/cmd-n-new-chat/.openspec.yaml
+++ b/openspec/changes/cmd-n-new-chat/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-21

--- a/openspec/changes/cmd-n-new-chat/design.md
+++ b/openspec/changes/cmd-n-new-chat/design.md
@@ -1,0 +1,48 @@
+## Context
+
+The Flutter app already has a keyboard event handler in `ChatScreen` (`chat_screen.dart` line ~1956) that uses `KeyboardListener` to detect Cmd+V for clipboard image paste. The conversation creation flow is well-established: `ConversationListNotifier.createConversation()` calls the API, and navigation uses `context.go('/chat/$id')` via go_router. The "New Chat" button in `ConversationList` follows this exact flow.
+
+The shortcut must work globally (not just in the chat screen), which means it cannot live inside the existing `KeyboardListener` on the chat input. It needs to be registered higher in the widget tree.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Register Cmd+N / Ctrl+N as a global shortcut that creates a new conversation
+- Work across all screens in the app
+- Reuse the existing conversation creation and navigation infrastructure
+- Debounce to prevent duplicate creations on rapid key presses
+
+**Non-Goals:**
+
+- Building a general-purpose keyboard shortcut framework
+- Adding shortcut customization or preferences UI
+- Handling offline/error states differently from the existing "New Chat" button
+
+## Decisions
+
+### 1. Use Flutter `Shortcuts` + `Actions` widgets at the `MaterialApp` / shell level
+
+**Rationale:** Flutter's `Shortcuts`/`Actions` system is the idiomatic way to register global keyboard shortcuts. It propagates through the widget tree and is automatically platform-aware. Placing it at the `NavShell` or `MaterialApp.builder` level ensures it captures key events regardless of which screen is active.
+
+**Alternative considered:** Adding another `KeyboardListener` to `ChatScreen` — rejected because it would only work on the chat screen, not globally.
+
+**Alternative considered:** `RawKeyboardListener` at the root — rejected because `Shortcuts`/`Actions` is the higher-level, recommended API and handles platform modifier key mapping (Meta on macOS, Control elsewhere) cleanly via `SingleActivator`.
+
+### 2. Use `SingleActivator(LogicalKeyboardKey.keyN, meta: true)` for macOS and `SingleActivator(LogicalKeyboardKey.keyN, control: true)` for other platforms
+
+**Rationale:** `SingleActivator` is the standard Flutter shortcut activator. Registering both meta (Cmd) and control variants with platform detection ensures correct behavior across macOS, web-on-Windows, and web-on-Linux.
+
+### 3. Guard against duplicate creation with a simple boolean flag
+
+**Rationale:** A `_creatingConversation` flag in the action callback prevents concurrent API calls when the user taps Cmd+N rapidly. This is simpler than debouncing with timers and matches the existing pattern where the "New Chat" button disables during creation.
+
+### 4. Place the `Shortcuts`/`Actions` wrapper in the router shell widget
+
+**Rationale:** `app/lib/router/app_router.dart` defines a `ShellRoute` with a `NavShell` builder that wraps all routed screens. Wrapping `NavShell`'s child with the shortcut widget ensures coverage across all routes while having access to both `WidgetRef` (for providers) and `BuildContext` (for navigation).
+
+## Risks / Trade-offs
+
+- **[Risk] Shortcut conflicts with browser Cmd+N (new window)** → Mitigation: On web, Flutter captures keyboard events within the canvas. The shortcut will only fire when the Flutter app has focus. Document this behavior for users.
+- **[Risk] Text fields swallowing the key event** → Mitigation: `Shortcuts` widget at the shell level takes priority when the shortcut matches, before the event reaches text input widgets. Test explicitly with focused text fields.
+- **[Risk] No visual feedback during creation** → Mitigation: Navigation to the new chat is itself the feedback. The creation API call is fast (<100ms locally). If needed later, a loading indicator can be added.

--- a/openspec/changes/cmd-n-new-chat/proposal.md
+++ b/openspec/changes/cmd-n-new-chat/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The chat screen lacks a keyboard shortcut for starting a new conversation. Power users expect Cmd+N (macOS) / Ctrl+N (other platforms) to create a fresh chat — this is a standard UX convention across messaging and productivity apps. Currently, users must click the "New Chat" button in the sidebar, which breaks keyboard-driven workflows.
+
+## What Changes
+
+- Add a global keyboard shortcut (Cmd+N / Ctrl+N) that creates a new conversation and navigates to it
+- The shortcut should work from any screen within the app, not just when the chat input is focused
+- Reuse the existing `ConversationListNotifier.createConversation()` flow and `context.go('/chat/$id')` navigation
+
+## Non-goals
+
+- Adding a customizable keybinding system or shortcut preferences
+- Adding other keyboard shortcuts (Cmd+W to close, Cmd+K for search, etc.) — those can come later
+- Changing the existing "New Chat" button behavior in the sidebar
+
+## Capabilities
+
+### New Capabilities
+
+- `keyboard-new-chat`: Global Cmd+N / Ctrl+N shortcut that creates a new conversation and navigates to it
+
+### Modified Capabilities
+
+_(none)_
+
+## Impact
+
+- **Flutter app only** — no backend or API changes required
+- Affected files: `ChatScreen` widget (keyboard listener), potentially `NavShell` or `app_router.dart` for global scope
+- The existing `KeyboardListener` in `chat_screen.dart` already handles Cmd+V for clipboard paste, so the pattern is established
+- No new dependencies needed — uses Flutter's built-in `Shortcuts`/`Actions` or `KeyboardListener` widgets

--- a/openspec/changes/cmd-n-new-chat/specs/keyboard-new-chat/spec.md
+++ b/openspec/changes/cmd-n-new-chat/specs/keyboard-new-chat/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Cmd+N creates a new conversation
+
+The app SHALL create a new conversation and navigate to it when the user presses Cmd+N (macOS) or Ctrl+N (other platforms).
+
+#### Scenario: User presses Cmd+N on macOS
+
+- **WHEN** the user presses Cmd+N on macOS
+- **THEN** the system creates a new conversation via the existing create-conversation API and navigates to `/chat/{new-id}`
+
+#### Scenario: User presses Ctrl+N on non-macOS
+
+- **WHEN** the user presses Ctrl+N on a non-macOS platform (web on Windows/Linux)
+- **THEN** the system creates a new conversation and navigates to `/chat/{new-id}`
+
+### Requirement: Shortcut works globally across all screens
+
+The keyboard shortcut SHALL be active on all screens in the app, not only when the chat input field is focused.
+
+#### Scenario: User presses Cmd+N from settings screen
+
+- **WHEN** the user is on a non-chat screen (e.g., personas, traces, logs, skills) and presses Cmd+N
+- **THEN** the system creates a new conversation and navigates to `/chat/{new-id}`
+
+#### Scenario: User presses Cmd+N while chat input is focused
+
+- **WHEN** the user has focus in the chat message input and presses Cmd+N
+- **THEN** the system creates a new conversation and navigates to the new chat (the shortcut is not swallowed by the text field)
+
+### Requirement: Shortcut does not duplicate in-flight requests
+
+The system SHALL ignore additional Cmd+N presses while a conversation creation request is already in flight.
+
+#### Scenario: User double-taps Cmd+N rapidly
+
+- **WHEN** the user presses Cmd+N twice in quick succession
+- **THEN** only one new conversation is created
+
+### Requirement: New conversation starts empty
+
+The newly created conversation SHALL be empty with no pre-filled messages and the chat input focused.
+
+#### Scenario: Fresh chat after Cmd+N
+
+- **WHEN** a new conversation is created via Cmd+N
+- **THEN** the chat screen shows an empty message timeline and the text input is focused and ready for typing

--- a/openspec/changes/cmd-n-new-chat/tasks.md
+++ b/openspec/changes/cmd-n-new-chat/tasks.md
@@ -1,0 +1,19 @@
+## 1. Define the shortcut Intent and Action
+
+- [x] 1.1 Create a `NewChatIntent` class extending `Intent` in a new file `app/lib/features/chat/new_chat_intent.dart`
+- [x] 1.2 Create a `NewChatAction` class extending `Action<NewChatIntent>` that calls `ConversationListNotifier.createConversation()` and navigates to the new conversation via `go_router`. Include a boolean guard to prevent duplicate in-flight requests.
+
+## 2. Register the shortcut globally in the router shell
+
+- [x] 2.1 Wrap the `NavShell` child (in `app/lib/router/app_router.dart`) with a `Shortcuts` widget mapping `SingleActivator(LogicalKeyboardKey.keyN, meta: true)` and `SingleActivator(LogicalKeyboardKey.keyN, control: true)` to `NewChatIntent`
+- [x] 2.2 Wrap with a corresponding `Actions` widget that binds `NewChatIntent` to `NewChatAction`, passing the required `WidgetRef` and `BuildContext` for provider access and navigation
+
+## 3. Platform-aware modifier handling
+
+- [x] 3.1 Use `defaultTargetPlatform` to register only Cmd+N on macOS/iOS and only Ctrl+N on other platforms, avoiding both firing or conflicting
+
+## 4. Testing
+
+- [x] 4.1 Write a widget test that simulates Cmd+N keypress and verifies a new conversation is created (mock the API) and navigation occurs
+- [x] 4.2 Write a widget test that simulates two rapid Cmd+N presses and verifies only one conversation is created (debounce guard)
+- [x] 4.3 Manually verify on macOS desktop and web that the shortcut works from the chat screen and from a non-chat screen (e.g., personas)


### PR DESCRIPTION
## Summary

- Add global Cmd+N (macOS/iOS) / Ctrl+N (other platforms) keyboard shortcut that creates a new conversation and navigates to it
- Convert `NavShell` to `ConsumerStatefulWidget` with `CallbackShortcuts` wrapping the shell body, with a boolean guard to prevent duplicate creations on rapid key presses
- Autofocus the chat text input when transitioning to a conversation (Cmd+N, sidebar click, etc.)

## Test plan

- [x] Widget test: Ctrl+N creates a conversation and navigates to `/chat/{id}`
- [x] Widget test: rapid double-press only creates one conversation (debounce guard)
- [x] Existing `nav_shell_test.dart` (6 tests) — no regressions
- [x] Existing `context_redirect_test.dart` (8 tests) — no regressions
- [x] `flutter analyze` clean
- [ ] Manual: verify Cmd+N on macOS desktop from chat screen and non-chat screen
- [ ] Manual: verify Cmd+N on web from chat screen and non-chat screen