### PR TITLE
fix(app): retain chat input focus after sending and improve cursor visibility

### DIFF
--- a/app/lib/features/chat/chat_screen.dart
+++ b/app/lib/features/chat/chat_screen.dart
@@ -166,7 +166,11 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     if (text.isEmpty && pending.isEmpty) return;
     if (isAppleTouch) HapticFeedback.lightImpact();
     _inputController.clear();
-    _inputFocus.requestFocus();
+    // Defer focus request: onSubmitted unfocuses the field after the callback
+    // returns, so an immediate requestFocus() gets overridden.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _inputFocus.requestFocus();
+    });
 
     // Upload pending attachments first, then send with IDs.
     final attachmentIds = <String>[];
@@ -1982,6 +1986,7 @@ class _InputRowState extends State<_InputRow> {
                           placeholder: widget.pendingAttachments.isNotEmpty
                               ? 'Add a caption...'
                               : 'Type a message...',
+                          cursorColor: colorScheme.primary,
                           padding: const EdgeInsets.symmetric(
                             horizontal: 14,
                             vertical: 10,
@@ -1995,6 +2000,7 @@ class _InputRowState extends State<_InputRow> {
                           key: const Key('message_input'),
                           controller: widget.controller,
                           focusNode: widget.focusNode,
+                          cursorColor: colorScheme.primary,
                           decoration: InputDecoration(
                             hintText: widget.pendingAttachments.isNotEmpty
                                 ? 'Add a caption...'

--- a/app/test/widget/features/chat/chat_screen_test.dart
+++ b/app/test/widget/features/chat/chat_screen_test.dart
@@ -23,6 +23,15 @@ class _FakeChatNotifier extends ChatNotifier {
   Future<ChatState> build() async => const ChatState();
 
   void push(ChatState s) => state = AsyncData(s);
+
+  @override
+  Future<void> sendMessage(
+    String message, {
+    List<String> attachmentIds = const [],
+    List<ChatAttachment> attachments = const [],
+  }) async {
+    // No-op — avoids HTTP calls in widget tests.
+  }
 }
 
 class _FakePersonasNotifier extends PersonasNotifier {
@@ -88,6 +97,73 @@ Future<({_FakeChatNotifier notifier})> pumpChatScreen(
 
 void main() {
   group('Chat screen — input behaviour', () {
+    testWidgets('input retains focus after tapping send button', (
+      tester,
+    ) async {
+      await pumpChatScreen(tester);
+
+      // Tap the input to focus it, then enter text.
+      final inputFinder = find.byKey(const Key('message_input'));
+      await tester.tap(inputFinder);
+      await tester.pump();
+      // Drain the 350 ms _onInputFocusChange timer triggered by gaining focus.
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.enterText(inputFinder, 'hello');
+      await tester.pump();
+
+      // Verify focus before sending.
+      final textField = tester.widget<TextField>(inputFinder);
+      expect(
+        textField.focusNode?.hasFocus,
+        isTrue,
+        reason: 'input should be focused before sending',
+      );
+
+      // Tap the send button.
+      await tester.tap(find.byKey(const Key('send_button')));
+      // Pump to process the post-frame callback that re-requests focus,
+      // then drain the 350 ms _onInputFocusChange timer.
+      await tester.pump();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      final afterSend = tester.widget<TextField>(inputFinder);
+      expect(
+        afterSend.focusNode?.hasFocus,
+        isTrue,
+        reason: 'input must retain focus after sending a message',
+      );
+    });
+
+    testWidgets('input retains focus after onSubmitted (Enter key)', (
+      tester,
+    ) async {
+      await pumpChatScreen(tester);
+
+      final inputFinder = find.byKey(const Key('message_input'));
+      await tester.tap(inputFinder);
+      await tester.pump();
+      // Drain the 350 ms _onInputFocusChange timer triggered by gaining focus.
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.enterText(inputFinder, 'hello');
+      await tester.pump();
+
+      // Simulate the Enter / Send text input action (triggers onSubmitted).
+      await tester.testTextInput.receiveAction(TextInputAction.send);
+      // Pump to process the post-frame callback that re-requests focus,
+      // then drain the 350 ms _onInputFocusChange timer.
+      await tester.pump();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      final afterSubmit = tester.widget<TextField>(inputFinder);
+      expect(
+        afterSubmit.focusNode?.hasFocus,
+        isTrue,
+        reason: 'input must retain focus after pressing Enter / Send',
+      );
+    });
+
     testWidgets('7.5: message_input field is enabled while isSending == true', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary
- **Focus retention**: Defers `requestFocus()` via `addPostFrameCallback` so the chat input stays focused after submitting a message (both via send button and Enter key). Previously `onSubmitted` would unfocus the field after the callback returned, overriding the immediate focus request.
- **Cursor visibility**: Adds explicit `cursorColor: colorScheme.primary` to both `CupertinoTextField` and `TextField` so the cursor is always visible when the input is empty.
- **Test fake**: Overrides `sendMessage` in the test's `_FakeChatNotifier` to avoid HTTP calls in widget tests.

## Test plan
- [x] Added widget test: input retains focus after tapping send button
- [x] Added widget test: input retains focus after `onSubmitted` (Enter key)
- [x] All 542 Flutter tests pass
- [x] `flutter analyze` — no issues
- [x] Pre-commit hooks pass (clippy, fmt, dart_pre_commit, flutter test)