### PR TITLE
fix(ci): disable code signing for ShareExtension in macOS CI build

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -52,6 +52,14 @@ jobs:
           CODE_SIGN_IDENTITY =
           EOF
 
+          # The ShareExtension target has its own build settings in the Xcode
+          # project and does not inherit from the Runner xcconfig files.
+          # Patch project.pbxproj to disable signing for all targets.
+          PBXPROJ=app/macos/Runner.xcodeproj/project.pbxproj
+          sed -i '' 's/CODE_SIGN_STYLE = Automatic/CODE_SIGN_STYLE = Manual/g' "$PBXPROJ"
+          sed -i '' 's/"CODE_SIGN_IDENTITY\[sdk=macosx\*\]" = "Apple Development"/"CODE_SIGN_IDENTITY[sdk=macosx*]" = ""/g' "$PBXPROJ"
+          sed -i '' 's/DEVELOPMENT_TEAM = WPW3QSLZ2F/DEVELOPMENT_TEAM = ""/g' "$PBXPROJ"
+
       - name: Install Rust target
         run: rustup target add aarch64-apple-darwin
 


### PR DESCRIPTION
## Summary

- The no-codesign macOS CI build (`flutter.yml`) only disabled code signing via `AppInfo.xcconfig`, which the **ShareExtension** target does not inherit
- Patch `project.pbxproj` with `sed` to switch all targets to manual signing with empty identity and team, fixing the `No profiles for 'com.cedricziel.assistant.macos.ShareExtension'` error

## Test plan

- [ ] Verify the `Build macOS Bundle (no-codesign)` job passes in CI
- [ ] Verify the release workflow (`release-please.yml`) is unaffected — it uses `fastlane mac provision` which handles signing separately

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration settings in CI/CD workflow for macOS builds.

---

**Note:** This is an internal build infrastructure change with no end-user visible impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->