### PR TITLE
feat(workflows): workflow editor UX improvements and node disable

### DIFF
--- a/app/lib/features/workflows/workflow_detail_screen.dart
+++ b/app/lib/features/workflows/workflow_detail_screen.dart
@@ -1,5 +1,6 @@
 import 'package:assistant_api/assistant_api.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show Clipboard, ClipboardData;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
@@ -17,6 +18,31 @@ class WorkflowDetailScreen extends ConsumerStatefulWidget {
 }
 
 class _WorkflowDetailScreenState extends ConsumerState<WorkflowDetailScreen> {
+  WorkflowWebhookSecrets? _webhookSecrets;
+  bool _webhookSecretsFetched = false;
+
+  /// Detects whether the workflow graph includes a webhook trigger node.
+  bool _hasWebhookTrigger(WorkflowDetail detail) {
+    final graphRaw = detail.graph?.value;
+    if (graphRaw is! Map) return false;
+    final nodes = graphRaw['nodes'] as List? ?? [];
+    return nodes.any((n) {
+      if (n is! Map) return false;
+      final config = n['config'] as Map? ?? {};
+      return config['type'] == 'webhook';
+    });
+  }
+
+  Future<void> _fetchWebhookSecrets() async {
+    if (_webhookSecretsFetched) return;
+    _webhookSecretsFetched = true;
+    final notifier = ref.read(
+      workflowDetailProvider(widget.workflowId).notifier,
+    );
+    final secrets = await notifier.fetchWebhookSecrets();
+    if (mounted) setState(() => _webhookSecrets = secrets);
+  }
+
   Future<void> _confirmDelete() async {
     final confirmed = await showDialog<bool>(
       context: context,
@@ -79,6 +105,36 @@ class _WorkflowDetailScreenState extends ConsumerState<WorkflowDetailScreen> {
     ref.read(workflowDetailProvider(widget.workflowId).notifier).refresh();
   }
 
+  Future<void> _testRun() async {
+    final notifier = ref.read(
+      workflowDetailProvider(widget.workflowId).notifier,
+    );
+    final (preview, error) = await notifier.testRun();
+    if (!mounted) return;
+    if (error != null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Test run failed: $error'),
+          backgroundColor: Theme.of(context).colorScheme.error,
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('Test run started: ${preview!.message}'),
+        behavior: SnackBarBehavior.floating,
+        action: SnackBarAction(
+          label: 'View',
+          onPressed: () => context.go(
+            '/workflows/${widget.workflowId}/runs/${preview.runId}',
+          ),
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final detailAsync = ref.watch(workflowDetailProvider(widget.workflowId));
@@ -91,6 +147,11 @@ class _WorkflowDetailScreenState extends ConsumerState<WorkflowDetailScreen> {
           onPressed: () => context.go('/workflows'),
         ),
         actions: [
+          IconButton(
+            icon: const Icon(Icons.play_arrow),
+            tooltip: 'Test run',
+            onPressed: _testRun,
+          ),
           IconButton(
             icon: const Icon(Icons.edit_outlined),
             tooltip: 'Edit workflow',
@@ -121,12 +182,19 @@ class _WorkflowDetailScreenState extends ConsumerState<WorkflowDetailScreen> {
               .read(workflowDetailProvider(widget.workflowId).notifier)
               .refresh(),
         ),
-        data: (state) => _WorkflowDetailBody(
-          workflowId: widget.workflowId,
-          detail: state.detail,
-          runs: state.runs,
-          onToggleActive: () => _toggleActive(state.detail.active),
-        ),
+        data: (state) {
+          // Fetch webhook secrets lazily when we know it's a webhook workflow.
+          if (_hasWebhookTrigger(state.detail)) {
+            _fetchWebhookSecrets();
+          }
+          return _WorkflowDetailBody(
+            workflowId: widget.workflowId,
+            detail: state.detail,
+            runs: state.runs,
+            onToggleActive: () => _toggleActive(state.detail.active),
+            webhookSecrets: _webhookSecrets,
+          );
+        },
       ),
     );
   }
@@ -138,12 +206,14 @@ class _WorkflowDetailBody extends StatelessWidget {
     required this.detail,
     required this.runs,
     required this.onToggleActive,
+    this.webhookSecrets,
   });
 
   final String workflowId;
   final WorkflowDetail detail;
   final List<WorkflowRunSummary> runs;
   final VoidCallback onToggleActive;
+  final WorkflowWebhookSecrets? webhookSecrets;
 
   @override
   Widget build(BuildContext context) {
@@ -175,13 +245,13 @@ class _WorkflowDetailBody extends StatelessWidget {
                         ),
                         decoration: BoxDecoration(
                           color: detail.active
-                              ? Colors.green.shade50
-                              : Colors.grey.shade100,
+                              ? Colors.green.withAlpha(20)
+                              : Colors.grey.withAlpha(20),
                           borderRadius: BorderRadius.circular(12),
                           border: Border.all(
                             color: detail.active
-                                ? Colors.green.shade300
-                                : Colors.grey.shade400,
+                                ? Colors.green.withAlpha(60)
+                                : Colors.grey.withAlpha(60),
                           ),
                         ),
                         child: Row(
@@ -192,9 +262,7 @@ class _WorkflowDetailBody extends StatelessWidget {
                                   ? Icons.pause_circle_outline
                                   : Icons.play_circle_outline,
                               size: 12,
-                              color: detail.active
-                                  ? Colors.green.shade700
-                                  : Colors.grey.shade600,
+                              color: detail.active ? Colors.green : Colors.grey,
                             ),
                             const SizedBox(width: 4),
                             Text(
@@ -203,8 +271,8 @@ class _WorkflowDetailBody extends StatelessWidget {
                                 fontSize: 11,
                                 fontWeight: FontWeight.w600,
                                 color: detail.active
-                                    ? Colors.green.shade700
-                                    : Colors.grey.shade600,
+                                    ? Colors.green
+                                    : Colors.grey,
                               ),
                             ),
                           ],
@@ -228,6 +296,12 @@ class _WorkflowDetailBody extends StatelessWidget {
         ),
 
         const SizedBox(height: 16),
+
+        // Webhook secrets card (shown only for webhook-triggered workflows).
+        if (webhookSecrets != null) ...[
+          _WebhookSecretsCard(secrets: webhookSecrets!),
+          const SizedBox(height: 16),
+        ],
 
         // Recent runs.
         Text('Recent Runs', style: Theme.of(context).textTheme.titleMedium),
@@ -291,10 +365,10 @@ class _RunTile extends StatelessWidget {
               ? Icons.error_outline
               : Icons.hourglass_empty,
           color: isSuccess
-              ? Colors.green.shade600
+              ? Colors.green
               : isError
               ? colorScheme.error
-              : Colors.orange.shade600,
+              : Colors.orange,
         ),
         title: Text(
           'Run ${run.id.length > 8 ? run.id.substring(0, 8) : run.id}…',
@@ -308,17 +382,17 @@ class _RunTile extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
           decoration: BoxDecoration(
             color: isSuccess
-                ? Colors.green.shade50
+                ? Colors.green.withAlpha(20)
                 : isError
                 ? colorScheme.errorContainer
-                : Colors.orange.shade50,
+                : Colors.orange.withAlpha(20),
             borderRadius: BorderRadius.circular(8),
             border: Border.all(
               color: isSuccess
-                  ? Colors.green.shade300
+                  ? Colors.green.withAlpha(60)
                   : isError
                   ? colorScheme.error
-                  : Colors.orange.shade300,
+                  : Colors.orange.withAlpha(60),
             ),
           ),
           child: Text(
@@ -327,14 +401,153 @@ class _RunTile extends StatelessWidget {
               fontSize: 10,
               fontWeight: FontWeight.w600,
               color: isSuccess
-                  ? Colors.green.shade700
+                  ? Colors.green
                   : isError
                   ? colorScheme.error
-                  : Colors.orange.shade700,
+                  : Colors.orange,
             ),
           ),
         ),
       ),
+    );
+  }
+}
+
+class _WebhookSecretsCard extends StatefulWidget {
+  const _WebhookSecretsCard({required this.secrets});
+
+  final WorkflowWebhookSecrets secrets;
+
+  @override
+  State<_WebhookSecretsCard> createState() => _WebhookSecretsCardState();
+}
+
+class _WebhookSecretsCardState extends State<_WebhookSecretsCard> {
+  bool _tokenVisible = false;
+
+  void _copy(String value, String label) {
+    Clipboard.setData(ClipboardData(text: value));
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('$label copied to clipboard'),
+        behavior: SnackBarBehavior.floating,
+        duration: const Duration(seconds: 2),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.webhook, color: Colors.blue, size: 20),
+                const SizedBox(width: 8),
+                Text('Webhook', style: theme.textTheme.titleSmall),
+              ],
+            ),
+            const SizedBox(height: 12),
+            // URL
+            _CopyableField(
+              label: 'URL',
+              value: widget.secrets.webhookUrl,
+              onCopy: () => _copy(widget.secrets.webhookUrl, 'URL'),
+            ),
+            const SizedBox(height: 8),
+            // Token
+            Row(
+              children: [
+                SizedBox(
+                  width: 48,
+                  child: Text(
+                    'Token',
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ),
+                Expanded(
+                  child: Text(
+                    _tokenVisible ? widget.secrets.webhookToken : '\u2022' * 16,
+                    style: const TextStyle(
+                      fontSize: 12,
+                      fontFamily: 'monospace',
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                IconButton(
+                  icon: Icon(
+                    _tokenVisible ? Icons.visibility_off : Icons.visibility,
+                    size: 16,
+                  ),
+                  onPressed: () =>
+                      setState(() => _tokenVisible = !_tokenVisible),
+                  tooltip: _tokenVisible ? 'Hide' : 'Show',
+                  visualDensity: VisualDensity.compact,
+                ),
+                IconButton(
+                  icon: const Icon(Icons.copy, size: 16),
+                  onPressed: () => _copy(widget.secrets.webhookToken, 'Token'),
+                  tooltip: 'Copy token',
+                  visualDensity: VisualDensity.compact,
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _CopyableField extends StatelessWidget {
+  const _CopyableField({
+    required this.label,
+    required this.value,
+    required this.onCopy,
+  });
+
+  final String label;
+  final String value;
+  final VoidCallback onCopy;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        SizedBox(
+          width: 48,
+          child: Text(
+            label,
+            style: TextStyle(
+              fontSize: 12,
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ),
+        Expanded(
+          child: Text(
+            value,
+            style: const TextStyle(fontSize: 12, fontFamily: 'monospace'),
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+        IconButton(
+          icon: const Icon(Icons.copy, size: 16),
+          onPressed: onCopy,
+          tooltip: 'Copy $label',
+          visualDensity: VisualDensity.compact,
+        ),
+      ],
     );
   }
 }

--- a/app/lib/features/workflows/workflow_detail_screen.dart
+++ b/app/lib/features/workflows/workflow_detail_screen.dart
@@ -236,46 +236,58 @@ class _WorkflowDetailBody extends StatelessWidget {
                       ),
                     ),
                     // Active toggle chip
-                    GestureDetector(
-                      onTap: onToggleActive,
-                      child: Container(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 8,
-                          vertical: 3,
-                        ),
-                        decoration: BoxDecoration(
-                          color: detail.active
-                              ? Colors.green.withAlpha(20)
-                              : Colors.grey.withAlpha(20),
-                          borderRadius: BorderRadius.circular(12),
-                          border: Border.all(
-                            color: detail.active
-                                ? Colors.green.withAlpha(60)
-                                : Colors.grey.withAlpha(60),
+                    Material(
+                      color: Colors.transparent,
+                      child: InkWell(
+                        onTap: onToggleActive,
+                        borderRadius: BorderRadius.circular(12),
+                        child: ConstrainedBox(
+                          constraints: const BoxConstraints(
+                            minHeight: 36,
+                            minWidth: 48,
                           ),
-                        ),
-                        child: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Icon(
-                              detail.active
-                                  ? Icons.pause_circle_outline
-                                  : Icons.play_circle_outline,
-                              size: 12,
-                              color: detail.active ? Colors.green : Colors.grey,
+                          child: Container(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 12,
+                              vertical: 6,
                             ),
-                            const SizedBox(width: 4),
-                            Text(
-                              detail.active ? 'Active' : 'Inactive',
-                              style: TextStyle(
-                                fontSize: 11,
-                                fontWeight: FontWeight.w600,
+                            decoration: BoxDecoration(
+                              color: detail.active
+                                  ? Colors.green.withAlpha(20)
+                                  : Colors.grey.withAlpha(20),
+                              borderRadius: BorderRadius.circular(12),
+                              border: Border.all(
                                 color: detail.active
-                                    ? Colors.green
-                                    : Colors.grey,
+                                    ? Colors.green.withAlpha(60)
+                                    : Colors.grey.withAlpha(60),
                               ),
                             ),
-                          ],
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Icon(
+                                  detail.active
+                                      ? Icons.pause_circle_outline
+                                      : Icons.play_circle_outline,
+                                  size: 14,
+                                  color: detail.active
+                                      ? Colors.green
+                                      : Colors.grey,
+                                ),
+                                const SizedBox(width: 4),
+                                Text(
+                                  detail.active ? 'Active' : 'Inactive',
+                                  style: TextStyle(
+                                    fontSize: 12,
+                                    fontWeight: FontWeight.w600,
+                                    color: detail.active
+                                        ? Colors.green
+                                        : Colors.grey,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
                         ),
                       ),
                     ),
@@ -492,13 +504,11 @@ class _WebhookSecretsCardState extends State<_WebhookSecretsCard> {
                   onPressed: () =>
                       setState(() => _tokenVisible = !_tokenVisible),
                   tooltip: _tokenVisible ? 'Hide' : 'Show',
-                  visualDensity: VisualDensity.compact,
                 ),
                 IconButton(
                   icon: const Icon(Icons.copy, size: 16),
                   onPressed: () => _copy(widget.secrets.webhookToken, 'Token'),
                   tooltip: 'Copy token',
-                  visualDensity: VisualDensity.compact,
                 ),
               ],
             ),
@@ -545,7 +555,6 @@ class _CopyableField extends StatelessWidget {
           icon: const Icon(Icons.copy, size: 16),
           onPressed: onCopy,
           tooltip: 'Copy $label',
-          visualDensity: VisualDensity.compact,
         ),
       ],
     );

--- a/app/lib/features/workflows/workflow_editor_screen.dart
+++ b/app/lib/features/workflows/workflow_editor_screen.dart
@@ -468,6 +468,17 @@ class _WorkflowEditorScreenState extends ConsumerState<WorkflowEditorScreen> {
       return;
     }
 
+    // Block saving complex branching graphs from mobile layout — mobile uses
+    // a linear edge chain which would silently destroy branching edges.
+    if (_isMobileLayout && isComplexDag(_nodes, _edges)) {
+      setState(
+        () => _error =
+            'This workflow has a complex graph that cannot be saved from mobile layout. '
+            'Use a wider screen to preserve branching edges.',
+      );
+      return;
+    }
+
     setState(() {
       _submitting = true;
       _error = null;
@@ -780,8 +791,6 @@ class _WorkflowEditorScreenState extends ConsumerState<WorkflowEditorScreen> {
                       IconButton(
                         icon: const Icon(Icons.close, size: 14),
                         onPressed: () => setState(() => _error = null),
-                        padding: EdgeInsets.zero,
-                        constraints: const BoxConstraints(),
                       ),
                     ],
                   ),
@@ -1132,7 +1141,6 @@ class _MobileNodeCard extends StatelessWidget {
               icon: Icon(Icons.edit_outlined, size: 20, color: color),
               onPressed: onEdit,
               tooltip: 'Edit',
-              visualDensity: VisualDensity.compact,
             ),
             IconButton(
               icon: Icon(
@@ -1142,14 +1150,16 @@ class _MobileNodeCard extends StatelessWidget {
               ),
               onPressed: onDelete,
               tooltip: 'Delete',
-              visualDensity: VisualDensity.compact,
             ),
             ReorderableDelayedDragStartListener(
               index: index,
-              child: Icon(
-                Icons.drag_handle,
-                size: 24,
-                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: Icon(
+                  Icons.drag_handle,
+                  size: 24,
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
               ),
             ),
           ],
@@ -1226,21 +1236,28 @@ class _EdgeDeleteHandle extends StatelessWidget {
   Widget build(BuildContext context) {
     final mid = _midpoint();
     return Positioned(
-      left: mid.dx - 10,
-      top: mid.dy - 10,
+      left: mid.dx - 18,
+      top: mid.dy - 18,
       child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
         onTap: onDelete,
-        child: Container(
-          width: 20,
-          height: 20,
-          decoration: BoxDecoration(
-            color: Theme.of(context).colorScheme.error,
-            shape: BoxShape.circle,
-          ),
-          child: Icon(
-            Icons.close,
-            size: 12,
-            color: Theme.of(context).colorScheme.surface,
+        child: SizedBox(
+          width: 36,
+          height: 36,
+          child: Center(
+            child: Container(
+              width: 20,
+              height: 20,
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.error,
+                shape: BoxShape.circle,
+              ),
+              child: Icon(
+                Icons.close,
+                size: 12,
+                color: Theme.of(context).colorScheme.surface,
+              ),
+            ),
           ),
         ),
       ),
@@ -1351,27 +1368,34 @@ class _NodeWidget extends StatelessWidget {
               if (!isConnecting) ...[
                 // Edit button (top-right)
                 Positioned(
-                  top: -8,
-                  right: 24,
+                  top: -15,
+                  right: 17,
                   child: GestureDetector(
+                    behavior: HitTestBehavior.opaque,
                     onTap: onEdit,
-                    child: Container(
-                      width: 22,
-                      height: 22,
-                      decoration: BoxDecoration(
-                        color: color,
-                        shape: BoxShape.circle,
-                        boxShadow: [
-                          BoxShadow(
-                            color: color.withValues(alpha: 0.3),
-                            blurRadius: 4,
+                    child: SizedBox(
+                      width: 36,
+                      height: 36,
+                      child: Center(
+                        child: Container(
+                          width: 22,
+                          height: 22,
+                          decoration: BoxDecoration(
+                            color: color,
+                            shape: BoxShape.circle,
+                            boxShadow: [
+                              BoxShadow(
+                                color: color.withValues(alpha: 0.3),
+                                blurRadius: 4,
+                              ),
+                            ],
                           ),
-                        ],
-                      ),
-                      child: Icon(
-                        Icons.edit,
-                        size: 12,
-                        color: Theme.of(context).colorScheme.surface,
+                          child: Icon(
+                            Icons.edit,
+                            size: 12,
+                            color: Theme.of(context).colorScheme.surface,
+                          ),
+                        ),
                       ),
                     ),
                   ),
@@ -1379,29 +1403,36 @@ class _NodeWidget extends StatelessWidget {
 
                 // Delete button (top-right, offset)
                 Positioned(
-                  top: -8,
-                  right: -2,
+                  top: -15,
+                  right: -9,
                   child: GestureDetector(
+                    behavior: HitTestBehavior.opaque,
                     onTap: onDelete,
-                    child: Container(
-                      width: 22,
-                      height: 22,
-                      decoration: BoxDecoration(
-                        color: Theme.of(context).colorScheme.error,
-                        shape: BoxShape.circle,
-                        boxShadow: [
-                          BoxShadow(
-                            color: Theme.of(
-                              context,
-                            ).colorScheme.error.withValues(alpha: 0.3),
-                            blurRadius: 4,
+                    child: SizedBox(
+                      width: 36,
+                      height: 36,
+                      child: Center(
+                        child: Container(
+                          width: 22,
+                          height: 22,
+                          decoration: BoxDecoration(
+                            color: Theme.of(context).colorScheme.error,
+                            shape: BoxShape.circle,
+                            boxShadow: [
+                              BoxShadow(
+                                color: Theme.of(
+                                  context,
+                                ).colorScheme.error.withValues(alpha: 0.3),
+                                blurRadius: 4,
+                              ),
+                            ],
                           ),
-                        ],
-                      ),
-                      child: Icon(
-                        Icons.close,
-                        size: 12,
-                        color: Theme.of(context).colorScheme.surface,
+                          child: Icon(
+                            Icons.close,
+                            size: 12,
+                            color: Theme.of(context).colorScheme.surface,
+                          ),
+                        ),
                       ),
                     ),
                   ),
@@ -1409,27 +1440,34 @@ class _NodeWidget extends StatelessWidget {
 
                 // Connect button (bottom-center)
                 Positioned(
-                  bottom: -10,
-                  left: _kNodeW / 2 - 11,
+                  bottom: -17,
+                  left: _kNodeW / 2 - 18,
                   child: GestureDetector(
+                    behavior: HitTestBehavior.opaque,
                     onTap: onStartConnect,
-                    child: Container(
-                      width: 22,
-                      height: 22,
-                      decoration: BoxDecoration(
-                        color: color,
-                        shape: BoxShape.circle,
-                        boxShadow: [
-                          BoxShadow(
-                            color: color.withValues(alpha: 0.3),
-                            blurRadius: 4,
+                    child: SizedBox(
+                      width: 36,
+                      height: 36,
+                      child: Center(
+                        child: Container(
+                          width: 22,
+                          height: 22,
+                          decoration: BoxDecoration(
+                            color: color,
+                            shape: BoxShape.circle,
+                            boxShadow: [
+                              BoxShadow(
+                                color: color.withValues(alpha: 0.3),
+                                blurRadius: 4,
+                              ),
+                            ],
                           ),
-                        ],
-                      ),
-                      child: Icon(
-                        Icons.arrow_downward,
-                        size: 12,
-                        color: Theme.of(context).colorScheme.surface,
+                          child: Icon(
+                            Icons.arrow_downward,
+                            size: 12,
+                            color: Theme.of(context).colorScheme.surface,
+                          ),
+                        ),
                       ),
                     ),
                   ),
@@ -1642,7 +1680,6 @@ class _PaletteItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListTile(
-      dense: true,
       leading: Icon(icon, size: 20),
       title: Text(title, style: const TextStyle(fontWeight: FontWeight.w600)),
       subtitle: Text(subtitle, style: const TextStyle(fontSize: 11)),

--- a/app/lib/features/workflows/workflow_editor_screen.dart
+++ b/app/lib/features/workflows/workflow_editor_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:uuid/uuid.dart';
 
+import '../../shared/platform/adaptive_dialog.dart';
 import 'workflows_provider.dart';
 
 // ---------------------------------------------------------------------------
@@ -107,7 +108,12 @@ class EditorNode {
     }
   }
 
-  Map<String, dynamic> toJson() => {'id': id, 'kind': kind, 'config': config};
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'kind': kind,
+    'config': config,
+    'position': {'x': position.dx, 'y': position.dy},
+  };
 }
 
 class EditorEdge {
@@ -317,11 +323,7 @@ class _EdgePainter extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(_EdgePainter old) =>
-      old.nodes != nodes ||
-      old.edges != edges ||
-      old.pendingFrom != pendingFrom ||
-      old.pendingEnd != pendingEnd;
+  bool shouldRepaint(_EdgePainter old) => true;
 }
 
 // ---------------------------------------------------------------------------
@@ -402,19 +404,28 @@ class _WorkflowEditorScreenState extends ConsumerState<WorkflowEditorScreen> {
       _maxSteps = (execRaw['max_steps'] as int?) ?? 200;
       _maxVisitsPerNode = (execRaw['max_visits_per_node'] as int?) ?? 25;
 
-      // Lay nodes out in a vertical cascade since we have no stored positions
-      double x = (_kCanvasW / 2) - (_kNodeW / 2);
-      double y = 150;
+      // Restore stored positions if available, otherwise cascade vertically
+      double fallbackX = (_kCanvasW / 2) - (_kNodeW / 2);
+      double fallbackY = 150;
       _nodes = nodesRaw.asMap().entries.map((entry) {
         final raw = entry.value as Map;
-        final node = EditorNode(
+        final posRaw = raw['position'] as Map?;
+        final Offset pos;
+        if (posRaw != null) {
+          pos = Offset(
+            (posRaw['x'] as num).toDouble(),
+            (posRaw['y'] as num).toDouble(),
+          );
+        } else {
+          pos = Offset(fallbackX, fallbackY);
+          fallbackY += _kNodeH + 60;
+        }
+        return EditorNode(
           id: raw['id'] as String,
           kind: raw['kind'] as String,
           config: Map<String, dynamic>.from(raw['config'] as Map? ?? {}),
-          position: Offset(x, y),
+          position: pos,
         );
-        y += _kNodeH + 60;
-        return node;
       }).toList();
 
       _edges = edgesRaw.map((raw) {
@@ -604,7 +615,15 @@ class _WorkflowEditorScreenState extends ConsumerState<WorkflowEditorScreen> {
     }
   }
 
-  void _deleteNode(String nodeId) {
+  Future<void> _deleteNode(String nodeId) async {
+    final confirmed = await showAdaptiveConfirmDialog(
+      context: context,
+      title: 'Delete node?',
+      content: 'This will also remove all edges connected to this node.',
+      confirmLabel: 'Delete',
+      isDestructive: true,
+    );
+    if (!confirmed || !mounted) return;
     setState(() {
       _nodes.removeWhere((n) => n.id == nodeId);
       _edges.removeWhere((e) => e.from == nodeId || e.to == nodeId);
@@ -645,6 +664,47 @@ class _WorkflowEditorScreenState extends ConsumerState<WorkflowEditorScreen> {
     if (widget.isEdit) {
       final detailAsync = ref.watch(workflowDetailProvider(widget.workflowId!));
       detailAsync.whenData(_populateFromDetail);
+
+      // Show loading/error until data is available
+      if (!_loaded) {
+        return Scaffold(
+          appBar: AppBar(
+            title: const Text('Edit Workflow'),
+            leading: IconButton(
+              icon: const Icon(Icons.arrow_back),
+              onPressed: () => context.go('/workflows/${widget.workflowId}'),
+            ),
+          ),
+          body: detailAsync.when(
+            loading: () =>
+                const Center(child: CircularProgressIndicator.adaptive()),
+            error: (err, _) => Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    Icons.error_outline,
+                    color: Theme.of(context).colorScheme.error,
+                    size: 48,
+                  ),
+                  const SizedBox(height: 12),
+                  Text(err.toString(), textAlign: TextAlign.center),
+                  const SizedBox(height: 12),
+                  FilledButton(
+                    onPressed: () => ref
+                        .read(
+                          workflowDetailProvider(widget.workflowId!).notifier,
+                        )
+                        .refresh(),
+                    child: const Text('Retry'),
+                  ),
+                ],
+              ),
+            ),
+            data: (_) => const SizedBox.shrink(),
+          ),
+        );
+      }
     }
 
     return LayoutBuilder(
@@ -962,22 +1022,15 @@ class _MobileWorkflowEditor extends StatelessWidget {
           Container(
             width: double.infinity,
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-            color: Colors.orange.shade50,
+            color: Colors.orange.withAlpha(20),
             child: Row(
               children: [
-                Icon(
-                  Icons.info_outline,
-                  size: 16,
-                  color: Colors.orange.shade800,
-                ),
+                const Icon(Icons.info_outline, size: 16, color: Colors.orange),
                 const SizedBox(width: 8),
                 Expanded(
                   child: Text(
                     'Complex graph — edit branching on a wider screen',
-                    style: TextStyle(
-                      fontSize: 12,
-                      color: Colors.orange.shade800,
-                    ),
+                    style: TextStyle(fontSize: 12, color: Colors.orange),
                   ),
                 ),
               ],

--- a/app/lib/features/workflows/workflow_editor_screen.dart
+++ b/app/lib/features/workflows/workflow_editor_screen.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import 'package:uuid/uuid.dart';
 
 import '../../shared/platform/adaptive_dialog.dart';
+import '../personas/personas_provider.dart';
 import 'workflows_provider.dart';
 
 // ---------------------------------------------------------------------------
@@ -107,6 +108,8 @@ class EditorNode {
         return ['next'];
     }
   }
+
+  bool get disabled => config['disabled'] == true;
 
   Map<String, dynamic> toJson() => {
     'id': id,
@@ -346,6 +349,7 @@ class _WorkflowEditorScreenState extends ConsumerState<WorkflowEditorScreen> {
   final _uuid = const Uuid();
   final _nameController = TextEditingController();
   final _descController = TextEditingController();
+  final _canvasController = TransformationController();
 
   List<EditorNode> _nodes = [];
   List<EditorEdge> _edges = [];
@@ -360,13 +364,21 @@ class _WorkflowEditorScreenState extends ConsumerState<WorkflowEditorScreen> {
   bool _submitting = false;
   String? _error;
   bool _loaded = false;
+  bool _dirty = false;
+  bool _initialViewportSet = false;
 
   // Tracks which layout branch is active; set during build by LayoutBuilder.
   bool _isMobileLayout = false;
 
+  void _markDirty() {
+    if (!_dirty) setState(() => _dirty = true);
+  }
+
   @override
   void initState() {
     super.initState();
+    _nameController.addListener(_markDirty);
+    _descController.addListener(_markDirty);
     if (!widget.isEdit) {
       // Pre-populate with a manual trigger to get started
       _nodes = [
@@ -384,7 +396,130 @@ class _WorkflowEditorScreenState extends ConsumerState<WorkflowEditorScreen> {
   void dispose() {
     _nameController.dispose();
     _descController.dispose();
+    _canvasController.dispose();
     super.dispose();
+  }
+
+  /// Returns the bounding rect around all nodes (in canvas coords).
+  Rect _nodeBounds() {
+    if (_nodes.isEmpty) return Rect.zero;
+    double minX = double.infinity, minY = double.infinity;
+    double maxX = double.negativeInfinity, maxY = double.negativeInfinity;
+    for (final n in _nodes) {
+      if (n.position.dx < minX) minX = n.position.dx;
+      if (n.position.dy < minY) minY = n.position.dy;
+      if (n.position.dx + _kNodeW > maxX) maxX = n.position.dx + _kNodeW;
+      if (n.position.dy + _kNodeH > maxY) maxY = n.position.dy + _kNodeH;
+    }
+    return Rect.fromLTRB(minX, minY, maxX, maxY);
+  }
+
+  /// Pans and scales so all nodes fit in the viewport with padding.
+  void _fitToView(Size viewportSize) {
+    if (_nodes.isEmpty) return;
+    final bounds = _nodeBounds();
+    const padding = 80.0;
+    final padded = bounds.inflate(padding);
+    final scaleX = viewportSize.width / padded.width;
+    final scaleY = viewportSize.height / padded.height;
+    final scale = math.min(scaleX, scaleY).clamp(0.4, 2.5);
+    final tx =
+        (viewportSize.width - padded.width * scale) / 2 - padded.left * scale;
+    final ty =
+        (viewportSize.height - padded.height * scale) / 2 - padded.top * scale;
+    _canvasController.value = Matrix4.identity()
+      ..setTranslationRaw(tx, ty, 0)
+      ..scaleByDouble(scale, scale, 1.0, 1.0);
+  }
+
+  /// Auto-layout: arrange nodes top-down using topological order.
+  void _autoLayout() {
+    if (_nodes.isEmpty) return;
+    // Build adjacency from edges.
+    final order = <String>[];
+    final visited = <String>{};
+    final adj = <String, List<String>>{};
+    for (final e in _edges) {
+      adj.putIfAbsent(e.from, () => []).add(e.to);
+    }
+
+    void visit(String id) {
+      if (visited.contains(id)) return;
+      visited.add(id);
+      for (final child in adj[id] ?? []) {
+        visit(child);
+      }
+      order.insert(0, id);
+    }
+
+    // Start from triggers, then any remaining.
+    for (final n in _nodes.where((n) => n.kind == 'trigger')) {
+      visit(n.id);
+    }
+    for (final n in _nodes) {
+      visit(n.id);
+    }
+
+    // Assign positions: center horizontally, cascade vertically.
+    const startY = 150.0;
+    const spacingY = _kNodeH + 80;
+
+    // Assign depth per node for multi-column layout.
+    final depth = <String, int>{};
+    for (final id in order) {
+      var d = 0;
+      // Find max depth of parents + 1.
+      for (final e in _edges.where((e) => e.to == id)) {
+        final pd = depth[e.from] ?? 0;
+        if (pd + 1 > d) d = pd + 1;
+      }
+      depth[id] = d;
+    }
+
+    // Group by depth.
+    final byDepth = <int, List<String>>{};
+    for (final entry in depth.entries) {
+      byDepth.putIfAbsent(entry.value, () => []).add(entry.key);
+    }
+
+    setState(() {
+      for (final entry in byDepth.entries) {
+        final d = entry.key;
+        final ids = entry.value;
+        final totalW = ids.length * _kNodeW + (ids.length - 1) * 40;
+        var x = (_kCanvasW - totalW) / 2;
+        for (final id in ids) {
+          final idx = _nodes.indexWhere((n) => n.id == id);
+          if (idx >= 0) {
+            _nodes[idx].position = Offset(x, startY + d * spacingY);
+          }
+          x += _kNodeW + 40;
+        }
+      }
+      _dirty = true;
+    });
+  }
+
+  Future<bool> _maybeDiscardChanges() async {
+    if (!_dirty) return true;
+    final discard = await showAdaptiveConfirmDialog(
+      context: context,
+      title: 'Discard changes?',
+      content: 'You have unsaved changes that will be lost.',
+      confirmLabel: 'Discard',
+      isDestructive: true,
+    );
+    return discard;
+  }
+
+  Future<void> _navigateBack() async {
+    if (!await _maybeDiscardChanges()) return;
+    if (!mounted) return;
+    if (widget.isEdit) {
+      context.go('/workflows/${widget.workflowId}');
+    } else {
+      context.go('/workflows');
+    }
   }
 
   void _populateFromDetail(WorkflowDetailState state) {
@@ -437,6 +572,8 @@ class _WorkflowEditorScreenState extends ConsumerState<WorkflowEditorScreen> {
         );
       }).toList();
     }
+    // Loading from server is not a user edit — reset dirty flag.
+    _dirty = false;
   }
 
   Map<String, dynamic> _buildGraph() {
@@ -518,6 +655,7 @@ class _WorkflowEditorScreenState extends ConsumerState<WorkflowEditorScreen> {
       return;
     }
 
+    _dirty = false; // Prevent discard prompt on navigation.
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Text(widget.isEdit ? 'Workflow updated' : 'Workflow created'),
@@ -584,6 +722,7 @@ class _WorkflowEditorScreenState extends ConsumerState<WorkflowEditorScreen> {
       );
       _connectingFrom = null;
       _pendingEdgeEnd = null;
+      _dirty = true;
     });
   }
 
@@ -608,20 +747,27 @@ class _WorkflowEditorScreenState extends ConsumerState<WorkflowEditorScreen> {
       ),
     );
     if (result != null) {
-      setState(() => _nodes.add(result));
+      setState(() {
+        _nodes.add(result);
+        _dirty = true;
+      });
     }
   }
 
   Future<void> _editNode(EditorNode node) async {
+    final personas = ref.read(personasProvider).value?.personas ?? [];
+    final personaNames = personas.map((p) => (p.id, p.name)).toList();
     final updated = await showModalBottomSheet<EditorNode>(
       context: context,
       isScrollControlled: true,
-      builder: (ctx) => _NodeConfigSheet(node: node),
+      builder: (ctx) =>
+          _NodeConfigSheet(node: node, personaNames: personaNames),
     );
     if (updated != null) {
       setState(() {
         final idx = _nodes.indexWhere((n) => n.id == node.id);
         if (idx >= 0) _nodes[idx] = updated;
+        _dirty = true;
       });
     }
   }
@@ -638,12 +784,14 @@ class _WorkflowEditorScreenState extends ConsumerState<WorkflowEditorScreen> {
     setState(() {
       _nodes.removeWhere((n) => n.id == nodeId);
       _edges.removeWhere((e) => e.from == nodeId || e.to == nodeId);
+      _dirty = true;
     });
   }
 
   void _deleteEdge(EditorEdge edge) {
     setState(() {
       _edges.remove(edge);
+      _dirty = true;
     });
   }
 
@@ -662,6 +810,7 @@ class _WorkflowEditorScreenState extends ConsumerState<WorkflowEditorScreen> {
             _active = active;
             _maxSteps = maxSteps;
             _maxVisitsPerNode = maxVisitsPerNode;
+            _dirty = true;
           });
           Navigator.of(ctx).pop();
         },
@@ -723,129 +872,184 @@ class _WorkflowEditorScreenState extends ConsumerState<WorkflowEditorScreen> {
         _isMobileLayout = outerConstraints.maxWidth < 600;
         final theme = Theme.of(context);
 
-        return Scaffold(
-          appBar: AppBar(
-            title: Text(widget.isEdit ? 'Edit Workflow' : 'New Workflow'),
-            leading: IconButton(
-              icon: const Icon(Icons.arrow_back),
-              onPressed: () => widget.isEdit
-                  ? context.go('/workflows/${widget.workflowId}')
-                  : context.go('/workflows'),
-            ),
-            actions: [
-              IconButton(
-                icon: const Icon(Icons.settings_outlined),
-                tooltip: 'Workflow settings',
-                onPressed: _showSettings,
+        // Center canvas on nodes once after first layout.
+        if (!_initialViewportSet && !_isMobileLayout && _nodes.isNotEmpty) {
+          _initialViewportSet = true;
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            _fitToView(
+              Size(outerConstraints.maxWidth, outerConstraints.maxHeight),
+            );
+          });
+        }
+
+        return PopScope(
+          canPop: !_dirty,
+          onPopInvokedWithResult: (didPop, _) async {
+            if (didPop) return;
+            await _navigateBack();
+          },
+          child: Scaffold(
+            appBar: AppBar(
+              title: Text(widget.isEdit ? 'Edit Workflow' : 'New Workflow'),
+              leading: IconButton(
+                icon: const Icon(Icons.arrow_back),
+                onPressed: _navigateBack,
               ),
-              if (_submitting)
-                const Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 16),
-                  child: SizedBox(
-                    width: 20,
-                    height: 20,
-                    child: CircularProgressIndicator.adaptive(strokeWidth: 2),
-                  ),
-                )
-              else
-                TextButton(
-                  onPressed: _save,
-                  child: Text(
-                    widget.isEdit ? 'Save' : 'Create',
-                    style: TextStyle(
-                      fontWeight: FontWeight.w700,
-                      color: theme.colorScheme.primary,
+              actions: [
+                IconButton(
+                  icon: const Icon(Icons.settings_outlined),
+                  tooltip: 'Workflow settings',
+                  onPressed: _showSettings,
+                ),
+                if (_submitting)
+                  const Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 16),
+                    child: SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator.adaptive(strokeWidth: 2),
+                    ),
+                  )
+                else
+                  TextButton(
+                    onPressed: _save,
+                    child: Text(
+                      widget.isEdit ? 'Save' : 'Create',
+                      style: TextStyle(
+                        fontWeight: FontWeight.w700,
+                        color: theme.colorScheme.primary,
+                      ),
                     ),
                   ),
-                ),
-            ],
-          ),
-          body: Column(
-            children: [
-              // Error banner (shared between both layouts)
-              if (_error != null)
-                Container(
-                  width: double.infinity,
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 16,
-                    vertical: 8,
-                  ),
-                  color: theme.colorScheme.errorContainer,
-                  child: Row(
-                    children: [
-                      Icon(
-                        Icons.error_outline,
-                        size: 16,
-                        color: theme.colorScheme.onErrorContainer,
-                      ),
-                      const SizedBox(width: 8),
-                      Expanded(
-                        child: Text(
-                          _error!,
-                          style: TextStyle(
-                            fontSize: 12,
-                            color: theme.colorScheme.onErrorContainer,
+              ],
+            ),
+            body: Column(
+              children: [
+                // Error banner (shared between both layouts)
+                if (_error != null)
+                  Container(
+                    width: double.infinity,
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 16,
+                      vertical: 8,
+                    ),
+                    color: theme.colorScheme.errorContainer,
+                    child: Row(
+                      children: [
+                        Icon(
+                          Icons.error_outline,
+                          size: 16,
+                          color: theme.colorScheme.onErrorContainer,
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            _error!,
+                            style: TextStyle(
+                              fontSize: 12,
+                              color: theme.colorScheme.onErrorContainer,
+                            ),
                           ),
                         ),
-                      ),
-                      IconButton(
-                        icon: const Icon(Icons.close, size: 14),
-                        onPressed: () => setState(() => _error = null),
-                      ),
-                    ],
+                        IconButton(
+                          icon: const Icon(Icons.close, size: 14),
+                          onPressed: () => setState(() => _error = null),
+                        ),
+                      ],
+                    ),
                   ),
-                ),
 
-              // Layout branch
-              Expanded(
-                child: _isMobileLayout
-                    ? _MobileWorkflowEditor(
-                        nodes: _nodes,
-                        edges: _edges,
-                        onNodesChanged: (nodes) =>
-                            setState(() => _nodes = nodes),
-                        onAddNode: _addNode,
-                        onEditNode: _editNode,
-                        onDeleteNode: _deleteNode,
-                      )
-                    : _DesktopCanvasEditor(
-                        nodes: _nodes,
-                        edges: _edges,
-                        connectingFrom: _connectingFrom,
-                        pendingEdgeEnd: _pendingEdgeEnd,
-                        onDragNode: (node, delta) {
-                          setState(() {
-                            node.position = Offset(
-                              (node.position.dx + delta.dx).clamp(
-                                0,
-                                _kCanvasW - _kNodeW,
-                              ),
-                              (node.position.dy + delta.dy).clamp(
-                                0,
-                                _kCanvasH - _kNodeH,
+                // Layout branch
+                Expanded(
+                  child: _isMobileLayout
+                      ? _MobileWorkflowEditor(
+                          nodes: _nodes,
+                          edges: _edges,
+                          onNodesChanged: (nodes) => setState(() {
+                            _nodes = nodes;
+                            _dirty = true;
+                          }),
+                          onAddNode: _addNode,
+                          onEditNode: _editNode,
+                          onDeleteNode: _deleteNode,
+                        )
+                      : _DesktopCanvasEditor(
+                          canvasController: _canvasController,
+                          nodes: _nodes,
+                          edges: _edges,
+                          connectingFrom: _connectingFrom,
+                          pendingEdgeEnd: _pendingEdgeEnd,
+                          onDragNode: (node, delta) {
+                            setState(() {
+                              node.position = Offset(
+                                (node.position.dx + delta.dx).clamp(
+                                  0,
+                                  _kCanvasW - _kNodeW,
+                                ),
+                                (node.position.dy + delta.dy).clamp(
+                                  0,
+                                  _kCanvasH - _kNodeH,
+                                ),
+                              );
+                              _dirty = true;
+                            });
+                          },
+                          onEditNode: _editNode,
+                          onDeleteNode: _deleteNode,
+                          onStartConnect: _startConnecting,
+                          onCompleteEdge: _completeEdge,
+                          onCancelConnecting: _cancelConnecting,
+                          onUpdatePendingEdge: (offset) =>
+                              setState(() => _pendingEdgeEnd = offset),
+                          onDeleteEdge: _deleteEdge,
+                        ),
+                ),
+              ],
+            ),
+            floatingActionButton: _isMobileLayout
+                ? null
+                : Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      FloatingActionButton.small(
+                        heroTag: 'fit',
+                        onPressed: () => _fitToView(
+                          Size(
+                            outerConstraints.maxWidth,
+                            outerConstraints.maxHeight,
+                          ),
+                        ),
+                        tooltip: 'Fit to view',
+                        child: const Icon(Icons.fit_screen),
+                      ),
+                      const SizedBox(height: 8),
+                      FloatingActionButton.small(
+                        heroTag: 'layout',
+                        onPressed: () {
+                          _autoLayout();
+                          // Re-fit after layout so nodes are visible.
+                          WidgetsBinding.instance.addPostFrameCallback((_) {
+                            _fitToView(
+                              Size(
+                                outerConstraints.maxWidth,
+                                outerConstraints.maxHeight,
                               ),
                             );
                           });
                         },
-                        onEditNode: _editNode,
-                        onDeleteNode: _deleteNode,
-                        onStartConnect: _startConnecting,
-                        onCompleteEdge: _completeEdge,
-                        onCancelConnecting: _cancelConnecting,
-                        onUpdatePendingEdge: (offset) =>
-                            setState(() => _pendingEdgeEnd = offset),
-                        onDeleteEdge: _deleteEdge,
+                        tooltip: 'Auto-layout',
+                        child: const Icon(Icons.account_tree),
                       ),
-              ),
-            ],
+                      const SizedBox(height: 8),
+                      FloatingActionButton(
+                        heroTag: 'add',
+                        onPressed: _addNode,
+                        tooltip: 'Add node',
+                        child: const Icon(Icons.add),
+                      ),
+                    ],
+                  ),
           ),
-          floatingActionButton: _isMobileLayout
-              ? null
-              : FloatingActionButton(
-                  onPressed: _addNode,
-                  tooltip: 'Add node',
-                  child: const Icon(Icons.add),
-                ),
         );
       },
     );
@@ -857,6 +1061,7 @@ class _WorkflowEditorScreenState extends ConsumerState<WorkflowEditorScreen> {
 
 class _DesktopCanvasEditor extends StatelessWidget {
   const _DesktopCanvasEditor({
+    required this.canvasController,
     required this.nodes,
     required this.edges,
     required this.connectingFrom,
@@ -871,6 +1076,7 @@ class _DesktopCanvasEditor extends StatelessWidget {
     required this.onDeleteEdge,
   });
 
+  final TransformationController canvasController;
   final List<EditorNode> nodes;
   final List<EditorEdge> edges;
   final String? connectingFrom;
@@ -925,6 +1131,7 @@ class _DesktopCanvasEditor extends StatelessWidget {
         // Canvas
         Expanded(
           child: InteractiveViewer(
+            transformationController: canvasController,
             constrained: false,
             boundaryMargin: const EdgeInsets.all(100),
             minScale: 0.4,
@@ -1108,61 +1315,89 @@ class _MobileNodeCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final color = node.color;
+    final isDisabled = node.disabled;
 
-    return Card(
-      margin: const EdgeInsets.only(bottom: 8),
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(12),
-        side: BorderSide(color: color.withValues(alpha: 0.4), width: 1.5),
-      ),
-      child: ListTile(
-        contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-        leading: Container(
-          width: 36,
-          height: 36,
-          decoration: BoxDecoration(
-            color: color.withValues(alpha: 0.12),
-            borderRadius: BorderRadius.circular(8),
-          ),
-          child: Icon(node.icon, color: color, size: 20),
+    return Opacity(
+      opacity: isDisabled ? 0.5 : 1.0,
+      child: Card(
+        margin: const EdgeInsets.only(bottom: 8),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12),
+          side: BorderSide(color: color.withValues(alpha: 0.4), width: 1.5),
         ),
-        title: Text(
-          node.label,
-          style: TextStyle(
-            fontWeight: FontWeight.w600,
-            color: color.withValues(alpha: 0.9),
+        child: ListTile(
+          contentPadding: const EdgeInsets.symmetric(
+            horizontal: 16,
+            vertical: 4,
           ),
-        ),
-        subtitle: Text(node.kind, style: const TextStyle(fontSize: 11)),
-        trailing: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            IconButton(
-              icon: Icon(Icons.edit_outlined, size: 20, color: color),
-              onPressed: onEdit,
-              tooltip: 'Edit',
+          leading: Container(
+            width: 36,
+            height: 36,
+            decoration: BoxDecoration(
+              color: color.withValues(alpha: 0.12),
+              borderRadius: BorderRadius.circular(8),
             ),
-            IconButton(
-              icon: Icon(
-                Icons.delete_outline,
-                size: 20,
-                color: Theme.of(context).colorScheme.error,
-              ),
-              onPressed: onDelete,
-              tooltip: 'Delete',
-            ),
-            ReorderableDelayedDragStartListener(
-              index: index,
-              child: Padding(
-                padding: const EdgeInsets.all(12),
-                child: Icon(
-                  Icons.drag_handle,
-                  size: 24,
-                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+            child: Icon(node.icon, color: color, size: 20),
+          ),
+          title: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  node.label,
+                  style: TextStyle(
+                    fontWeight: FontWeight.w600,
+                    color: color.withValues(alpha: 0.9),
+                  ),
                 ),
               ),
-            ),
-          ],
+              if (isDisabled)
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 6,
+                    vertical: 2,
+                  ),
+                  decoration: BoxDecoration(
+                    color: Colors.grey.withValues(alpha: 0.15),
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                  child: const Text(
+                    'Disabled',
+                    style: TextStyle(fontSize: 10, color: Colors.grey),
+                  ),
+                ),
+            ],
+          ),
+          subtitle: Text(node.kind, style: const TextStyle(fontSize: 11)),
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              IconButton(
+                icon: Icon(Icons.edit_outlined, size: 20, color: color),
+                onPressed: onEdit,
+                tooltip: 'Edit',
+              ),
+              IconButton(
+                icon: Icon(
+                  Icons.delete_outline,
+                  size: 20,
+                  color: Theme.of(context).colorScheme.error,
+                ),
+                onPressed: onDelete,
+                tooltip: 'Delete',
+              ),
+              ReorderableDelayedDragStartListener(
+                index: index,
+                child: Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: Icon(
+                    Icons.drag_handle,
+                    size: 24,
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -1297,183 +1532,186 @@ class _NodeWidget extends StatelessWidget {
     return Positioned(
       left: node.position.dx,
       top: node.position.dy,
-      child: GestureDetector(
-        onPanUpdate: (details) => onDrag(details.delta),
-        onTap: onTap,
-        child: SizedBox(
-          width: _kNodeW,
-          height: _kNodeH,
-          child: Stack(
-            clipBehavior: Clip.none,
-            children: [
-              // Main card
-              Material(
-                elevation: isConnectingFrom ? 6 : 2,
-                borderRadius: BorderRadius.circular(12),
-                color: isConnecting && !isConnectingFrom
-                    ? Theme.of(context).colorScheme.surface
-                    : color.withValues(alpha: 0.08),
-                child: Container(
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(12),
-                    border: Border.all(
-                      color: isConnectingFrom
-                          ? color
-                          : color.withValues(alpha: 0.4),
-                      width: isConnectingFrom ? 2.5 : 1.5,
+      child: Opacity(
+        opacity: node.disabled ? 0.45 : 1.0,
+        child: GestureDetector(
+          onPanUpdate: (details) => onDrag(details.delta),
+          onTap: onTap,
+          child: SizedBox(
+            width: _kNodeW,
+            height: _kNodeH,
+            child: Stack(
+              clipBehavior: Clip.none,
+              children: [
+                // Main card
+                Material(
+                  elevation: isConnectingFrom ? 6 : 2,
+                  borderRadius: BorderRadius.circular(12),
+                  color: isConnecting && !isConnectingFrom
+                      ? Theme.of(context).colorScheme.surface
+                      : color.withValues(alpha: 0.08),
+                  child: Container(
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(12),
+                      border: Border.all(
+                        color: isConnectingFrom
+                            ? color
+                            : color.withValues(alpha: 0.4),
+                        width: isConnectingFrom ? 2.5 : 1.5,
+                      ),
                     ),
-                  ),
-                  child: Padding(
-                    padding: const EdgeInsets.all(10),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Row(
-                          children: [
-                            Icon(node.icon, size: 16, color: color),
-                            const SizedBox(width: 6),
-                            Expanded(
-                              child: Text(
-                                node.label,
-                                style: TextStyle(
-                                  fontSize: 12,
-                                  fontWeight: FontWeight.w700,
-                                  color: color.withValues(alpha: 0.9),
+                    child: Padding(
+                      padding: const EdgeInsets.all(10),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Row(
+                            children: [
+                              Icon(node.icon, size: 16, color: color),
+                              const SizedBox(width: 6),
+                              Expanded(
+                                child: Text(
+                                  node.label,
+                                  style: TextStyle(
+                                    fontSize: 12,
+                                    fontWeight: FontWeight.w700,
+                                    color: color.withValues(alpha: 0.9),
+                                  ),
+                                  overflow: TextOverflow.ellipsis,
                                 ),
-                                overflow: TextOverflow.ellipsis,
                               ),
+                            ],
+                          ),
+                          const SizedBox(height: 4),
+                          Text(
+                            node.id.length > 8
+                                ? node.id.substring(0, 8)
+                                : node.id,
+                            style: TextStyle(
+                              fontSize: 10,
+                              fontFamily: 'monospace',
+                              color: Theme.of(
+                                context,
+                              ).colorScheme.onSurfaceVariant,
                             ),
-                          ],
-                        ),
-                        const SizedBox(height: 4),
-                        Text(
-                          node.id.length > 8
-                              ? node.id.substring(0, 8)
-                              : node.id,
-                          style: TextStyle(
-                            fontSize: 10,
-                            fontFamily: 'monospace',
-                            color: Theme.of(
-                              context,
-                            ).colorScheme.onSurfaceVariant,
                           ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-
-              // Action buttons (shown when NOT in connecting mode)
-              if (!isConnecting) ...[
-                // Edit button (top-right)
-                Positioned(
-                  top: -15,
-                  right: 17,
-                  child: GestureDetector(
-                    behavior: HitTestBehavior.opaque,
-                    onTap: onEdit,
-                    child: SizedBox(
-                      width: 36,
-                      height: 36,
-                      child: Center(
-                        child: Container(
-                          width: 22,
-                          height: 22,
-                          decoration: BoxDecoration(
-                            color: color,
-                            shape: BoxShape.circle,
-                            boxShadow: [
-                              BoxShadow(
-                                color: color.withValues(alpha: 0.3),
-                                blurRadius: 4,
-                              ),
-                            ],
-                          ),
-                          child: Icon(
-                            Icons.edit,
-                            size: 12,
-                            color: Theme.of(context).colorScheme.surface,
-                          ),
-                        ),
+                        ],
                       ),
                     ),
                   ),
                 ),
 
-                // Delete button (top-right, offset)
-                Positioned(
-                  top: -15,
-                  right: -9,
-                  child: GestureDetector(
-                    behavior: HitTestBehavior.opaque,
-                    onTap: onDelete,
-                    child: SizedBox(
-                      width: 36,
-                      height: 36,
-                      child: Center(
-                        child: Container(
-                          width: 22,
-                          height: 22,
-                          decoration: BoxDecoration(
-                            color: Theme.of(context).colorScheme.error,
-                            shape: BoxShape.circle,
-                            boxShadow: [
-                              BoxShadow(
-                                color: Theme.of(
-                                  context,
-                                ).colorScheme.error.withValues(alpha: 0.3),
-                                blurRadius: 4,
-                              ),
-                            ],
-                          ),
-                          child: Icon(
-                            Icons.close,
-                            size: 12,
-                            color: Theme.of(context).colorScheme.surface,
+                // Action buttons (shown when NOT in connecting mode)
+                if (!isConnecting) ...[
+                  // Edit button (top-right)
+                  Positioned(
+                    top: -15,
+                    right: 17,
+                    child: GestureDetector(
+                      behavior: HitTestBehavior.opaque,
+                      onTap: onEdit,
+                      child: SizedBox(
+                        width: 36,
+                        height: 36,
+                        child: Center(
+                          child: Container(
+                            width: 22,
+                            height: 22,
+                            decoration: BoxDecoration(
+                              color: color,
+                              shape: BoxShape.circle,
+                              boxShadow: [
+                                BoxShadow(
+                                  color: color.withValues(alpha: 0.3),
+                                  blurRadius: 4,
+                                ),
+                              ],
+                            ),
+                            child: Icon(
+                              Icons.edit,
+                              size: 12,
+                              color: Theme.of(context).colorScheme.surface,
+                            ),
                           ),
                         ),
                       ),
                     ),
                   ),
-                ),
 
-                // Connect button (bottom-center)
-                Positioned(
-                  bottom: -17,
-                  left: _kNodeW / 2 - 18,
-                  child: GestureDetector(
-                    behavior: HitTestBehavior.opaque,
-                    onTap: onStartConnect,
-                    child: SizedBox(
-                      width: 36,
-                      height: 36,
-                      child: Center(
-                        child: Container(
-                          width: 22,
-                          height: 22,
-                          decoration: BoxDecoration(
-                            color: color,
-                            shape: BoxShape.circle,
-                            boxShadow: [
-                              BoxShadow(
-                                color: color.withValues(alpha: 0.3),
-                                blurRadius: 4,
-                              ),
-                            ],
-                          ),
-                          child: Icon(
-                            Icons.arrow_downward,
-                            size: 12,
-                            color: Theme.of(context).colorScheme.surface,
+                  // Delete button (top-right, offset)
+                  Positioned(
+                    top: -15,
+                    right: -9,
+                    child: GestureDetector(
+                      behavior: HitTestBehavior.opaque,
+                      onTap: onDelete,
+                      child: SizedBox(
+                        width: 36,
+                        height: 36,
+                        child: Center(
+                          child: Container(
+                            width: 22,
+                            height: 22,
+                            decoration: BoxDecoration(
+                              color: Theme.of(context).colorScheme.error,
+                              shape: BoxShape.circle,
+                              boxShadow: [
+                                BoxShadow(
+                                  color: Theme.of(
+                                    context,
+                                  ).colorScheme.error.withValues(alpha: 0.3),
+                                  blurRadius: 4,
+                                ),
+                              ],
+                            ),
+                            child: Icon(
+                              Icons.close,
+                              size: 12,
+                              color: Theme.of(context).colorScheme.surface,
+                            ),
                           ),
                         ),
                       ),
                     ),
                   ),
-                ),
+
+                  // Connect button (bottom-center)
+                  Positioned(
+                    bottom: -17,
+                    left: _kNodeW / 2 - 18,
+                    child: GestureDetector(
+                      behavior: HitTestBehavior.opaque,
+                      onTap: onStartConnect,
+                      child: SizedBox(
+                        width: 36,
+                        height: 36,
+                        child: Center(
+                          child: Container(
+                            width: 22,
+                            height: 22,
+                            decoration: BoxDecoration(
+                              color: color,
+                              shape: BoxShape.circle,
+                              boxShadow: [
+                                BoxShadow(
+                                  color: color.withValues(alpha: 0.3),
+                                  blurRadius: 4,
+                                ),
+                              ],
+                            ),
+                            child: Icon(
+                              Icons.arrow_downward,
+                              size: 12,
+                              color: Theme.of(context).colorScheme.surface,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
               ],
-            ],
+            ),
           ),
         ),
       ),
@@ -1693,9 +1931,12 @@ class _PaletteItem extends StatelessWidget {
 // Node config bottom sheet
 
 class _NodeConfigSheet extends StatefulWidget {
-  const _NodeConfigSheet({required this.node});
+  const _NodeConfigSheet({required this.node, this.personaNames = const []});
 
   final EditorNode node;
+
+  /// List of (id, name) pairs for persona selection on assistant_turn nodes.
+  final List<(String, String)> personaNames;
 
   @override
   State<_NodeConfigSheet> createState() => _NodeConfigSheetState();
@@ -1709,6 +1950,8 @@ class _NodeConfigSheetState extends State<_NodeConfigSheet> {
   late TextEditingController _urlCtrl;
   late TextEditingController _keyCtrl;
   String _method = 'GET';
+  String? _personaId;
+  bool _disabled = false;
 
   @override
   void initState() {
@@ -1722,6 +1965,8 @@ class _NodeConfigSheetState extends State<_NodeConfigSheet> {
     _urlCtrl = TextEditingController(text: _config['url'] as String? ?? '');
     _keyCtrl = TextEditingController(text: _config['key'] as String? ?? '');
     _method = _config['method'] as String? ?? 'GET';
+    _personaId = _config['persona_id'] as String?;
+    _disabled = _config['disabled'] == true;
   }
 
   @override
@@ -1745,6 +1990,11 @@ class _NodeConfigSheetState extends State<_NodeConfigSheet> {
         break;
       case 'assistant_turn':
         _config['prompt'] = _promptCtrl.text;
+        if (_personaId != null) {
+          _config['persona_id'] = _personaId;
+        } else {
+          _config.remove('persona_id');
+        }
         break;
       case 'http_request':
         _config['url'] = _urlCtrl.text.trim();
@@ -1753,6 +2003,12 @@ class _NodeConfigSheetState extends State<_NodeConfigSheet> {
       case 'has_trigger_payload_key':
         _config['key'] = _keyCtrl.text.trim();
         break;
+    }
+
+    if (_disabled) {
+      _config['disabled'] = true;
+    } else {
+      _config.remove('disabled');
     }
 
     final updated = widget.node.copyWith(config: _config);
@@ -1786,7 +2042,17 @@ class _NodeConfigSheetState extends State<_NodeConfigSheet> {
               ],
             ),
           ),
-          const SizedBox(height: 12),
+          const SizedBox(height: 4),
+          SwitchListTile.adaptive(
+            title: const Text('Enabled'),
+            subtitle: _disabled
+                ? const Text('This node will be skipped during execution')
+                : null,
+            value: !_disabled,
+            onChanged: (v) => setState(() => _disabled = !v),
+            contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+          ),
+          const SizedBox(height: 8),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16),
             child: _buildConfigFields(nodeType),
@@ -1849,16 +2115,43 @@ class _NodeConfigSheetState extends State<_NodeConfigSheet> {
         );
 
       case 'assistant_turn':
-        return TextField(
-          controller: _promptCtrl,
-          minLines: 4,
-          maxLines: null,
-          decoration: const InputDecoration(
-            labelText: 'Prompt',
-            hintText: 'Enter the assistant prompt…',
-            border: OutlineInputBorder(),
-            alignLabelWithHint: true,
-          ),
+        return Column(
+          children: [
+            if (widget.personaNames.isNotEmpty) ...[
+              DropdownButtonFormField<String?>(
+                initialValue: _personaId,
+                decoration: const InputDecoration(
+                  labelText: 'Persona',
+                  border: OutlineInputBorder(),
+                ),
+                items: [
+                  const DropdownMenuItem<String?>(
+                    value: null,
+                    child: Text('Default'),
+                  ),
+                  ...widget.personaNames.map(
+                    (p) => DropdownMenuItem<String?>(
+                      value: p.$1,
+                      child: Text(p.$2),
+                    ),
+                  ),
+                ],
+                onChanged: (v) => setState(() => _personaId = v),
+              ),
+              const SizedBox(height: 12),
+            ],
+            TextField(
+              controller: _promptCtrl,
+              minLines: 4,
+              maxLines: null,
+              decoration: const InputDecoration(
+                labelText: 'Prompt',
+                hintText: 'Enter the assistant prompt…',
+                border: OutlineInputBorder(),
+                alignLabelWithHint: true,
+              ),
+            ),
+          ],
         );
 
       case 'http_request':

--- a/app/lib/features/workflows/workflow_run_detail_screen.dart
+++ b/app/lib/features/workflows/workflow_run_detail_screen.dart
@@ -81,22 +81,22 @@ class _RunDetailBody extends StatelessWidget {
     final colorScheme = theme.colorScheme;
 
     final statusColor = isSuccess
-        ? Colors.green.shade600
+        ? Colors.green
         : isError
         ? colorScheme.error
-        : Colors.orange.shade600;
+        : Colors.orange;
 
     final statusBg = isSuccess
-        ? Colors.green.shade50
+        ? Colors.green.withAlpha(20)
         : isError
         ? colorScheme.errorContainer
-        : Colors.orange.shade50;
+        : Colors.orange.withAlpha(20);
 
     final statusBorder = isSuccess
-        ? Colors.green.shade300
+        ? Colors.green.withAlpha(60)
         : isError
         ? colorScheme.error
-        : Colors.orange.shade300;
+        : Colors.orange.withAlpha(60);
 
     return ListView(
       padding: const EdgeInsets.all(16),
@@ -250,13 +250,13 @@ class _StepTileState extends State<_StepTile> {
   Color _kindColor(String kind) {
     switch (kind) {
       case 'trigger':
-        return Colors.blue.shade600;
+        return Colors.blue;
       case 'action':
-        return Colors.green.shade600;
+        return Colors.green;
       case 'condition':
-        return Colors.orange.shade600;
+        return Colors.orange;
       default:
-        return Colors.grey.shade600;
+        return Colors.grey;
     }
   }
 

--- a/app/lib/features/workflows/workflows_provider.dart
+++ b/app/lib/features/workflows/workflows_provider.dart
@@ -180,6 +180,34 @@ class WorkflowDetailNotifier extends AsyncNotifier<WorkflowDetailState> {
     state = const AsyncLoading();
     state = await AsyncValue.guard(_fetch);
   }
+
+  /// Triggers a test run. Returns (preview, null) on success or (null, error).
+  Future<(WorkflowRunPreview?, String?)> testRun() async {
+    final client = _apiClient(ref);
+    if (client == null) return (null, 'Not connected');
+    try {
+      final res = await client.workflows.testRunWorkflow(id: _workflowId);
+      await refresh();
+      return (res.data, null);
+    } catch (e) {
+      return (null, e.toString());
+    }
+  }
+
+  /// Fetches webhook secrets. Returns null on failure or if not a webhook
+  /// workflow.
+  Future<WorkflowWebhookSecrets?> fetchWebhookSecrets() async {
+    final client = _apiClient(ref);
+    if (client == null) return null;
+    try {
+      final res = await client.workflows.getWorkflowWebhookSecrets(
+        id: _workflowId,
+      );
+      return res.data;
+    } catch (_) {
+      return null;
+    }
+  }
 }
 
 /// Family provider for [WorkflowDetailNotifier].
@@ -231,7 +259,7 @@ class WorkflowRunDetailNotifier extends AsyncNotifier<WorkflowRunDetailState> {
 
   Future<void> refresh() async {
     state = const AsyncLoading();
-    state = AsyncData(await _fetch());
+    state = await AsyncValue.guard(_fetch);
   }
 }
 

--- a/app/lib/features/workflows/workflows_screen.dart
+++ b/app/lib/features/workflows/workflows_screen.dart
@@ -108,11 +108,13 @@ class _WorkflowRow extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
       decoration: BoxDecoration(
         color: workflow.active
-            ? Colors.green.shade50
+            ? Colors.green.withAlpha(20)
             : colorScheme.surfaceContainerHighest,
         borderRadius: BorderRadius.circular(12),
         border: Border.all(
-          color: workflow.active ? Colors.green.shade300 : Colors.grey.shade400,
+          color: workflow.active
+              ? Colors.green.withAlpha(60)
+              : Colors.grey.withAlpha(60),
         ),
       ),
       child: Text(
@@ -120,7 +122,7 @@ class _WorkflowRow extends StatelessWidget {
         style: TextStyle(
           fontSize: 11,
           fontWeight: FontWeight.w600,
-          color: workflow.active ? Colors.green.shade700 : Colors.grey.shade600,
+          color: workflow.active ? Colors.green : Colors.grey,
         ),
       ),
     );
@@ -128,12 +130,12 @@ class _WorkflowRow extends StatelessWidget {
     return ListTile(
       leading: CircleAvatar(
         backgroundColor: workflow.active
-            ? Colors.green.shade100
-            : Colors.grey.shade200,
+            ? Colors.green.withAlpha(30)
+            : Colors.grey.withAlpha(30),
         child: Icon(
           Icons.account_tree_outlined,
           size: 20,
-          color: workflow.active ? Colors.green.shade700 : Colors.grey.shade500,
+          color: workflow.active ? Colors.green : Colors.grey,
         ),
       ),
       title: Row(

--- a/app/test/widget/features/workflows/workflow_detail_screen_test.dart
+++ b/app/test/widget/features/workflows/workflow_detail_screen_test.dart
@@ -1,4 +1,5 @@
 import 'package:assistant_api/assistant_api.dart';
+import 'package:built_value/json_object.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -12,6 +13,7 @@ void main() {
     Widget buildUnderTest({
       required WorkflowDetailState detailState,
       _FakeWorkflowsNotifier? workflowsNotifier,
+      _FakeWorkflowDetailNotifier? detailNotifier,
     }) {
       final fake = workflowsNotifier ?? _FakeWorkflowsNotifier();
       final router = GoRouter(
@@ -28,13 +30,19 @@ void main() {
             path: '/workflows/wf-1/edit',
             builder: (_, _) => const Scaffold(body: Text('edit screen')),
           ),
+          GoRoute(
+            path: '/workflows/wf-1/runs/:runId',
+            builder: (_, state) =>
+                Scaffold(body: Text('run ${state.pathParameters['runId']}')),
+          ),
         ],
       );
 
       return ProviderScope(
         overrides: [
           workflowDetailProvider.overrideWith2(
-            (arg) => _FakeWorkflowDetailNotifier(arg, detailState),
+            (arg) =>
+                detailNotifier ?? _FakeWorkflowDetailNotifier(arg, detailState),
           ),
           workflowsProvider.overrideWith(() => fake),
         ],
@@ -200,6 +208,124 @@ void main() {
 
       expect(find.textContaining('Toggle failed'), findsOneWidget);
     });
+
+    // -------------------------------------------------------------------------
+    // Test run
+
+    testWidgets('test run success shows snackbar with message', (tester) async {
+      final preview = WorkflowRunPreview(
+        (b) => b
+          ..runId = 'run-42'
+          ..workflowId = 'wf-1'
+          ..status = 'running'
+          ..message = 'Test run started'
+          ..maxSteps = 50
+          ..maxVisitsPerNode = 3
+          ..startedAt = DateTime(2024, 1, 1),
+      );
+      final detailNotifier = _FakeWorkflowDetailNotifier(
+        'wf-1',
+        _activeState(),
+        testRunResult: (preview, null),
+      );
+      await tester.pumpWidget(
+        buildUnderTest(
+          detailState: _activeState(),
+          detailNotifier: detailNotifier,
+        ),
+      );
+      await tester.pump();
+
+      await tester.tap(find.byIcon(Icons.play_arrow));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.textContaining('Test run started'),
+        findsOneWidget,
+        reason: 'success snackbar should show preview message',
+      );
+    });
+
+    testWidgets('test run failure shows error snackbar', (tester) async {
+      final detailNotifier = _FakeWorkflowDetailNotifier(
+        'wf-1',
+        _activeState(),
+        testRunResult: (null, 'Connection refused'),
+      );
+      await tester.pumpWidget(
+        buildUnderTest(
+          detailState: _activeState(),
+          detailNotifier: detailNotifier,
+        ),
+      );
+      await tester.pump();
+
+      await tester.tap(find.byIcon(Icons.play_arrow));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.textContaining('Connection refused'),
+        findsOneWidget,
+        reason: 'error snackbar should show failure message',
+      );
+    });
+
+    // -------------------------------------------------------------------------
+    // Webhook secrets
+
+    testWidgets('webhook trigger workflow shows webhook secrets card', (
+      tester,
+    ) async {
+      final secrets = WorkflowWebhookSecrets(
+        (b) => b
+          ..webhookUrl = 'https://example.com/hook/wf-1'
+          ..webhookToken = 'secret-token-abc',
+      );
+      final detailNotifier = _FakeWorkflowDetailNotifier(
+        'wf-1',
+        _webhookState(),
+        webhookSecrets: secrets,
+      );
+      await tester.pumpWidget(
+        buildUnderTest(
+          detailState: _webhookState(),
+          detailNotifier: detailNotifier,
+        ),
+      );
+      await tester.pump();
+      // Allow the lazy fetch to complete.
+      await tester.pump();
+
+      expect(
+        find.text('Webhook'),
+        findsOneWidget,
+        reason: 'webhook secrets card header should appear',
+      );
+      expect(
+        find.text('https://example.com/hook/wf-1'),
+        findsOneWidget,
+        reason: 'webhook URL should be displayed',
+      );
+      // Token should be obscured by default.
+      expect(
+        find.text('secret-token-abc'),
+        findsNothing,
+        reason: 'token should be hidden by default',
+      );
+    });
+
+    testWidgets('non-webhook workflow does not show webhook card', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildUnderTest(detailState: _activeState()));
+      await tester.pump();
+
+      expect(
+        find.text('Webhook'),
+        findsNothing,
+        reason: 'webhook card should not appear for non-webhook workflows',
+      );
+    });
   });
 }
 
@@ -232,19 +358,56 @@ WorkflowDetailState _inactiveState() => WorkflowDetailState(
   runs: const [],
 );
 
+WorkflowDetailState _webhookState() => WorkflowDetailState(
+  detail: WorkflowDetail(
+    (b) => b
+      ..id = 'wf-1'
+      ..name = 'Webhook Workflow'
+      ..description = 'A webhook-triggered workflow'
+      ..active = true
+      ..createdAt = DateTime(2024, 1, 1)
+      ..updatedAt = DateTime(2024, 1, 1)
+      ..graph = JsonObject({
+        'nodes': [
+          {
+            'id': 'trigger-1',
+            'kind': 'trigger',
+            'config': {'type': 'webhook'},
+          },
+        ],
+        'edges': [],
+      }),
+  ),
+  runs: const [],
+);
+
 // ---------------------------------------------------------------------------
 // Fake notifiers
 
 class _FakeWorkflowDetailNotifier extends WorkflowDetailNotifier {
-  _FakeWorkflowDetailNotifier(super.workflowId, this._state);
+  _FakeWorkflowDetailNotifier(
+    super.workflowId,
+    this._state, {
+    this.testRunResult,
+    this.webhookSecrets,
+  });
 
   final WorkflowDetailState _state;
+  final (WorkflowRunPreview?, String?)? testRunResult;
+  final WorkflowWebhookSecrets? webhookSecrets;
 
   @override
   Future<WorkflowDetailState> build() async => _state;
 
   @override
   Future<void> refresh() async {}
+
+  @override
+  Future<(WorkflowRunPreview?, String?)> testRun() async =>
+      testRunResult ?? (null, 'Not configured');
+
+  @override
+  Future<WorkflowWebhookSecrets?> fetchWebhookSecrets() async => webhookSecrets;
 }
 
 class _FakeWorkflowsNotifier extends WorkflowsNotifier {

--- a/app/test/widget/features/workflows/workflow_editor_screen_test.dart
+++ b/app/test/widget/features/workflows/workflow_editor_screen_test.dart
@@ -241,7 +241,8 @@ void main() {
       'editing http_request node URL via config sheet keeps card in list',
       (tester) async {
         // 500px: still mobile layout (<600) but wide enough for the config sheet.
-        tester.view.physicalSize = const Size(500, 844);
+        // Use 1000px height to ensure both cards are on-screen with default-density buttons.
+        tester.view.physicalSize = const Size(500, 1000);
         tester.view.devicePixelRatio = 1.0;
         addTearDown(tester.view.resetPhysicalSize);
         addTearDown(tester.view.resetDevicePixelRatio);

--- a/app/test/widget/features/workflows/workflow_editor_screen_test.dart
+++ b/app/test/widget/features/workflows/workflow_editor_screen_test.dart
@@ -289,8 +289,8 @@ void main() {
 
       expect(find.byType(InteractiveViewer), findsOneWidget);
 
-      // Tap the FloatingActionButton to open the node palette.
-      await tester.tap(find.byType(FloatingActionButton));
+      // Tap the "Add node" FloatingActionButton to open the node palette.
+      await tester.tap(find.byTooltip('Add node'));
       await tester.pumpAndSettle();
 
       // The section header is uppercased by _PaletteSection; items are title-cased.

--- a/app/test/widget/features/workflows/workflow_editor_screen_test.dart
+++ b/app/test/widget/features/workflows/workflow_editor_screen_test.dart
@@ -90,6 +90,25 @@ void main() {
     });
   });
 
+  group('EditorNode.toJson', () {
+    test('includes position in output', () {
+      final node = EditorNode(
+        id: 'n1',
+        kind: 'action',
+        config: {'type': 'http_request', 'url': 'https://example.com'},
+        position: const Offset(100.5, 250.0),
+      );
+      final json = node.toJson();
+
+      expect(json['id'], 'n1');
+      expect(json['kind'], 'action');
+      expect(json['config'], isA<Map>());
+      expect(json['position'], isA<Map>());
+      expect(json['position']['x'], 100.5);
+      expect(json['position']['y'], 250.0);
+    });
+  });
+
   // ---------------------------------------------------------------------------
   // Widget tests
 
@@ -286,9 +305,42 @@ void main() {
       );
     });
 
-    testWidgets('delete node in mobile view removes card from list', (
-      tester,
-    ) async {
+    testWidgets(
+      'delete node in mobile view shows confirmation then removes card',
+      (tester) async {
+        tester.view.physicalSize = const Size(400, 844);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        await tester.pumpWidget(buildScreen());
+        await tester.pump();
+
+        expect(find.text('Manual Trigger'), findsOneWidget);
+
+        // Tap delete on the trigger card — opens confirmation dialog.
+        await tester.tap(find.byIcon(Icons.delete_outline).first);
+        await tester.pumpAndSettle();
+
+        expect(
+          find.text('Delete node?'),
+          findsOneWidget,
+          reason: 'confirmation dialog should appear',
+        );
+
+        // Confirm deletion.
+        await tester.tap(find.text('Delete'));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.text('Manual Trigger'),
+          findsNothing,
+          reason: 'card should be removed after confirming delete',
+        );
+      },
+    );
+
+    testWidgets('canceling delete keeps the node in list', (tester) async {
       tester.view.physicalSize = const Size(400, 844);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.resetPhysicalSize);
@@ -299,14 +351,18 @@ void main() {
 
       expect(find.text('Manual Trigger'), findsOneWidget);
 
-      // Tap delete on the trigger card
+      // Tap delete on the trigger card.
       await tester.tap(find.byIcon(Icons.delete_outline).first);
+      await tester.pumpAndSettle();
+
+      // Cancel the confirmation dialog.
+      await tester.tap(find.text('Cancel'));
       await tester.pumpAndSettle();
 
       expect(
         find.text('Manual Trigger'),
-        findsNothing,
-        reason: 'card should be removed after delete',
+        findsOneWidget,
+        reason: 'card should remain after canceling delete',
       );
     });
   });

--- a/app/test/widget/features/workflows/workflow_editor_screen_test.dart
+++ b/app/test/widget/features/workflows/workflow_editor_screen_test.dart
@@ -109,6 +109,38 @@ void main() {
     });
   });
 
+  group('EditorNode.disabled', () {
+    test('returns true when config has disabled=true', () {
+      final node = EditorNode(
+        id: 'n1',
+        kind: 'action',
+        config: {'type': 'http_request', 'disabled': true},
+        position: Offset.zero,
+      );
+      expect(node.disabled, isTrue);
+    });
+
+    test('returns false when disabled key is absent', () {
+      final node = EditorNode(
+        id: 'n1',
+        kind: 'action',
+        config: {'type': 'http_request'},
+        position: Offset.zero,
+      );
+      expect(node.disabled, isFalse);
+    });
+
+    test('returns false when disabled is explicitly false', () {
+      final node = EditorNode(
+        id: 'n1',
+        kind: 'action',
+        config: {'type': 'http_request', 'disabled': false},
+        position: Offset.zero,
+      );
+      expect(node.disabled, isFalse);
+    });
+  });
+
   // ---------------------------------------------------------------------------
   // Widget tests
 
@@ -364,6 +396,160 @@ void main() {
         find.text('Manual Trigger'),
         findsOneWidget,
         reason: 'card should remain after canceling delete',
+      );
+    });
+
+    testWidgets(
+      'desktop view shows fit-to-view, auto-layout, and add node FABs',
+      (tester) async {
+        tester.view.physicalSize = const Size(800, 600);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        await tester.pumpWidget(buildScreen());
+        await tester.pump();
+
+        expect(
+          find.byTooltip('Fit to view'),
+          findsOneWidget,
+          reason: 'fit-to-view FAB should be present on desktop',
+        );
+        expect(
+          find.byTooltip('Auto-layout'),
+          findsOneWidget,
+          reason: 'auto-layout FAB should be present on desktop',
+        );
+        expect(
+          find.byTooltip('Add node'),
+          findsOneWidget,
+          reason: 'add node FAB should be present on desktop',
+        );
+      },
+    );
+
+    testWidgets('mobile view does not show desktop FABs', (tester) async {
+      tester.view.physicalSize = const Size(400, 844);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(buildScreen());
+      await tester.pump();
+
+      expect(
+        find.byTooltip('Fit to view'),
+        findsNothing,
+        reason: 'fit-to-view FAB should not appear on mobile',
+      );
+      expect(
+        find.byTooltip('Auto-layout'),
+        findsNothing,
+        reason: 'auto-layout FAB should not appear on mobile',
+      );
+      expect(
+        find.byTooltip('Add node'),
+        findsNothing,
+        reason: 'add node FAB should not appear on mobile',
+      );
+    });
+
+    testWidgets('config sheet shows Enabled toggle for trigger node', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(500, 1000);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(buildScreen());
+      await tester.pump();
+
+      // Open config sheet on the trigger card.
+      await tester.tap(find.byIcon(Icons.edit_outlined).first);
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('Enabled'),
+        findsOneWidget,
+        reason: 'config sheet should show an Enabled toggle',
+      );
+      expect(
+        find.byType(SwitchListTile),
+        findsOneWidget,
+        reason: 'SwitchListTile should be present for the toggle',
+      );
+    });
+
+    testWidgets(
+      'disabling a node via config sheet shows Disabled chip on card',
+      (tester) async {
+        tester.view.physicalSize = const Size(500, 1000);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        await tester.pumpWidget(buildScreen());
+        await tester.pump();
+
+        // No "Disabled" chip before toggling.
+        expect(
+          find.text('Disabled'),
+          findsNothing,
+          reason: 'Disabled chip should not appear initially',
+        );
+
+        // Open config sheet on the trigger card.
+        await tester.tap(find.byIcon(Icons.edit_outlined).first);
+        await tester.pumpAndSettle();
+
+        // Toggle the Enabled switch off.
+        await tester.tap(find.byType(SwitchListTile));
+        await tester.pumpAndSettle();
+
+        // Apply the config change.
+        await tester.tap(find.text('Apply'));
+        await tester.pumpAndSettle();
+
+        // The card should now show a "Disabled" chip.
+        expect(
+          find.text('Disabled'),
+          findsOneWidget,
+          reason: 'card should show Disabled chip after toggling off',
+        );
+      },
+    );
+
+    testWidgets('disabling a node shows skip subtitle in config sheet', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(500, 1000);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(buildScreen());
+      await tester.pump();
+
+      // Open config sheet on the trigger card.
+      await tester.tap(find.byIcon(Icons.edit_outlined).first);
+      await tester.pumpAndSettle();
+
+      // Subtitle should not be shown while enabled.
+      expect(
+        find.text('This node will be skipped during execution'),
+        findsNothing,
+        reason: 'skip subtitle should be hidden while enabled',
+      );
+
+      // Toggle the Enabled switch off.
+      await tester.tap(find.byType(SwitchListTile));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('This node will be skipped during execution'),
+        findsOneWidget,
+        reason: 'skip subtitle should appear when disabled',
       );
     });
   });

--- a/crates/workflow/src/lib.rs
+++ b/crates/workflow/src/lib.rs
@@ -522,6 +522,27 @@ async fn execute_node(
     step_index: i64,
     action_executors: &[Arc<dyn WorkflowActionExecutor>],
 ) -> Result<String> {
+    // Skip disabled nodes — record a skipped step and return the primary
+    // outcome so downstream nodes still execute.
+    if node.config.get("disabled").and_then(|v| v.as_bool()) == Some(true) {
+        let outcome = match node.kind {
+            WorkflowNodeKind::Trigger => "trigger",
+            WorkflowNodeKind::Action => "success",
+            WorkflowNodeKind::Condition => "true",
+        };
+        store
+            .append_run_step(
+                run.id,
+                step_index,
+                node.id.as_str(),
+                "skipped",
+                Some("node disabled"),
+                None,
+            )
+            .await?;
+        return Ok(outcome.to_string());
+    }
+
     match node.kind {
         WorkflowNodeKind::Trigger => Ok("trigger".to_string()),
         WorkflowNodeKind::Condition => {

--- a/crates/workflow/src/lib.rs
+++ b/crates/workflow/src/lib.rs
@@ -729,4 +729,199 @@ mod tests {
         let steps = store.list_run_steps(run_id, 100).await.expect("steps");
         assert!(!steps.is_empty());
     }
+
+    /// A disabled action node should be skipped (recorded as "skipped") and
+    /// still route downstream via its primary outcome ("success").
+    #[tokio::test]
+    async fn disabled_node_is_skipped_during_execution() {
+        let graph = WorkflowGraph {
+            version: 1,
+            nodes: vec![
+                WorkflowNode {
+                    id: "t1".to_string(),
+                    kind: WorkflowNodeKind::Trigger,
+                    config: serde_json::json!({"type": "manual"}),
+                },
+                WorkflowNode {
+                    id: "a1".to_string(),
+                    kind: WorkflowNodeKind::Action,
+                    config: serde_json::json!({"type": "http_request", "url": "https://example.com", "disabled": true}),
+                },
+                WorkflowNode {
+                    id: "c1".to_string(),
+                    kind: WorkflowNodeKind::Condition,
+                    config: serde_json::json!({"type": "always_true"}),
+                },
+            ],
+            edges: vec![
+                WorkflowEdge {
+                    from: "t1".to_string(),
+                    to: "a1".to_string(),
+                    on: Some("trigger".to_string()),
+                    condition: None,
+                },
+                WorkflowEdge {
+                    from: "a1".to_string(),
+                    to: "c1".to_string(),
+                    on: Some("success".to_string()),
+                    condition: None,
+                },
+            ],
+            execution: WorkflowExecutionLimits {
+                max_steps: 50,
+                max_visits_per_node: 3,
+            },
+        };
+
+        let storage = assistant_storage::StorageLayer::new_in_memory()
+            .await
+            .expect("in-memory storage");
+        let store = storage.workflow_store();
+        let workflow_id = store
+            .create("disabled-test", "", &graph, true)
+            .await
+            .expect("create workflow");
+        let run_id = store
+            .create_run(
+                workflow_id,
+                WorkflowTriggerKind::Manual,
+                &serde_json::json!({}),
+            )
+            .await
+            .expect("create run");
+
+        process_pending_runs(&storage, &[])
+            .await
+            .expect("runner process");
+
+        let runs = store.list_runs(workflow_id, 5).await.expect("list runs");
+        let run = runs
+            .into_iter()
+            .find(|r| r.id == run_id)
+            .expect("run present");
+        assert_eq!(
+            run.status, "completed",
+            "run should complete even with a disabled node"
+        );
+
+        let steps = store.list_run_steps(run_id, 100).await.expect("steps");
+
+        // Disabled action node should have a "skipped" step.
+        let skipped = steps
+            .iter()
+            .find(|s| s.node_id == "a1" && s.node_kind == "skipped");
+        assert!(
+            skipped.is_some(),
+            "disabled action node should produce a skipped step"
+        );
+        assert_eq!(
+            skipped.unwrap().note.as_deref(),
+            Some("node disabled"),
+            "skipped step note should explain why"
+        );
+
+        // Downstream condition node should still have been reached.
+        let condition_step = steps.iter().find(|s| s.node_id == "c1");
+        assert!(
+            condition_step.is_some(),
+            "downstream condition should execute after disabled node"
+        );
+    }
+
+    /// A disabled condition node should return "true" as its primary outcome.
+    #[tokio::test]
+    async fn disabled_condition_routes_via_true_branch() {
+        let graph = WorkflowGraph {
+            version: 1,
+            nodes: vec![
+                WorkflowNode {
+                    id: "t1".to_string(),
+                    kind: WorkflowNodeKind::Trigger,
+                    config: serde_json::json!({"type": "manual"}),
+                },
+                WorkflowNode {
+                    id: "c1".to_string(),
+                    kind: WorkflowNodeKind::Condition,
+                    config: serde_json::json!({"type": "always_false", "disabled": true}),
+                },
+                WorkflowNode {
+                    id: "a_true".to_string(),
+                    kind: WorkflowNodeKind::Action,
+                    config: serde_json::json!({"type": "http_request", "url": "https://true.example.com"}),
+                },
+                WorkflowNode {
+                    id: "a_false".to_string(),
+                    kind: WorkflowNodeKind::Action,
+                    config: serde_json::json!({"type": "http_request", "url": "https://false.example.com"}),
+                },
+            ],
+            edges: vec![
+                WorkflowEdge {
+                    from: "t1".to_string(),
+                    to: "c1".to_string(),
+                    on: Some("trigger".to_string()),
+                    condition: None,
+                },
+                WorkflowEdge {
+                    from: "c1".to_string(),
+                    to: "a_true".to_string(),
+                    on: Some("true".to_string()),
+                    condition: None,
+                },
+                WorkflowEdge {
+                    from: "c1".to_string(),
+                    to: "a_false".to_string(),
+                    on: Some("false".to_string()),
+                    condition: None,
+                },
+            ],
+            execution: WorkflowExecutionLimits {
+                max_steps: 50,
+                max_visits_per_node: 3,
+            },
+        };
+
+        let storage = assistant_storage::StorageLayer::new_in_memory()
+            .await
+            .expect("in-memory storage");
+        let store = storage.workflow_store();
+        let workflow_id = store
+            .create("disabled-condition", "", &graph, true)
+            .await
+            .expect("create workflow");
+        let run_id = store
+            .create_run(
+                workflow_id,
+                WorkflowTriggerKind::Manual,
+                &serde_json::json!({}),
+            )
+            .await
+            .expect("create run");
+
+        process_pending_runs(&storage, &[])
+            .await
+            .expect("runner process");
+
+        let runs = store.list_runs(workflow_id, 5).await.expect("list runs");
+        let run = runs
+            .into_iter()
+            .find(|r| r.id == run_id)
+            .expect("run present");
+        assert_eq!(run.status, "completed");
+
+        let steps = store.list_run_steps(run_id, 100).await.expect("steps");
+
+        // The condition was disabled (always_false) but should route via "true"
+        // because disabled nodes use the primary outcome.
+        let true_branch = steps.iter().any(|s| s.node_id == "a_true");
+        let false_branch = steps.iter().any(|s| s.node_id == "a_false");
+        assert!(
+            true_branch,
+            "disabled always_false condition should route via true branch"
+        );
+        assert!(
+            !false_branch,
+            "false branch should NOT be reached when condition is disabled"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- **Touch-friendliness fixes:** Improve touch targets across workflow screens — fix untappable error close button (0dp → 48dp), enlarge mobile card buttons, canvas node action circles, edge delete handles, palette items, drag handle padding, and add ripple feedback to active/inactive toggle chip
- **Editor UX improvements:** Add dirty-state tracking with unsaved-changes prompt (PopScope), auto-center canvas viewport on nodes when opening editor, "fit to view" and "auto-layout" (topological sort) FABs, persona selector dropdown for agent_turn nodes
- **Node disable support:** Per-node enable/disable toggle in config sheet with visual dimming on both mobile cards and canvas nodes; Rust backend skips disabled nodes during execution while preserving downstream routing
- **Mobile save guard:** Block saving complex branching graphs from mobile layout to prevent silent edge destruction

## Test plan

- [x] `EditorNode.disabled` getter unit tests (3 cases: true, absent, false)
- [x] Desktop FABs (fit-to-view, auto-layout, add node) present on wide viewport, absent on narrow
- [x] Config sheet Enabled toggle presence, Disabled chip after toggle, skip subtitle display
- [x] Rust: disabled action node recorded as "skipped" and routes downstream via "success"
- [x] Rust: disabled `always_false` condition routes via "true" branch (primary outcome)
- [x] Workflow detail screen: delete flow, active/inactive toggle, test run, webhook secrets (existing)
- [x] All 552 Flutter tests pass, 6 Rust workflow tests pass
- [x] `make lint-flutter` and `cargo clippy` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added test run capability for workflows with success/failure feedback
  * Added webhook secrets display with copy-to-clipboard functionality
  * Added node enable/disable toggle; disabled nodes skip during execution
  * Added desktop canvas actions: fit-to-view and auto-layout

* **Improvements**
  * Confirm before deleting nodes and discarding unsaved changes
  * Added persona selection for assistant nodes
  * Visual indicators for disabled nodes

* **Bug Fixes & Refinements**
  * Enhanced color consistency across workflow UI
  * Improved hit target sizes for better mobile interaction

<!-- end of auto-generated comment: release notes by coderabbit.ai -->