### PR TITLE
fix(integration-tests): speed up smoke tests on CPU-only CI runners

### DIFF
--- a/crates/integration-tests/tests/smoke.rs
+++ b/crates/integration-tests/tests/smoke.rs
@@ -115,7 +115,12 @@ async fn build_fixture(base_url: &str) -> Result<Fixture> {
         model: MODEL.to_string(),
         base_url: base_url.to_string(),
         timeout_secs: 120,
-        retry_config: assistant_llm::RetryConfig::default(),
+        // Disable HTTP-level retries.  On CPU-only CI runners Ollama returns
+        // 500 after a 2-minute inference timeout — that is deterministic, not
+        // transient, so retrying the same prompt just burns another 2 min.
+        // The orchestrator's tool-calling loop already provides iteration-level
+        // "retries" with an evolving prompt.
+        retry_config: assistant_llm::RetryConfig::disabled(),
     };
     let llm = Arc::new(LlmClient::new(llm_config)?);
 
@@ -123,9 +128,6 @@ async fn build_fixture(base_url: &str) -> Result<Fixture> {
     // Disable learning so background skill-eval LLM calls don't compete with
     // the test's own LLM calls on the CPU-only CI Ollama instance.
     config.learning.enabled = false;
-    // Cap tool-calling iterations — the default (80) is far too high for a slow
-    // CPU-only model and causes multi-minute timeout cascades.
-    config.llm.max_iterations = 10;
     let executor = Arc::new(ToolExecutor::new(
         storage.clone(),
         llm.clone(),

--- a/crates/integration-tests/tests/smoke.rs
+++ b/crates/integration-tests/tests/smoke.rs
@@ -119,7 +119,13 @@ async fn build_fixture(base_url: &str) -> Result<Fixture> {
     };
     let llm = Arc::new(LlmClient::new(llm_config)?);
 
-    let config = AssistantConfig::default();
+    let mut config = AssistantConfig::default();
+    // Disable learning so background skill-eval LLM calls don't compete with
+    // the test's own LLM calls on the CPU-only CI Ollama instance.
+    config.learning.enabled = false;
+    // Cap tool-calling iterations — the default (80) is far too high for a slow
+    // CPU-only model and causes multi-minute timeout cascades.
+    config.llm.max_iterations = 10;
     let executor = Arc::new(ToolExecutor::new(
         storage.clone(),
         llm.clone(),
@@ -230,16 +236,19 @@ async fn test_tool_loop_terminates() -> Result<()> {
     let (_container, base_url) = resolve_ollama().await?;
     let f = build_fixture(&base_url).await?;
 
-    let result = f
-        .orchestrator
-        .run_turn(
-            "What is 2 + 2?",
-            f.conversation_id,
-            Interface::Cli,
-            None,
-            vec![],
-        )
-        .await?;
+    let result = tokio::time::timeout(Duration::from_secs(300), async {
+        f.orchestrator
+            .run_turn(
+                "What is 2 + 2?",
+                f.conversation_id,
+                Interface::Cli,
+                None,
+                vec![],
+            )
+            .await
+    })
+    .await
+    .map_err(|_| anyhow::anyhow!("test_tool_loop_terminates timed out after 5 minutes"))??;
 
     assert!(!result.answer.is_empty());
     Ok(())
@@ -254,29 +263,33 @@ async fn test_self_analyze_runs() -> Result<()> {
     let (_container, base_url) = resolve_ollama().await?;
     let f = build_fixture(&base_url).await?;
 
-    // Produce some traces for the memory-append tool.
-    f.orchestrator
-        .run_turn(
-            "Use memory-append to store the value 'hello' under key 'smoke-test' in target 'memory'",
-            f.conversation_id,
-            Interface::Cli,
-            None,
-            vec![],
-        )
-        .await?;
+    tokio::time::timeout(Duration::from_secs(300), async {
+        // Produce some traces for the memory-append tool.
+        f.orchestrator
+            .run_turn(
+                "Use memory-append to store the value 'hello' under key 'smoke-test' in target 'memory'",
+                f.conversation_id,
+                Interface::Cli,
+                None,
+                vec![],
+            )
+            .await?;
 
-    // Trigger self-analyze — it should complete without error.
-    let result = f
-        .orchestrator
-        .run_turn(
-            "Analyse the memory-append skill and suggest improvements",
-            f.conversation_id,
-            Interface::Cli,
-            None,
-            vec![],
-        )
-        .await?;
+        // Trigger self-analyze — it should complete without error.
+        let result = f
+            .orchestrator
+            .run_turn(
+                "Analyse the memory-append skill and suggest improvements",
+                f.conversation_id,
+                Interface::Cli,
+                None,
+                vec![],
+            )
+            .await?;
 
-    assert!(!result.answer.is_empty());
-    Ok(())
+        assert!(!result.answer.is_empty());
+        Ok(())
+    })
+    .await
+    .map_err(|_| anyhow::anyhow!("test_self_analyze_runs timed out after 5 minutes"))?
 }


### PR DESCRIPTION
## Summary

Root cause: `reqwest-retry` middleware treats Ollama 500 responses as transient and retries up to 5 times with exponential backoff. On CPU-only GitHub Actions runners, these 500s are **deterministic inference timeouts** (the model can't finish in 2 minutes), not transient failures. Each futile retry burns another 2 minutes, so a single failed LLM call wastes up to **12 minutes** (6 attempts × 2 min).

This has been the case since the smoke tests were introduced — it's not a regression from any specific PR.

### Changes

- **Disable HTTP-level retries** (`RetryConfig::disabled()`) in the smoke test fixture — the orchestrator's tool-calling loop already provides iteration-level "retries" with an evolving prompt, so HTTP retries are redundant and harmful here
- **Disable learning** in the smoke test fixture — prevents background `spawn_post_turn_eval` LLM calls from competing with test LLM calls for the single Ollama instance
- **Add 5-minute `tokio::time::timeout`** per LLM-calling test as a safety net

### Impact

Each failed LLM call now takes ~2 min (one timeout) instead of ~12 min (6 timeouts). For a typical run with ~8 failed calls, this saves **~80 minutes of wasted Ollama time**, bringing total smoke test duration from ~23 min closer to ~5-10 min.

## Test plan

- [ ] CI smoke tests pass and complete faster
- [ ] `cargo check -p assistant-integration-tests` passes
- [ ] `cargo clippy -p assistant-integration-tests -- -D warnings` clean