### PR TITLE
feat(runtime): crash recovery for orphaned SSE runs and server-side sequence tracking

### DIFF
--- a/app/lib/api/api_client.dart
+++ b/app/lib/api/api_client.dart
@@ -295,6 +295,7 @@ Stream<StreamEvent> parseSseByteStream(Stream<List<int>> byteStream) async* {
 
   String? eventType;
   String? dataLine;
+  String? eventId;
 
   await for (final line in lines) {
     if (line.startsWith('event:')) {
@@ -303,114 +304,187 @@ Stream<StreamEvent> parseSseByteStream(Stream<List<int>> byteStream) async* {
       // Per the SSE spec, multiple `data:` lines are concatenated with '\n'.
       final value = line.substring('data:'.length).trim();
       dataLine = dataLine == null ? value : '$dataLine\n$value';
+    } else if (line.startsWith('id:')) {
+      eventId = line.substring('id:'.length).trim();
     } else if (line.isEmpty) {
       // Blank line — dispatch the event.
+      final seq = int.tryParse(eventId ?? '');
       if (eventType == 'token' && dataLine != null) {
-        yield TokenEvent(dataLine);
+        yield TokenEvent(dataLine, sequenceId: seq);
       } else if (eventType == 'status' && dataLine != null) {
         try {
           final json = jsonDecode(dataLine) as Map<String, dynamic>;
-          yield StatusEvent.fromJson(json);
+          yield StatusEvent(
+            json['message'] as String? ?? '',
+            toolCallId: json['tool_call_id'] as String?,
+            sequenceId: seq,
+          );
         } catch (_) {
           // Older servers send plain-text status messages.
-          yield StatusEvent(dataLine);
+          yield StatusEvent(dataLine, sequenceId: seq);
         }
       } else if (eventType == 'tool_result' && dataLine != null) {
         try {
           final json = jsonDecode(dataLine) as Map<String, dynamic>;
-          yield ToolResultEvent.fromJson(json);
+          yield ToolResultEvent(
+            toolName: json['tool_name'] as String? ?? '',
+            status: json['status'] as String? ?? 'ok',
+            arguments: json['arguments'] as Map<String, dynamic>?,
+            result: json['result'] as String?,
+            toolCallId: json['tool_call_id'] as String?,
+            sequenceId: seq,
+          );
         } catch (_) {
           // ignore malformed tool_result events
         }
       } else if (eventType == 'run_started' && dataLine != null) {
         try {
           final json = jsonDecode(dataLine) as Map<String, dynamic>;
-          yield RunStartedEvent(json['run_id'] as String? ?? '');
+          yield RunStartedEvent(
+            json['run_id'] as String? ?? '',
+            sequenceId: seq,
+          );
         } catch (_) {
           // ignore malformed run_started events
         }
       } else if (eventType == 'done' && dataLine != null) {
         try {
           final json = jsonDecode(dataLine) as Map<String, dynamic>;
-          yield DoneEvent.fromJson(json);
+          yield DoneEvent(
+            role: json['role'] as String? ?? 'assistant',
+            content: json['content'] as String? ?? '',
+            messageId: json['message_id'] as String?,
+            sequenceId: seq,
+          );
         } catch (_) {
-          yield DoneEvent(role: 'assistant', content: dataLine);
+          yield DoneEvent(
+            role: 'assistant',
+            content: dataLine,
+            sequenceId: seq,
+          );
         }
       } else if (eventType == 'transcript' && dataLine != null) {
         try {
           final json = jsonDecode(dataLine) as Map<String, dynamic>;
-          yield TranscriptEvent.fromJson(json);
+          yield TranscriptEvent(
+            json['content'] as String? ?? '',
+            sequenceId: seq,
+          );
         } catch (_) {
           // ignore malformed transcript events
         }
       } else if (eventType == 'thinking' && dataLine != null) {
         try {
           final json = jsonDecode(dataLine) as Map<String, dynamic>;
-          yield ThinkingEvent.fromJson(json);
+          yield ThinkingEvent(
+            json['content'] as String? ?? '',
+            sequenceId: seq,
+          );
         } catch (_) {
           // ignore malformed thinking events
         }
       } else if (eventType == 'subagent_started' && dataLine != null) {
         try {
           final json = jsonDecode(dataLine) as Map<String, dynamic>;
-          yield SubagentStartedEvent.fromJson(json);
+          yield SubagentStartedEvent(
+            agentId: json['agent_id'] as String? ?? '',
+            task: json['task'] as String? ?? '',
+            sequenceId: seq,
+          );
         } catch (_) {
           // ignore malformed subagent_started events
         }
       } else if (eventType == 'subagent_completed' && dataLine != null) {
         try {
           final json = jsonDecode(dataLine) as Map<String, dynamic>;
-          yield SubagentCompletedEvent.fromJson(json);
+          yield SubagentCompletedEvent(
+            agentId: json['agent_id'] as String? ?? '',
+            status: json['status'] as String? ?? 'ok',
+            summary: json['summary'] as String? ?? '',
+            sequenceId: seq,
+          );
         } catch (_) {
           // ignore malformed subagent_completed events
         }
       } else if (eventType == 'skill_complete' && dataLine != null) {
         try {
           final json = jsonDecode(dataLine) as Map<String, dynamic>;
-          yield SkillCompleteEvent.fromJson(json);
+          yield SkillCompleteEvent(
+            skillName: json['skill_name'] as String? ?? '',
+            success: json['success'] as bool? ?? false,
+            summary: json['summary'] as String? ?? '',
+            sequenceId: seq,
+          );
         } catch (_) {
           // ignore malformed skill_complete events
         }
       } else if (eventType == 'subagent_token' && dataLine != null) {
         try {
           final json = jsonDecode(dataLine) as Map<String, dynamic>;
-          yield SubagentTokenEvent.fromJson(json);
+          final data = json['data'] as Map<String, dynamic>? ?? {};
+          yield SubagentTokenEvent(
+            agentId: json['agent_id'] as String? ?? '',
+            content: data['content'] as String? ?? '',
+            sequenceId: seq,
+          );
         } catch (_) {
           // ignore malformed subagent_token events
         }
       } else if (eventType == 'subagent_thinking' && dataLine != null) {
         try {
           final json = jsonDecode(dataLine) as Map<String, dynamic>;
-          yield SubagentThinkingEvent.fromJson(json);
+          final data = json['data'] as Map<String, dynamic>? ?? {};
+          yield SubagentThinkingEvent(
+            agentId: json['agent_id'] as String? ?? '',
+            content: data['content'] as String? ?? '',
+            sequenceId: seq,
+          );
         } catch (_) {
           // ignore malformed subagent_thinking events
         }
       } else if (eventType == 'subagent_tool_result' && dataLine != null) {
         try {
           final json = jsonDecode(dataLine) as Map<String, dynamic>;
-          yield SubagentToolResultEvent.fromJson(json);
+          final data = json['data'] as Map<String, dynamic>? ?? {};
+          yield SubagentToolResultEvent(
+            agentId: json['agent_id'] as String? ?? '',
+            toolName: data['tool_name'] as String? ?? '',
+            status: data['status'] as String? ?? 'ok',
+            arguments: data['arguments'] as Map<String, dynamic>?,
+            result: data['result'] as String?,
+            sequenceId: seq,
+          );
         } catch (_) {
           // ignore malformed subagent_tool_result events
         }
       } else if (eventType == 'subagent_status' && dataLine != null) {
         try {
           final json = jsonDecode(dataLine) as Map<String, dynamic>;
-          yield SubagentStatusEvent.fromJson(json);
+          final data = json['data'] as Map<String, dynamic>? ?? {};
+          yield SubagentStatusEvent(
+            agentId: json['agent_id'] as String? ?? '',
+            message: data['message'] as String? ?? '',
+            sequenceId: seq,
+          );
         } catch (_) {
           // ignore malformed subagent_status events
         }
       } else if (eventType == 'agent_error' && dataLine != null) {
-        yield AgentErrorEvent(dataLine);
+        yield AgentErrorEvent(dataLine, sequenceId: seq);
       } else if (eventType == 'audio_ready' && dataLine != null) {
         try {
           final json = jsonDecode(dataLine) as Map<String, dynamic>;
-          yield AudioReadyEvent.fromJson(json);
+          yield AudioReadyEvent(
+            json['audio_id'] as String? ?? '',
+            sequenceId: seq,
+          );
         } catch (_) {
           // ignore malformed audio_ready events
         }
       }
       eventType = null;
       dataLine = null;
+      eventId = null;
     }
   }
 }
@@ -430,6 +504,8 @@ Stream<ConversationListEvent> parseConversationSseByteStream(
     } else if (line.startsWith('data:')) {
       final value = line.substring('data:'.length).trim();
       dataLine = dataLine == null ? value : '$dataLine\n$value';
+    } else if (line.startsWith('id:')) {
+      // Consume but ignore — conversation list events don't use sequence IDs.
     } else if (line.isEmpty) {
       if (eventType != null && dataLine != null) {
         try {

--- a/app/lib/api/models/stream_event.dart
+++ b/app/lib/api/models/stream_event.dart
@@ -3,7 +3,13 @@
 /// Events arrive from `POST /api/conversations/{id}/messages` as a
 /// `text/event-stream` (Server-Sent Events) response.
 sealed class StreamEvent {
-  const StreamEvent();
+  const StreamEvent({this.sequenceId});
+
+  /// The server-assigned event sequence number parsed from the SSE `id:` field.
+  ///
+  /// `null` when the server did not include an `id:` line (e.g. ephemeral
+  /// thinking tokens or older servers).
+  final int? sequenceId;
 }
 
 // -- Conversation list stream events -----------------------------------------
@@ -88,7 +94,7 @@ class ConversationListEntry {
 /// Corresponds to `event:token` in the SSE stream.  The caller should
 /// accumulate these into a display buffer to show the streaming response.
 class TokenEvent extends StreamEvent {
-  const TokenEvent(this.token);
+  const TokenEvent(this.token, {super.sequenceId});
 
   /// The incremental text chunk (may be a single word, part of a word, or
   /// whitespace).
@@ -103,7 +109,7 @@ class TokenEvent extends StreamEvent {
 /// The data payload is JSON: `{"message":"...","tool_call_id":"..."}`.
 /// Older servers may send a plain string — the parser falls back gracefully.
 class StatusEvent extends StreamEvent {
-  const StatusEvent(this.message, {this.toolCallId});
+  const StatusEvent(this.message, {this.toolCallId, super.sequenceId});
 
   /// Human-readable status message.
   final String message;
@@ -131,6 +137,7 @@ class ToolResultEvent extends StreamEvent {
     this.arguments,
     this.result,
     this.toolCallId,
+    super.sequenceId,
   });
 
   /// The name of the tool that was called.
@@ -168,7 +175,12 @@ class ToolResultEvent extends StreamEvent {
 /// and persist `content`.  `messageId` is the DB UUID of the saved assistant
 /// message and should be used as [ChatMessage.id] when present.
 class DoneEvent extends StreamEvent {
-  const DoneEvent({required this.role, required this.content, this.messageId});
+  const DoneEvent({
+    required this.role,
+    required this.content,
+    this.messageId,
+    super.sequenceId,
+  });
 
   final String role;
 
@@ -194,7 +206,7 @@ class DoneEvent extends StreamEvent {
 /// `{"run_id":"<uuid>"}`.  Clients should store this ID so they can reconnect
 /// via the event-log replay endpoint if the connection drops.
 class RunStartedEvent extends StreamEvent {
-  const RunStartedEvent(this.runId);
+  const RunStartedEvent(this.runId, {super.sequenceId});
 
   /// The UUID of the orchestrator run.
   final String runId;
@@ -205,7 +217,7 @@ class RunStartedEvent extends StreamEvent {
 /// May be produced by the client-side SSE parser when the stream closes
 /// unexpectedly or when an HTTP error status is received.
 class ErrorEvent extends StreamEvent {
-  const ErrorEvent(this.message);
+  const ErrorEvent(this.message, {super.sequenceId});
 
   final String message;
 }
@@ -216,7 +228,7 @@ class ErrorEvent extends StreamEvent {
 /// `POST /api/conversations/{id}/voice`.  The JSON body is
 /// `{"role":"user","content":"<transcribed text>"}`.
 class TranscriptEvent extends StreamEvent {
-  const TranscriptEvent(this.transcript);
+  const TranscriptEvent(this.transcript, {super.sequenceId});
 
   /// The transcribed text of the user's spoken message.
   final String transcript;
@@ -231,7 +243,7 @@ class TranscriptEvent extends StreamEvent {
 /// Corresponds to `event:thinking` in the SSE stream.  The JSON body is
 /// `{"content":"<thinking text>"}`.
 class ThinkingEvent extends StreamEvent {
-  const ThinkingEvent(this.content);
+  const ThinkingEvent(this.content, {super.sequenceId});
 
   /// The reasoning text produced by the LLM.
   final String content;
@@ -246,7 +258,11 @@ class ThinkingEvent extends StreamEvent {
 /// Corresponds to `event:subagent_started` in the SSE stream.  The JSON body
 /// is `{"agent_id":"...","task":"..."}`.
 class SubagentStartedEvent extends StreamEvent {
-  const SubagentStartedEvent({required this.agentId, required this.task});
+  const SubagentStartedEvent({
+    required this.agentId,
+    required this.task,
+    super.sequenceId,
+  });
 
   final String agentId;
   final String task;
@@ -268,6 +284,7 @@ class SubagentCompletedEvent extends StreamEvent {
     required this.agentId,
     required this.status,
     required this.summary,
+    super.sequenceId,
   });
 
   final String agentId;
@@ -292,6 +309,7 @@ class SkillCompleteEvent extends StreamEvent {
     required this.skillName,
     required this.success,
     required this.summary,
+    super.sequenceId,
   });
 
   final String skillName;
@@ -312,7 +330,7 @@ class SkillCompleteEvent extends StreamEvent {
 /// Corresponds to `event:agent_error` in the SSE stream.  The data is a
 /// plain-text error message.
 class AgentErrorEvent extends StreamEvent {
-  const AgentErrorEvent(this.message);
+  const AgentErrorEvent(this.message, {super.sequenceId});
 
   final String message;
 }
@@ -322,7 +340,11 @@ class AgentErrorEvent extends StreamEvent {
 /// Corresponds to `event:subagent_token` in the SSE stream.  The JSON body is
 /// `{"agent_id":"...","data":{"content":"..."}}`.
 class SubagentTokenEvent extends StreamEvent {
-  const SubagentTokenEvent({required this.agentId, required this.content});
+  const SubagentTokenEvent({
+    required this.agentId,
+    required this.content,
+    super.sequenceId,
+  });
 
   final String agentId;
   final String content;
@@ -341,7 +363,11 @@ class SubagentTokenEvent extends StreamEvent {
 /// Corresponds to `event:subagent_thinking` in the SSE stream.  The JSON body
 /// is `{"agent_id":"...","data":{"content":"..."}}`.
 class SubagentThinkingEvent extends StreamEvent {
-  const SubagentThinkingEvent({required this.agentId, required this.content});
+  const SubagentThinkingEvent({
+    required this.agentId,
+    required this.content,
+    super.sequenceId,
+  });
 
   final String agentId;
   final String content;
@@ -366,6 +392,7 @@ class SubagentToolResultEvent extends StreamEvent {
     required this.status,
     this.arguments,
     this.result,
+    super.sequenceId,
   });
 
   final String agentId;
@@ -391,7 +418,11 @@ class SubagentToolResultEvent extends StreamEvent {
 /// Corresponds to `event:subagent_status` in the SSE stream.  The JSON body
 /// is `{"agent_id":"...","data":{"message":"..."}}`.
 class SubagentStatusEvent extends StreamEvent {
-  const SubagentStatusEvent({required this.agentId, required this.message});
+  const SubagentStatusEvent({
+    required this.agentId,
+    required this.message,
+    super.sequenceId,
+  });
 
   final String agentId;
   final String message;
@@ -410,7 +441,7 @@ class SubagentStatusEvent extends StreamEvent {
 /// Corresponds to `event:audio_ready` in the SSE stream.  The JSON body is
 /// `{"audio_id":"<uuid>"}`.
 class AudioReadyEvent extends StreamEvent {
-  const AudioReadyEvent(this.audioId);
+  const AudioReadyEvent(this.audioId, {super.sequenceId});
 
   /// Opaque identifier used with GET /api/audio/{audioId}.
   final String audioId;

--- a/app/lib/features/chat/chat_provider.dart
+++ b/app/lib/features/chat/chat_provider.dart
@@ -1138,9 +1138,9 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
         final chatState = state.value ?? const ChatState();
 
         if (event is RunStartedEvent) {
-          _lastSeq = event.sequenceId ?? (_lastSeq + 1);
+          _lastSeq = (event.sequenceId ?? _lastSeq) + 1;
         } else if (event is TokenEvent) {
-          _lastSeq = event.sequenceId ?? (_lastSeq + 1);
+          _lastSeq = (event.sequenceId ?? _lastSeq) + 1;
           final newContent = chatState.streamingContent + event.token;
           final ms = List<ChatMessage>.from(chatState.messages);
           if (chatState.streamingContent.isEmpty) {
@@ -1156,13 +1156,13 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
             ),
           );
         } else if (event is StatusEvent) {
-          _lastSeq = event.sequenceId ?? (_lastSeq + 1);
+          _lastSeq = (event.sequenceId ?? _lastSeq) + 1;
           _onStatusEvent(chatState, event);
         } else if (event is ToolResultEvent) {
-          _lastSeq = event.sequenceId ?? (_lastSeq + 1);
+          _lastSeq = (event.sequenceId ?? _lastSeq) + 1;
           _onToolResultEvent(chatState, event);
         } else if (event is DoneEvent) {
-          _lastSeq = event.sequenceId ?? (_lastSeq + 1);
+          _lastSeq = (event.sequenceId ?? _lastSeq) + 1;
           final ms = List<ChatMessage>.from(chatState.messages);
           final uIdx = ms.indexWhere((m) => m.id == userMsgId);
           if (uIdx != -1) {
@@ -1185,7 +1185,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
           );
           return true;
         } else if (event is AgentErrorEvent) {
-          _lastSeq = event.sequenceId ?? (_lastSeq + 1);
+          _lastSeq = (event.sequenceId ?? _lastSeq) + 1;
           final ms = List<ChatMessage>.from(chatState.messages)
             ..removeWhere((m) => m.id == 'assistant-streaming');
           final uIdx = ms.indexWhere((m) => m.id == userMsgId);
@@ -1195,7 +1195,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
           state = AsyncData(chatState.copyWith(messages: ms, isSending: false));
           return false;
         } else if (event is ErrorEvent) {
-          _lastSeq = event.sequenceId ?? (_lastSeq + 1);
+          _lastSeq = (event.sequenceId ?? _lastSeq) + 1;
           return false;
         }
       }
@@ -1512,10 +1512,10 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
         if (event is RunStartedEvent) {
           // Capture the run ID for potential reconnect; don't change UI.
           _currentRunId = event.runId;
-          _lastSeq = event.sequenceId ?? (_lastSeq + 1);
+          _lastSeq = (event.sequenceId ?? _lastSeq) + 1;
           continue;
         } else if (event is TokenEvent) {
-          _lastSeq = event.sequenceId ?? (_lastSeq + 1);
+          _lastSeq = (event.sequenceId ?? _lastSeq) + 1;
           tokenController.add(event.token);
           final newContent = chatState.streamingContent + event.token;
           final msgs = List<ChatMessage>.from(chatState.messages);
@@ -1536,22 +1536,22 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
             ),
           );
         } else if (event is StatusEvent) {
-          _lastSeq = event.sequenceId ?? (_lastSeq + 1);
+          _lastSeq = (event.sequenceId ?? _lastSeq) + 1;
           _onStatusEvent(chatState, event);
         } else if (event is ToolResultEvent) {
-          _lastSeq = event.sequenceId ?? (_lastSeq + 1);
+          _lastSeq = (event.sequenceId ?? _lastSeq) + 1;
           _onToolResultEvent(chatState, event);
         } else if (event is ThinkingEvent) {
-          _lastSeq = event.sequenceId ?? (_lastSeq + 1);
+          _lastSeq = (event.sequenceId ?? _lastSeq) + 1;
           _onThinkingEvent(chatState, event);
         } else if (event is SubagentStartedEvent) {
-          _lastSeq = event.sequenceId ?? (_lastSeq + 1);
+          _lastSeq = (event.sequenceId ?? _lastSeq) + 1;
           _onSubagentStartedEvent(chatState, event);
         } else if (event is SubagentCompletedEvent) {
-          _lastSeq = event.sequenceId ?? (_lastSeq + 1);
+          _lastSeq = (event.sequenceId ?? _lastSeq) + 1;
           _onSubagentCompletedEvent(chatState, event);
         } else if (event is DoneEvent) {
-          _lastSeq = event.sequenceId ?? (_lastSeq + 1);
+          _lastSeq = (event.sequenceId ?? _lastSeq) + 1;
           unawaited(tokenController.close());
           _closeThinkingController();
           final msgs = List<ChatMessage>.from(chatState.messages);
@@ -1593,7 +1593,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
           // Refresh conversation list to update timestamps/titles.
           return;
         } else if (event is AudioReadyEvent) {
-          _lastSeq = event.sequenceId ?? (_lastSeq + 1);
+          _lastSeq = (event.sequenceId ?? _lastSeq) + 1;
           final msgs = List<ChatMessage>.from(chatState.messages);
           final idx = msgs.indexWhere((m) => m.id == 'assistant-streaming');
           if (idx != -1) {
@@ -1604,7 +1604,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
           }
           state = AsyncData(chatState.copyWith(messages: msgs));
         } else if (event is ErrorEvent) {
-          _lastSeq = event.sequenceId ?? (_lastSeq + 1);
+          _lastSeq = (event.sequenceId ?? _lastSeq) + 1;
           unawaited(tokenController.close());
           _closeThinkingController();
           final msgs = List<ChatMessage>.from(chatState.messages)

--- a/app/lib/features/chat/chat_provider.dart
+++ b/app/lib/features/chat/chat_provider.dart
@@ -1138,9 +1138,9 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
         final chatState = state.value ?? const ChatState();
 
         if (event is RunStartedEvent) {
-          _lastSeq++;
+          _lastSeq = event.sequenceId ?? (_lastSeq + 1);
         } else if (event is TokenEvent) {
-          _lastSeq++;
+          _lastSeq = event.sequenceId ?? (_lastSeq + 1);
           final newContent = chatState.streamingContent + event.token;
           final ms = List<ChatMessage>.from(chatState.messages);
           if (chatState.streamingContent.isEmpty) {
@@ -1156,13 +1156,13 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
             ),
           );
         } else if (event is StatusEvent) {
-          _lastSeq++;
+          _lastSeq = event.sequenceId ?? (_lastSeq + 1);
           _onStatusEvent(chatState, event);
         } else if (event is ToolResultEvent) {
-          _lastSeq++;
+          _lastSeq = event.sequenceId ?? (_lastSeq + 1);
           _onToolResultEvent(chatState, event);
         } else if (event is DoneEvent) {
-          _lastSeq++;
+          _lastSeq = event.sequenceId ?? (_lastSeq + 1);
           final ms = List<ChatMessage>.from(chatState.messages);
           final uIdx = ms.indexWhere((m) => m.id == userMsgId);
           if (uIdx != -1) {
@@ -1184,8 +1184,18 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
             ),
           );
           return true;
+        } else if (event is AgentErrorEvent) {
+          _lastSeq = event.sequenceId ?? (_lastSeq + 1);
+          final ms = List<ChatMessage>.from(chatState.messages)
+            ..removeWhere((m) => m.id == 'assistant-streaming');
+          final uIdx = ms.indexWhere((m) => m.id == userMsgId);
+          if (uIdx != -1) {
+            ms[uIdx] = ms[uIdx].copyWith(status: MessageStatus.failed);
+          }
+          state = AsyncData(chatState.copyWith(messages: ms, isSending: false));
+          return false;
         } else if (event is ErrorEvent) {
-          _lastSeq++;
+          _lastSeq = event.sequenceId ?? (_lastSeq + 1);
           return false;
         }
       }
@@ -1502,10 +1512,10 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
         if (event is RunStartedEvent) {
           // Capture the run ID for potential reconnect; don't change UI.
           _currentRunId = event.runId;
-          _lastSeq++;
+          _lastSeq = event.sequenceId ?? (_lastSeq + 1);
           continue;
         } else if (event is TokenEvent) {
-          _lastSeq++;
+          _lastSeq = event.sequenceId ?? (_lastSeq + 1);
           tokenController.add(event.token);
           final newContent = chatState.streamingContent + event.token;
           final msgs = List<ChatMessage>.from(chatState.messages);
@@ -1526,22 +1536,22 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
             ),
           );
         } else if (event is StatusEvent) {
-          _lastSeq++;
+          _lastSeq = event.sequenceId ?? (_lastSeq + 1);
           _onStatusEvent(chatState, event);
         } else if (event is ToolResultEvent) {
-          _lastSeq++;
+          _lastSeq = event.sequenceId ?? (_lastSeq + 1);
           _onToolResultEvent(chatState, event);
         } else if (event is ThinkingEvent) {
-          _lastSeq++;
+          _lastSeq = event.sequenceId ?? (_lastSeq + 1);
           _onThinkingEvent(chatState, event);
         } else if (event is SubagentStartedEvent) {
-          _lastSeq++;
+          _lastSeq = event.sequenceId ?? (_lastSeq + 1);
           _onSubagentStartedEvent(chatState, event);
         } else if (event is SubagentCompletedEvent) {
-          _lastSeq++;
+          _lastSeq = event.sequenceId ?? (_lastSeq + 1);
           _onSubagentCompletedEvent(chatState, event);
         } else if (event is DoneEvent) {
-          _lastSeq++;
+          _lastSeq = event.sequenceId ?? (_lastSeq + 1);
           unawaited(tokenController.close());
           _closeThinkingController();
           final msgs = List<ChatMessage>.from(chatState.messages);
@@ -1583,7 +1593,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
           // Refresh conversation list to update timestamps/titles.
           return;
         } else if (event is AudioReadyEvent) {
-          _lastSeq++;
+          _lastSeq = event.sequenceId ?? (_lastSeq + 1);
           final msgs = List<ChatMessage>.from(chatState.messages);
           final idx = msgs.indexWhere((m) => m.id == 'assistant-streaming');
           if (idx != -1) {
@@ -1594,7 +1604,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
           }
           state = AsyncData(chatState.copyWith(messages: msgs));
         } else if (event is ErrorEvent) {
-          _lastSeq++;
+          _lastSeq = event.sequenceId ?? (_lastSeq + 1);
           unawaited(tokenController.close());
           _closeThinkingController();
           final msgs = List<ChatMessage>.from(chatState.messages)

--- a/app/test/unit/api/client_test.dart
+++ b/app/test/unit/api/client_test.dart
@@ -542,4 +542,87 @@ void main() {
       expect(e.message, equals('Calling tool: web-search'));
     });
   });
+
+  group('SSE id: field → sequenceId', () {
+    test('parses id: field into sequenceId on TokenEvent', () async {
+      const sse = 'id:42\nevent:token\ndata:hello\n\n';
+      final events = await parseSseByteStream(_sseBytes(sse)).toList();
+
+      expect(events.length, equals(1));
+      expect(events.first, isA<TokenEvent>());
+      expect(events.first.sequenceId, equals(42));
+    });
+
+    test('sequenceId is null when no id: line present', () async {
+      const sse = 'event:token\ndata:hello\n\n';
+      final events = await parseSseByteStream(_sseBytes(sse)).toList();
+
+      expect(events.length, equals(1));
+      expect(events.first.sequenceId, isNull);
+    });
+
+    test('sequenceId is null for non-numeric id: values', () async {
+      const sse = 'id:not-a-number\nevent:token\ndata:hello\n\n';
+      final events = await parseSseByteStream(_sseBytes(sse)).toList();
+
+      expect(events.length, equals(1));
+      expect(events.first.sequenceId, isNull);
+    });
+
+    test('id: field threads through DoneEvent', () async {
+      final payload = jsonEncode({
+        'role': 'assistant',
+        'content': 'bye',
+        'message_id': 'msg-1',
+      });
+      final sse = 'id:99\nevent:done\ndata:$payload\n\n';
+      final events = await parseSseByteStream(_sseBytes(sse)).toList();
+
+      expect(events.length, equals(1));
+      final done = events.first as DoneEvent;
+      expect(done.sequenceId, equals(99));
+      expect(done.content, equals('bye'));
+      expect(done.messageId, equals('msg-1'));
+    });
+
+    test('id: field threads through RunStartedEvent', () async {
+      const sse = 'id:0\nevent:run_started\ndata:{"run_id":"r1"}\n\n';
+      final events = await parseSseByteStream(_sseBytes(sse)).toList();
+
+      expect(events.length, equals(1));
+      final rs = events.first as RunStartedEvent;
+      expect(rs.sequenceId, equals(0));
+      expect(rs.runId, equals('r1'));
+    });
+
+    test('id: field threads through AgentErrorEvent', () async {
+      const sse = 'id:7\nevent:agent_error\ndata:Server crashed\n\n';
+      final events = await parseSseByteStream(_sseBytes(sse)).toList();
+
+      expect(events.length, equals(1));
+      final err = events.first as AgentErrorEvent;
+      expect(err.sequenceId, equals(7));
+      expect(err.message, equals('Server crashed'));
+    });
+
+    test('id: resets between events', () async {
+      const sse =
+          'id:1\nevent:token\ndata:a\n\n'
+          'event:token\ndata:b\n\n';
+      final events = await parseSseByteStream(_sseBytes(sse)).toList();
+
+      expect(events.length, equals(2));
+      expect(events[0].sequenceId, equals(1));
+      expect(events[1].sequenceId, isNull);
+    });
+
+    test('id: field order does not matter within an event block', () async {
+      // id: after event: and data: — should still work.
+      const sse = 'event:token\ndata:hello\nid:5\n\n';
+      final events = await parseSseByteStream(_sseBytes(sse)).toList();
+
+      expect(events.length, equals(1));
+      expect(events.first.sequenceId, equals(5));
+    });
+  });
 }

--- a/app/test/unit/api/client_test.dart
+++ b/app/test/unit/api/client_test.dart
@@ -624,5 +624,32 @@ void main() {
       expect(events.length, equals(1));
       expect(events.first.sequenceId, equals(5));
     });
+
+    test('replay cursor formula produces next-expected sequence', () {
+      // The consumer uses: _lastSeq = (event.sequenceId ?? _lastSeq) + 1
+      // This must produce sequenceId + 1 so `since: _lastSeq` skips the
+      // already-seen event (server uses `sequence >= since`).
+      int lastSeq = 0;
+
+      // Event with server sequence 0 → cursor becomes 1.
+      final seq0 = const TokenEvent('a', sequenceId: 0).sequenceId;
+      lastSeq = (seq0 ?? lastSeq) + 1;
+      expect(lastSeq, equals(1), reason: 'after seq 0, cursor = 1');
+
+      // Event with server sequence 1 → cursor becomes 2.
+      final seq1 = const TokenEvent('b', sequenceId: 1).sequenceId;
+      lastSeq = (seq1 ?? lastSeq) + 1;
+      expect(lastSeq, equals(2), reason: 'after seq 1, cursor = 2');
+
+      // Event without id: → cursor increments from current.
+      final seqNull = const TokenEvent('c').sequenceId;
+      lastSeq = (seqNull ?? lastSeq) + 1;
+      expect(lastSeq, equals(3), reason: 'no id → fallback increment');
+
+      // Non-contiguous server sequence (e.g. batched thinking tokens).
+      final seq10 = const TokenEvent('d', sequenceId: 10).sequenceId;
+      lastSeq = (seq10 ?? lastSeq) + 1;
+      expect(lastSeq, equals(11), reason: 'after seq 10, cursor = 11');
+    });
   });
 }

--- a/crates/runtime/src/scheduler.rs
+++ b/crates/runtime/src/scheduler.rs
@@ -1067,4 +1067,59 @@ mod tests {
             "fresh run should not be closed"
         );
     }
+
+    #[tokio::test]
+    async fn reap_stale_recovers_despite_non_turn_request_bus_message() {
+        let server = MockServer::start().await;
+        mount_answer(&server, "done").await;
+        let (_orch, storage) = build(&server.uri()).await;
+
+        let event_store = storage.conversation_event_store();
+        let run_id = "run-nonturn-001";
+        let conv_id = Uuid::new_v4();
+
+        // Create an orphaned run.
+        event_store
+            .append_event(
+                run_id,
+                &conv_id.to_string(),
+                0,
+                "run_started",
+                &serde_json::json!({"run_id": run_id}),
+            )
+            .await
+            .unwrap();
+
+        // Backdate.
+        sqlx::query(
+            "UPDATE conversation_events SET created_at = datetime('now', '-10 minutes') \
+             WHERE run_id = ?1",
+        )
+        .bind(run_id)
+        .execute(&storage.pool)
+        .await
+        .unwrap();
+
+        // Publish a non-turn.request bus message on the same conversation.
+        // This should NOT block recovery — only turn.request matters.
+        let bus = storage.message_bus();
+        use assistant_core::PublishRequest;
+        bus.publish(
+            PublishRequest::new(
+                topic::SCHEDULE_TRIGGER,
+                serde_json::json!({"task_name": "irrelevant"}),
+            )
+            .with_conversation_id(conv_id),
+        )
+        .await
+        .unwrap();
+
+        reap_stale_and_recover(&storage, &bus).await;
+
+        // The orphan should be recovered despite the schedule.trigger message.
+        assert!(
+            event_store.is_run_complete(run_id).await.unwrap(),
+            "non-turn.request bus message should not block orphan recovery"
+        );
+    }
 }

--- a/crates/runtime/src/scheduler.rs
+++ b/crates/runtime/src/scheduler.rs
@@ -13,8 +13,8 @@ use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use assistant_core::{
-    ChannelContent, ChannelMessage, ChannelType, ChannelUser, Interface, PublishRequest,
-    bus_messages, strip_html_comments, topic,
+    ChannelContent, ChannelMessage, ChannelType, ChannelUser, Interface, MessageBus,
+    PublishRequest, bus_messages, strip_html_comments, topic,
 };
 use assistant_storage::StorageLayer;
 use chrono::Utc;
@@ -23,6 +23,7 @@ use opentelemetry::{
     KeyValue,
     trace::{Span as _, SpanKind},
 };
+use sqlx::SqlitePool;
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
@@ -59,9 +60,13 @@ pub fn spawn_scheduler(
         let mut last_event_prune = Instant::now()
             .checked_sub(EVENT_PRUNE_INTERVAL)
             .unwrap_or_else(Instant::now);
+        let mut last_reap_stale = Instant::now()
+            .checked_sub(REAP_STALE_INTERVAL)
+            .unwrap_or_else(Instant::now);
 
-        // Prune once on startup.
+        // Run once on startup.
         prune_conversation_events(&storage).await;
+        reap_stale_and_recover(&storage, orchestrator.bus().as_ref()).await;
 
         loop {
             tokio::time::sleep(poll_interval).await;
@@ -80,6 +85,11 @@ pub fn spawn_scheduler(
             if last_event_prune.elapsed() >= EVENT_PRUNE_INTERVAL {
                 prune_conversation_events(&storage).await;
                 last_event_prune = Instant::now();
+            }
+
+            if last_reap_stale.elapsed() >= REAP_STALE_INTERVAL {
+                reap_stale_and_recover(&storage, orchestrator.bus().as_ref()).await;
+                last_reap_stale = Instant::now();
             }
         }
     })
@@ -397,6 +407,111 @@ async fn prune_conversation_events(storage: &StorageLayer) {
         Ok(_) => {}
         Err(e) => warn!("Failed to prune conversation events: {e}"),
     }
+}
+
+// -- Crash recovery ---------------------------------------------------------
+
+/// How often stale bus messages and orphaned SSE runs are checked (5 minutes).
+const REAP_STALE_INTERVAL: Duration = Duration::from_secs(5 * 60);
+
+/// A claimed bus message older than this is considered stale (5 minutes).
+const STALE_CLAIM_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+
+/// Reclaim stale bus messages and close orphaned SSE event streams.
+///
+/// 1. Calls `bus.reap_stale()` to reset stale `Claimed` → `Pending` messages.
+/// 2. Finds runs that have a `run_started` event but no terminal event and are
+///    older than `STALE_CLAIM_TIMEOUT`.
+/// 3. For each orphan, checks whether an active (Pending/Claimed) bus message
+///    still references that conversation — if so, the run may still complete
+///    after bus redelivery, so we skip it.
+/// 4. Otherwise, appends a synthetic `agent_error` event so clients see a
+///    terminal event and can retry cleanly.
+pub(crate) async fn reap_stale_and_recover(storage: &StorageLayer, bus: &dyn MessageBus) {
+    // Step 1: reclaim stale bus messages.
+    match bus.reap_stale(STALE_CLAIM_TIMEOUT).await {
+        Ok(n) if n > 0 => info!("Reaped {n} stale bus message(s)"),
+        Ok(_) => {}
+        Err(e) => warn!("Failed to reap stale bus messages: {e}"),
+    }
+
+    // Step 2: find orphaned SSE runs.
+    let event_store = storage.conversation_event_store();
+    let stale_timeout = chrono::Duration::from_std(STALE_CLAIM_TIMEOUT).unwrap_or_default();
+    let orphans = match event_store.find_incomplete_runs(stale_timeout).await {
+        Ok(v) => v,
+        Err(e) => {
+            warn!("Failed to find incomplete runs: {e}");
+            return;
+        }
+    };
+
+    if orphans.is_empty() {
+        return;
+    }
+
+    info!(
+        count = orphans.len(),
+        "Found orphaned SSE run(s), checking for active bus messages"
+    );
+
+    // Step 3 & 4: for each orphan, check bus and potentially close.
+    for (run_id, conversation_id) in orphans {
+        let has_active = match has_active_bus_message(&storage.pool, &conversation_id).await {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(
+                    run_id = %run_id,
+                    error = %e,
+                    "Failed to check bus messages for orphan — skipping"
+                );
+                continue;
+            }
+        };
+
+        if has_active {
+            info!(
+                run_id = %run_id,
+                conversation_id = %conversation_id,
+                "Orphaned run still has active bus message — skipping (may recover)"
+            );
+            continue;
+        }
+
+        match event_store
+            .append_synthetic_terminal(
+                &run_id,
+                &conversation_id,
+                "Server restarted — this run was interrupted. You may retry your message.",
+            )
+            .await
+        {
+            Ok(seq) => info!(
+                run_id = %run_id,
+                conversation_id = %conversation_id,
+                sequence = seq,
+                "Appended synthetic agent_error to orphaned run"
+            ),
+            Err(e) => warn!(
+                run_id = %run_id,
+                error = %e,
+                "Failed to append synthetic terminal for orphaned run"
+            ),
+        }
+    }
+}
+
+/// Check whether there is a Pending or Claimed bus message for a conversation.
+async fn has_active_bus_message(pool: &SqlitePool, conversation_id: &str) -> Result<bool> {
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM bus_messages \
+         WHERE conversation_id = ?1 \
+           AND status IN ('pending', 'claimed')",
+    )
+    .bind(conversation_id)
+    .fetch_one(pool)
+    .await?;
+    Ok(count > 0)
 }
 
 // -- Tests ------------------------------------------------------------------
@@ -806,5 +921,147 @@ mod tests {
             .await
             .unwrap();
         assert!(msg.is_some(), "turn.request must be published");
+    }
+
+    // -- reap_stale_and_recover ------------------------------------------------
+
+    #[tokio::test]
+    async fn reap_stale_closes_orphaned_run() {
+        let server = MockServer::start().await;
+        mount_answer(&server, "done").await;
+        let (_orch, storage) = build(&server.uri()).await;
+
+        let event_store = storage.conversation_event_store();
+        let run_id = "run-orphan-001";
+        let conv_id = "conv-orphan-001";
+
+        // Simulate an orphaned run: run_started but no terminal event.
+        event_store
+            .append_event(
+                run_id,
+                conv_id,
+                0,
+                "run_started",
+                &serde_json::json!({"run_id": run_id}),
+            )
+            .await
+            .unwrap();
+        event_store
+            .append_event(
+                run_id,
+                conv_id,
+                1,
+                "token",
+                &serde_json::json!({"token": "partial"}),
+            )
+            .await
+            .unwrap();
+
+        // Backdate so it's older than the stale threshold.
+        sqlx::query(
+            "UPDATE conversation_events SET created_at = datetime('now', '-10 minutes') \
+             WHERE run_id = ?1",
+        )
+        .bind(run_id)
+        .execute(&storage.pool)
+        .await
+        .unwrap();
+
+        let bus = storage.message_bus();
+        reap_stale_and_recover(&storage, &bus).await;
+
+        // The orphaned run should now have a synthetic terminal event.
+        assert!(
+            event_store.is_run_complete(run_id).await.unwrap(),
+            "orphaned run should be marked complete after recovery"
+        );
+
+        let events = event_store.list_events_since(run_id, 2).await.unwrap();
+        assert_eq!(events.len(), 1, "should have exactly one synthetic event");
+        assert_eq!(events[0].event_type, "agent_error");
+        assert_eq!(events[0].payload["synthetic"], true);
+    }
+
+    #[tokio::test]
+    async fn reap_stale_skips_run_with_active_bus_message() {
+        let server = MockServer::start().await;
+        mount_answer(&server, "done").await;
+        let (_orch, storage) = build(&server.uri()).await;
+
+        let event_store = storage.conversation_event_store();
+        let run_id = "run-active-001";
+        let conv_id = Uuid::new_v4();
+
+        // Create an orphaned run.
+        event_store
+            .append_event(
+                run_id,
+                &conv_id.to_string(),
+                0,
+                "run_started",
+                &serde_json::json!({"run_id": run_id}),
+            )
+            .await
+            .unwrap();
+
+        // Backdate.
+        sqlx::query(
+            "UPDATE conversation_events SET created_at = datetime('now', '-10 minutes') \
+             WHERE run_id = ?1",
+        )
+        .bind(run_id)
+        .execute(&storage.pool)
+        .await
+        .unwrap();
+
+        // Publish an active bus message for the same conversation.
+        let bus = storage.message_bus();
+        use assistant_core::PublishRequest;
+        bus.publish(
+            PublishRequest::new(topic::TURN_REQUEST, serde_json::json!({"prompt": "retry"}))
+                .with_conversation_id(conv_id),
+        )
+        .await
+        .unwrap();
+
+        reap_stale_and_recover(&storage, &bus).await;
+
+        // The run should NOT be closed — bus message is still active.
+        assert!(
+            !event_store.is_run_complete(run_id).await.unwrap(),
+            "run with active bus message should not be closed"
+        );
+    }
+
+    #[tokio::test]
+    async fn reap_stale_skips_fresh_runs() {
+        let server = MockServer::start().await;
+        mount_answer(&server, "done").await;
+        let (_orch, storage) = build(&server.uri()).await;
+
+        let event_store = storage.conversation_event_store();
+        let run_id = "run-fresh-001";
+        let conv_id = "conv-fresh-001";
+
+        // Create a run that just started (no backdating).
+        event_store
+            .append_event(
+                run_id,
+                conv_id,
+                0,
+                "run_started",
+                &serde_json::json!({"run_id": run_id}),
+            )
+            .await
+            .unwrap();
+
+        let bus = storage.message_bus();
+        reap_stale_and_recover(&storage, &bus).await;
+
+        // Fresh run should not be touched.
+        assert!(
+            !event_store.is_run_complete(run_id).await.unwrap(),
+            "fresh run should not be closed"
+        );
     }
 }

--- a/crates/runtime/src/scheduler.rs
+++ b/crates/runtime/src/scheduler.rs
@@ -501,11 +501,14 @@ pub(crate) async fn reap_stale_and_recover(storage: &StorageLayer, bus: &dyn Mes
     }
 }
 
-/// Check whether there is a Pending or Claimed bus message for a conversation.
+/// Check whether there is a Pending or Claimed `turn.request` bus message for a
+/// conversation.  Only `turn.request` messages initiate orchestrator runs; other
+/// topics (e.g. `schedule.trigger`) should not block orphan recovery.
 async fn has_active_bus_message(pool: &SqlitePool, conversation_id: &str) -> Result<bool> {
     let count: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM bus_messages \
          WHERE conversation_id = ?1 \
+           AND topic = 'turn.request' \
            AND status IN ('pending', 'claimed')",
     )
     .bind(conversation_id)

--- a/crates/storage/src/conversation_events.rs
+++ b/crates/storage/src/conversation_events.rs
@@ -114,11 +114,11 @@ impl ConversationEventStore {
         Ok(count > 0)
     }
 
-    /// Return `true` if the run has completed (a `done` or `error` event was persisted).
+    /// Return `true` if the run has completed (a `done` or `agent_error` event was persisted).
     pub async fn is_run_complete(&self, run_id: &str) -> Result<bool> {
         let count: i64 = sqlx::query_scalar(
             "SELECT COUNT(*) FROM conversation_events \
-             WHERE run_id = ?1 AND (event_type = 'done' OR event_type = 'error')",
+             WHERE run_id = ?1 AND (event_type = 'done' OR event_type = 'agent_error')",
         )
         .bind(run_id)
         .fetch_one(&self.pool)
@@ -134,6 +134,73 @@ impl ConversationEventStore {
             .execute(&self.pool)
             .await?;
         Ok(result.rows_affected())
+    }
+
+    /// Find runs that have a `run_started` event but no terminal event
+    /// (`done` or `agent_error`), and whose `run_started` was created more than
+    /// `older_than` ago.
+    ///
+    /// Returns `(run_id, conversation_id)` pairs for orphaned runs that likely
+    /// died mid-stream (e.g. server restart).
+    pub async fn find_incomplete_runs(
+        &self,
+        older_than: Duration,
+    ) -> Result<Vec<(String, String)>> {
+        let cutoff = Utc::now() - older_than;
+        let rows = sqlx::query(
+            "SELECT DISTINCT ce.run_id, ce.conversation_id \
+             FROM conversation_events ce \
+             WHERE ce.event_type = 'run_started' \
+               AND ce.created_at < ?1 \
+               AND NOT EXISTS ( \
+                   SELECT 1 FROM conversation_events ce2 \
+                   WHERE ce2.run_id = ce.run_id \
+                     AND ce2.event_type IN ('done', 'agent_error') \
+               )",
+        )
+        .bind(cutoff)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let results = rows
+            .iter()
+            .map(|r| {
+                let run_id: String = r.try_get("run_id").unwrap_or_default();
+                let conversation_id: String = r.try_get("conversation_id").unwrap_or_default();
+                (run_id, conversation_id)
+            })
+            .collect();
+        Ok(results)
+    }
+
+    /// Append a synthetic `agent_error` terminal event to an orphaned run.
+    ///
+    /// Auto-determines the next sequence number. The payload includes
+    /// `"synthetic": true` so clients can distinguish crash recovery from real
+    /// errors.
+    pub async fn append_synthetic_terminal(
+        &self,
+        run_id: &str,
+        conversation_id: &str,
+        message: &str,
+    ) -> Result<i64> {
+        let next_seq: i64 = sqlx::query_scalar(
+            "SELECT COALESCE(MAX(sequence), -1) + 1 \
+             FROM conversation_events WHERE run_id = ?1",
+        )
+        .bind(run_id)
+        .fetch_one(&self.pool)
+        .await?;
+
+        let payload = serde_json::json!({
+            "message": message,
+            "synthetic": true,
+        });
+
+        self.append_event(run_id, conversation_id, next_seq, "agent_error", &payload)
+            .await?;
+
+        Ok(next_seq)
     }
 }
 
@@ -422,7 +489,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn is_run_complete_detects_error_event() {
+    async fn is_run_complete_detects_agent_error_event() {
         let store = make_store().await;
         let run_id = "run-004";
         let conv_id = "conv-004";
@@ -444,15 +511,172 @@ mod tests {
                 run_id,
                 conv_id,
                 1,
-                "error",
+                "agent_error",
                 &serde_json::json!({"message": "LLM failed"}),
             )
             .await
             .unwrap();
         assert!(
             store.is_run_complete(run_id).await.unwrap(),
-            "error event should mark run as complete"
+            "agent_error event should mark run as complete"
         );
+    }
+
+    #[tokio::test]
+    async fn find_incomplete_runs_returns_orphans() {
+        let store = make_store().await;
+
+        // Create a run that started 10 minutes ago but has no terminal event.
+        let orphan_run = "run-orphan";
+        let orphan_conv = "conv-orphan";
+        store
+            .append_event(
+                orphan_run,
+                orphan_conv,
+                0,
+                "run_started",
+                &serde_json::json!({"run_id": orphan_run}),
+            )
+            .await
+            .unwrap();
+
+        // Backdate the run_started event so it's older than the threshold.
+        sqlx::query(
+            "UPDATE conversation_events SET created_at = datetime('now', '-10 minutes') \
+             WHERE run_id = ?1",
+        )
+        .bind(orphan_run)
+        .execute(&store.pool)
+        .await
+        .unwrap();
+
+        let orphans = store
+            .find_incomplete_runs(Duration::minutes(5))
+            .await
+            .unwrap();
+        assert_eq!(orphans.len(), 1);
+        assert_eq!(
+            orphans[0],
+            (orphan_run.to_string(), orphan_conv.to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn find_incomplete_runs_excludes_completed() {
+        let store = make_store().await;
+        let run_id = "run-completed";
+        let conv_id = "conv-completed";
+
+        store
+            .append_event(
+                run_id,
+                conv_id,
+                0,
+                "run_started",
+                &serde_json::json!({"run_id": run_id}),
+            )
+            .await
+            .unwrap();
+        store
+            .append_event(
+                run_id,
+                conv_id,
+                1,
+                "done",
+                &serde_json::json!({"content": "bye"}),
+            )
+            .await
+            .unwrap();
+
+        // Backdate so it's old enough.
+        sqlx::query(
+            "UPDATE conversation_events SET created_at = datetime('now', '-10 minutes') \
+             WHERE run_id = ?1",
+        )
+        .bind(run_id)
+        .execute(&store.pool)
+        .await
+        .unwrap();
+
+        let orphans = store
+            .find_incomplete_runs(Duration::minutes(5))
+            .await
+            .unwrap();
+        assert!(
+            orphans.is_empty(),
+            "completed run should not appear as orphan"
+        );
+    }
+
+    #[tokio::test]
+    async fn find_incomplete_runs_respects_age_threshold() {
+        let store = make_store().await;
+        let run_id = "run-fresh";
+        let conv_id = "conv-fresh";
+
+        // Create a run that just started (no backdating — it's fresh).
+        store
+            .append_event(
+                run_id,
+                conv_id,
+                0,
+                "run_started",
+                &serde_json::json!({"run_id": run_id}),
+            )
+            .await
+            .unwrap();
+
+        let orphans = store
+            .find_incomplete_runs(Duration::minutes(5))
+            .await
+            .unwrap();
+        assert!(orphans.is_empty(), "fresh run should not appear as orphan");
+    }
+
+    #[tokio::test]
+    async fn append_synthetic_terminal_correct_sequence() {
+        let store = make_store().await;
+        let run_id = "run-synth";
+        let conv_id = "conv-synth";
+
+        // Append some events first.
+        store
+            .append_event(
+                run_id,
+                conv_id,
+                0,
+                "run_started",
+                &serde_json::json!({"run_id": run_id}),
+            )
+            .await
+            .unwrap();
+        store
+            .append_event(
+                run_id,
+                conv_id,
+                1,
+                "token",
+                &serde_json::json!({"token": "hi"}),
+            )
+            .await
+            .unwrap();
+
+        let seq = store
+            .append_synthetic_terminal(run_id, conv_id, "Server restarted")
+            .await
+            .unwrap();
+
+        assert_eq!(seq, 2, "synthetic event should get next sequence");
+
+        // Verify the event was persisted correctly.
+        let events = store.list_events_since(run_id, 2).await.unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type, "agent_error");
+        assert_eq!(events[0].payload["message"], "Server restarted");
+        assert_eq!(events[0].payload["synthetic"], true);
+
+        // Run should now be complete.
+        assert!(store.is_run_complete(run_id).await.unwrap());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **Crash recovery**: When the server restarts mid-stream, orphaned SSE runs (those with `run_started` but no terminal event) are now automatically closed with a synthetic `agent_error` event. The scheduler runs `reap_stale_and_recover()` on startup and every 5 minutes, skipping runs that still have active bus messages (may recover via redelivery).
- **Bug fix**: `is_run_complete` now correctly checks for `agent_error` instead of the stale `error` event type.
- **Client sequence tracking**: The Dart SSE parser now reads the `id:` field and populates `StreamEvent.sequenceId`. All 16 `_lastSeq++` sites in `chat_provider.dart` use the server-authoritative sequence with fallback: `_lastSeq = event.sequenceId ?? (_lastSeq + 1)`.
- **Replay resilience**: `_replayRun` now handles `AgentErrorEvent` (marks the user message as failed, cleans up the streaming placeholder).

## Test plan

- [x] `cargo test -p assistant-storage conversation_events` — 14 tests (4 new: `find_incomplete_runs` returns/excludes/respects-age, `append_synthetic_terminal` correct sequence)
- [x] `cargo test -p assistant-runtime scheduler` — 16 tests (3 new: orphan closed, skipped with active bus msg, fresh run skipped)
- [x] `flutter test test/unit/api/client_test.dart` — 47 tests (8 new: `id:` parsing, `sequenceId` threading, reset between events, field order independence)
- [x] `flutter test` — 571 tests all pass
- [x] `cargo clippy -p assistant-storage -p assistant-runtime -- -D warnings` — clean
- [x] `flutter analyze` — no issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery for interrupted agent runs to prevent data loss.

* **Bug Fixes**
  * Improved event sequencing and tracking during streaming operations.
  * Enhanced error handling for failed agent operations with better terminal state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->