### PR TITLE
fix(app): share extension credential sync — direct Keychain writes via IOSOptions

### DIFF
--- a/app/ios/Runner/SharedCredentialsChannel.swift
+++ b/app/ios/Runner/SharedCredentialsChannel.swift
@@ -1,8 +1,9 @@
 import Flutter
 import AssistantIntents
 
-/// Method channel that writes credentials to the shared Keychain access group
-/// so that app extensions (share extension, Siri) can read them.
+/// Method channel that exposes the Apple Team ID prefix to Dart so that
+/// `flutter_secure_storage` can write to the shared Keychain access group
+/// using `IOSOptions(groupId:)`.
 final class SharedCredentialsChannel {
     static let channelName = "com.cedricziel.assistant/shared_credentials"
 
@@ -10,42 +11,8 @@ final class SharedCredentialsChannel {
         let channel = FlutterMethodChannel(name: channelName, binaryMessenger: messenger)
         channel.setMethodCallHandler { call, result in
             switch call.method {
-            case "syncCredentials":
-                guard let args = call.arguments as? [String: Any] else {
-                    result(FlutterError(code: "INVALID_ARGS", message: "Expected a map", details: nil))
-                    return
-                }
-                let serverUrl = args["serverUrl"] as? String
-                let authToken = args["authToken"] as? String
-
-                let keychain = KeychainHelper(
-                    service: "com.cedricziel.assistant",
-                    sharedAccessGroup: "\(KeychainHelper.teamPrefix)com.cedricziel.assistant.shared"
-                )
-
-                let serverOK: Bool
-                if let url = serverUrl, !url.isEmpty {
-                    serverOK = keychain.write(key: "assistant_siri_server_url", value: url)
-                } else {
-                    serverOK = keychain.delete(key: "assistant_siri_server_url")
-                }
-
-                let tokenOK: Bool
-                if let token = authToken, !token.isEmpty {
-                    tokenOK = keychain.write(key: "assistant_siri_auth_token", value: token)
-                } else {
-                    tokenOK = keychain.delete(key: "assistant_siri_auth_token")
-                }
-
-                guard serverOK && tokenOK else {
-                    result(FlutterError(
-                        code: "KEYCHAIN_SYNC_FAILED",
-                        message: "Failed to sync credentials to the shared Keychain access group",
-                        details: nil
-                    ))
-                    return
-                }
-                result(true)
+            case "getTeamPrefix":
+                result(KeychainHelper.teamPrefix)
 
             default:
                 result(FlutterMethodNotImplemented)

--- a/app/lib/features/contexts/data/context_repository.dart
+++ b/app/lib/features/contexts/data/context_repository.dart
@@ -285,7 +285,14 @@ class ContextRepository {
     final platform = defaultTargetPlatform;
 
     // iOS: write directly via flutter_secure_storage.
-    if (platform == TargetPlatform.iOS && iosOptions != null) {
+    if (platform == TargetPlatform.iOS) {
+      if (iosOptions == null) {
+        debugPrint(
+          'Skipping shared Keychain sync on iOS: Apple team prefix '
+          'unavailable (getTeamPrefix returned null at startup).',
+        );
+        return;
+      }
       final storage = const FlutterSecureStorage();
       try {
         if (serverUrl != null && serverUrl.isNotEmpty) {

--- a/app/lib/features/contexts/data/context_repository.dart
+++ b/app/lib/features/contexts/data/context_repository.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -14,6 +15,13 @@ const _kTokenPrefix = 'assistant_context_token_';
 /// Swift App Intent code reads these directly from the Keychain.
 const _kSiriServerUrl = 'assistant_siri_server_url';
 const _kSiriAuthToken = 'assistant_siri_auth_token';
+
+/// The Keychain service name that the native Swift `KeychainHelper` uses.
+/// Must match the `service` parameter in `KeychainHelper(service:)`.
+const _kNativeKeychainService = 'com.cedricziel.assistant';
+
+/// The suffix of the shared Keychain access group (without the team prefix).
+const _kSharedAccessGroupSuffix = 'com.cedricziel.assistant.shared';
 
 /// Abstraction over platform secure key-value storage.
 ///
@@ -46,14 +54,35 @@ class FlutterSecureStorageAdapter implements SecureKeyValueStorage {
 /// [SharedPreferences].  Auth tokens live in [SecureKeyValueStorage]
 /// (platform keychain / secure enclave).
 class ContextRepository {
-  const ContextRepository({
+  ContextRepository({
     required SharedPreferences prefs,
     required SecureKeyValueStorage secureStorage,
+    String? appleTeamPrefix,
   }) : _prefs = prefs,
-       _secureStorage = secureStorage;
+       _secureStorage = secureStorage,
+       _appleTeamPrefix = appleTeamPrefix;
 
   final SharedPreferences _prefs;
   final SecureKeyValueStorage _secureStorage;
+
+  /// Apple Team ID prefix (e.g. "ABCDE12345."), resolved at startup.
+  /// `null` on web or when the native channel is unavailable.
+  final String? _appleTeamPrefix;
+
+  /// Returns `IOSOptions` that target the shared Keychain access group with
+  /// the correct service name so items are readable by the native Swift
+  /// `KeychainHelper`.
+  ///
+  /// Returns `null` if the team prefix is unavailable (web, or native call
+  /// failed).
+  IOSOptions? get _sharedIOSOptions {
+    final prefix = _appleTeamPrefix;
+    if (prefix == null || prefix.isEmpty) return null;
+    return IOSOptions(
+      accountName: _kNativeKeychainService,
+      groupId: '$prefix$_kSharedAccessGroupSuffix',
+    );
+  }
 
   // -- Read -----------------------------------------------------------------
 
@@ -189,35 +218,29 @@ class ContextRepository {
   // -- Siri credential sync -------------------------------------------------
 
   /// Writes the active context's server URL and auth token to well-known
-  /// Keychain keys so native Swift App Intent code can access them without
-  /// the Flutter engine running.
+  /// Keychain keys so native Swift code (App Intents, share extension) can
+  /// access them without the Flutter engine running.
   ///
-  /// Credentials are written to both the app's default Keychain scope (for
-  /// Siri/Shortcuts backward compatibility) and the shared Keychain access
-  /// group (for the share extension and other app extensions).
+  /// On iOS, credentials are written directly to the shared Keychain access
+  /// group via `flutter_secure_storage` with `IOSOptions(groupId:)`.
+  ///
+  /// On macOS, the `flutter_secure_storage` plugin ignores `groupId`, so the
+  /// write is performed via a native method channel instead.
+  ///
+  /// The default-scope write (Siri/Shortcuts backward compat) is always done.
   ///
   /// Call this whenever the active context changes or credentials are updated.
   Future<void> syncSiriCredentials() async {
     final activeId = getActiveContextId();
     if (activeId == null) {
-      await _secureStorage.delete(key: _kSiriServerUrl);
-      await _secureStorage.delete(key: _kSiriAuthToken);
-      await SharedCredentialsChannel.syncCredentials(
-        serverUrl: null,
-        authToken: null,
-      );
+      await _clearSiriCredentials();
       return;
     }
 
     final contexts = await loadContexts();
     final active = contexts.where((c) => c.id == activeId).firstOrNull;
     if (active == null) {
-      await _secureStorage.delete(key: _kSiriServerUrl);
-      await _secureStorage.delete(key: _kSiriAuthToken);
-      await SharedCredentialsChannel.syncCredentials(
-        serverUrl: null,
-        authToken: null,
-      );
+      await _clearSiriCredentials();
       return;
     }
 
@@ -234,12 +257,69 @@ class ContextRepository {
       await _secureStorage.delete(key: _kSiriAuthToken);
     }
 
-    // Write to shared Keychain group (share extension access).
-    // Fire-and-forget: don't block the save flow on platform channel response.
-    SharedCredentialsChannel.syncCredentials(
+    // Write to shared Keychain group (share extension + app extensions).
+    await _syncSharedKeychain(
       serverUrl: active.serverUrl,
       authToken: authToken,
     );
+  }
+
+  Future<void> _clearSiriCredentials() async {
+    await _secureStorage.delete(key: _kSiriServerUrl);
+    await _secureStorage.delete(key: _kSiriAuthToken);
+    await _syncSharedKeychain(serverUrl: null, authToken: null);
+  }
+
+  /// Writes credentials to the shared Keychain access group.
+  ///
+  /// On iOS: uses `flutter_secure_storage` with `IOSOptions(groupId:)`.
+  /// On macOS: uses native method channel (plugin ignores `groupId`).
+  Future<void> _syncSharedKeychain({
+    required String? serverUrl,
+    required String? authToken,
+  }) async {
+    if (kIsWeb) return;
+
+    final iosOptions = _sharedIOSOptions;
+
+    final platform = defaultTargetPlatform;
+
+    // iOS: write directly via flutter_secure_storage.
+    if (platform == TargetPlatform.iOS && iosOptions != null) {
+      final storage = const FlutterSecureStorage();
+      try {
+        if (serverUrl != null && serverUrl.isNotEmpty) {
+          await storage.write(
+            key: _kSiriServerUrl,
+            value: serverUrl,
+            iOptions: iosOptions,
+          );
+        } else {
+          await storage.delete(key: _kSiriServerUrl, iOptions: iosOptions);
+        }
+
+        if (authToken != null && authToken.isNotEmpty) {
+          await storage.write(
+            key: _kSiriAuthToken,
+            value: authToken,
+            iOptions: iosOptions,
+          );
+        } else {
+          await storage.delete(key: _kSiriAuthToken, iOptions: iosOptions);
+        }
+      } catch (e) {
+        debugPrint('Failed to sync credentials to shared Keychain: $e');
+      }
+      return;
+    }
+
+    // macOS: use native method channel (groupId has no effect in the plugin).
+    if (platform == TargetPlatform.macOS) {
+      await SharedCredentialsChannel.syncCredentialsMacOS(
+        serverUrl: serverUrl,
+        authToken: authToken,
+      );
+    }
   }
 
   // -- Internal helpers -----------------------------------------------------

--- a/app/lib/features/contexts/data/shared_credentials_channel.dart
+++ b/app/lib/features/contexts/data/shared_credentials_channel.dart
@@ -1,15 +1,46 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
-/// Platform channel that writes credentials to the shared Keychain access
-/// group so native app extensions can read them.
+/// Platform channel that bridges to native Apple code for shared Keychain
+/// operations.
+///
+/// On iOS, only [getTeamPrefix] is needed — `flutter_secure_storage` writes
+/// directly to the shared Keychain group via `IOSOptions(groupId:)`.
+///
+/// On macOS, the `flutter_secure_storage` plugin ignores `groupId`
+/// (`#if os(iOS)` in the native code), so [syncCredentialsMacOS] performs the
+/// write on the native side.
 class SharedCredentialsChannel {
   static const _channel = MethodChannel(
     'com.cedricziel.assistant/shared_credentials',
   );
 
-  /// Writes (or clears) the server URL and auth token in the shared
-  /// Keychain access group.
-  static Future<void> syncCredentials({
+  static String? _cachedTeamPrefix;
+
+  /// Returns the Apple Team ID prefix (e.g. "ABCDE12345.") resolved at
+  /// runtime from the Keychain. The result is cached for the app's lifetime.
+  ///
+  /// Returns `null` on platforms without a native channel (web).
+  static Future<String?> getTeamPrefix() async {
+    if (_cachedTeamPrefix != null) return _cachedTeamPrefix;
+
+    try {
+      final prefix = await _channel.invokeMethod<String>('getTeamPrefix');
+      _cachedTeamPrefix = prefix;
+      return prefix;
+    } on MissingPluginException {
+      // Web platform — no native channel available.
+      return null;
+    } catch (e) {
+      debugPrint('SharedCredentialsChannel.getTeamPrefix failed: $e');
+      return null;
+    }
+  }
+
+  /// Writes credentials to the shared Keychain access group via the native
+  /// method channel. **Only used on macOS** where `flutter_secure_storage`'s
+  /// `IOSOptions.groupId` has no effect.
+  static Future<void> syncCredentialsMacOS({
     required String? serverUrl,
     required String? authToken,
   }) async {
@@ -19,9 +50,9 @@ class SharedCredentialsChannel {
         'authToken': authToken,
       });
     } on MissingPluginException {
-      // Platform doesn't support the channel (e.g. web). Silently ignore.
-    } catch (_) {
-      // Binding not initialized (unit tests) or other platform error.
+      // Web platform — no native channel available.
+    } catch (e) {
+      debugPrint('SharedCredentialsChannel.syncCredentialsMacOS failed: $e');
     }
   }
 }

--- a/app/lib/features/contexts/providers/context_providers.dart
+++ b/app/lib/features/contexts/providers/context_providers.dart
@@ -3,6 +3,7 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../data/context_repository.dart';
+import '../data/shared_credentials_channel.dart';
 import '../models/context_model.dart';
 
 // -- Repository provider (override in ProviderScope for testing) ------------
@@ -20,6 +21,10 @@ final contextRepositoryProvider = Provider<ContextRepository>((ref) {
 
 /// Creates the production [ContextRepository].
 ///
+/// Fetches the Apple Team ID prefix at startup so the repository can write
+/// directly to the shared Keychain access group on iOS via
+/// `IOSOptions(groupId:)`.
+///
 /// Usage in `main()`:
 /// ```dart
 /// final repo = await createContextRepository();
@@ -30,9 +35,11 @@ final contextRepositoryProvider = Provider<ContextRepository>((ref) {
 /// ```
 Future<ContextRepository> createContextRepository() async {
   final prefs = await SharedPreferences.getInstance();
+  final teamPrefix = await SharedCredentialsChannel.getTeamPrefix();
   return ContextRepository(
     prefs: prefs,
     secureStorage: const FlutterSecureStorageAdapter(FlutterSecureStorage()),
+    appleTeamPrefix: teamPrefix,
   );
 }
 

--- a/app/macos/Runner/SharedCredentialsChannel.swift
+++ b/app/macos/Runner/SharedCredentialsChannel.swift
@@ -1,8 +1,12 @@
 import FlutterMacOS
 import AssistantIntents
 
-/// Method channel that writes credentials to the shared Keychain access group
-/// so that app extensions (share extension) can read them.
+/// Method channel that exposes the Apple Team ID prefix to Dart and writes
+/// credentials to the shared Keychain access group for macOS app extensions.
+///
+/// On macOS, `flutter_secure_storage`'s `groupId` (kSecAttrAccessGroup) is
+/// guarded behind `#if os(iOS)` in the plugin's native code, so it has no
+/// effect. We therefore keep the direct Keychain write for macOS.
 final class SharedCredentialsChannel {
     static let channelName = "com.cedricziel.assistant/shared_credentials"
 
@@ -10,6 +14,9 @@ final class SharedCredentialsChannel {
         let channel = FlutterMethodChannel(name: channelName, binaryMessenger: messenger)
         channel.setMethodCallHandler { call, result in
             switch call.method {
+            case "getTeamPrefix":
+                result(KeychainHelper.teamPrefix)
+
             case "syncCredentials":
                 guard let args = call.arguments as? [String: Any] else {
                     result(FlutterError(code: "INVALID_ARGS", message: "Expected a map", details: nil))

--- a/app/packages/AssistantIntents/Sources/AssistantIntents/API/KeychainHelper.swift
+++ b/app/packages/AssistantIntents/Sources/AssistantIntents/API/KeychainHelper.swift
@@ -23,39 +23,46 @@ public struct KeychainHelper {
     private let sharedAccessGroup: String?
 
     /// The Apple Team ID prefix (e.g. "ABCDE12345.") read from the app's
-    /// entitlements at runtime. Returns an empty string if unavailable.
-    public static var teamPrefix: String {
-        guard let entitlements = Bundle.main.infoDictionary,
-              let appId = entitlements["AppIdentifierPrefix"] as? String else {
-            // Fallback: query Keychain for the team prefix.
-            let query: [String: Any] = [
-                kSecClass as String: kSecClassGenericPassword,
-                kSecAttrAccount as String: "__team_prefix_probe__",
-                kSecReturnAttributes as String: true,
-            ]
-            // Write a throwaway item to read back the access group.
-            let addQuery: [String: Any] = [
-                kSecClass as String: kSecClassGenericPassword,
-                kSecAttrAccount as String: "__team_prefix_probe__",
-                kSecValueData as String: Data("x".utf8),
-            ]
-            SecItemAdd(addQuery as CFDictionary, nil)
-            var result: AnyObject?
-            let status = SecItemCopyMatching(query as CFDictionary, &result)
-            // Clean up probe.
-            SecItemDelete(addQuery as CFDictionary)
-            if status == errSecSuccess,
-               let attrs = result as? [String: Any],
-               let group = attrs[kSecAttrAccessGroup as String] as? String {
-                // group is "TEAMID.bundleid" — extract "TEAMID."
-                if let dotIndex = group.firstIndex(of: ".") {
-                    return String(group[...dotIndex])
-                }
-            }
-            return ""
+    /// entitlements at runtime. Cached after first access (thread-safe via
+    /// Swift's static let guarantee).
+    ///
+    /// Returns an empty string if the prefix cannot be determined.
+    public static let teamPrefix: String = {
+        if let entitlements = Bundle.main.infoDictionary,
+           let appId = entitlements["AppIdentifierPrefix"] as? String {
+            return appId
         }
-        return appId
-    }
+        // Fallback: query Keychain for the team prefix by writing a throwaway
+        // item and reading back the system-assigned access group.
+        let probeAccount = "__team_prefix_probe__"
+        let addQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: probeAccount,
+            kSecValueData as String: Data("x".utf8),
+        ]
+        SecItemAdd(addQuery as CFDictionary, nil)
+
+        let readQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: probeAccount,
+            kSecReturnAttributes as String: true,
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(readQuery as CFDictionary, &result)
+
+        // Clean up probe.
+        SecItemDelete(addQuery as CFDictionary)
+
+        if status == errSecSuccess,
+           let attrs = result as? [String: Any],
+           let group = attrs[kSecAttrAccessGroup as String] as? String {
+            // group is "TEAMID.bundleid" — extract "TEAMID."
+            if let dotIndex = group.firstIndex(of: ".") {
+                return String(group[...dotIndex])
+            }
+        }
+        return ""
+    }()
 
     public init(service: String? = nil, sharedAccessGroup: String? = nil) {
         self.service = service ?? Bundle.main.bundleIdentifier ?? "com.cedricziel.assistant"
@@ -143,10 +150,11 @@ public struct KeychainHelper {
         return status == errSecSuccess || status == errSecItemNotFound
     }
 
-    /// Returns `true` if non-empty credentials are available.
+    /// Returns `true` if a non-empty server URL is available.
+    ///
+    /// An auth token is optional — servers may not require authentication.
     public var hasCredentials: Bool {
-        guard let url = serverURL, !url.isEmpty,
-              let token = authToken, !token.isEmpty else {
+        guard let url = serverURL, !url.isEmpty else {
             return false
         }
         return true

--- a/app/packages/AssistantIntents/Sources/AssistantIntents/API/KeychainHelper.swift
+++ b/app/packages/AssistantIntents/Sources/AssistantIntents/API/KeychainHelper.swift
@@ -35,23 +35,31 @@ public struct KeychainHelper {
         // Fallback: query Keychain for the team prefix by writing a throwaway
         // item and reading back the system-assigned access group.
         let probeAccount = "__team_prefix_probe__"
-        let addQuery: [String: Any] = [
+        let probeService = "\(Bundle.main.bundleIdentifier ?? "com.cedricziel.assistant").team-prefix-probe"
+        let baseQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: probeService,
             kSecAttrAccount as String: probeAccount,
-            kSecValueData as String: Data("x".utf8),
         ]
-        SecItemAdd(addQuery as CFDictionary, nil)
 
-        let readQuery: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrAccount as String: probeAccount,
-            kSecReturnAttributes as String: true,
-        ]
+        // Remove any stale probe first so the read-back reflects this process.
+        SecItemDelete(baseQuery as CFDictionary)
+
+        var addQuery = baseQuery
+        addQuery[kSecValueData as String] = Data("x".utf8)
+
+        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        guard addStatus == errSecSuccess else {
+            return ""
+        }
+
+        var readQuery = baseQuery
+        readQuery[kSecReturnAttributes as String] = true
         var result: AnyObject?
         let status = SecItemCopyMatching(readQuery as CFDictionary, &result)
 
         // Clean up probe.
-        SecItemDelete(addQuery as CFDictionary)
+        SecItemDelete(baseQuery as CFDictionary)
 
         if status == errSecSuccess,
            let attrs = result as? [String: Any],

--- a/app/packages/AssistantIntents/Tests/AssistantIntentsTests/KeychainHelperTests.swift
+++ b/app/packages/AssistantIntents/Tests/AssistantIntentsTests/KeychainHelperTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+
+@testable import AssistantIntents
+
+final class KeychainHelperTests: XCTestCase {
+
+  /// Unique service name per test run to avoid cross-contamination with the
+  /// real app's Keychain items.
+  private let service = "com.cedricziel.assistant.tests.\(UUID().uuidString)"
+
+  private lazy var keychain = KeychainHelper(service: service)
+
+  override func tearDown() {
+    // Clean up test Keychain items.
+    keychain.delete(key: "assistant_siri_server_url")
+    keychain.delete(key: "assistant_siri_auth_token")
+    super.tearDown()
+  }
+
+  // MARK: - hasCredentials
+
+  func testHasCredentials_returnsFalse_whenNothingStored() {
+    XCTAssertFalse(keychain.hasCredentials)
+  }
+
+  func testHasCredentials_returnsTrue_whenOnlyServerURLStored() {
+    keychain.write(key: "assistant_siri_server_url", value: "https://example.com")
+    // No auth token written — server does not require auth.
+    XCTAssertTrue(
+      keychain.hasCredentials,
+      "hasCredentials should be true with only a server URL (no auth token)"
+    )
+  }
+
+  func testHasCredentials_returnsTrue_whenBothURLAndTokenStored() {
+    keychain.write(key: "assistant_siri_server_url", value: "https://example.com")
+    keychain.write(key: "assistant_siri_auth_token", value: "tok-123")
+    XCTAssertTrue(keychain.hasCredentials)
+  }
+
+  func testHasCredentials_returnsFalse_whenServerURLIsEmpty() {
+    keychain.write(key: "assistant_siri_server_url", value: "")
+    XCTAssertFalse(keychain.hasCredentials)
+  }
+
+  // MARK: - Read / Write / Delete
+
+  func testWriteAndRead() {
+    keychain.write(key: "assistant_siri_server_url", value: "https://test.local")
+    XCTAssertEqual(keychain.serverURL, "https://test.local")
+  }
+
+  func testDeleteRemovesValue() {
+    keychain.write(key: "assistant_siri_auth_token", value: "secret")
+    keychain.delete(key: "assistant_siri_auth_token")
+    XCTAssertNil(keychain.authToken)
+  }
+}

--- a/openspec/changes/fix-share-extension-credentials/design.md
+++ b/openspec/changes/fix-share-extension-credentials/design.md
@@ -2,7 +2,7 @@
 
 The share extension credential pipeline had three layers:
 
-```
+```text
 Flutter ContextRepository
   → flutter_secure_storage (app-only keychain, Siri backward compat)
   → SharedCredentialsChannel (Dart method channel → Swift)
@@ -29,7 +29,7 @@ Current code demanded both URL and non-empty auth token. Changed to require only
 
 **Old architecture (method channel bridge):**
 
-```
+```text
 Dart syncSiriCredentials()
   → flutter_secure_storage (default scope, Siri compat)
   → MethodChannel "syncCredentials" → Swift → KeychainHelper.write()
@@ -38,7 +38,7 @@ Dart syncSiriCredentials()
 
 **New architecture (direct write):**
 
-```
+```text
 Dart syncSiriCredentials()
   → flutter_secure_storage (default scope, Siri compat)
   → flutter_secure_storage with IOSOptions(
@@ -61,11 +61,12 @@ Direct writes through `flutter_secure_storage` are synchronous to the Keychain �
 **macOS limitation:** The `flutter_secure_storage_darwin` plugin wraps `groupId` in `#if os(iOS)` — it has no effect on macOS. For macOS, the method channel `syncCredentials` call is retained as a fallback.
 
 **Key mapping:**
-| Dart | Native Keychain | Value |
-|------|----------------|-------|
-| `IOSOptions(accountName:)` | `kSecAttrService` | `"com.cedricziel.assistant"` |
-| `IOSOptions(groupId:)` | `kSecAttrAccessGroup` | `"TEAMID.com.cedricziel.assistant.shared"` |
-| `write(key:)` | `kSecAttrAccount` | `"assistant_siri_server_url"` or `"assistant_siri_auth_token"` |
+
+| Dart                       | Native Keychain       | Value                                                          |
+| -------------------------- | --------------------- | -------------------------------------------------------------- |
+| `IOSOptions(accountName:)` | `kSecAttrService`     | `"com.cedricziel.assistant"`                                   |
+| `IOSOptions(groupId:)`     | `kSecAttrAccessGroup` | `"TEAMID.com.cedricziel.assistant.shared"`                     |
+| `write(key:)`              | `kSecAttrAccount`     | `"assistant_siri_server_url"` or `"assistant_siri_auth_token"` |
 
 These match what the Swift `KeychainHelper` reads with in the share extension.
 

--- a/openspec/changes/fix-share-extension-credentials/design.md
+++ b/openspec/changes/fix-share-extension-credentials/design.md
@@ -1,0 +1,87 @@
+## Context
+
+The share extension credential pipeline had three layers:
+
+```
+Flutter ContextRepository
+  → flutter_secure_storage (app-only keychain, Siri backward compat)
+  → SharedCredentialsChannel (Dart method channel → Swift)
+      → KeychainHelper.write() (shared keychain group)
+
+Share Extension
+  → KeychainHelper.read() (shared keychain group)
+  → KeychainHelper.hasCredentials (gate for showing UI vs "Not Connected")
+```
+
+The shared Keychain group (`TEAMID.com.cedricziel.assistant.shared`) and App Group (`group.com.cedricziel.assistant`) entitlements are correctly configured on both the Runner and ShareExtension targets. The architecture was sound but the method channel bridge introduced race conditions and silent failures.
+
+## Decisions
+
+### D1: `hasCredentials` requires only a server URL
+
+Current code demanded both URL and non-empty auth token. Changed to require only a non-empty server URL.
+
+**Why:** The `AssistantContext` model in Dart explicitly documents `authToken: null` as "server requires no auth." The Keychain helper should match this contract.
+
+### D6: Direct Keychain writes via `flutter_secure_storage` IOSOptions (replaces D2–D5)
+
+`flutter_secure_storage` v10 supports `IOSOptions(groupId:)` which maps directly to `kSecAttrAccessGroup`. This eliminates the need for a Swift method channel bridge to write shared Keychain items.
+
+**Old architecture (method channel bridge):**
+
+```
+Dart syncSiriCredentials()
+  → flutter_secure_storage (default scope, Siri compat)
+  → MethodChannel "syncCredentials" → Swift → KeychainHelper.write()
+     to shared access group
+```
+
+**New architecture (direct write):**
+
+```
+Dart syncSiriCredentials()
+  → flutter_secure_storage (default scope, Siri compat)
+  → flutter_secure_storage with IOSOptions(
+      accountName: "com.cedricziel.assistant",  // kSecAttrService
+      groupId: "TEAMID.com.cedricziel.assistant.shared"  // kSecAttrAccessGroup
+    )
+```
+
+**Why:** The method channel bridge was a workaround for something `flutter_secure_storage` supports natively. The bridge introduced:
+
+- A race condition (fire-and-forget, unawaited call)
+- Silent error swallowing (all exceptions caught and ignored)
+- No recovery path (failed sync stayed failed)
+- Extra Swift code to maintain
+
+Direct writes through `flutter_secure_storage` are synchronous to the Keychain — no race condition, no fire-and-forget.
+
+**Team prefix resolution:** `IOSOptions(groupId:)` requires the full access group including the Apple Team ID prefix (e.g. `ABCDE12345.com.cedricziel.assistant.shared`). The team prefix is resolved once at startup via a lightweight `getTeamPrefix` method channel call and cached for the app's lifetime.
+
+**macOS limitation:** The `flutter_secure_storage_darwin` plugin wraps `groupId` in `#if os(iOS)` — it has no effect on macOS. For macOS, the method channel `syncCredentials` call is retained as a fallback.
+
+**Key mapping:**
+| Dart | Native Keychain | Value |
+|------|----------------|-------|
+| `IOSOptions(accountName:)` | `kSecAttrService` | `"com.cedricziel.assistant"` |
+| `IOSOptions(groupId:)` | `kSecAttrAccessGroup` | `"TEAMID.com.cedricziel.assistant.shared"` |
+| `write(key:)` | `kSecAttrAccount` | `"assistant_siri_server_url"` or `"assistant_siri_auth_token"` |
+
+These match what the Swift `KeychainHelper` reads with in the share extension.
+
+### SharedCredentialsChannel changes
+
+| Method            | iOS                                       | macOS                                    |
+| ----------------- | ----------------------------------------- | ---------------------------------------- |
+| `getTeamPrefix`   | Returns `KeychainHelper.teamPrefix`       | Returns `KeychainHelper.teamPrefix`      |
+| `syncCredentials` | **Removed** (direct write via IOSOptions) | **Retained** (groupId ignored by plugin) |
+
+## Risks / Trade-offs
+
+**[Risk] Team prefix unavailable at startup** — If the native channel isn't registered when `getTeamPrefix` is called, the prefix is `null` and shared Keychain writes are skipped. Mitigated: the channel is registered in `didInitializeImplicitFlutterEngine` which fires before `main()` calls `createContextRepository()`.
+
+**[Risk] macOS still uses method channel** — Accepted. The `flutter_secure_storage_darwin` plugin's `#if os(iOS)` guard means we can't eliminate the bridge on macOS. When/if the plugin adds macOS support for `groupId`, the method channel can be removed there too.
+
+**[Eliminated risk] Fire-and-forget race condition** — Direct `flutter_secure_storage` writes complete synchronously. No method channel timing dependency.
+
+**[Eliminated risk] Silent error swallowing** — `flutter_secure_storage` throws on failure. Errors are caught and logged via `debugPrint`.

--- a/openspec/changes/fix-share-extension-credentials/proposal.md
+++ b/openspec/changes/fix-share-extension-credentials/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The iOS share extension always shows "Not Connected" even when the user is logged in and has an active context with valid credentials. The extension cannot access the shared Keychain credentials due to three compounding bugs in the credential sync pipeline:
+
+1. **`hasCredentials` requires an auth token** — `KeychainHelper.hasCredentials` demands both a server URL _and_ a non-empty auth token. Servers configured without auth (token is nil) always fail this check, making the share extension permanently unusable.
+
+2. **Fire-and-forget sync with silent error swallowing** — The `SharedCredentialsChannel.syncCredentials()` call in `context_repository.dart` is unawaited. If the method channel isn't registered yet (race with `didInitializeImplicitFlutterEngine`), or the Flutter engine tears down before the call completes, credentials never reach the shared Keychain group. Both the Dart and Swift sides silently swallow all errors.
+
+3. **No recovery path** — There is no mechanism to re-sync or verify shared Keychain credentials. If the initial sync fails, the shared Keychain stays empty until the user deactivates and reactivates their context — and they have no way of knowing that's the fix.
+
+## What Changes
+
+- **Fix `hasCredentials` to accept URL-only** — A valid server URL is sufficient. The auth token should be optional (matching the `AssistantContext` model where `authToken: null` means "server requires no auth").
+- **Await the shared Keychain sync** — Make the `SharedCredentialsChannel.syncCredentials()` call awaited so failures are observable. Log errors instead of swallowing them.
+- **Add a verification round-trip** — After writing credentials via the method channel, read them back from the shared Keychain to confirm they landed. If verification fails, retry once and log an error.
+- **Sync credentials on app foreground** — Re-sync shared Keychain credentials when the app returns to foreground, covering the case where the initial sync failed due to a race condition.
+
+## Non-goals
+
+- Changing the overall credential sharing architecture (shared Keychain group via method channel is correct)
+- Adding UI in the main app for diagnosing share extension issues
+- Offline queueing in the share extension
+- Changing how `flutter_secure_storage` itself is configured
+
+## Impact
+
+- **Swift** (`AssistantIntents` package): `KeychainHelper.hasCredentials` logic change
+- **Dart** (`context_repository.dart`): Await the sync call, add logging on failure
+- **Dart** (`shared_credentials_channel.dart`): Stop swallowing errors, propagate failures
+- **Swift** (`SharedCredentialsChannel.swift`): Add verification read-back after write
+- **Dart** (app lifecycle): Add foreground re-sync hook

--- a/openspec/changes/fix-share-extension-credentials/proposal.md
+++ b/openspec/changes/fix-share-extension-credentials/proposal.md
@@ -11,21 +11,20 @@ The iOS share extension always shows "Not Connected" even when the user is logge
 ## What Changes
 
 - **Fix `hasCredentials` to accept URL-only** — A valid server URL is sufficient. The auth token should be optional (matching the `AssistantContext` model where `authToken: null` means "server requires no auth").
-- **Await the shared Keychain sync** — Make the `SharedCredentialsChannel.syncCredentials()` call awaited so failures are observable. Log errors instead of swallowing them.
-- **Add a verification round-trip** — After writing credentials via the method channel, read them back from the shared Keychain to confirm they landed. If verification fails, retry once and log an error.
-- **Sync credentials on app foreground** — Re-sync shared Keychain credentials when the app returns to foreground, covering the case where the initial sync failed due to a race condition.
+- **Eliminate method channel bridge on iOS** — Replace fire-and-forget `syncCredentials` method channel with direct `flutter_secure_storage` writes using `IOSOptions(groupId:)` which maps to `kSecAttrAccessGroup`. This removes the race condition and makes writes synchronous to the Keychain.
+- **Retain method channel for macOS** — The `flutter_secure_storage_darwin` plugin guards `groupId` behind `#if os(iOS)`, so macOS continues using the native `syncCredentials` method channel as a fallback.
+- **Resolve team prefix at startup** — Fetch the Apple Team ID prefix once via a lightweight `getTeamPrefix` method channel call, cache it, and inject into `ContextRepository` for constructing `IOSOptions(groupId:)`.
+- **Cache `KeychainHelper.teamPrefix`** — Change from `static var` (recomputed on every access via Keychain probe) to `static let` (cached, thread-safe).
 
 ## Non-goals
 
-- Changing the overall credential sharing architecture (shared Keychain group via method channel is correct)
 - Adding UI in the main app for diagnosing share extension issues
 - Offline queueing in the share extension
-- Changing how `flutter_secure_storage` itself is configured
 
 ## Impact
 
-- **Swift** (`AssistantIntents` package): `KeychainHelper.hasCredentials` logic change
-- **Dart** (`context_repository.dart`): Await the sync call, add logging on failure
-- **Dart** (`shared_credentials_channel.dart`): Stop swallowing errors, propagate failures
-- **Swift** (`SharedCredentialsChannel.swift`): Add verification read-back after write
-- **Dart** (app lifecycle): Add foreground re-sync hook
+- **Swift** (`AssistantIntents` package): `KeychainHelper.hasCredentials` accepts URL-only; `teamPrefix` cached via `static let`
+- **Swift** (`SharedCredentialsChannel.swift`): iOS removes `syncCredentials`, adds `getTeamPrefix`; macOS retains both
+- **Dart** (`context_repository.dart`): Direct `IOSOptions(groupId:)` writes on iOS; method channel fallback on macOS
+- **Dart** (`shared_credentials_channel.dart`): `getTeamPrefix()` (cached) replaces `syncCredentials()` on iOS; `syncCredentialsMacOS()` retained
+- **Dart** (`context_providers.dart`): Fetches team prefix at startup, injects into `ContextRepository`

--- a/openspec/changes/fix-share-extension-credentials/tasks.md
+++ b/openspec/changes/fix-share-extension-credentials/tasks.md
@@ -4,7 +4,7 @@
 
 - [x] **T5: Add unit test for `hasCredentials` without token** — Write a Swift test confirming that `hasCredentials` returns `true` when `serverURL` is set but `authToken` is nil/empty.
 
-- [x] **T7: Replace `syncCredentials` with `getTeamPrefix` in SharedCredentialsChannel (Swift)** — Both iOS and macOS `SharedCredentialsChannel.swift`: remove the `syncCredentials` case and add a `getTeamPrefix` case that returns `KeychainHelper.teamPrefix`. (Design: D6)
+- [x] **T7: Add `getTeamPrefix` in SharedCredentialsChannel (Swift)** — iOS removes the `syncCredentials` case and uses direct `IOSOptions(groupId:)` writes; macOS retains `syncCredentials` as the fallback and also adds `getTeamPrefix`. (Design: D6)
 
 - [x] **T8: Replace `syncCredentials` with `getTeamPrefix` in SharedCredentialsChannel (Dart)** — `shared_credentials_channel.dart`: remove `syncCredentials`, add `getTeamPrefix()` that calls the native side and caches the result. Log errors instead of swallowing. (Design: D6)
 

--- a/openspec/changes/fix-share-extension-credentials/tasks.md
+++ b/openspec/changes/fix-share-extension-credentials/tasks.md
@@ -1,0 +1,17 @@
+## Tasks
+
+- [x] **T1: Fix `hasCredentials` to accept URL-only** — `app/packages/AssistantIntents/Sources/AssistantIntents/API/KeychainHelper.swift` — Change `hasCredentials` to only require a non-empty `serverURL`. Remove the `authToken` guard from the check. (Design: D1)
+
+- [x] **T5: Add unit test for `hasCredentials` without token** — Write a Swift test confirming that `hasCredentials` returns `true` when `serverURL` is set but `authToken` is nil/empty.
+
+- [x] **T7: Replace `syncCredentials` with `getTeamPrefix` in SharedCredentialsChannel (Swift)** — Both iOS and macOS `SharedCredentialsChannel.swift`: remove the `syncCredentials` case and add a `getTeamPrefix` case that returns `KeychainHelper.teamPrefix`. (Design: D6)
+
+- [x] **T8: Replace `syncCredentials` with `getTeamPrefix` in SharedCredentialsChannel (Dart)** — `shared_credentials_channel.dart`: remove `syncCredentials`, add `getTeamPrefix()` that calls the native side and caches the result. Log errors instead of swallowing. (Design: D6)
+
+- [x] **T9: Write directly to shared Keychain via IOSOptions in syncSiriCredentials** — `context_repository.dart`: use `flutter_secure_storage` with `IOSOptions(accountName: 'com.cedricziel.assistant', groupId: '$teamPrefix...')` to write Siri credentials directly. Keep method channel fallback for macOS where `groupId` is ignored by the plugin. (Design: D6)
+
+- [x] **T10: Fetch team prefix at startup and inject into ContextRepository** — `context_providers.dart` + `main.dart`: call `SharedCredentialsChannel.getTeamPrefix()` during init, pass to `ContextRepository` constructor so it has the prefix for `IOSOptions`. (Design: D6)
+
+- [x] **T11: Remove foreground re-sync from main.dart** — The direct-write approach eliminates the race condition, so the foreground re-sync (T4) is no longer needed. Revert the `_resyncSharedCredentials` addition.
+
+- [ ] **T12: Manual verification on device** — Build and run on a physical iPhone. Connect to a server. Open share sheet from Safari or Files. Confirm the share extension shows the form instead of "Not Connected." Share a file and confirm it arrives in the conversation.


### PR DESCRIPTION
## Summary

- **Fix share extension "Not Connected" on iOS** — the share extension couldn't read credentials because the method channel bridge between Flutter and native Swift had race conditions and silent failures
- **Eliminate method channel bridge on iOS** — replace fire-and-forget `syncCredentials` method channel with direct `flutter_secure_storage` writes using `IOSOptions(groupId:)` which maps to `kSecAttrAccessGroup`
- **Fix `hasCredentials` to accept URL-only** — servers may not require auth tokens; the gate now only requires a non-empty server URL

### What changed

| Layer | Before | After |
|-------|--------|-------|
| iOS credential sync | Dart → MethodChannel → Swift `KeychainHelper.write()` (fire-and-forget, unawaited) | Dart → `flutter_secure_storage` with `IOSOptions(groupId:)` (synchronous to Keychain) |
| macOS credential sync | Same method channel (also broken) | Retained method channel (plugin ignores `groupId` on macOS via `#if os(iOS)`) |
| `hasCredentials` | Required both URL **and** auth token | Requires only non-empty server URL |
| `KeychainHelper.teamPrefix` | `static var` — recomputed on every access (Keychain probe each time) | `static let` — cached, thread-safe |
| `SharedCredentialsChannel` (Swift) | `syncCredentials` case | `getTeamPrefix` case (iOS); both `getTeamPrefix` + `syncCredentials` (macOS) |
| `SharedCredentialsChannel` (Dart) | `syncCredentials()` fire-and-forget | `getTeamPrefix()` (cached) + `syncCredentialsMacOS()` |
| Team prefix | Resolved on native side only | Fetched once at startup via method channel, injected into `ContextRepository` |

### Files changed

- `app/packages/AssistantIntents/Sources/AssistantIntents/API/KeychainHelper.swift` — `hasCredentials` URL-only, `teamPrefix` cached
- `app/packages/AssistantIntents/Tests/AssistantIntentsTests/KeychainHelperTests.swift` — **new** 6 unit tests
- `app/ios/Runner/SharedCredentialsChannel.swift` — replaced `syncCredentials` with `getTeamPrefix`
- `app/macos/Runner/SharedCredentialsChannel.swift` — added `getTeamPrefix`, kept `syncCredentials`
- `app/lib/features/contexts/data/shared_credentials_channel.dart` — `getTeamPrefix()` + `syncCredentialsMacOS()`
- `app/lib/features/contexts/data/context_repository.dart` — direct `IOSOptions` writes, platform routing
- `app/lib/features/contexts/providers/context_providers.dart` — fetch team prefix at startup

## Test plan

- [x] Swift unit tests pass (12/12 including 6 new KeychainHelper tests)
- [x] Flutter unit tests pass (279/279)
- [x] `make lint-flutter` passes
- [ ] Manual: build on physical iPhone, connect to server, open share sheet → should show form (not "Not Connected")
- [ ] Manual: share a file from Safari/Files → should arrive in conversation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for servers that don't require authentication.

* **Bug Fixes**
  * Improved credential synchronization reliability between the app and share extension on iOS and macOS.
  * Enhanced error reporting for credential sync operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->