### PR TITLE
fix(app): render tool calls as timeline entries and fix streaming progress indicator

### DIFF
--- a/app/lib/api/api_client.dart
+++ b/app/lib/api/api_client.dart
@@ -324,10 +324,7 @@ Stream<StreamEvent> parseSseByteStream(Stream<List<int>> byteStream) async* {
       } else if (eventType == 'done' && dataLine != null) {
         try {
           final json = jsonDecode(dataLine) as Map<String, dynamic>;
-          yield DoneEvent(
-            role: json['role'] as String? ?? 'assistant',
-            content: json['content'] as String? ?? '',
-          );
+          yield DoneEvent.fromJson(json);
         } catch (_) {
           yield DoneEvent(role: 'assistant', content: dataLine);
         }

--- a/app/lib/features/chat/chat_provider.dart
+++ b/app/lib/features/chat/chat_provider.dart
@@ -564,54 +564,91 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
     }
   }
 
-  /// Push a pending [ToolCallRecord] onto the streaming assistant message and
-  /// update state.  Called from both [_streamMessage] and [_streamVoiceMessage]
-  /// when a [StatusEvent] is received.
+  /// Create a tool-call timeline entry and insert it before the streaming
+  /// assistant placeholder. Called from both [_streamMessage] and
+  /// [_streamVoiceMessage] when a [StatusEvent] is received.
   void _onStatusEvent(ChatState chatState, String statusMessage) {
     final toolName = _extractToolName(statusMessage);
     final msgs = List<ChatMessage>.from(chatState.messages);
+
+    // Complete any currently-active timeline entries before adding a new one.
+    _completeActiveTimelineEntries(msgs);
+
+    final entryId =
+        'toolcall-$toolName-${DateTime.now().millisecondsSinceEpoch}';
+    final entry = ChatMessage(
+      id: entryId,
+      role: 'assistant',
+      content: '',
+      isStreaming: true,
+      timelineType: TimelineEntryType.toolCall,
+      toolCalls: [
+        ToolCallRecord(toolName: toolName, status: ToolCallStatus.pending),
+      ],
+    );
+
+    // Insert before the assistant-streaming placeholder so tool calls render
+    // above the reply bubble.
     final idx = msgs.indexWhere((m) => m.id == 'assistant-streaming');
     if (idx != -1) {
-      msgs[idx].toolCalls.add(
-        ToolCallRecord(toolName: toolName, status: ToolCallStatus.pending),
-      );
+      msgs.insert(idx, entry);
+    } else {
+      msgs.add(entry);
     }
+
     state = AsyncData(
       chatState.copyWith(messages: msgs, statusMessage: statusMessage),
     );
   }
 
-  /// Resolve the pending [ToolCallRecord] for [event] and update state.
+  /// Resolve the pending tool-call timeline entry for [event] and update state.
   /// Called from both [_streamMessage] and [_streamVoiceMessage].
   void _onToolResultEvent(ChatState chatState, ToolResultEvent event) {
     final resolvedStatus = _parseToolStatus(event.status);
     final msgs = List<ChatMessage>.from(chatState.messages);
-    final idx = msgs.indexWhere((m) => m.id == 'assistant-streaming');
-    if (idx != -1) {
-      final callIdx = msgs[idx].toolCalls.indexWhere(
-        (tc) =>
-            tc.toolName == event.toolName &&
-            tc.status == ToolCallStatus.pending,
-      );
-      if (callIdx != -1) {
-        msgs[idx].toolCalls[callIdx].status = resolvedStatus;
-        msgs[idx].toolCalls[callIdx].arguments = event.arguments;
-        msgs[idx].toolCalls[callIdx].result = event.result;
-        msgs[idx].toolCalls[callIdx].duration = DateTime.now().difference(
-          msgs[idx].toolCalls[callIdx].startedAt,
-        );
-      } else {
-        // No matching pending chip — append a resolved record directly.
-        msgs[idx].toolCalls.add(
+
+    // Find the pending tool-call timeline entry matching the tool name.
+    final entryIdx = msgs.lastIndexWhere(
+      (m) =>
+          m.timelineType == TimelineEntryType.toolCall &&
+          m.toolCalls.isNotEmpty &&
+          m.toolCalls.first.toolName == event.toolName &&
+          m.toolCalls.first.status == ToolCallStatus.pending,
+    );
+
+    if (entryIdx != -1) {
+      final record = msgs[entryIdx].toolCalls.first;
+      record.status = resolvedStatus;
+      record.arguments = event.arguments;
+      record.result = event.result;
+      record.duration = DateTime.now().difference(record.startedAt);
+      msgs[entryIdx].isStreaming = false;
+    } else {
+      // No matching pending entry — insert a resolved one directly.
+      final entryId =
+          'toolcall-${event.toolName}-${DateTime.now().millisecondsSinceEpoch}';
+      final idx = msgs.indexWhere((m) => m.id == 'assistant-streaming');
+      final entry = ChatMessage(
+        id: entryId,
+        role: 'assistant',
+        content: '',
+        timelineType: TimelineEntryType.toolCall,
+        toolCalls: [
           ToolCallRecord(
             toolName: event.toolName,
             status: resolvedStatus,
             arguments: event.arguments,
             result: event.result,
           ),
-        );
+        ],
+      );
+      if (idx != -1) {
+        msgs.insert(idx, entry);
+      } else {
+        msgs.add(entry);
       }
     }
+
     state = AsyncData(
       chatState.copyWith(
         messages: msgs,
@@ -839,36 +876,48 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
         id: conversationId,
       );
       final detail = response.data!;
-      final messages = detail.messages
-          .map(
-            (m) => ChatMessage(
-              id: m.id,
-              role: m.role,
-              content: m.content,
-              ttsAvailable: m.ttsAvailable,
-              toolCalls: m.toolCalls
-                  ?.map(
-                    (tc) => ToolCallRecord(
-                      toolName: tc.name,
-                      status: _parseToolStatus(tc.status),
-                      arguments: tc.arguments?.asMap.cast<String, dynamic>(),
-                      result: tc.result,
-                    ),
-                  )
-                  .toList(),
-              attachments: m.attachments
-                  ?.map(
-                    (a) => ChatAttachment(
-                      id: a.id,
-                      filename: a.filename,
-                      mimeType: a.mimeType,
-                      url: a.url,
-                    ),
-                  )
-                  .toList(),
+      final messages = <ChatMessage>[];
+      for (final m in detail.messages) {
+        // Convert persisted tool calls into separate timeline entries so
+        // they render identically to the streaming path.
+        final toolCalls = m.toolCalls?.toList() ?? <dynamic>[];
+        for (final tc in toolCalls) {
+          messages.add(
+            ChatMessage(
+              id: 'toolcall-${tc.name}-${m.id}',
+              role: 'assistant',
+              content: '',
+              timelineType: TimelineEntryType.toolCall,
+              toolCalls: [
+                ToolCallRecord(
+                  toolName: tc.name,
+                  status: _parseToolStatus(tc.status),
+                  arguments: tc.arguments?.asMap.cast<String, dynamic>(),
+                  result: tc.result,
+                ),
+              ],
             ),
-          )
-          .toList();
+          );
+        }
+        messages.add(
+          ChatMessage(
+            id: m.id,
+            role: m.role,
+            content: m.content,
+            ttsAvailable: m.ttsAvailable,
+            attachments: m.attachments
+                ?.map(
+                  (a) => ChatAttachment(
+                    id: a.id,
+                    filename: a.filename,
+                    mimeType: a.mimeType,
+                    url: a.url,
+                  ),
+                )
+                .toList(),
+          ),
+        );
+      }
 
       state = AsyncData(
         ChatState(conversationId: conversationId, messages: messages),
@@ -1104,12 +1153,10 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
           }
           final aIdx = ms.indexWhere((m) => m.id == 'assistant-streaming');
           if (aIdx != -1) {
-            final placeholder = ms[aIdx];
             ms[aIdx] = ChatMessage(
               id: 'assistant-${DateTime.now().millisecondsSinceEpoch}',
               role: 'assistant',
               content: event.content,
-              toolCalls: placeholder.toolCalls,
             );
           }
           state = AsyncData(
@@ -1308,7 +1355,6 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
               content: event.content,
               audioId: placeholder.audioId,
               ttsAvailable: placeholder.ttsAvailable,
-              toolCalls: placeholder.toolCalls,
             );
           }
           state = AsyncData(
@@ -1495,7 +1541,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
             msgs[userIdx] = msgs[userIdx].copyWith(status: MessageStatus.ok);
           }
           // Replace streaming placeholder with final assistant message,
-          // preserving audio id and accumulated tool call records.
+          // preserving audio id. Tool calls are separate timeline entries.
           final assistantId =
               event.messageId ??
               'assistant-${DateTime.now().millisecondsSinceEpoch}';
@@ -1508,7 +1554,6 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
               content: event.content,
               audioId: placeholder.audioId,
               ttsAvailable: placeholder.ttsAvailable,
-              toolCalls: placeholder.toolCalls,
             );
           }
           state = AsyncData(
@@ -1564,14 +1609,12 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
         final msgs = List<ChatMessage>.from(finalState.messages);
         final idx = msgs.indexWhere((m) => m.id == 'assistant-streaming');
         if (idx != -1) {
-          final placeholder = msgs[idx];
           msgs[idx] = ChatMessage(
             id: 'assistant-${DateTime.now().millisecondsSinceEpoch}',
             role: 'assistant',
             content: finalState.streamingContent.isNotEmpty
                 ? finalState.streamingContent
                 : '(incomplete response)',
-            toolCalls: placeholder.toolCalls,
           );
         }
         // Mark user message as ok — we got at least a partial response.

--- a/app/lib/features/chat/chat_screen.dart
+++ b/app/lib/features/chat/chat_screen.dart
@@ -33,7 +33,6 @@ import 'commands_provider.dart';
 import 'conversation_list.dart';
 import 'image_utils.dart';
 import 'streaming_timeline_entry.dart';
-import 'tool_call_chip.dart';
 import 'voice_recorder_button.dart';
 
 /// Main chat screen.
@@ -683,13 +682,7 @@ class _MessageBubble extends StatelessWidget {
                   ? Border.all(color: colorScheme.error, width: 1.5)
                   : null,
             ),
-            child:
-                message.isStreaming &&
-                    message.content.isEmpty &&
-                    message.toolCalls.isEmpty &&
-                    message.tokenStream == null
-                ? _streamingDotsIndicator()
-                : isUser
+            child: isUser
                 ? Column(
                     crossAxisAlignment: CrossAxisAlignment.end,
                     mainAxisSize: MainAxisSize.min,
@@ -742,25 +735,9 @@ class _MessageBubble extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      // Tool call chips — one per invocation, in order.
-                      if (message.toolCalls.isNotEmpty)
-                        Padding(
-                          padding: const EdgeInsets.only(bottom: 4),
-                          child: Wrap(
-                            spacing: 4,
-                            runSpacing: 4,
-                            children: message.toolCalls
-                                .map((tc) => ToolCallChip(record: tc))
-                                .toList(),
-                          ),
-                        ),
-                      // Divider between chips and reply text.
-                      if (message.toolCalls.isNotEmpty &&
-                          message.content.isNotEmpty)
-                        const Padding(
-                          padding: EdgeInsets.only(bottom: 6),
-                          child: Divider(height: 1, thickness: 0.5),
-                        ),
+                      // Animated dots while waiting for first token.
+                      if (message.isStreaming && message.content.isEmpty)
+                        _streamingDotsIndicator(),
                       if (message.isStreaming && message.tokenStream != null)
                         StreamMarkdown(
                           stream: message.tokenStream!,
@@ -783,7 +760,7 @@ class _MessageBubble extends StatelessWidget {
                           builderRegistry: BuilderRegistry()
                             ..register('mermaid', const MermaidBuilder()),
                         )
-                      else
+                      else if (message.content.isNotEmpty)
                         SmoothMarkdown(
                           data: message.content,
                           styleSheet:

--- a/app/test/unit/api/sse_parser_test.dart
+++ b/app/test/unit/api/sse_parser_test.dart
@@ -87,6 +87,19 @@ void main() {
       expect(done.content, equals('hi'));
     });
 
+    test('DoneEvent preserves messageId when present in JSON', () async {
+      const raw =
+          'event: done\ndata: {"role":"assistant","content":"ok","message_id":"abc-123"}\n\n';
+      final events = await parseSseByteStream(_uint8Stream(raw)).toList();
+      expect(events, hasLength(1));
+      final done = events.first as DoneEvent;
+      expect(
+        done.messageId,
+        equals('abc-123'),
+        reason: 'messageId must be parsed from the done event JSON',
+      );
+    });
+
     test('DoneEvent falls back when data is not valid JSON', () async {
       const raw = 'event: done\ndata: not-json\n\n';
       final events = await parseSseByteStream(_uint8Stream(raw)).toList();

--- a/app/test/widget/features/chat/chat_screen_test.dart
+++ b/app/test/widget/features/chat/chat_screen_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:assistant_api/assistant_api.dart' hide ServerCapabilities;
@@ -8,6 +9,7 @@ import 'package:assistant_app/api/models/server_profile.dart';
 import 'package:assistant_app/features/chat/audio_player_widget.dart';
 import 'package:assistant_app/features/chat/chat_provider.dart';
 import 'package:assistant_app/features/chat/chat_screen.dart';
+import 'package:assistant_app/features/chat/streaming_timeline_entry.dart';
 import 'package:assistant_app/features/connection/connection_provider.dart';
 import 'package:assistant_app/features/personas/personas_provider.dart';
 import 'package:cached_network_image/cached_network_image.dart';
@@ -894,15 +896,17 @@ void main() {
 
   group('Chat screen — streaming dots gate', () {
     testWidgets(
-      'tool call chips render during streaming even when content is empty',
+      'tool call timeline entry renders as StreamingTimelineEntry during streaming',
       (tester) async {
         final res = await pumpChatScreen(tester);
 
-        final assistantMsg = ChatMessage(
-          id: 'assistant-streaming',
+        // Tool calls are separate timeline entries, not chips on the bubble.
+        final toolCallEntry = ChatMessage(
+          id: 'toolcall-web-search-1',
           role: 'assistant',
           content: '',
           isStreaming: true,
+          timelineType: TimelineEntryType.toolCall,
           toolCalls: [
             ToolCallRecord(
               toolName: 'web-search',
@@ -910,22 +914,33 @@ void main() {
             ),
           ],
         );
+        final assistantMsg = ChatMessage(
+          id: 'assistant-streaming',
+          role: 'assistant',
+          content: '',
+          isStreaming: true,
+        );
 
         res.notifier.push(
           ChatState(
             conversationId: 'c1',
-            messages: [assistantMsg],
+            messages: [toolCallEntry, assistantMsg],
             isSending: true,
           ),
         );
         await tester.pump();
 
-        // Tool call chip should be visible (not hidden behind dots).
+        // Tool call renders as a StreamingTimelineEntry (vertical, outside bubble).
+        expect(
+          find.byType(StreamingTimelineEntry),
+          findsOneWidget,
+          reason:
+              'Tool call must render as StreamingTimelineEntry, not a chip in the bubble',
+        );
         expect(
           find.text('web-search'),
           findsOneWidget,
-          reason:
-              'Tool call chip must render during streaming even when content is empty',
+          reason: 'Tool name must be visible in the timeline entry',
         );
       },
     );
@@ -966,5 +981,97 @@ void main() {
         );
       },
     );
+
+    testWidgets(
+      'dots shown when streaming with tokenStream set but no content yet',
+      (tester) async {
+        final res = await pumpChatScreen(tester);
+
+        // This matches real behaviour: the provider always creates the
+        // placeholder with a non-null tokenStream.
+        final controller = StreamController<String>.broadcast();
+        addTearDown(controller.close);
+
+        final assistantMsg = ChatMessage(
+          id: 'assistant-streaming',
+          role: 'assistant',
+          content: '',
+          isStreaming: true,
+          tokenStream: controller.stream,
+        );
+
+        res.notifier.push(
+          ChatState(
+            conversationId: 'c1',
+            messages: [assistantMsg],
+            isSending: true,
+          ),
+        );
+        await tester.pump();
+
+        // Dots indicator must appear even when tokenStream is non-null.
+        expect(
+          find.byWidgetPredicate(
+            (w) => w is SizedBox && w.height == 16 && w.width == 40,
+          ),
+          findsOneWidget,
+          reason:
+              'Dots indicator must show before first token even when tokenStream is set',
+        );
+      },
+    );
+
+    testWidgets('dots disappear once content arrives', (tester) async {
+      final res = await pumpChatScreen(tester);
+
+      final controller = StreamController<String>.broadcast();
+      addTearDown(controller.close);
+
+      final assistantMsg = ChatMessage(
+        id: 'assistant-streaming',
+        role: 'assistant',
+        content: '',
+        isStreaming: true,
+        tokenStream: controller.stream,
+      );
+
+      res.notifier.push(
+        ChatState(
+          conversationId: 'c1',
+          messages: [assistantMsg],
+          isSending: true,
+        ),
+      );
+      await tester.pump();
+
+      // Dots should be visible initially.
+      expect(
+        find.byWidgetPredicate(
+          (w) => w is SizedBox && w.height == 16 && w.width == 40,
+        ),
+        findsOneWidget,
+      );
+
+      // Simulate first token arriving — update content.
+      assistantMsg.content = 'Hello';
+      res.notifier.push(
+        ChatState(
+          conversationId: 'c1',
+          messages: [assistantMsg],
+          isSending: true,
+          streamingContent: 'Hello',
+        ),
+      );
+      await tester.pump();
+
+      // Dots must be gone now.
+      expect(
+        find.byWidgetPredicate(
+          (w) => w is SizedBox && w.height == 16 && w.width == 40,
+        ),
+        findsNothing,
+        reason: 'Dots must disappear once content starts streaming',
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary

- **Tool calls rendered as vertical timeline entries** instead of horizontal chips inside the assistant bubble. This makes streaming and reload render identically — tool calls appear as `StreamingTimelineEntry` widgets above the reply bubble, with spinner/status icon, duration badge, and expandable arguments/result.
- **Fixed streaming dots indicator** that never appeared: the condition checked `tokenStream == null` but the streaming placeholder always had a non-null `tokenStream`. Dots now show inside the assistant column while waiting for the first token.
- **Fixed `DoneEvent.messageId` being dropped** by the SSE parser — now uses `DoneEvent.fromJson()` instead of manual construction.

## Test plan

- [x] New test: tool call timeline entry renders as `StreamingTimelineEntry` during streaming
- [x] New test: dots shown when `tokenStream` is set but no content yet
- [x] New test: dots disappear once content arrives
- [x] New test: `DoneEvent` preserves `messageId` from JSON
- [x] All 559 Flutter tests pass
- [x] `flutter analyze --fatal-infos` — zero issues
- [x] `dart format` — no changes needed
- [ ] Manual: send a message, observe tool calls appear as vertical timeline entries with spinner → checkmark
- [ ] Manual: reload conversation, verify tool calls render identically
- [ ] Manual: observe animated dots while agent is inferencing before first token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Tool calls now appear as separate timeline entries within chat conversations.
  * Streaming indicators for chat messages have been refined.
  * Tool call chip display format has been removed from the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->