### PR TITLE
feat(runtime): propagate tool_call_id for stable tool-call correlation

### DIFF
--- a/app/lib/api/api_client.dart
+++ b/app/lib/api/api_client.dart
@@ -306,7 +306,13 @@ Stream<StreamEvent> parseSseByteStream(Stream<List<int>> byteStream) async* {
       if (eventType == 'token' && dataLine != null) {
         yield TokenEvent(dataLine);
       } else if (eventType == 'status' && dataLine != null) {
-        yield StatusEvent(dataLine);
+        try {
+          final json = jsonDecode(dataLine) as Map<String, dynamic>;
+          yield StatusEvent.fromJson(json);
+        } catch (_) {
+          // Older servers send plain-text status messages.
+          yield StatusEvent(dataLine);
+        }
       } else if (eventType == 'tool_result' && dataLine != null) {
         try {
           final json = jsonDecode(dataLine) as Map<String, dynamic>;

--- a/app/lib/api/models/stream_event.dart
+++ b/app/lib/api/models/stream_event.dart
@@ -99,23 +99,38 @@ class TokenEvent extends StreamEvent {
 ///
 /// Corresponds to `event:status` in the SSE stream.  The caller may display
 /// this as a transient status indicator (e.g. "Calling tool: web-search").
+///
+/// The data payload is JSON: `{"message":"...","tool_call_id":"..."}`.
+/// Older servers may send a plain string — the parser falls back gracefully.
 class StatusEvent extends StreamEvent {
-  const StatusEvent(this.message);
+  const StatusEvent(this.message, {this.toolCallId});
 
   /// Human-readable status message.
   final String message;
+
+  /// Provider-assigned tool-call ID (e.g. Anthropic `tool_use_id`).
+  /// `null` when the server does not include it.
+  final String? toolCallId;
+
+  factory StatusEvent.fromJson(Map<String, dynamic> json) {
+    return StatusEvent(
+      json['message'] as String? ?? '',
+      toolCallId: json['tool_call_id'] as String?,
+    );
+  }
 }
 
 /// A tool execution completed.
 ///
 /// Corresponds to `event:tool_result` in the SSE stream.  The JSON body is
-/// `{"tool_name":"...","status":"ok"|"error"|"denied","arguments":{...},"result":"..."}`.
+/// `{"tool_name":"...","status":"ok"|"error"|"denied","arguments":{...},"result":"...","tool_call_id":"..."}`.
 class ToolResultEvent extends StreamEvent {
   const ToolResultEvent({
     required this.toolName,
     required this.status,
     this.arguments,
     this.result,
+    this.toolCallId,
   });
 
   /// The name of the tool that was called.
@@ -130,12 +145,17 @@ class ToolResultEvent extends StreamEvent {
   /// The tool's output, truncated for display (may be null).
   final String? result;
 
+  /// Provider-assigned tool-call ID (e.g. Anthropic `tool_use_id`).
+  /// `null` for providers that do not use IDs (Ollama) or older servers.
+  final String? toolCallId;
+
   factory ToolResultEvent.fromJson(Map<String, dynamic> json) {
     return ToolResultEvent(
       toolName: json['tool_name'] as String? ?? '',
       status: json['status'] as String? ?? 'ok',
       arguments: json['arguments'] as Map<String, dynamic>?,
       result: json['result'] as String?,
+      toolCallId: json['tool_call_id'] as String?,
     );
   }
 }

--- a/app/lib/features/chat/chat_provider.dart
+++ b/app/lib/features/chat/chat_provider.dart
@@ -221,6 +221,7 @@ class ToolCallRecord {
   ToolCallRecord({
     required this.toolName,
     required this.status,
+    this.toolCallId,
     this.arguments,
     this.result,
     DateTime? startedAt,
@@ -228,6 +229,10 @@ class ToolCallRecord {
   }) : startedAt = startedAt ?? DateTime.now();
 
   final String toolName;
+
+  /// Provider-assigned tool-call ID (e.g. Anthropic `tool_use_id`).
+  /// Used to correlate StatusEvent → ToolResultEvent when available.
+  final String? toolCallId;
 
   /// Mutable so the pending chip can be updated to a resolved status in place
   /// during streaming, matching the pattern used for [ChatMessage.content].
@@ -567,8 +572,8 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
   /// Create a tool-call timeline entry and insert it before the streaming
   /// assistant placeholder. Called from both [_streamMessage] and
   /// [_streamVoiceMessage] when a [StatusEvent] is received.
-  void _onStatusEvent(ChatState chatState, String statusMessage) {
-    final toolName = _extractToolName(statusMessage);
+  void _onStatusEvent(ChatState chatState, StatusEvent event) {
+    final toolName = _extractToolName(event.message);
     final msgs = List<ChatMessage>.from(chatState.messages);
 
     // Complete any currently-active timeline entries before adding a new one.
@@ -583,7 +588,11 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
       isStreaming: true,
       timelineType: TimelineEntryType.toolCall,
       toolCalls: [
-        ToolCallRecord(toolName: toolName, status: ToolCallStatus.pending),
+        ToolCallRecord(
+          toolName: toolName,
+          status: ToolCallStatus.pending,
+          toolCallId: event.toolCallId,
+        ),
       ],
     );
 
@@ -597,7 +606,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
     }
 
     state = AsyncData(
-      chatState.copyWith(messages: msgs, statusMessage: statusMessage),
+      chatState.copyWith(messages: msgs, statusMessage: event.message),
     );
   }
 
@@ -607,14 +616,22 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
     final resolvedStatus = _parseToolStatus(event.status);
     final msgs = List<ChatMessage>.from(chatState.messages);
 
-    // Find the pending tool-call timeline entry matching the tool name.
-    final entryIdx = msgs.lastIndexWhere(
-      (m) =>
-          m.timelineType == TimelineEntryType.toolCall &&
-          m.toolCalls.isNotEmpty &&
-          m.toolCalls.first.toolName == event.toolName &&
-          m.toolCalls.first.status == ToolCallStatus.pending,
-    );
+    // Match by toolCallId when available (stable), fall back to tool name.
+    final entryIdx = event.toolCallId != null
+        ? msgs.lastIndexWhere(
+            (m) =>
+                m.timelineType == TimelineEntryType.toolCall &&
+                m.toolCalls.isNotEmpty &&
+                m.toolCalls.first.toolCallId == event.toolCallId &&
+                m.toolCalls.first.status == ToolCallStatus.pending,
+          )
+        : msgs.lastIndexWhere(
+            (m) =>
+                m.timelineType == TimelineEntryType.toolCall &&
+                m.toolCalls.isNotEmpty &&
+                m.toolCalls.first.toolName == event.toolName &&
+                m.toolCalls.first.status == ToolCallStatus.pending,
+          );
 
     if (entryIdx != -1) {
       final record = msgs[entryIdx].toolCalls.first;
@@ -1140,7 +1157,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
           );
         } else if (event is StatusEvent) {
           _lastSeq++;
-          _onStatusEvent(chatState, event.message);
+          _onStatusEvent(chatState, event);
         } else if (event is ToolResultEvent) {
           _lastSeq++;
           _onToolResultEvent(chatState, event);
@@ -1306,7 +1323,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
             ),
           );
         } else if (event is StatusEvent) {
-          _onStatusEvent(chatState, event.message);
+          _onStatusEvent(chatState, event);
         } else if (event is ToolResultEvent) {
           _onToolResultEvent(chatState, event);
         } else if (event is ThinkingEvent) {
@@ -1510,7 +1527,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
           );
         } else if (event is StatusEvent) {
           _lastSeq++;
-          _onStatusEvent(chatState, event.message);
+          _onStatusEvent(chatState, event);
         } else if (event is ToolResultEvent) {
           _lastSeq++;
           _onToolResultEvent(chatState, event);

--- a/app/test/unit/api/sse_parser_test.dart
+++ b/app/test/unit/api/sse_parser_test.dart
@@ -152,6 +152,48 @@ void main() {
     });
 
     // -----------------------------------------------------------------------
+    // Status event with tool_call_id
+    // -----------------------------------------------------------------------
+
+    test('StatusEvent parses toolCallId from JSON data', () async {
+      const raw =
+          'event: status\ndata: {"message":"Calling tool: web-search","tool_call_id":"call_abc123"}\n\n';
+      final events = await parseSseByteStream(_uint8Stream(raw)).toList();
+      expect(events, hasLength(1));
+      final status = events.first as StatusEvent;
+      expect(status.message, equals('Calling tool: web-search'));
+      expect(status.toolCallId, equals('call_abc123'));
+    });
+
+    test('StatusEvent handles plain-text data for backwards compat', () async {
+      const raw = 'event: status\ndata: Calling tool: file-read\n\n';
+      final events = await parseSseByteStream(_uint8Stream(raw)).toList();
+      expect(events, hasLength(1));
+      final status = events.first as StatusEvent;
+      expect(status.message, equals('Calling tool: file-read'));
+      expect(status.toolCallId, isNull);
+    });
+
+    test('ToolResultEvent parses toolCallId from JSON data', () async {
+      const raw =
+          'event: tool_result\ndata: {"tool_name":"web-search","status":"ok","tool_call_id":"call_xyz789"}\n\n';
+      final events = await parseSseByteStream(_uint8Stream(raw)).toList();
+      expect(events, hasLength(1));
+      final result = events.first as ToolResultEvent;
+      expect(result.toolName, equals('web-search'));
+      expect(result.toolCallId, equals('call_xyz789'));
+    });
+
+    test('ToolResultEvent has null toolCallId when not in JSON', () async {
+      const raw =
+          'event: tool_result\ndata: {"tool_name":"file-read","status":"ok"}\n\n';
+      final events = await parseSseByteStream(_uint8Stream(raw)).toList();
+      expect(events, hasLength(1));
+      final result = events.first as ToolResultEvent;
+      expect(result.toolCallId, isNull);
+    });
+
+    // -----------------------------------------------------------------------
     // Empty stream
     // -----------------------------------------------------------------------
 

--- a/crates/runtime/src/orchestrator/dispatch.rs
+++ b/crates/runtime/src/orchestrator/dispatch.rs
@@ -110,6 +110,7 @@ impl Orchestrator {
         turn_attachments: &mut Vec<Attachment>,
         turn_attachment_ids: &mut Vec<Uuid>,
         event_sink: Option<&mpsc::Sender<OrchestratorEvent>>,
+        tool_call_id: Option<&str>,
     ) -> String {
         let duration_ms = elapsed.as_millis() as i64;
         let span_name = format!("execute_tool {tool_name}");
@@ -245,6 +246,7 @@ impl Orchestrator {
                     status: tool_status.to_string(),
                     arguments: tool_arguments.cloned(),
                     result: truncated_result,
+                    tool_call_id: tool_call_id.map(|s| s.to_string()),
                 })
                 .await;
 
@@ -315,6 +317,7 @@ impl Orchestrator {
         tool_handlers: &[Arc<dyn ToolHandler>],
         instrument_span: &tracing::Span,
         event_sink: Option<&mpsc::Sender<OrchestratorEvent>>,
+        tool_call_id: Option<&str>,
     ) -> DispatchOutcome {
         // Confirmation gate.
         let requires_confirm = tool_handlers
@@ -350,6 +353,7 @@ impl Orchestrator {
                         status: "denied".to_string(),
                         arguments: Some(params.clone()),
                         result: Some(observation.clone()),
+                        tool_call_id: tool_call_id.map(|s| s.to_string()),
                     })
                     .await;
             }
@@ -358,7 +362,10 @@ impl Orchestrator {
 
         if let Some(sink) = event_sink {
             let _ = sink
-                .send(OrchestratorEvent::Status(format!("Calling tool: {name}")))
+                .send(OrchestratorEvent::Status {
+                    message: format!("Calling tool: {name}"),
+                    tool_call_id: tool_call_id.map(|s| s.to_string()),
+                })
                 .await;
         }
 
@@ -385,6 +392,7 @@ impl Orchestrator {
             turn_attachments,
             turn_attachment_ids,
             event_sink,
+            tool_call_id,
         )
         .await;
 

--- a/crates/runtime/src/orchestrator/mod.rs
+++ b/crates/runtime/src/orchestrator/mod.rs
@@ -708,6 +708,7 @@ impl Orchestrator {
                     for tool_call_item in tool_call_items {
                         let name = tool_call_item.name;
                         let params = tool_call_item.params;
+                        let tool_call_id = tool_call_item.id;
                         let turn_index = base_turn + iteration as i64 + 1;
                         let active_skill_guard = self.active_skill.read().await;
                         let active_skill_ref = active_skill_guard.as_deref();
@@ -752,9 +753,10 @@ impl Orchestrator {
 
                             if let Some(sink) = token_sink.as_ref() {
                                 let _ = sink
-                                    .send(OrchestratorEvent::Status(format!(
-                                        "Calling tool: {name}"
-                                    )))
+                                    .send(OrchestratorEvent::Status {
+                                        message: format!("Calling tool: {name}"),
+                                        tool_call_id: tool_call_id.clone(),
+                                    })
                                     .await;
                             }
 
@@ -777,6 +779,7 @@ impl Orchestrator {
                                 &mut turn_attachments,
                                 &mut turn_attachment_ids,
                                 token_sink.as_ref(),
+                                tool_call_id.as_deref(),
                             )
                             .await;
                         } else {
@@ -801,6 +804,7 @@ impl Orchestrator {
                                     &tool_handlers,
                                     &builtin_span,
                                     token_sink.as_ref(),
+                                    tool_call_id.as_deref(),
                                 )
                                 .await;
                             if matches!(outcome, DispatchOutcome::Denied) {
@@ -1117,6 +1121,7 @@ impl Orchestrator {
                     for tool_call_item in tool_call_items {
                         let name = tool_call_item.name;
                         let params = tool_call_item.params;
+                        let tool_call_id = tool_call_item.id;
                         let turn_index = base_turn + iteration as i64 + 1;
                         let active_skill_guard = self.active_skill.read().await;
                         let active_skill_ref = active_skill_guard.as_deref();
@@ -1147,6 +1152,7 @@ impl Orchestrator {
                                 &tool_handlers,
                                 &iteration_span,
                                 token_sink.as_ref(),
+                                tool_call_id.as_deref(),
                             )
                             .await;
                         if matches!(outcome, DispatchOutcome::Denied) {

--- a/crates/runtime/src/orchestrator/stream_event.rs
+++ b/crates/runtime/src/orchestrator/stream_event.rs
@@ -19,7 +19,13 @@ pub enum OrchestratorEvent {
     /// A human-readable status update while the turn is in progress.
     ///
     /// Examples: `"Calling tool: web-search"`, `"Processing results…"`.
-    Status(String),
+    Status {
+        /// Human-readable status message.
+        message: String,
+        /// Provider-assigned tool-call ID (e.g. Anthropic `tool_use_id`).
+        /// `None` for status messages that are not tool-call related.
+        tool_call_id: Option<String>,
+    },
 
     /// A tool call completed (successfully or with an error).
     ToolResult {
@@ -31,6 +37,9 @@ pub enum OrchestratorEvent {
         arguments: Option<serde_json::Value>,
         /// The tool's output, truncated to a reasonable display length.
         result: Option<String>,
+        /// Provider-assigned tool-call ID (e.g. Anthropic `tool_use_id`).
+        /// `None` for providers that do not use IDs (Ollama).
+        tool_call_id: Option<String>,
     },
 
     /// A skill run completed (success or failure).
@@ -180,6 +189,55 @@ mod tests {
     }
 
     #[test]
+    fn status_event_carries_tool_call_id() {
+        let event = OrchestratorEvent::Status {
+            message: "Calling tool: web-search".to_string(),
+            tool_call_id: Some("call_abc123".to_string()),
+        };
+        match event {
+            OrchestratorEvent::Status {
+                message,
+                tool_call_id,
+            } => {
+                assert_eq!(message, "Calling tool: web-search");
+                assert_eq!(tool_call_id.as_deref(), Some("call_abc123"));
+            }
+            _ => panic!("expected Status variant"),
+        }
+    }
+
+    #[test]
+    fn status_event_without_tool_call_id() {
+        let event = OrchestratorEvent::Status {
+            message: "Processing…".to_string(),
+            tool_call_id: None,
+        };
+        match event {
+            OrchestratorEvent::Status { tool_call_id, .. } => {
+                assert!(tool_call_id.is_none());
+            }
+            _ => panic!("expected Status variant"),
+        }
+    }
+
+    #[test]
+    fn tool_result_carries_tool_call_id() {
+        let event = OrchestratorEvent::ToolResult {
+            tool_name: "file-read".to_string(),
+            status: "ok".to_string(),
+            arguments: None,
+            result: Some("contents".to_string()),
+            tool_call_id: Some("call_xyz789".to_string()),
+        };
+        match event {
+            OrchestratorEvent::ToolResult { tool_call_id, .. } => {
+                assert_eq!(tool_call_id.as_deref(), Some("call_xyz789"));
+            }
+            _ => panic!("expected ToolResult variant"),
+        }
+    }
+
+    #[test]
     fn subagent_event_wraps_inner_events() {
         let event = OrchestratorEvent::SubagentEvent {
             agent_id: "research-agent".to_string(),
@@ -188,6 +246,7 @@ mod tests {
                 status: "ok".to_string(),
                 arguments: Some(serde_json::json!({"query": "rust async"})),
                 result: Some("Found results".to_string()),
+                tool_call_id: Some("call_inner_123".to_string()),
             }),
         };
         match event {

--- a/crates/runtime/src/orchestrator/subagent.rs
+++ b/crates/runtime/src/orchestrator/subagent.rs
@@ -423,6 +423,7 @@ impl SubagentRunner for Orchestrator {
 
                             let name = tool_call_item.name;
                             let params = tool_call_item.params;
+                            let tool_call_id = tool_call_item.id;
                             let turn_index = base_turn + iteration as i64 + 1;
 
                             // -- OTel: tool span (child of agent span) ---------
@@ -502,6 +503,7 @@ impl SubagentRunner for Orchestrator {
                                 &mut scratch_attachments,
                                 &mut scratch_attachment_ids,
                                 child_event_sink.as_ref(),
+                                tool_call_id.as_deref(),
                             )
                             .await;
 

--- a/crates/web-ui/src/api/mod.rs
+++ b/crates/web-ui/src/api/mod.rs
@@ -973,9 +973,15 @@ pub async fn send_message(
                     let e = Event::default().event("token").data(token.clone());
                     ("token", p, e)
                 }
-                OrchestratorEvent::Status(ref msg) => {
-                    let p = serde_json::json!({"message": msg});
-                    let e = Event::default().event("status").data(msg.clone());
+                OrchestratorEvent::Status {
+                    ref message,
+                    ref tool_call_id,
+                } => {
+                    let mut p = serde_json::json!({"message": message});
+                    if let Some(id) = tool_call_id {
+                        p["tool_call_id"] = serde_json::Value::String(id.clone());
+                    }
+                    let e = Event::default().event("status").data(p.to_string());
                     ("status", p, e)
                 }
                 OrchestratorEvent::ToolResult {
@@ -983,6 +989,7 @@ pub async fn send_message(
                     ref status,
                     ref arguments,
                     ref result,
+                    ref tool_call_id,
                 } => {
                     let mut p = serde_json::json!({"tool_name": tool_name, "status": status});
                     if let Some(args) = arguments {
@@ -990,6 +997,9 @@ pub async fn send_message(
                     }
                     if let Some(res) = result {
                         p["result"] = serde_json::Value::String(res.clone());
+                    }
+                    if let Some(id) = tool_call_id {
+                        p["tool_call_id"] = serde_json::Value::String(id.clone());
                     }
                     let e = Event::default().event("tool_result").data(p.to_string());
                     ("tool_result", p, e)
@@ -1099,18 +1109,29 @@ pub async fn send_message(
                         OrchestratorEvent::Thinking(t) => {
                             ("subagent_thinking", serde_json::json!({"content": t}))
                         }
-                        OrchestratorEvent::Status(s) => {
-                            ("subagent_status", serde_json::json!({"message": s}))
+                        OrchestratorEvent::Status {
+                            message,
+                            tool_call_id,
+                        } => {
+                            let mut d = serde_json::json!({"message": message});
+                            if let Some(id) = tool_call_id {
+                                d["tool_call_id"] = serde_json::Value::String(id.clone());
+                            }
+                            ("subagent_status", d)
                         }
                         OrchestratorEvent::ToolResult {
                             tool_name,
                             status,
                             arguments,
                             result,
-                        } => (
-                            "subagent_tool_result",
-                            serde_json::json!({"tool_name": tool_name, "status": status, "arguments": arguments, "result": result}),
-                        ),
+                            tool_call_id,
+                        } => {
+                            let mut d = serde_json::json!({"tool_name": tool_name, "status": status, "arguments": arguments, "result": result});
+                            if let Some(id) = tool_call_id {
+                                d["tool_call_id"] = serde_json::Value::String(id.clone());
+                            }
+                            ("subagent_tool_result", d)
+                        }
                         other => (
                             "subagent_event",
                             serde_json::json!({"type": format!("{other:?}")}),
@@ -1774,12 +1795,22 @@ pub async fn send_voice_message(
                     full_text.push_str(&token);
                     Event::default().event("token").data(token)
                 }
-                OrchestratorEvent::Status(msg) => Event::default().event("status").data(msg),
+                OrchestratorEvent::Status {
+                    message,
+                    tool_call_id,
+                } => {
+                    let mut data = serde_json::json!({"message": message});
+                    if let Some(id) = tool_call_id {
+                        data["tool_call_id"] = serde_json::Value::String(id);
+                    }
+                    Event::default().event("status").data(data.to_string())
+                }
                 OrchestratorEvent::ToolResult {
                     tool_name,
                     status,
                     arguments,
                     result,
+                    tool_call_id,
                 } => {
                     let mut data = serde_json::json!({
                         "tool_name": tool_name,
@@ -1790,6 +1821,9 @@ pub async fn send_voice_message(
                     }
                     if let Some(res) = result {
                         data["result"] = serde_json::Value::String(res);
+                    }
+                    if let Some(id) = tool_call_id {
+                        data["tool_call_id"] = serde_json::Value::String(id);
                     }
                     Event::default().event("tool_result").data(data.to_string())
                 }
@@ -1836,18 +1870,29 @@ pub async fn send_voice_message(
                         OrchestratorEvent::Thinking(t) => {
                             ("thinking", serde_json::json!({"content": t}))
                         }
-                        OrchestratorEvent::Status(s) => {
-                            ("status", serde_json::json!({"message": s}))
+                        OrchestratorEvent::Status {
+                            message,
+                            tool_call_id,
+                        } => {
+                            let mut d = serde_json::json!({"message": message});
+                            if let Some(id) = tool_call_id {
+                                d["tool_call_id"] = serde_json::Value::String(id.clone());
+                            }
+                            ("status", d)
                         }
                         OrchestratorEvent::ToolResult {
                             tool_name,
                             status,
                             arguments,
                             result,
-                        } => (
-                            "tool_result",
-                            serde_json::json!({"tool_name": tool_name, "status": status, "arguments": arguments, "result": result}),
-                        ),
+                            tool_call_id,
+                        } => {
+                            let mut d = serde_json::json!({"tool_name": tool_name, "status": status, "arguments": arguments, "result": result});
+                            if let Some(id) = tool_call_id {
+                                d["tool_call_id"] = serde_json::Value::String(id.clone());
+                            }
+                            ("tool_result", d)
+                        }
                         other => ("event", serde_json::json!({"type": format!("{other:?}")})),
                     };
                     let event_type = format!("subagent_{inner_type}");


### PR DESCRIPTION
## Summary

- Threads provider-assigned `tool_call_id` (e.g. Anthropic `tool_use_id`) end-to-end from the LLM response through `OrchestratorEvent::Status` / `OrchestratorEvent::ToolResult`, SSE serialization, and into the Flutter client
- Flutter `_onToolResultEvent` now matches by `toolCallId` when available, falling back to tool-name matching for providers that don't supply IDs (Ollama)
- Fixes a latent bug where two concurrent calls to the same tool could resolve against the wrong pending timeline entry

### Rust changes
- `OrchestratorEvent::Status` converted from tuple to struct variant with `message` + `tool_call_id: Option<String>`
- `OrchestratorEvent::ToolResult` gains `tool_call_id: Option<String>`
- `ToolCallItem.id` threaded through `dispatch.rs`, `mod.rs`, `subagent.rs`
- All 4 SSE serialization sites in `web-ui` include `tool_call_id` when present

### Flutter changes
- `StatusEvent` gains `toolCallId` field, now parsed from JSON (with plain-text fallback)
- `ToolResultEvent` gains `toolCallId` field
- `ToolCallRecord` gains `toolCallId` for correlation storage
- `_onToolResultEvent` matches by ID when available

## Test plan
- [x] 8 Rust unit tests pass (3 new: `status_event_carries_tool_call_id`, `status_event_without_tool_call_id`, `tool_result_carries_tool_call_id`)
- [x] 14 Flutter SSE parser tests pass (4 new: JSON status parsing, plain-text fallback, tool_result with/without toolCallId)
- [x] 32 chat screen widget tests pass
- [x] `cargo clippy -D warnings` clean
- [x] `flutter analyze` clean