### PR TITLE
fix(web-ui): align SSE with spec and harden for production

### DIFF
--- a/app/lib/api/api_client.dart
+++ b/app/lib/api/api_client.dart
@@ -300,7 +300,9 @@ Stream<StreamEvent> parseSseByteStream(Stream<List<int>> byteStream) async* {
     if (line.startsWith('event:')) {
       eventType = line.substring('event:'.length).trim();
     } else if (line.startsWith('data:')) {
-      dataLine = line.substring('data:'.length).trim();
+      // Per the SSE spec, multiple `data:` lines are concatenated with '\n'.
+      final value = line.substring('data:'.length).trim();
+      dataLine = dataLine == null ? value : '$dataLine\n$value';
     } else if (line.isEmpty) {
       // Blank line — dispatch the event.
       if (eventType == 'token' && dataLine != null) {
@@ -426,7 +428,8 @@ Stream<ConversationListEvent> parseConversationSseByteStream(
     if (line.startsWith('event:')) {
       eventType = line.substring('event:'.length).trim();
     } else if (line.startsWith('data:')) {
-      dataLine = line.substring('data:'.length).trim();
+      final value = line.substring('data:'.length).trim();
+      dataLine = dataLine == null ? value : '$dataLine\n$value';
     } else if (line.isEmpty) {
       if (eventType != null && dataLine != null) {
         try {

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -284,10 +284,10 @@ packages:
     dependency: "direct dev"
     description:
       name: dart_pre_commit
-      sha256: "2b1bbfb743412cf951fed41e27c693a1e1419e94c87d871531b3d3d5422ffd35"
+      sha256: cd8962e2e8e6cc3800c960ea85449e5407792ac52c053cbd9966af7a077c9f32
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.1+1"
+    version: "6.1.2"
   dbus:
     dependency: transitive
     description:
@@ -640,10 +640,10 @@ packages:
     dependency: transitive
     description:
       name: injectable
-      sha256: "32b36a9d87f18662bee0b1951b81f47a01f2bf28cd6ea94f60bc5453c7bf598c"
+      sha256: "1da6399509e44ddb0d8a4a35291d7122c4efb5c625a9d733bf5e48d4a72e379e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.7.1+4"
+    version: "3.0.0"
   intl:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -50,13 +50,13 @@ dev_dependencies:
   audioplayers_platform_interface: ^7.1.1
   flutter_launcher_icons: ^0.14.4
   built_collection: ^5.1.1
-  dart_pre_commit: ^6.1.1+1
+  dart_pre_commit: ^6.1.2
 flutter_launcher_icons:
   web:
     generate: true
     image_path: macos/Runner/Assets.xcassets/AppIcon.appiconset/app_icon_1024.png
-    background_color: '#080C1A'
-    theme_color: '#080C1A'
+    background_color: "#080C1A"
+    theme_color: "#080C1A"
 flutter:
   uses-material-design: true
   assets:

--- a/crates/web-ui/src/api/mod.rs
+++ b/crates/web-ui/src/api/mod.rs
@@ -50,6 +50,22 @@ where
     }
 }
 
+/// Build an SSE response with keepalive pings and `Cache-Control: no-cache`.
+///
+/// Keepalive prevents proxies from closing idle connections (nginx default 60s,
+/// AWS ALB 60s).  `Cache-Control: no-cache` prevents intermediaries from
+/// buffering the stream.
+fn sse_response(rx: mpsc::Receiver<Result<Event, Infallible>>) -> Response {
+    let mut response = Sse::new(ReceiverStream::new(rx))
+        .keep_alive(KeepAlive::default())
+        .into_response();
+    response.headers_mut().insert(
+        header::CACHE_CONTROL,
+        header::HeaderValue::from_static("no-cache"),
+    );
+    response
+}
+
 // -- Conversation API below --------------------------------------------------
 //
 // Designed for native/external clients (mobile apps, desktop apps, etc.)
@@ -92,7 +108,7 @@ use axum::{
     http::{StatusCode, header},
     response::{
         IntoResponse, Response,
-        sse::{Event, Sse},
+        sse::{Event, KeepAlive, Sse},
     },
     routing::{delete, get, patch, post},
 };
@@ -513,7 +529,7 @@ pub async fn stream_conversations(
         }
     });
 
-    Sse::new(ReceiverStream::new(sse_rx)).into_response()
+    sse_response(sse_rx)
 }
 
 /// `POST /api/conversations` — create a new conversation.
@@ -927,10 +943,11 @@ pub async fn send_message(
     // Emit run_started as first SSE event so the client learns the run_id.
     let run_started_sse = Event::default()
         .event("run_started")
-        .data(run_started_payload.to_string());
+        .data(run_started_payload.to_string())
+        .id("0");
     if sse_tx.send(Ok(run_started_sse)).await.is_err() {
         run_broadcaster.finish_run(&run_id).await;
-        return Sse::new(ReceiverStream::new(sse_rx)).into_response();
+        return sse_response(sse_rx);
     }
 
     tokio::spawn(async move {
@@ -1043,7 +1060,7 @@ pub async fn send_message(
                     }
                     let p = serde_json::json!({"message": message});
                     let e = Event::default().event("agent_error").data(message.clone());
-                    ("error", p, e)
+                    ("agent_error", p, e)
                 }
                 OrchestratorEvent::Thinking(ref content) => {
                     // Send SSE immediately for real-time rendering.
@@ -1162,6 +1179,7 @@ pub async fn send_message(
                 payload: payload.clone(),
             };
             let _ = broadcast_tx.send(live);
+            let sse_event = sse_event.id(seq.to_string());
             seq += 1;
 
             if sse_tx.send(Ok(sse_event)).await.is_err() {
@@ -1221,7 +1239,10 @@ pub async fn send_message(
             payload: done_data.clone(),
         });
 
-        let done = Event::default().event("done").data(done_data.to_string());
+        let done = Event::default()
+            .event("done")
+            .data(done_data.to_string())
+            .id(seq.to_string());
         let _ = sse_tx.send(Ok(done)).await;
 
         // Signal run completion — drops broadcast channel, subscribers observe close.
@@ -1241,7 +1262,7 @@ pub async fn send_message(
 
     // Include run_id in response headers as a fallback for clients that crash
     // before receiving the run_started SSE event.
-    let mut response = Sse::new(ReceiverStream::new(sse_rx)).into_response();
+    let mut response = sse_response(sse_rx);
     if let Ok(hv) = run_id.to_string().parse::<header::HeaderValue>() {
         response.headers_mut().insert("X-Run-Id", hv);
     }
@@ -1435,7 +1456,7 @@ pub async fn stream_run_events(
     // Check if the run completed before we even arrived.
     let already_complete = past_events
         .iter()
-        .any(|e| e.event_type == "done" || e.event_type == "error");
+        .any(|e| e.event_type == "done" || e.event_type == "agent_error");
 
     let conv_id_str_clone = conv_id_str.clone();
     tokio::spawn(async move {
@@ -1443,7 +1464,8 @@ pub async fn stream_run_events(
         for row in past_events {
             let ev = Event::default()
                 .event(row.event_type.as_str())
-                .data(row.payload.to_string());
+                .data(row.payload.to_string())
+                .id(row.sequence.to_string());
             if sse_tx.send(Ok(ev)).await.is_err() {
                 return;
             }
@@ -1465,8 +1487,9 @@ pub async fn stream_run_events(
                 Ok(live) => {
                     let ev = Event::default()
                         .event(live.event_type.as_str())
-                        .data(live.payload.to_string());
-                    let is_terminal = live.event_type == "done" || live.event_type == "error";
+                        .data(live.payload.to_string())
+                        .id(live.sequence.to_string());
+                    let is_terminal = live.event_type == "done" || live.event_type == "agent_error";
                     if sse_tx.send(Ok(ev)).await.is_err() {
                         return;
                     }
@@ -1490,7 +1513,7 @@ pub async fn stream_run_events(
         }
     });
 
-    Sse::new(ReceiverStream::new(sse_rx)).into_response()
+    sse_response(sse_rx)
 }
 
 // -- Quick-message handler --------------------------------------------------
@@ -1947,7 +1970,7 @@ pub async fn send_voice_message(
         }
     });
 
-    Sse::new(ReceiverStream::new(sse_rx)).into_response()
+    sse_response(sse_rx)
 }
 
 /// `GET /api/messages/{id}/audio` — synthesize TTS audio for an assistant


### PR DESCRIPTION
## Summary

- **Fix event type mismatch**: `AgentError` was persisted as `"error"` but sent as `event: agent_error` over SSE. Replayed events arrived as `event: error` which the client silently dropped. Now persists as `"agent_error"` consistently, and terminal-event checks in `stream_run_events` are updated to match.
- **Add KeepAlive to all REST SSE endpoints**: `send_message`, `stream_conversations`, `stream_run_events`, and `send_voice_message` now send keepalive comment pings (15s default) to prevent proxy idle timeouts (nginx 60s, AWS ALB 60s, Cloudflare 100s).
- **Set `Cache-Control: no-cache`** on SSE responses to prevent intermediary buffering (nginx `proxy_buffering`, CDN caches).
- **Add SSE `id:` field** with the server's sequence number on all durable events (`run_started`, main events, `done`, replayed, live-tailed) for spec-compliant reconnection support.
- **Fix Dart SSE parsers** to concatenate multiple `data:` lines with newlines per the SSE spec instead of overwriting.

## Test plan

- [x] All 131 `assistant-web-ui` Rust tests pass (including SSE-specific: `stream_run_events_replays_completed_run`, `stream_run_events_tails_live_broadcaster`, `send_message_streams_sse_tokens`)
- [x] All 39 Dart SSE client tests pass
- [x] `cargo clippy -p assistant-web-ui -- -D warnings` clean
- [x] `flutter analyze` clean
- [x] `cargo fmt` / `dart format` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SSE parser to correctly handle multiple consecutive data lines in streams.
  * Corrected error event type mapping to properly classify agent errors.
  * Improved terminal run completion detection for streaming events.

* **Improvements**
  * Enhanced SSE response handling with keep-alive configuration and cache control headers.
  * Added sequential event ID tracking for improved event correlation.

* **Chores**
  * Updated development dependencies and configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->