### PR TITLE
feat(web-ui): route traces, logs, and analytics through pluggable backends

### DIFF
--- a/crates/storage/src/logs.rs
+++ b/crates/storage/src/logs.rs
@@ -77,6 +77,52 @@ impl LogStore {
         rows.into_iter().map(Self::row_to_log).collect()
     }
 
+    /// Return recent logs (not agent-scoped) with optional time and
+    /// conversation filters.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn list_recent_filtered(
+        &self,
+        limit: i64,
+        min_severity: Option<i32>,
+        target_filter: Option<&str>,
+        search: Option<&str>,
+        trace_id: Option<&str>,
+        conversation_id: Option<&str>,
+        since: Option<DateTime<Utc>>,
+        until: Option<DateTime<Utc>>,
+    ) -> Result<Vec<RecordedLog>> {
+        let rows = sqlx::query(
+            "SELECT l.id, l.timestamp, l.observed_timestamp, l.severity_number, l.severity_text, \
+                    l.body, l.trace_id, l.span_id, dt.name AS span_name, l.service_name, l.target, l.attributes \
+             FROM logs l \
+             LEFT JOIN distributed_traces dt ON dt.span_id = l.span_id AND dt.trace_id = l.trace_id \
+             WHERE (?1 IS NULL OR l.severity_number >= ?1) \
+               AND (?2 IS NULL OR l.target = ?2) \
+               AND (?3 IS NULL OR l.body LIKE '%' || ?3 || '%') \
+               AND (?4 IS NULL OR l.trace_id = ?4) \
+               AND (?5 IS NULL OR l.timestamp >= ?5) \
+               AND (?6 IS NULL OR l.timestamp <= ?6) \
+               AND (?7 IS NULL OR EXISTS ( \
+                   SELECT 1 FROM distributed_traces dt2 \
+                   WHERE dt2.trace_id = l.trace_id AND dt2.conversation_id = ?7 \
+               )) \
+             ORDER BY l.timestamp DESC \
+             LIMIT ?8",
+        )
+        .bind(min_severity)
+        .bind(target_filter)
+        .bind(search)
+        .bind(trace_id)
+        .bind(since)
+        .bind(until)
+        .bind(conversation_id)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter().map(Self::row_to_log).collect()
+    }
+
     /// Return recent logs scoped to a specific assistant agent.
     #[allow(clippy::too_many_arguments)]
     pub async fn list_recent_for_agent(

--- a/crates/storage/src/traces.rs
+++ b/crates/storage/src/traces.rs
@@ -63,6 +63,19 @@ pub struct TraceFilter {
     pub until: Option<DateTime<Utc>>,
 }
 
+impl TraceFilter {
+    /// Returns `true` when any filter beyond `skill` is set, meaning the
+    /// caller must apply additional in-memory filtering.
+    pub fn has_post_filters(&self) -> bool {
+        self.status.is_some()
+            || self.conversation.is_some()
+            || self.min_duration_ms.is_some()
+            || self.interface.is_some()
+            || self.since.is_some()
+            || self.until.is_some()
+    }
+}
+
 /// A persisted OpenTelemetry span row enriched with tool metadata.
 #[derive(Debug, Clone)]
 pub struct RecordedSpan {

--- a/crates/web-ui/src/api/analytics.rs
+++ b/crates/web-ui/src/api/analytics.rs
@@ -16,17 +16,16 @@ use axum::{
     routing::get,
 };
 use serde::{Deserialize, Serialize};
-use sqlx::SqlitePool;
 use tokio::sync::RwLock;
 use tracing::warn;
 
-use assistant_storage::MetricsStore;
+use crate::backends::MetricsBackend;
 
 // -- State -------------------------------------------------------------------
 
 #[derive(Clone)]
 pub struct AnalyticsApiState {
-    pub pool: SqlitePool,
+    pub metrics_backend: Arc<dyn MetricsBackend>,
     pub agent_id: Arc<RwLock<String>>,
 }
 
@@ -135,14 +134,14 @@ pub async fn get_analytics(
     let bucket_mins = bucket_minutes(window_hours);
 
     let agent_id = state.agent_id.read().await.clone();
-    let store = MetricsStore::for_agent(state.pool, &agent_id);
+    let backend = &state.metrics_backend;
 
     let (summary_res, models_res, tools_res, token_series_res, request_series_res) = tokio::join!(
-        store.summary(window_hours),
-        store.model_comparison(window_hours),
-        store.tool_usage(window_hours),
-        store.token_usage_over_time(window_hours, bucket_mins),
-        store.request_rate(window_hours, bucket_mins),
+        backend.summary(window_hours, &agent_id),
+        backend.model_comparison(window_hours, &agent_id),
+        backend.tool_usage(window_hours, &agent_id),
+        backend.token_usage_over_time(window_hours, bucket_mins, &agent_id),
+        backend.request_rate(window_hours, bucket_mins, &agent_id),
     );
 
     let summary = match summary_res {
@@ -228,12 +227,14 @@ mod tests {
 
     use assistant_storage::StorageLayer;
 
+    use crate::backends::SqliteMetricsBackend;
+
     use super::{AnalyticsApiState, analytics_api_router};
 
     async fn test_state() -> (AnalyticsApiState, Arc<StorageLayer>) {
         let storage = Arc::new(StorageLayer::new_in_memory().await.unwrap());
         let state = AnalyticsApiState {
-            pool: storage.pool.clone(),
+            metrics_backend: Arc::new(SqliteMetricsBackend::new(storage.pool.clone())),
             agent_id: Arc::new(RwLock::new("default".to_string())),
         };
         (state, storage)

--- a/crates/web-ui/src/api/logs.rs
+++ b/crates/web-ui/src/api/logs.rs
@@ -6,6 +6,8 @@
 //! |--------|------------|---------------------------|
 //! | GET    | `/api/logs`| List recent log entries   |
 
+use std::sync::Arc;
+
 use axum::{
     Json, Router,
     extract::{Query, State},
@@ -15,14 +17,15 @@ use axum::{
 };
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use sqlx::SqlitePool;
 use tracing::warn;
+
+use crate::backends::LogBackend;
 
 // -- State -------------------------------------------------------------------
 
 #[derive(Clone)]
 pub struct LogsApiState {
-    pub pool: SqlitePool,
+    pub log_backend: Arc<dyn LogBackend>,
 }
 
 // -- Response types ----------------------------------------------------------
@@ -111,41 +114,33 @@ pub async fn list_logs(
     Query(params): Query<LogsQueryParams>,
 ) -> Response {
     let limit = params.limit.unwrap_or(100).min(500);
-    let store = assistant_storage::logs::LogStore::new(state.pool);
 
     let min_severity = params.severity.as_deref().and_then(severity_text_to_number);
 
     let search = params.search.as_deref().filter(|s| !s.is_empty());
     let trace_id = params.trace_id.as_deref();
+    let conversation_id = params.conversation.as_deref();
 
-    // Use list_recent (not scoped to agent) so all logs are visible.
-    match store
-        .list_recent(
+    // Use the pluggable backend (SQLite or Iceberg) with an empty agent_id
+    // so all logs are visible in the top-level view.
+    match state
+        .log_backend
+        .list_recent_logs(
             limit,
             min_severity,
             None, // target filter not exposed in API v1
             search,
             trace_id,
+            conversation_id,
+            params.since,
+            params.until,
+            "", // empty agent_id → unscoped
         )
         .await
     {
         Ok(logs) => {
             let mut entries: Vec<LogEntryResponse> = logs
                 .into_iter()
-                .filter(|l| {
-                    // Apply post-fetch time and conversation filters.
-                    if let Some(since) = params.since
-                        && l.timestamp < since
-                    {
-                        return false;
-                    }
-                    if let Some(until) = params.until
-                        && l.timestamp > until
-                    {
-                        return false;
-                    }
-                    true
-                })
                 .map(|l| {
                     let severity = l
                         .severity_number
@@ -204,12 +199,14 @@ mod tests {
 
     use assistant_storage::StorageLayer;
 
+    use crate::backends::SqliteLogBackend;
+
     use super::{LogsApiState, logs_router};
 
     async fn test_state() -> (LogsApiState, Arc<StorageLayer>) {
         let storage = Arc::new(StorageLayer::new_in_memory().await.unwrap());
         let state = LogsApiState {
-            pool: storage.pool.clone(),
+            log_backend: Arc::new(SqliteLogBackend::new(storage.pool.clone())),
         };
         (state, storage)
     }

--- a/crates/web-ui/src/api/traces.rs
+++ b/crates/web-ui/src/api/traces.rs
@@ -7,6 +7,8 @@
 //! | GET    | `/api/traces`         | List recent traces (filtered)    |
 //! | GET    | `/api/traces/{id}`    | Get a single trace with spans    |
 
+use std::sync::Arc;
+
 use axum::{
     Json, Router,
     extract::{Path, Query, State},
@@ -16,14 +18,15 @@ use axum::{
 };
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use sqlx::SqlitePool;
 use tracing::warn;
+
+use crate::backends::TraceBackend;
 
 // -- State -------------------------------------------------------------------
 
 #[derive(Clone)]
 pub struct TracesApiState {
-    pub pool: SqlitePool,
+    pub trace_backend: Arc<dyn TraceBackend>,
 }
 
 // -- Response types ----------------------------------------------------------
@@ -107,7 +110,6 @@ pub async fn list_traces(
     Query(params): Query<TracesQueryParams>,
 ) -> Response {
     let limit = params.limit.unwrap_or(50).min(200);
-    let store = assistant_storage::traces::TraceStore::new(state.pool);
 
     let filter = assistant_storage::traces::TraceFilter {
         skill: params.skill.clone(),
@@ -121,38 +123,16 @@ pub async fn list_traces(
         ..Default::default()
     };
 
-    match store
-        .list_recent_traces(limit, filter.skill.as_deref())
+    // Use the pluggable backend (SQLite or Iceberg) with an empty agent_id
+    // so all traces are visible in the top-level view.
+    match state
+        .trace_backend
+        .list_recent_traces(limit, &filter, "")
         .await
     {
         Ok(traces) => {
             let mut summaries: Vec<TraceSummaryResponse> = traces
                 .into_iter()
-                .filter(|t| {
-                    // Apply post-fetch filters (status, conversation, since, until).
-                    if let Some(ref status) = filter.status {
-                        let trace_status = if t.error_count > 0 { "error" } else { "ok" };
-                        if trace_status != status.as_str() {
-                            return false;
-                        }
-                    }
-                    if let Some(conv_id) = filter.conversation
-                        && t.conversation_id != Some(conv_id)
-                    {
-                        return false;
-                    }
-                    if let Some(since) = filter.since
-                        && t.start_time < since
-                    {
-                        return false;
-                    }
-                    if let Some(until) = filter.until
-                        && t.start_time > until
-                    {
-                        return false;
-                    }
-                    true
-                })
                 .map(|t| {
                     let status = if t.error_count > 0 { "error" } else { "ok" }.to_string();
                     let duration_ms = t
@@ -205,9 +185,8 @@ pub async fn get_trace(
     State(state): State<TracesApiState>,
     Path(trace_id): Path<String>,
 ) -> Response {
-    let store = assistant_storage::traces::TraceStore::new(state.pool);
-
-    match store.get_trace(&trace_id).await {
+    // Use the pluggable backend with an empty agent_id for the top-level view.
+    match state.trace_backend.get_trace(&trace_id, "").await {
         Ok(spans) if spans.is_empty() => (
             StatusCode::NOT_FOUND,
             Json(serde_json::json!({"error": "Trace not found"})),
@@ -264,12 +243,14 @@ mod tests {
 
     use assistant_storage::StorageLayer;
 
+    use crate::backends::SqliteTraceBackend;
+
     use super::{TracesApiState, traces_router};
 
     async fn test_state() -> (TracesApiState, Arc<StorageLayer>) {
         let storage = Arc::new(StorageLayer::new_in_memory().await.unwrap());
         let state = TracesApiState {
-            pool: storage.pool.clone(),
+            trace_backend: Arc::new(SqliteTraceBackend::new(storage.pool.clone())),
         };
         (state, storage)
     }

--- a/crates/web-ui/src/backends/iceberg.rs
+++ b/crates/web-ui/src/backends/iceberg.rs
@@ -719,8 +719,8 @@ struct MetricRow {
     attributes: Value,
 }
 
-/// Parse all metric rows from batches, filtering by window.
-fn parse_metric_rows(batches: &[RecordBatch], window_hours: i64) -> Vec<MetricRow> {
+/// Parse all metric rows from batches, filtering by window and agent.
+fn parse_metric_rows(batches: &[RecordBatch], window_hours: i64, agent_id: &str) -> Vec<MetricRow> {
     let cutoff = Utc::now() - chrono::Duration::hours(window_hours);
     let mut rows = Vec::new();
 
@@ -732,6 +732,15 @@ fn parse_metric_rows(batches: &[RecordBatch], window_hours: i64) -> Vec<MetricRo
             };
             if recorded_at < cutoff {
                 continue;
+            }
+
+            // Filter by agent_id when provided (the Parquet schema has a
+            // dedicated `agent_id` column written by the Iceberg exporter).
+            if !agent_id.is_empty() {
+                let row_agent = str_col(batch, "agent_id", i).unwrap_or("");
+                if row_agent != agent_id {
+                    continue;
+                }
             }
 
             let attrs_str = str_col(batch, "attributes", i).unwrap_or("{}");
@@ -753,17 +762,24 @@ fn parse_metric_rows(batches: &[RecordBatch], window_hours: i64) -> Vec<MetricRo
 }
 
 /// Format a timestamp into a bucket string for a given bucket width in minutes.
+///
+/// Uses epoch-based rounding so bucket widths > 60 minutes (e.g. 180, 360)
+/// produce correct multi-hour buckets.
 fn bucket_key(ts: &DateTime<Utc>, bucket_minutes: i64) -> String {
-    let minute = ts.format("%M").to_string().parse::<i64>().unwrap_or(0);
-    let bucketed = (minute / bucket_minutes) * bucket_minutes;
-    format!("{}:{:02}:00Z", ts.format("%Y-%m-%dT%H"), bucketed)
+    let bucket_seconds = bucket_minutes.max(1) * 60;
+    let bucketed = (ts.timestamp() / bucket_seconds) * bucket_seconds;
+    Utc.timestamp_opt(bucketed, 0)
+        .single()
+        .unwrap_or(*ts)
+        .format("%Y-%m-%dT%H:%M:00Z")
+        .to_string()
 }
 
 #[async_trait]
 impl MetricsBackend for IcebergMetricsBackend {
-    async fn summary(&self, window_hours: i64, _agent_id: &str) -> Result<MetricsSummary> {
+    async fn summary(&self, window_hours: i64, agent_id: &str) -> Result<MetricsSummary> {
         let batches = self.load_all_batches();
-        let rows = parse_metric_rows(&batches, window_hours);
+        let rows = parse_metric_rows(&batches, window_hours, agent_id);
 
         let mut token_in: f64 = 0.0;
         let mut token_out: f64 = 0.0;
@@ -832,10 +848,10 @@ impl MetricsBackend for IcebergMetricsBackend {
         &self,
         window_hours: i64,
         bucket_minutes: i64,
-        _agent_id: &str,
+        agent_id: &str,
     ) -> Result<Vec<TimeSeriesPoint>> {
         let batches = self.load_all_batches();
-        let rows = parse_metric_rows(&batches, window_hours);
+        let rows = parse_metric_rows(&batches, window_hours, agent_id);
 
         let mut buckets: std::collections::BTreeMap<String, f64> = Default::default();
         for row in &rows {
@@ -855,10 +871,10 @@ impl MetricsBackend for IcebergMetricsBackend {
     async fn model_comparison(
         &self,
         window_hours: i64,
-        _agent_id: &str,
+        agent_id: &str,
     ) -> Result<Vec<ModelTokenUsage>> {
         let batches = self.load_all_batches();
-        let rows = parse_metric_rows(&batches, window_hours);
+        let rows = parse_metric_rows(&batches, window_hours, agent_id);
 
         struct Acc {
             input: f64,
@@ -882,11 +898,15 @@ impl MetricsBackend for IcebergMetricsBackend {
                 count: 0.0,
             });
             match token_type {
-                Some("input") => acc.input += row.sum.unwrap_or(0.0),
+                Some("input") => {
+                    acc.input += row.sum.unwrap_or(0.0);
+                    // Only count requests from input rows to avoid double-counting
+                    // (each LLM call emits both an input and output token row).
+                    acc.count += row.count.unwrap_or(0) as f64;
+                }
                 Some("output") => acc.output += row.sum.unwrap_or(0.0),
                 _ => {}
             }
-            acc.count += row.count.unwrap_or(0) as f64;
         }
 
         let mut result: Vec<ModelTokenUsage> = map
@@ -906,9 +926,9 @@ impl MetricsBackend for IcebergMetricsBackend {
         Ok(result)
     }
 
-    async fn tool_usage(&self, window_hours: i64, _agent_id: &str) -> Result<Vec<ToolUsageStats>> {
+    async fn tool_usage(&self, window_hours: i64, agent_id: &str) -> Result<Vec<ToolUsageStats>> {
         let batches = self.load_all_batches();
-        let rows = parse_metric_rows(&batches, window_hours);
+        let rows = parse_metric_rows(&batches, window_hours, agent_id);
 
         let mut map: HashMap<String, f64> = HashMap::new();
         for row in &rows {
@@ -942,10 +962,10 @@ impl MetricsBackend for IcebergMetricsBackend {
         &self,
         window_hours: i64,
         bucket_minutes: i64,
-        _agent_id: &str,
+        agent_id: &str,
     ) -> Result<Vec<TimeSeriesPoint>> {
         let batches = self.load_all_batches();
-        let rows = parse_metric_rows(&batches, window_hours);
+        let rows = parse_metric_rows(&batches, window_hours, agent_id);
 
         let mut buckets: std::collections::BTreeMap<String, f64> = Default::default();
         for row in &rows {

--- a/crates/web-ui/src/backends/iceberg.rs
+++ b/crates/web-ui/src/backends/iceberg.rs
@@ -13,7 +13,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use arrow_array::cast::AsArray;
-use arrow_array::types::{Int32Type, Int64Type, TimestampMicrosecondType};
+use arrow_array::types::{Float64Type, Int32Type, Int64Type, TimestampMicrosecondType};
 use arrow_array::{Array, RecordBatch};
 use async_trait::async_trait;
 use chrono::{DateTime, TimeZone, Utc};
@@ -23,10 +23,11 @@ use uuid::Uuid;
 
 use assistant_core::IcebergConfig;
 use assistant_storage::{
-    LogStats, RecordedLog, RecordedSpan, SkillStatsProvider, TraceFilter, TraceStats, TraceSummary,
+    LogStats, MetricsSummary, ModelTokenUsage, RecordedLog, RecordedSpan, SkillStatsProvider,
+    TimeSeriesPoint, ToolUsageStats, TraceFilter, TraceStats, TraceSummary,
 };
 
-use super::{LogBackend, TraceBackend};
+use super::{LogBackend, MetricsBackend, TraceBackend};
 
 // -- helpers ------------------------------------------------------------------
 
@@ -121,6 +122,17 @@ fn i64_col(batch: &RecordBatch, col: &str, i: usize) -> Option<i64> {
 fn i32_col(batch: &RecordBatch, col: &str, i: usize) -> Option<i32> {
     let idx = batch.schema().index_of(col).ok()?;
     let arr = batch.column(idx).as_primitive_opt::<Int32Type>()?;
+    if arr.is_null(i) {
+        None
+    } else {
+        Some(arr.value(i))
+    }
+}
+
+/// Extract a nullable `f64` at row `i`.
+fn f64_col(batch: &RecordBatch, col: &str, i: usize) -> Option<f64> {
+    let idx = batch.schema().index_of(col).ok()?;
+    let arr = batch.column(idx).as_primitive_opt::<Float64Type>()?;
     if arr.is_null(i) {
         None
     } else {
@@ -653,5 +665,300 @@ impl SkillStatsProvider for IcebergTraceBackend {
             total_output_tokens,
             common_errors,
         })
+    }
+}
+
+// -- IcebergMetricsBackend ----------------------------------------------------
+
+// OTel semantic convention metric names.
+const GEN_AI_TOKEN_USAGE: &str = "gen_ai.client.token.usage";
+const GEN_AI_OPERATION_DURATION: &str = "gen_ai.client.operation.duration";
+const ASSISTANT_TURN_COUNT: &str = "assistant.turn.count";
+const ASSISTANT_TOOL_INVOCATIONS: &str = "assistant.tool.invocations";
+const ASSISTANT_ERROR_COUNT: &str = "assistant.error.count";
+const GEN_AI_TOKEN_TYPE: &str = "gen_ai.token.type";
+
+pub struct IcebergMetricsBackend {
+    config: IcebergConfig,
+}
+
+impl IcebergMetricsBackend {
+    pub fn new(config: IcebergConfig) -> Self {
+        Self { config }
+    }
+
+    fn metrics_data_dir(&self) -> PathBuf {
+        warehouse_path(&self.config)
+            .join(&self.config.namespace)
+            .join("assistant_metric_points")
+            .join("data")
+    }
+
+    fn load_all_batches(&self) -> Vec<RecordBatch> {
+        let dir = self.metrics_data_dir();
+        let files = collect_parquet_files(&dir);
+        let mut batches = Vec::new();
+        for f in &files {
+            match read_parquet(f) {
+                Ok(b) => batches.extend(b),
+                Err(e) => tracing::warn!("skipping metric parquet file {}: {e}", f.display()),
+            }
+        }
+        batches
+    }
+}
+
+/// A parsed metric row from Parquet.
+struct MetricRow {
+    metric_name: String,
+    recorded_at: DateTime<Utc>,
+    value: Option<f64>,
+    count: Option<i64>,
+    sum: Option<f64>,
+    model: Option<String>,
+    attributes: Value,
+}
+
+/// Parse all metric rows from batches, filtering by window.
+fn parse_metric_rows(batches: &[RecordBatch], window_hours: i64) -> Vec<MetricRow> {
+    let cutoff = Utc::now() - chrono::Duration::hours(window_hours);
+    let mut rows = Vec::new();
+
+    for batch in batches {
+        for i in 0..batch.num_rows() {
+            let recorded_at = match ts_col(batch, "recorded_at", i) {
+                Some(t) => t,
+                None => continue,
+            };
+            if recorded_at < cutoff {
+                continue;
+            }
+
+            let attrs_str = str_col(batch, "attributes", i).unwrap_or("{}");
+            let attributes: Value =
+                serde_json::from_str(attrs_str).unwrap_or(Value::Object(Default::default()));
+
+            rows.push(MetricRow {
+                metric_name: str_col_req(batch, "metric_name", i).to_string(),
+                recorded_at,
+                value: f64_col(batch, "value", i),
+                count: i64_col(batch, "count", i),
+                sum: f64_col(batch, "sum", i),
+                model: str_col(batch, "model", i).map(str::to_string),
+                attributes,
+            });
+        }
+    }
+    rows
+}
+
+/// Format a timestamp into a bucket string for a given bucket width in minutes.
+fn bucket_key(ts: &DateTime<Utc>, bucket_minutes: i64) -> String {
+    let minute = ts.format("%M").to_string().parse::<i64>().unwrap_or(0);
+    let bucketed = (minute / bucket_minutes) * bucket_minutes;
+    format!("{}:{:02}:00Z", ts.format("%Y-%m-%dT%H"), bucketed)
+}
+
+#[async_trait]
+impl MetricsBackend for IcebergMetricsBackend {
+    async fn summary(&self, window_hours: i64, _agent_id: &str) -> Result<MetricsSummary> {
+        let batches = self.load_all_batches();
+        let rows = parse_metric_rows(&batches, window_hours);
+
+        let mut token_in: f64 = 0.0;
+        let mut token_out: f64 = 0.0;
+        let mut requests: f64 = 0.0;
+        let mut tools: f64 = 0.0;
+        let mut errors: f64 = 0.0;
+        let mut duration_sum: f64 = 0.0;
+        let mut duration_count: f64 = 0.0;
+        let mut models: std::collections::HashSet<String> = Default::default();
+
+        for row in &rows {
+            match row.metric_name.as_str() {
+                n if n == GEN_AI_TOKEN_USAGE => {
+                    let token_type = row
+                        .attributes
+                        .get(GEN_AI_TOKEN_TYPE)
+                        .and_then(|v| v.as_str());
+                    let s = row.sum.unwrap_or(0.0);
+                    match token_type {
+                        Some("input") => token_in += s,
+                        Some("output") => token_out += s,
+                        _ => {}
+                    }
+                    if let Some(ref m) = row.model {
+                        models.insert(m.clone());
+                    }
+                }
+                n if n == ASSISTANT_TURN_COUNT => {
+                    requests += row.value.unwrap_or(0.0);
+                }
+                n if n == ASSISTANT_TOOL_INVOCATIONS => {
+                    tools += row.value.unwrap_or(0.0);
+                }
+                n if n == ASSISTANT_ERROR_COUNT => {
+                    errors += row.value.unwrap_or(0.0);
+                }
+                n if n == GEN_AI_OPERATION_DURATION => {
+                    duration_sum += row.sum.unwrap_or(0.0);
+                    duration_count += row.count.unwrap_or(0) as f64;
+                }
+                _ => {}
+            }
+        }
+
+        let avg_duration_s = if duration_count > 0.0 {
+            duration_sum / duration_count
+        } else {
+            0.0
+        };
+
+        let mut unique_models: Vec<String> = models.into_iter().collect();
+        unique_models.sort();
+
+        Ok(MetricsSummary {
+            total_tokens_in: token_in as i64,
+            total_tokens_out: token_out as i64,
+            total_requests: requests as i64,
+            total_tool_invocations: tools as i64,
+            avg_duration_s,
+            error_count: errors as i64,
+            unique_models,
+        })
+    }
+
+    async fn token_usage_over_time(
+        &self,
+        window_hours: i64,
+        bucket_minutes: i64,
+        _agent_id: &str,
+    ) -> Result<Vec<TimeSeriesPoint>> {
+        let batches = self.load_all_batches();
+        let rows = parse_metric_rows(&batches, window_hours);
+
+        let mut buckets: std::collections::BTreeMap<String, f64> = Default::default();
+        for row in &rows {
+            if row.metric_name != GEN_AI_TOKEN_USAGE {
+                continue;
+            }
+            let key = bucket_key(&row.recorded_at, bucket_minutes);
+            *buckets.entry(key).or_default() += row.sum.unwrap_or(0.0);
+        }
+
+        Ok(buckets
+            .into_iter()
+            .map(|(bucket, value)| TimeSeriesPoint { bucket, value })
+            .collect())
+    }
+
+    async fn model_comparison(
+        &self,
+        window_hours: i64,
+        _agent_id: &str,
+    ) -> Result<Vec<ModelTokenUsage>> {
+        let batches = self.load_all_batches();
+        let rows = parse_metric_rows(&batches, window_hours);
+
+        struct Acc {
+            input: f64,
+            output: f64,
+            count: f64,
+        }
+
+        let mut map: HashMap<String, Acc> = HashMap::new();
+        for row in &rows {
+            if row.metric_name != GEN_AI_TOKEN_USAGE {
+                continue;
+            }
+            let model = row.model.clone().unwrap_or_else(|| "unknown".to_string());
+            let token_type = row
+                .attributes
+                .get(GEN_AI_TOKEN_TYPE)
+                .and_then(|v| v.as_str());
+            let acc = map.entry(model).or_insert(Acc {
+                input: 0.0,
+                output: 0.0,
+                count: 0.0,
+            });
+            match token_type {
+                Some("input") => acc.input += row.sum.unwrap_or(0.0),
+                Some("output") => acc.output += row.sum.unwrap_or(0.0),
+                _ => {}
+            }
+            acc.count += row.count.unwrap_or(0) as f64;
+        }
+
+        let mut result: Vec<ModelTokenUsage> = map
+            .into_iter()
+            .map(|(model, acc)| ModelTokenUsage {
+                model,
+                input_tokens: acc.input as i64,
+                output_tokens: acc.output as i64,
+                request_count: acc.count as i64,
+                avg_duration_s: 0.0,
+            })
+            .collect();
+
+        result.sort_by(|a, b| {
+            (b.input_tokens + b.output_tokens).cmp(&(a.input_tokens + a.output_tokens))
+        });
+        Ok(result)
+    }
+
+    async fn tool_usage(&self, window_hours: i64, _agent_id: &str) -> Result<Vec<ToolUsageStats>> {
+        let batches = self.load_all_batches();
+        let rows = parse_metric_rows(&batches, window_hours);
+
+        let mut map: HashMap<String, f64> = HashMap::new();
+        for row in &rows {
+            if row.metric_name != ASSISTANT_TOOL_INVOCATIONS {
+                continue;
+            }
+            let tool_name = row
+                .attributes
+                .get("span.name")
+                .or_else(|| row.attributes.get("tool.name"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown")
+                .to_string();
+            *map.entry(tool_name).or_default() += row.value.unwrap_or(0.0);
+        }
+
+        let mut result: Vec<ToolUsageStats> = map
+            .into_iter()
+            .map(|(tool_name, invocations)| ToolUsageStats {
+                tool_name,
+                invocations: invocations as i64,
+                avg_duration_s: 0.0,
+            })
+            .collect();
+
+        result.sort_by_key(|t| std::cmp::Reverse(t.invocations));
+        Ok(result)
+    }
+
+    async fn request_rate(
+        &self,
+        window_hours: i64,
+        bucket_minutes: i64,
+        _agent_id: &str,
+    ) -> Result<Vec<TimeSeriesPoint>> {
+        let batches = self.load_all_batches();
+        let rows = parse_metric_rows(&batches, window_hours);
+
+        let mut buckets: std::collections::BTreeMap<String, f64> = Default::default();
+        for row in &rows {
+            if row.metric_name != ASSISTANT_TURN_COUNT {
+                continue;
+            }
+            let key = bucket_key(&row.recorded_at, bucket_minutes);
+            *buckets.entry(key).or_default() += row.value.unwrap_or(0.0);
+        }
+
+        Ok(buckets
+            .into_iter()
+            .map(|(bucket, value)| TimeSeriesPoint { bucket, value })
+            .collect())
     }
 }

--- a/crates/web-ui/src/backends/mod.rs
+++ b/crates/web-ui/src/backends/mod.rs
@@ -16,13 +16,16 @@ use anyhow::Result;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 
-use assistant_storage::{LogStats, RecordedLog, RecordedSpan, TraceFilter, TraceSummary};
+use assistant_storage::{
+    LogStats, MetricsSummary, ModelTokenUsage, RecordedLog, RecordedSpan, TimeSeriesPoint,
+    ToolUsageStats, TraceFilter, TraceSummary,
+};
 
 pub mod iceberg;
 pub mod sqlite;
 
-pub use iceberg::{IcebergLogBackend, IcebergTraceBackend};
-pub use sqlite::{SqliteLogBackend, SqliteTraceBackend};
+pub use iceberg::{IcebergLogBackend, IcebergMetricsBackend, IcebergTraceBackend};
+pub use sqlite::{SqliteLogBackend, SqliteMetricsBackend, SqliteTraceBackend};
 
 // -- TraceBackend -------------------------------------------------------------
 
@@ -45,6 +48,41 @@ pub trait TraceBackend: Send + Sync {
     /// `agent_id` is used by the SQLite backend for per-agent scoping and
     /// ignored by the Iceberg backend.
     async fn get_trace(&self, trace_id: &str, agent_id: &str) -> Result<Vec<RecordedSpan>>;
+}
+
+// -- MetricsBackend -----------------------------------------------------------
+
+/// Read-side interface for metric point data (analytics dashboard).
+#[async_trait]
+pub trait MetricsBackend: Send + Sync {
+    /// Overall summary for the last `window_hours` hours.
+    async fn summary(&self, window_hours: i64, agent_id: &str) -> Result<MetricsSummary>;
+
+    /// Token-usage time series grouped into fixed-width time buckets.
+    async fn token_usage_over_time(
+        &self,
+        window_hours: i64,
+        bucket_minutes: i64,
+        agent_id: &str,
+    ) -> Result<Vec<TimeSeriesPoint>>;
+
+    /// Per-model token-usage breakdown.
+    async fn model_comparison(
+        &self,
+        window_hours: i64,
+        agent_id: &str,
+    ) -> Result<Vec<ModelTokenUsage>>;
+
+    /// Tool invocation statistics.
+    async fn tool_usage(&self, window_hours: i64, agent_id: &str) -> Result<Vec<ToolUsageStats>>;
+
+    /// Request-rate time series (turns per bucket).
+    async fn request_rate(
+        &self,
+        window_hours: i64,
+        bucket_minutes: i64,
+        agent_id: &str,
+    ) -> Result<Vec<TimeSeriesPoint>>;
 }
 
 // -- LogBackend ---------------------------------------------------------------

--- a/crates/web-ui/src/backends/sqlite.rs
+++ b/crates/web-ui/src/backends/sqlite.rs
@@ -1,4 +1,4 @@
-//! SQLite-backed query backends — thin wrappers around `TraceStore`/`LogStore`.
+//! SQLite-backed query backends — thin wrappers around storage stores.
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -6,10 +6,11 @@ use chrono::{DateTime, Utc};
 use sqlx::SqlitePool;
 
 use assistant_storage::{
-    LogStats, LogStore, RecordedLog, RecordedSpan, TraceFilter, TraceStore, TraceSummary,
+    LogStats, LogStore, MetricsStore, MetricsSummary, ModelTokenUsage, RecordedLog, RecordedSpan,
+    TimeSeriesPoint, ToolUsageStats, TraceFilter, TraceStore, TraceSummary,
 };
 
-use super::{LogBackend, TraceBackend};
+use super::{LogBackend, MetricsBackend, TraceBackend};
 
 // -- SqliteTraceBackend -------------------------------------------------------
 
@@ -31,15 +32,26 @@ impl TraceBackend for SqliteTraceBackend {
         filter: &TraceFilter,
         agent_id: &str,
     ) -> Result<Vec<TraceSummary>> {
-        TraceStore::new(self.pool.clone())
-            .list_recent_traces_for_agent(limit, filter, agent_id)
-            .await
+        let store = TraceStore::new(self.pool.clone());
+        if agent_id.is_empty() {
+            // Unscoped: return all traces (top-level API view).
+            store
+                .list_recent_traces(limit, filter.skill.as_deref())
+                .await
+        } else {
+            store
+                .list_recent_traces_for_agent(limit, filter, agent_id)
+                .await
+        }
     }
 
     async fn get_trace(&self, trace_id: &str, agent_id: &str) -> Result<Vec<RecordedSpan>> {
-        TraceStore::new(self.pool.clone())
-            .get_trace_for_agent(trace_id, agent_id)
-            .await
+        let store = TraceStore::new(self.pool.clone());
+        if agent_id.is_empty() {
+            store.get_trace(trace_id).await
+        } else {
+            store.get_trace_for_agent(trace_id, agent_id).await
+        }
     }
 }
 
@@ -69,36 +81,112 @@ impl LogBackend for SqliteLogBackend {
         until: Option<DateTime<Utc>>,
         agent_id: &str,
     ) -> Result<Vec<RecordedLog>> {
-        LogStore::new(self.pool.clone())
-            .list_recent_for_agent(
-                limit,
-                min_severity,
-                target_filter,
-                search,
-                trace_id,
-                conversation_id,
-                since,
-                until,
-                agent_id,
-            )
-            .await
+        let store = LogStore::new(self.pool.clone());
+        if agent_id.is_empty() {
+            // Unscoped: return all logs (top-level API view).
+            store
+                .list_recent(limit, min_severity, target_filter, search, trace_id)
+                .await
+        } else {
+            store
+                .list_recent_for_agent(
+                    limit,
+                    min_severity,
+                    target_filter,
+                    search,
+                    trace_id,
+                    conversation_id,
+                    since,
+                    until,
+                    agent_id,
+                )
+                .await
+        }
     }
 
     async fn get_log(&self, id: &str, agent_id: &str) -> Result<Option<RecordedLog>> {
-        LogStore::new(self.pool.clone())
-            .get_log_for_agent(id, agent_id)
-            .await
+        let store = LogStore::new(self.pool.clone());
+        if agent_id.is_empty() {
+            store.get_log(id).await
+        } else {
+            store.get_log_for_agent(id, agent_id).await
+        }
     }
 
     async fn log_stats(&self, agent_id: &str) -> Result<LogStats> {
-        LogStore::new(self.pool.clone())
-            .stats_for_agent(agent_id)
-            .await
+        let store = LogStore::new(self.pool.clone());
+        if agent_id.is_empty() {
+            store.stats().await
+        } else {
+            store.stats_for_agent(agent_id).await
+        }
     }
 
     async fn list_targets(&self, agent_id: &str) -> Result<Vec<String>> {
-        LogStore::new(self.pool.clone())
-            .list_targets_for_agent(agent_id)
+        let store = LogStore::new(self.pool.clone());
+        if agent_id.is_empty() {
+            store.list_targets().await
+        } else {
+            store.list_targets_for_agent(agent_id).await
+        }
+    }
+}
+
+// -- SqliteMetricsBackend -----------------------------------------------------
+
+pub struct SqliteMetricsBackend {
+    pool: SqlitePool,
+}
+
+impl SqliteMetricsBackend {
+    pub fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl MetricsBackend for SqliteMetricsBackend {
+    async fn summary(&self, window_hours: i64, agent_id: &str) -> Result<MetricsSummary> {
+        MetricsStore::for_agent(self.pool.clone(), agent_id)
+            .summary(window_hours)
+            .await
+    }
+
+    async fn token_usage_over_time(
+        &self,
+        window_hours: i64,
+        bucket_minutes: i64,
+        agent_id: &str,
+    ) -> Result<Vec<TimeSeriesPoint>> {
+        MetricsStore::for_agent(self.pool.clone(), agent_id)
+            .token_usage_over_time(window_hours, bucket_minutes)
+            .await
+    }
+
+    async fn model_comparison(
+        &self,
+        window_hours: i64,
+        agent_id: &str,
+    ) -> Result<Vec<ModelTokenUsage>> {
+        MetricsStore::for_agent(self.pool.clone(), agent_id)
+            .model_comparison(window_hours)
+            .await
+    }
+
+    async fn tool_usage(&self, window_hours: i64, agent_id: &str) -> Result<Vec<ToolUsageStats>> {
+        MetricsStore::for_agent(self.pool.clone(), agent_id)
+            .tool_usage(window_hours)
+            .await
+    }
+
+    async fn request_rate(
+        &self,
+        window_hours: i64,
+        bucket_minutes: i64,
+        agent_id: &str,
+    ) -> Result<Vec<TimeSeriesPoint>> {
+        MetricsStore::for_agent(self.pool.clone(), agent_id)
+            .request_rate(window_hours, bucket_minutes)
             .await
     }
 }

--- a/crates/web-ui/src/backends/sqlite.rs
+++ b/crates/web-ui/src/backends/sqlite.rs
@@ -34,10 +34,44 @@ impl TraceBackend for SqliteTraceBackend {
     ) -> Result<Vec<TraceSummary>> {
         let store = TraceStore::new(self.pool.clone());
         if agent_id.is_empty() {
-            // Unscoped: return all traces (top-level API view).
-            store
-                .list_recent_traces(limit, filter.skill.as_deref())
-                .await
+            // Unscoped: the base query only accepts a skill filter, so we
+            // fetch a larger batch and apply the remaining filters in memory.
+            let fetch_limit = if filter.has_post_filters() {
+                limit * 4
+            } else {
+                limit
+            };
+            let mut traces = store
+                .list_recent_traces(fetch_limit, filter.skill.as_deref())
+                .await?;
+            if filter.has_post_filters() {
+                traces.retain(|t| {
+                    if let Some(ref status) = filter.status {
+                        let t_status = if t.error_count > 0 { "error" } else { "ok" };
+                        if t_status != status.as_str() {
+                            return false;
+                        }
+                    }
+                    if let Some(conv) = filter.conversation
+                        && t.conversation_id != Some(conv)
+                    {
+                        return false;
+                    }
+                    if let Some(since) = filter.since
+                        && t.start_time < since
+                    {
+                        return false;
+                    }
+                    if let Some(until) = filter.until
+                        && t.start_time > until
+                    {
+                        return false;
+                    }
+                    true
+                });
+                traces.truncate(limit as usize);
+            }
+            Ok(traces)
         } else {
             store
                 .list_recent_traces_for_agent(limit, filter, agent_id)
@@ -85,7 +119,16 @@ impl LogBackend for SqliteLogBackend {
         if agent_id.is_empty() {
             // Unscoped: return all logs (top-level API view).
             store
-                .list_recent(limit, min_severity, target_filter, search, trace_id)
+                .list_recent_filtered(
+                    limit,
+                    min_severity,
+                    target_filter,
+                    search,
+                    trace_id,
+                    conversation_id,
+                    since,
+                    until,
+                )
                 .await
         } else {
             store

--- a/crates/web-ui/src/main.rs
+++ b/crates/web-ui/src/main.rs
@@ -38,8 +38,8 @@ use axum::{
     routing::{get, post},
 };
 use backends::{
-    IcebergLogBackend, IcebergTraceBackend, LogBackend, SqliteLogBackend, SqliteTraceBackend,
-    TraceBackend,
+    IcebergLogBackend, IcebergMetricsBackend, IcebergTraceBackend, LogBackend, MetricsBackend,
+    SqliteLogBackend, SqliteMetricsBackend, SqliteTraceBackend, TraceBackend,
 };
 use clap::Parser;
 use serde_json::json;
@@ -135,6 +135,7 @@ pub(crate) struct AppState {
     pub(crate) nats_token: Option<String>,
     pub(crate) trace_backend: Arc<dyn TraceBackend>,
     pub(crate) log_backend: Arc<dyn LogBackend>,
+    pub(crate) metrics_backend: Arc<dyn MetricsBackend>,
     pub(crate) push_dispatcher: Option<Arc<PushDispatcher>>,
 }
 
@@ -328,20 +329,25 @@ async fn run_with_args(args: Args) -> Result<()> {
 
     let registry = Arc::new(registry);
 
-    let (trace_backend, log_backend): (Arc<dyn TraceBackend>, Arc<dyn LogBackend>) =
-        match config.observability.exporter {
-            OtelExporter::Iceberg => {
-                let iceberg_cfg = config.observability.iceberg.clone();
-                (
-                    Arc::new(IcebergTraceBackend::new(iceberg_cfg.clone())),
-                    Arc::new(IcebergLogBackend::new(iceberg_cfg)),
-                )
-            }
-            _ => (
-                Arc::new(SqliteTraceBackend::new(storage.pool.clone())),
-                Arc::new(SqliteLogBackend::new(storage.pool.clone())),
-            ),
-        };
+    let (trace_backend, log_backend, metrics_backend): (
+        Arc<dyn TraceBackend>,
+        Arc<dyn LogBackend>,
+        Arc<dyn MetricsBackend>,
+    ) = match config.observability.exporter {
+        OtelExporter::Iceberg => {
+            let iceberg_cfg = config.observability.iceberg.clone();
+            (
+                Arc::new(IcebergTraceBackend::new(iceberg_cfg.clone())),
+                Arc::new(IcebergLogBackend::new(iceberg_cfg.clone())),
+                Arc::new(IcebergMetricsBackend::new(iceberg_cfg)),
+            )
+        }
+        _ => (
+            Arc::new(SqliteTraceBackend::new(storage.pool.clone())),
+            Arc::new(SqliteLogBackend::new(storage.pool.clone())),
+            Arc::new(SqliteMetricsBackend::new(storage.pool.clone())),
+        ),
+    };
 
     // -- Push dispatcher (built here so AppState can hold a reference) -------
     let push_store_for_state = Arc::new(storage.push_subscription_store());
@@ -373,6 +379,7 @@ async fn run_with_args(args: Args) -> Result<()> {
             .or_else(|| std::env::var("NATS_TOKEN").ok()),
         trace_backend,
         log_backend,
+        metrics_backend,
         push_dispatcher: push_dispatcher_for_state,
     };
 
@@ -600,11 +607,11 @@ async fn run_with_args(args: Args) -> Result<()> {
     };
 
     let traces_api_state = api::traces::TracesApiState {
-        pool: storage.pool.clone(),
+        trace_backend: state.trace_backend.clone(),
     };
 
     let logs_api_state = api::logs::LogsApiState {
-        pool: storage.pool.clone(),
+        log_backend: state.log_backend.clone(),
     };
 
     let skills_api_state = api::skills::SkillsApiState {
@@ -622,7 +629,7 @@ async fn run_with_args(args: Args) -> Result<()> {
     };
 
     let analytics_api_state = api::analytics::AnalyticsApiState {
-        pool: storage.pool.clone(),
+        metrics_backend: state.metrics_backend.clone(),
         agent_id: state.agent_id.clone(),
     };
 


### PR DESCRIPTION
## Summary

- **Traces/logs/analytics API endpoints now respect the configured observability backend** (SQLite or Iceberg) instead of always reading from SQLite
- Added `MetricsBackend` trait with `SqliteMetricsBackend` and `IcebergMetricsBackend` implementations — the missing third leg alongside the existing `TraceBackend`/`LogBackend`
- `IcebergMetricsBackend` scans `assistant_metric_points` Parquet files and aggregates OTel metrics (token usage, turn counts, tool invocations, operation duration, errors) in memory

### What changed

| File | Change |
|------|--------|
| `api/traces.rs` | `TracesApiState` holds `Arc<dyn TraceBackend>` instead of `SqlitePool` |
| `api/logs.rs` | `LogsApiState` holds `Arc<dyn LogBackend>` instead of `SqlitePool` |
| `api/analytics.rs` | `AnalyticsApiState` holds `Arc<dyn MetricsBackend>` instead of `SqlitePool` |
| `backends/mod.rs` | New `MetricsBackend` trait |
| `backends/sqlite.rs` | `SqliteMetricsBackend` + unscoped fallback for empty `agent_id` |
| `backends/iceberg.rs` | `IcebergMetricsBackend` scanning Parquet files |
| `main.rs` | Backend selection now creates all three backends; wired into API states |

## Test plan

- [x] All 131 existing `assistant-web-ui` tests pass (no regressions)
- [x] Clippy clean, format clean, workspace check passes
- [ ] Manual verification with `exporter = "iceberg"` config on a deployment with Parquet data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Iceberg (Parquet) data format as an analytics data source, complementing existing database options.

* **Refactor**
  * Modernized the analytics, logs, and traces architecture with pluggable backend implementations. This enhances flexibility in data source selection and enables seamless integration of new storage formats without requiring core application changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->