### PR TITLE
feat: core identity types, auth abstractions, and assistant-auth crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.2.17",
+ "password-hash",
+]
+
+[[package]]
 name = "array-init"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,6 +381,21 @@ dependencies = [
  "serde",
  "serde_json",
  "utoipa",
+]
+
+[[package]]
+name = "assistant-auth"
+version = "0.1.134"
+dependencies = [
+ "anyhow",
+ "argon2",
+ "assistant-core",
+ "chrono",
+ "jsonwebtoken",
+ "rand 0.9.4",
+ "serde",
+ "tempfile",
+ "uuid",
 ]
 
 [[package]]
@@ -1111,6 +1138,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3384,6 +3420,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4171,10 +4222,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
 
 [[package]]
 name = "pem-rfc7468"
@@ -5103,9 +5175,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -5609,6 +5681,18 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "siphasher"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,7 +385,7 @@ dependencies = [
 
 [[package]]
 name = "assistant-auth"
-version = "0.1.134"
+version = "0.1.135"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,8 +171,8 @@ rand = "0.9"
 # Internal crates
 opentelemetry-exporter-sqlite = { path = "crates/opentelemetry-exporter-sqlite" }
 opentelemetry-exporter-iceberg = { path = "crates/opentelemetry-exporter-iceberg" }
-core = { path = "crates/core" }
-auth = { path = "crates/auth" }
+core = { path = "crates/core", package = "assistant-core" }
+auth = { path = "crates/auth", package = "assistant-auth" }
 skills = { path = "crates/skills" }
 storage = { path = "crates/storage" }
 runtime = { path = "crates/runtime" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [workspace]
 members = [
+    "crates/auth",
     "crates/core",
     "crates/skills",
     "crates/llm-provider",
@@ -163,10 +164,15 @@ iceberg-catalog-rest = "0.9"
 arrow-array = "57.3"
 arrow-schema = "57.3"
 parquet = { version = "57.3", default-features = false, features = ["arrow", "async"] }
+# Authentication
+jsonwebtoken = "9"
+argon2 = { version = "0.5", features = ["std"] }
+rand = "0.9"
 # Internal crates
 opentelemetry-exporter-sqlite = { path = "crates/opentelemetry-exporter-sqlite" }
 opentelemetry-exporter-iceberg = { path = "crates/opentelemetry-exporter-iceberg" }
 core = { path = "crates/core" }
+auth = { path = "crates/auth" }
 skills = { path = "crates/skills" }
 storage = { path = "crates/storage" }
 runtime = { path = "crates/runtime" }

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "assistant-auth"
+version = "0.1.134"
+license.workspace = true
+edition.workspace = true
+description = "Authentication and authorization: OAuth2 server, JWT, password hashing, OIDC, API keys"
+
+[dependencies]
+assistant-core = { path = "../core" }
+
+# Serialization
+serde = { workspace = true }
+
+# Error handling
+anyhow = { workspace = true }
+
+# IDs and time
+uuid = { workspace = true }
+chrono = { workspace = true }
+
+# JWT signing and validation
+jsonwebtoken = { workspace = true }
+
+# Password hashing (argon2id)
+argon2 = { workspace = true }
+
+# Cryptographic randomness
+rand = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assistant-auth"
-version = "0.1.134"
+version = "0.1.135"
 license.workspace = true
 edition.workspace = true
 description = "Authentication and authorization: OAuth2 server, JWT, password hashing, OIDC, API keys"

--- a/crates/auth/src/jwt.rs
+++ b/crates/auth/src/jwt.rs
@@ -1,7 +1,7 @@
 //! JWT signing and validation.
 //!
-//! Uses RS256 (RSA-PKCS1-SHA256) for broad compatibility with OAuth2 clients.
-//! Keys can be generated fresh or loaded from PEM files.
+//! Uses HS256 (HMAC-SHA256) with a 256-bit shared secret for single-server
+//! deployments. Keys can be generated fresh or loaded from secret files.
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -46,35 +46,26 @@ pub struct Claims {
     pub spaces: HashMap<String, String>,
     /// OAuth2 client ID that requested this token.
     pub client_id: String,
-    /// Space-separated scope string.
+    /// Space-separated scope string (standard OAuth2 format).
     #[serde(default)]
     pub scope: String,
+    /// Optional per-scope resource ID restrictions (e.g. from API keys).
+    /// Key = scope string ("personas:read"), value = allowed resource IDs.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub scope_restrictions: HashMap<String, Vec<String>>,
 }
 
 // -- Key pair --
 
-/// An RSA key pair for signing and verifying JWTs.
+/// A shared secret for signing and verifying JWTs (HS256).
 pub struct JwtKeyPair {
     encoding: EncodingKey,
     decoding: DecodingKey,
 }
 
 impl JwtKeyPair {
-    /// Generate a new RSA-2048 key pair.
+    /// Generate a new 256-bit random shared secret.
     pub fn generate() -> Result<Self> {
-        use jsonwebtoken::jwk;
-        // Use the rsa crate would be heavier. Instead we generate via
-        // jsonwebtoken's built-in RSA key generation isn't available,
-        // so we use a simpler HMAC-based approach for now and upgrade
-        // to RSA when the `rsa` crate is added.
-        //
-        // For v1 we use HS256 with a 256-bit random secret, which is
-        // secure for a single-server deployment (no key distribution needed).
-        let _ = jwk::AlgorithmParameters::OctetKey(jwk::OctetKeyParameters {
-            key_type: jwk::OctetKeyType::Octet,
-            value: String::new(),
-        });
-
         let secret = generate_secret();
         Ok(Self {
             encoding: EncodingKey::from_secret(&secret),
@@ -102,13 +93,25 @@ impl JwtKeyPair {
                 std::fs::create_dir_all(parent)
                     .with_context(|| format!("creating directory for {path:?}"))?;
             }
-            std::fs::write(path, &secret)
-                .with_context(|| format!("writing JWT secret to {path:?}"))?;
-            // Restrict permissions on Unix.
+            // On Unix, create file with 0600 atomically to avoid a race
+            // where umask could briefly make the secret world-readable.
             #[cfg(unix)]
             {
-                use std::os::unix::fs::PermissionsExt;
-                std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+                use std::io::Write;
+                use std::os::unix::fs::OpenOptionsExt;
+                let mut f = std::fs::OpenOptions::new()
+                    .write(true)
+                    .create_new(true)
+                    .mode(0o600)
+                    .open(path)
+                    .with_context(|| format!("writing JWT secret to {path:?}"))?;
+                f.write_all(&secret)
+                    .with_context(|| format!("writing JWT secret to {path:?}"))?;
+            }
+            #[cfg(not(unix))]
+            {
+                std::fs::write(path, &secret)
+                    .with_context(|| format!("writing JWT secret to {path:?}"))?;
             }
             Ok(Self::from_secret(&secret))
         }
@@ -170,6 +173,14 @@ impl JwtManager {
             .collect::<Vec<_>>()
             .join(" ");
 
+        // Preserve resource-ID restrictions (e.g. from API keys).
+        let mut scope_restrictions = HashMap::new();
+        for s in &ctx.scopes {
+            if let Some(ids) = &s.resource_ids {
+                scope_restrictions.insert(s.to_string(), ids.clone());
+            }
+        }
+
         let claims = Claims {
             iss: self.issuer.clone(),
             sub: ctx.user_id.0.clone(),
@@ -184,6 +195,7 @@ impl JwtManager {
             spaces,
             client_id: ctx.client_id.clone(),
             scope: scope_str,
+            scope_restrictions,
         };
 
         let header = Header::new(Algorithm::HS256);
@@ -232,7 +244,14 @@ pub fn claims_to_context(claims: &Claims) -> Result<AuthContext> {
         claims
             .scope
             .split(' ')
-            .map(parse_scope)
+            .map(|s| {
+                let mut scope = parse_scope(s)?;
+                // Restore resource-ID restrictions from the JWT if present.
+                if let Some(ids) = claims.scope_restrictions.get(s) {
+                    scope.resource_ids = Some(ids.clone());
+                }
+                Ok(scope)
+            })
             .collect::<Result<Vec<_>>>()?
     };
 

--- a/crates/auth/src/jwt.rs
+++ b/crates/auth/src/jwt.rs
@@ -1,0 +1,460 @@
+//! JWT signing and validation.
+//!
+//! Uses RS256 (RSA-PKCS1-SHA256) for broad compatibility with OAuth2 clients.
+//! Keys can be generated fresh or loaded from PEM files.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use anyhow::{Context, Result, bail};
+use chrono::{Duration, Utc};
+use jsonwebtoken::{
+    Algorithm, DecodingKey, EncodingKey, Header, TokenData, Validation, decode, encode,
+};
+use serde::{Deserialize, Serialize};
+
+use assistant_core::auth::AuthContext;
+use assistant_core::identity::{OrgId, Role, SpaceId, UserId};
+
+// -- Claims --
+
+/// JWT claims issued by the assistant server.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Claims {
+    /// Issuer (the assistant server URL).
+    pub iss: String,
+    /// Subject (user ID).
+    pub sub: String,
+    /// Audience.
+    pub aud: String,
+    /// Expiration (unix timestamp).
+    pub exp: i64,
+    /// Issued at (unix timestamp).
+    pub iat: i64,
+    /// Unique token ID.
+    pub jti: String,
+
+    /// Organization ID.
+    pub org_id: String,
+    /// Organization slug.
+    pub org_slug: String,
+    /// User email.
+    pub email: String,
+    /// User display name.
+    pub name: String,
+    /// Space → role mapping.
+    pub spaces: HashMap<String, String>,
+    /// OAuth2 client ID that requested this token.
+    pub client_id: String,
+    /// Space-separated scope string.
+    #[serde(default)]
+    pub scope: String,
+}
+
+// -- Key pair --
+
+/// An RSA key pair for signing and verifying JWTs.
+pub struct JwtKeyPair {
+    encoding: EncodingKey,
+    decoding: DecodingKey,
+}
+
+impl JwtKeyPair {
+    /// Generate a new RSA-2048 key pair.
+    pub fn generate() -> Result<Self> {
+        use jsonwebtoken::jwk;
+        // Use the rsa crate would be heavier. Instead we generate via
+        // jsonwebtoken's built-in RSA key generation isn't available,
+        // so we use a simpler HMAC-based approach for now and upgrade
+        // to RSA when the `rsa` crate is added.
+        //
+        // For v1 we use HS256 with a 256-bit random secret, which is
+        // secure for a single-server deployment (no key distribution needed).
+        let _ = jwk::AlgorithmParameters::OctetKey(jwk::OctetKeyParameters {
+            key_type: jwk::OctetKeyType::Octet,
+            value: String::new(),
+        });
+
+        let secret = generate_secret();
+        Ok(Self {
+            encoding: EncodingKey::from_secret(&secret),
+            decoding: DecodingKey::from_secret(&secret),
+        })
+    }
+
+    /// Create a key pair from a shared secret (HS256).
+    pub fn from_secret(secret: &[u8]) -> Self {
+        Self {
+            encoding: EncodingKey::from_secret(secret),
+            decoding: DecodingKey::from_secret(secret),
+        }
+    }
+
+    /// Load a key pair from a secret file, or generate and persist one.
+    pub fn load_or_generate(path: &Path) -> Result<Self> {
+        if path.exists() {
+            let secret =
+                std::fs::read(path).with_context(|| format!("reading JWT secret from {path:?}"))?;
+            Ok(Self::from_secret(&secret))
+        } else {
+            let secret = generate_secret();
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)
+                    .with_context(|| format!("creating directory for {path:?}"))?;
+            }
+            std::fs::write(path, &secret)
+                .with_context(|| format!("writing JWT secret to {path:?}"))?;
+            // Restrict permissions on Unix.
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+            }
+            Ok(Self::from_secret(&secret))
+        }
+    }
+}
+
+/// Generate a 256-bit random secret.
+fn generate_secret() -> Vec<u8> {
+    use rand::Rng;
+    let mut rng = rand::rng();
+    let mut secret = vec![0u8; 32];
+    rng.fill(&mut secret[..]);
+    secret
+}
+
+// -- Signer / Validator --
+
+/// Signs and validates JWTs for the assistant server.
+pub struct JwtManager {
+    key_pair: JwtKeyPair,
+    issuer: String,
+    audience: String,
+    /// Access token lifetime.
+    access_ttl: Duration,
+}
+
+impl JwtManager {
+    /// Create a new JWT manager.
+    pub fn new(key_pair: JwtKeyPair, issuer: String, audience: String) -> Self {
+        Self {
+            key_pair,
+            issuer,
+            audience,
+            access_ttl: Duration::hours(1),
+        }
+    }
+
+    /// Override the default access token TTL.
+    pub fn with_access_ttl(mut self, ttl: Duration) -> Self {
+        self.access_ttl = ttl;
+        self
+    }
+
+    /// Sign a JWT for the given auth context.
+    pub fn sign(&self, ctx: &AuthContext, org_slug: &str, name: &str) -> Result<String> {
+        let now = Utc::now();
+        let exp = now + self.access_ttl;
+
+        let spaces: HashMap<String, String> = ctx
+            .space_roles
+            .iter()
+            .map(|(s, r)| (s.0.clone(), r.to_string()))
+            .collect();
+
+        let scope_str = ctx
+            .scopes
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        let claims = Claims {
+            iss: self.issuer.clone(),
+            sub: ctx.user_id.0.clone(),
+            aud: self.audience.clone(),
+            exp: exp.timestamp(),
+            iat: now.timestamp(),
+            jti: uuid::Uuid::new_v4().to_string(),
+            org_id: ctx.org_id.0.clone(),
+            org_slug: org_slug.to_owned(),
+            email: ctx.email.clone(),
+            name: name.to_owned(),
+            spaces,
+            client_id: ctx.client_id.clone(),
+            scope: scope_str,
+        };
+
+        let header = Header::new(Algorithm::HS256);
+        encode(&header, &claims, &self.key_pair.encoding).context("failed to sign JWT")
+    }
+
+    /// Validate a JWT and return the claims.
+    pub fn validate(&self, token: &str) -> Result<Claims> {
+        let mut validation = Validation::new(Algorithm::HS256);
+        validation.set_issuer(&[&self.issuer]);
+        validation.set_audience(&[&self.audience]);
+
+        let token_data: TokenData<Claims> =
+            decode(token, &self.key_pair.decoding, &validation).context("JWT validation failed")?;
+
+        Ok(token_data.claims)
+    }
+
+    /// Validate a JWT and reconstruct an [`AuthContext`] from the claims.
+    pub fn validate_to_context(&self, token: &str) -> Result<AuthContext> {
+        let claims = self.validate(token)?;
+        claims_to_context(&claims)
+    }
+}
+
+/// Convert decoded JWT claims into an [`AuthContext`].
+pub fn claims_to_context(claims: &Claims) -> Result<AuthContext> {
+    let space_roles: HashMap<SpaceId, Role> = claims
+        .spaces
+        .iter()
+        .map(|(space_id, role_str)| {
+            let role = match role_str.as_str() {
+                "org_admin" => Role::OrgAdmin,
+                "space_admin" => Role::SpaceAdmin,
+                "member" => Role::Member,
+                "viewer" => Role::Viewer,
+                other => bail!("unknown role in JWT: {other}"),
+            };
+            Ok((SpaceId(space_id.clone()), role))
+        })
+        .collect::<Result<_>>()?;
+
+    let scopes = if claims.scope.is_empty() {
+        vec![]
+    } else {
+        claims
+            .scope
+            .split(' ')
+            .map(parse_scope)
+            .collect::<Result<Vec<_>>>()?
+    };
+
+    Ok(AuthContext {
+        user_id: UserId(claims.sub.clone()),
+        org_id: OrgId(claims.org_id.clone()),
+        email: claims.email.clone(),
+        space_roles,
+        scopes,
+        client_id: claims.client_id.clone(),
+    })
+}
+
+/// Parse a scope string like `"personas:read"` into a [`Scope`].
+fn parse_scope(s: &str) -> Result<assistant_core::identity::Scope> {
+    use assistant_core::identity::{Action, ResourceKind, Scope};
+
+    let (res_str, act_str) = s
+        .split_once(':')
+        .with_context(|| format!("invalid scope format: {s}"))?;
+
+    let resource = match res_str {
+        "personas" => ResourceKind::Personas,
+        "conversations" => ResourceKind::Conversations,
+        "messages" => ResourceKind::Messages,
+        "skills" => ResourceKind::Skills,
+        "interfaces" => ResourceKind::Interfaces,
+        "bindings" => ResourceKind::Bindings,
+        "users" => ResourceKind::Users,
+        "org" => ResourceKind::Org,
+        "api_keys" => ResourceKind::ApiKeys,
+        "spaces" => ResourceKind::Spaces,
+        other => bail!("unknown resource kind in scope: {other}"),
+    };
+
+    let action = match act_str {
+        "read" => Action::Read,
+        "write" => Action::Write,
+        "delete" => Action::Delete,
+        "execute" => Action::Execute,
+        "manage" => Action::Manage,
+        other => bail!("unknown action in scope: {other}"),
+    };
+
+    Ok(Scope::new(resource, action))
+}
+
+#[cfg(test)]
+mod tests {
+    use assistant_core::identity::{Action, ResourceKind, Scope};
+
+    use super::*;
+
+    fn make_test_context() -> AuthContext {
+        let mut space_roles = HashMap::new();
+        space_roles.insert(SpaceId::from("eng"), Role::Member);
+        space_roles.insert(SpaceId::from("mktg"), Role::Viewer);
+
+        AuthContext {
+            user_id: UserId::from("usr_alice"),
+            org_id: OrgId::from("org_acme"),
+            email: "alice@acme.com".into(),
+            space_roles,
+            scopes: vec![
+                Scope::new(ResourceKind::Personas, Action::Read),
+                Scope::new(ResourceKind::Conversations, Action::Write),
+            ],
+            client_id: "webui".into(),
+        }
+    }
+
+    #[test]
+    fn sign_and_validate_roundtrip() {
+        let kp = JwtKeyPair::generate().unwrap();
+        let mgr = JwtManager::new(kp, "https://test.local".into(), "https://test.local".into());
+
+        let ctx = make_test_context();
+        let token = mgr.sign(&ctx, "acme", "Alice").unwrap();
+
+        let claims = mgr.validate(&token).unwrap();
+        assert_eq!(claims.sub, "usr_alice");
+        assert_eq!(claims.org_id, "org_acme");
+        assert_eq!(claims.email, "alice@acme.com");
+        assert_eq!(claims.client_id, "webui");
+        assert_eq!(claims.spaces.get("eng"), Some(&"member".to_string()));
+        assert_eq!(claims.spaces.get("mktg"), Some(&"viewer".to_string()));
+        assert!(claims.scope.contains("personas:read"));
+        assert!(claims.scope.contains("conversations:write"));
+    }
+
+    #[test]
+    fn validate_to_context_roundtrip() {
+        let kp = JwtKeyPair::generate().unwrap();
+        let mgr = JwtManager::new(kp, "https://test.local".into(), "https://test.local".into());
+
+        let ctx = make_test_context();
+        let token = mgr.sign(&ctx, "acme", "Alice").unwrap();
+
+        let restored = mgr.validate_to_context(&token).unwrap();
+        assert_eq!(restored.user_id, ctx.user_id);
+        assert_eq!(restored.org_id, ctx.org_id);
+        assert_eq!(restored.email, ctx.email);
+        assert_eq!(restored.client_id, ctx.client_id);
+        assert_eq!(restored.role_in(&SpaceId::from("eng")), Some(&Role::Member));
+        assert_eq!(
+            restored.role_in(&SpaceId::from("mktg")),
+            Some(&Role::Viewer)
+        );
+    }
+
+    #[test]
+    fn expired_token_is_rejected() {
+        let kp = JwtKeyPair::generate().unwrap();
+        let mgr = JwtManager::new(kp, "https://test.local".into(), "https://test.local".into())
+            .with_access_ttl(Duration::seconds(-120)); // Well past the 60s default leeway.
+
+        let ctx = make_test_context();
+        let token = mgr.sign(&ctx, "acme", "Alice").unwrap();
+
+        let err = mgr.validate(&token);
+        assert!(
+            err.is_err(),
+            "expected validation to fail for expired token"
+        );
+        // Verify the root cause is an expiration error (in the anyhow chain).
+        let debug_msg = format!("{:?}", err.unwrap_err());
+        assert!(
+            debug_msg.contains("ExpiredSignature") || debug_msg.contains("expired"),
+            "expected expiration error in chain, got: {debug_msg}"
+        );
+    }
+
+    #[test]
+    fn wrong_secret_is_rejected() {
+        let kp1 = JwtKeyPair::from_secret(b"secret-one-that-is-long-enough!!");
+        let kp2 = JwtKeyPair::from_secret(b"secret-two-that-is-long-enough!!");
+
+        let mgr1 = JwtManager::new(
+            kp1,
+            "https://test.local".into(),
+            "https://test.local".into(),
+        );
+        let mgr2 = JwtManager::new(
+            kp2,
+            "https://test.local".into(),
+            "https://test.local".into(),
+        );
+
+        let ctx = make_test_context();
+        let token = mgr1.sign(&ctx, "acme", "Alice").unwrap();
+
+        let err = mgr2.validate(&token);
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn wrong_issuer_is_rejected() {
+        let kp = JwtKeyPair::generate().unwrap();
+        // Sign with issuer A.
+        let secret = generate_secret();
+        let kp_sign = JwtKeyPair::from_secret(&secret);
+        let kp_verify = JwtKeyPair::from_secret(&secret);
+
+        let mgr_sign = JwtManager::new(kp_sign, "https://a.local".into(), "https://a.local".into());
+        let mgr_verify = JwtManager::new(
+            kp_verify,
+            "https://b.local".into(),
+            "https://a.local".into(),
+        );
+
+        let ctx = make_test_context();
+        let token = mgr_sign.sign(&ctx, "acme", "Alice").unwrap();
+
+        let err = mgr_verify.validate(&token);
+        assert!(err.is_err());
+        let _ = kp; // suppress unused warning
+    }
+
+    #[test]
+    fn parse_scope_roundtrip() {
+        let scope = parse_scope("personas:read").unwrap();
+        assert_eq!(scope.resource, ResourceKind::Personas);
+        assert_eq!(scope.action, Action::Read);
+
+        let scope = parse_scope("org:manage").unwrap();
+        assert_eq!(scope.resource, ResourceKind::Org);
+        assert_eq!(scope.action, Action::Manage);
+    }
+
+    #[test]
+    fn parse_scope_invalid_format() {
+        assert!(parse_scope("invalid").is_err());
+        assert!(parse_scope("unknown:read").is_err());
+        assert!(parse_scope("personas:unknown").is_err());
+    }
+
+    #[test]
+    fn load_or_generate_creates_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("jwt.secret");
+
+        let kp1 = JwtKeyPair::load_or_generate(&path).unwrap();
+        assert!(path.exists());
+
+        // Loading again should produce the same key.
+        let kp2 = JwtKeyPair::load_or_generate(&path).unwrap();
+
+        // Verify same key by signing+validating across instances.
+        let mgr1 = JwtManager::new(
+            kp1,
+            "https://test.local".into(),
+            "https://test.local".into(),
+        );
+        let mgr2 = JwtManager::new(
+            kp2,
+            "https://test.local".into(),
+            "https://test.local".into(),
+        );
+
+        let ctx = make_test_context();
+        let token = mgr1.sign(&ctx, "acme", "Alice").unwrap();
+        let claims = mgr2.validate(&token).unwrap();
+        assert_eq!(claims.sub, "usr_alice");
+    }
+}

--- a/crates/auth/src/lib.rs
+++ b/crates/auth/src/lib.rs
@@ -4,9 +4,9 @@
 //! - JWT signing and validation ([`jwt`])
 //! - Password hashing with argon2id ([`password`])
 //! - OAuth2 server logic ([`oauth2`])
-//! - API key management ([`api_keys`]) *(coming in PR 4)*
-//! - OIDC federation ([`oidc`]) *(coming in PR 4)*
-//! - Axum middleware extractors ([`middleware`]) *(coming in PR 4)*
+//! - API key management (`api_keys`) *(coming in PR 4)*
+//! - OIDC federation (`oidc`) *(coming in PR 4)*
+//! - Axum middleware extractors (`middleware`) *(coming in PR 4)*
 
 pub mod jwt;
 pub mod oauth2;

--- a/crates/auth/src/lib.rs
+++ b/crates/auth/src/lib.rs
@@ -1,0 +1,13 @@
+//! Authentication and authorization for the assistant.
+//!
+//! This crate provides:
+//! - JWT signing and validation ([`jwt`])
+//! - Password hashing with argon2id ([`password`])
+//! - OAuth2 server logic ([`oauth2`])
+//! - API key management ([`api_keys`]) *(coming in PR 4)*
+//! - OIDC federation ([`oidc`]) *(coming in PR 4)*
+//! - Axum middleware extractors ([`middleware`]) *(coming in PR 4)*
+
+pub mod jwt;
+pub mod oauth2;
+pub mod password;

--- a/crates/auth/src/oauth2/mod.rs
+++ b/crates/auth/src/oauth2/mod.rs
@@ -1,0 +1,7 @@
+//! OAuth2 authorization server logic.
+//!
+//! Sub-modules are added in PR 3:
+//! - [`pkce`] — PKCE challenge/verification
+//! - [`server`] — Authorization code grant + refresh tokens
+//! - [`device`] — Device code flow
+//! - [`clients`] — Dynamic client registration (RFC 7591)

--- a/crates/auth/src/oauth2/mod.rs
+++ b/crates/auth/src/oauth2/mod.rs
@@ -1,7 +1,7 @@
 //! OAuth2 authorization server logic.
 //!
 //! Sub-modules are added in PR 3:
-//! - [`pkce`] — PKCE challenge/verification
-//! - [`server`] — Authorization code grant + refresh tokens
-//! - [`device`] — Device code flow
-//! - [`clients`] — Dynamic client registration (RFC 7591)
+//! - `pkce` — PKCE challenge/verification
+//! - `server` — Authorization code grant + refresh tokens
+//! - `device` — Device code flow
+//! - `clients` — Dynamic client registration (RFC 7591)

--- a/crates/auth/src/password.rs
+++ b/crates/auth/src/password.rs
@@ -1,0 +1,85 @@
+//! Password hashing and verification using argon2id.
+//!
+//! Uses the OWASP-recommended argon2id algorithm with sensible defaults.
+
+use anyhow::{Result, bail};
+use argon2::{
+    Argon2, PasswordHash, PasswordHasher, PasswordVerifier,
+    password_hash::{SaltString, rand_core::OsRng},
+};
+
+/// Hash a plaintext password using argon2id.
+///
+/// Returns the PHC-formatted hash string (includes algorithm, salt, and hash).
+pub fn hash_password(plain: &str) -> Result<String> {
+    if plain.is_empty() {
+        bail!("password must not be empty");
+    }
+
+    let salt = SaltString::generate(&mut OsRng);
+    let argon2 = Argon2::default(); // argon2id with default params
+
+    let hash = argon2
+        .hash_password(plain.as_bytes(), &salt)
+        .map_err(|e| anyhow::anyhow!("password hashing failed: {e}"))?;
+
+    Ok(hash.to_string())
+}
+
+/// Verify a plaintext password against a PHC-formatted argon2id hash.
+pub fn verify_password(plain: &str, hash: &str) -> Result<bool> {
+    let parsed_hash = PasswordHash::new(hash)
+        .map_err(|e| anyhow::anyhow!("invalid password hash format: {e}"))?;
+
+    let argon2 = Argon2::default();
+    match argon2.verify_password(plain.as_bytes(), &parsed_hash) {
+        Ok(()) => Ok(true),
+        Err(argon2::password_hash::Error::Password) => Ok(false),
+        Err(e) => Err(anyhow::anyhow!("password verification error: {e}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash_and_verify_correct_password() {
+        let hash = hash_password("hunter2").unwrap();
+        assert!(verify_password("hunter2", &hash).unwrap());
+    }
+
+    #[test]
+    fn wrong_password_fails_verification() {
+        let hash = hash_password("hunter2").unwrap();
+        assert!(!verify_password("wrong", &hash).unwrap());
+    }
+
+    #[test]
+    fn different_hashes_for_same_input() {
+        let h1 = hash_password("same-password").unwrap();
+        let h2 = hash_password("same-password").unwrap();
+        // Different salts → different hashes.
+        assert_ne!(h1, h2);
+        // But both verify.
+        assert!(verify_password("same-password", &h1).unwrap());
+        assert!(verify_password("same-password", &h2).unwrap());
+    }
+
+    #[test]
+    fn empty_password_is_rejected() {
+        assert!(hash_password("").is_err());
+    }
+
+    #[test]
+    fn hash_is_phc_format() {
+        let hash = hash_password("test").unwrap();
+        // PHC format starts with $argon2id$
+        assert!(hash.starts_with("$argon2id$"), "unexpected format: {hash}");
+    }
+
+    #[test]
+    fn invalid_hash_format_returns_error() {
+        assert!(verify_password("test", "not-a-hash").is_err());
+    }
+}

--- a/crates/core/src/auth.rs
+++ b/crates/core/src/auth.rs
@@ -55,7 +55,8 @@ impl AuthContext {
     ///
     /// Permission is granted if:
     /// 1. The user is an org admin (bypasses space-level checks), OR
-    /// 2. The user holds a sufficient role in the space AND the scopes
+    /// 2. The user holds an org-level management scope (e.g. `org:manage`), OR
+    /// 3. The user holds a sufficient role in the space AND the scopes
     ///    include the requested resource+action.
     pub fn can(
         &self,
@@ -66,6 +67,15 @@ impl AuthContext {
     ) -> bool {
         // Org admins can do everything.
         if self.is_org_admin() {
+            return true;
+        }
+
+        // Org-level management scope bypasses space-role checks.
+        if self
+            .scopes
+            .iter()
+            .any(|s| s.resource == ResourceKind::Org && s.action == Action::Manage)
+        {
             return true;
         }
 
@@ -359,8 +369,16 @@ mod tests {
     #[test]
     fn role_in_returns_correct_role() {
         let ctx = make_member("eng");
-        assert_eq!(ctx.role_in(&SpaceId::from("eng")), Some(&Role::Member));
-        assert_eq!(ctx.role_in(&SpaceId::from("mktg")), None);
+        assert_eq!(
+            ctx.role_in(&SpaceId::from("eng")),
+            Some(&Role::Member),
+            "should return Member role for assigned space"
+        );
+        assert_eq!(
+            ctx.role_in(&SpaceId::from("mktg")),
+            None,
+            "should return None for unassigned space"
+        );
     }
 
     // -- org admin bypasses --

--- a/crates/core/src/auth.rs
+++ b/crates/core/src/auth.rs
@@ -1,0 +1,497 @@
+//! Authentication and authorization abstractions.
+//!
+//! Defines the [`AuthContext`] that is threaded through every authenticated
+//! operation, and the [`AuthProvider`] / [`IdentityResolver`] traits that are
+//! implemented in the `assistant-auth` crate.
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::Interface;
+use crate::identity::{Action, OrgId, ResourceKind, Role, Scope, SpaceId, UserId};
+
+// -- AuthContext --
+
+/// The resolved identity and authorization context for a request.
+///
+/// Built by the auth middleware from a JWT, API key, or session cookie.
+/// Every authenticated operation receives this — downstream code never
+/// sees tokens, passwords, or OIDC claims.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AuthContext {
+    /// The authenticated user.
+    pub user_id: UserId,
+    /// The organization this user belongs to.
+    pub org_id: OrgId,
+    /// The user's email address.
+    pub email: String,
+    /// Role assignments per space. Key = space ID, value = role in that space.
+    pub space_roles: HashMap<SpaceId, Role>,
+    /// Granted scopes (full set for session tokens, restricted for API keys).
+    pub scopes: Vec<Scope>,
+    /// Which OAuth2 client issued this request.
+    pub client_id: String,
+}
+
+impl AuthContext {
+    /// Returns `true` if this context carries the `OrgAdmin` role in any space,
+    /// or has the `org:manage` scope.
+    pub fn is_org_admin(&self) -> bool {
+        self.space_roles
+            .values()
+            .any(|r| matches!(r, Role::OrgAdmin))
+    }
+
+    /// Returns the role this user holds in the given space, if any.
+    pub fn role_in(&self, space: &SpaceId) -> Option<&Role> {
+        self.space_roles.get(space)
+    }
+
+    /// Check whether this context permits the given action on a resource
+    /// within a space, optionally targeting a specific resource ID.
+    ///
+    /// Permission is granted if:
+    /// 1. The user is an org admin (bypasses space-level checks), OR
+    /// 2. The user holds a sufficient role in the space AND the scopes
+    ///    include the requested resource+action.
+    pub fn can(
+        &self,
+        space: &SpaceId,
+        resource: &ResourceKind,
+        action: &Action,
+        target_id: Option<&str>,
+    ) -> bool {
+        // Org admins can do everything.
+        if self.is_org_admin() {
+            return true;
+        }
+
+        // Must have a role in this space.
+        let role = match self.role_in(space) {
+            Some(r) => r,
+            None => return false,
+        };
+
+        // Check role-based permission.
+        let role_allows = match role {
+            Role::OrgAdmin => true, // Already handled above, but defensive.
+            Role::SpaceAdmin => true,
+            Role::Member => Self::member_can(resource, action),
+            Role::Viewer => Self::viewer_can(resource, action),
+        };
+
+        if !role_allows {
+            return false;
+        }
+
+        // Check scope-based permission (API keys may have restricted scopes).
+        self.scopes
+            .iter()
+            .any(|s| s.covers(resource, action, target_id))
+    }
+
+    /// What a Member role is allowed to do.
+    fn member_can(resource: &ResourceKind, action: &Action) -> bool {
+        matches!(
+            (resource, action),
+            (
+                ResourceKind::Personas,
+                Action::Read | Action::Write | Action::Delete
+            ) | (
+                ResourceKind::Conversations,
+                Action::Read | Action::Write | Action::Delete
+            ) | (ResourceKind::Messages, Action::Read | Action::Write)
+                | (ResourceKind::Skills, Action::Read | Action::Execute)
+                | (ResourceKind::Interfaces, Action::Read)
+                | (
+                    ResourceKind::Bindings,
+                    Action::Read | Action::Write | Action::Delete
+                )
+                | (
+                    ResourceKind::ApiKeys,
+                    Action::Read | Action::Write | Action::Delete
+                )
+        )
+    }
+
+    /// What a Viewer role is allowed to do.
+    fn viewer_can(resource: &ResourceKind, action: &Action) -> bool {
+        matches!(
+            (resource, action),
+            (ResourceKind::Personas, Action::Read)
+                | (ResourceKind::Conversations, Action::Read)
+                | (ResourceKind::Messages, Action::Read)
+                | (ResourceKind::Skills, Action::Read)
+                | (ResourceKind::Interfaces, Action::Read)
+                | (ResourceKind::Bindings, Action::Read)
+                | (
+                    ResourceKind::ApiKeys,
+                    Action::Read | Action::Write | Action::Delete
+                )
+        )
+    }
+}
+
+// -- OAuth2 types --
+
+/// An OAuth2 authorization request.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AuthorizeRequest {
+    pub client_id: String,
+    pub redirect_uri: String,
+    pub response_type: String,
+    pub scope: Option<String>,
+    pub state: Option<String>,
+    pub code_challenge: Option<String>,
+    pub code_challenge_method: Option<String>,
+}
+
+/// The result of an authorization request.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum AuthorizeResponse {
+    /// Redirect the user to this URL (e.g., IdP login page or callback with code).
+    Redirect { url: String },
+    /// Render a login form (password mode).
+    LoginRequired {
+        client_id: String,
+        state: Option<String>,
+    },
+}
+
+/// An OAuth2 token grant request.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "grant_type")]
+pub enum TokenGrant {
+    #[serde(rename = "authorization_code")]
+    AuthorizationCode {
+        code: String,
+        redirect_uri: String,
+        client_id: String,
+        code_verifier: Option<String>,
+    },
+    #[serde(rename = "refresh_token")]
+    RefreshToken {
+        refresh_token: String,
+        client_id: String,
+    },
+    #[serde(rename = "urn:ietf:params:oauth:grant-type:device_code")]
+    DeviceCode {
+        device_code: String,
+        client_id: String,
+    },
+    #[serde(rename = "client_credentials")]
+    ClientCredentials {
+        client_id: String,
+        client_secret: String,
+    },
+}
+
+/// A token response from the OAuth2 token endpoint.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TokenResponse {
+    pub access_token: String,
+    pub token_type: String,
+    pub expires_in: u64,
+    pub refresh_token: Option<String>,
+    pub scope: Option<String>,
+}
+
+/// A request to register a new OAuth2 client (RFC 7591).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ClientRegistration {
+    pub client_name: String,
+    pub redirect_uris: Vec<String>,
+    pub grant_types: Vec<String>,
+    pub response_types: Option<Vec<String>>,
+    pub token_endpoint_auth_method: Option<String>,
+}
+
+/// Information about a registered OAuth2 client.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ClientInfo {
+    pub client_id: String,
+    pub client_name: String,
+    pub client_secret: Option<String>,
+    pub redirect_uris: Vec<String>,
+    pub grant_types: Vec<String>,
+    pub token_endpoint_auth_method: String,
+}
+
+// -- Traits --
+
+/// Authenticates and authorizes requests.
+///
+/// Implemented in the `assistant-auth` crate with password-based and
+/// OIDC-based providers. All implementations issue the assistant's own
+/// JWTs regardless of the upstream identity source.
+#[async_trait]
+pub trait AuthProvider: Send + Sync {
+    /// Validate a bearer token (JWT or API key) and return the resolved context.
+    async fn authenticate(&self, token: &str) -> Result<AuthContext>;
+
+    /// Start an OAuth2 authorization flow.
+    async fn authorize(&self, req: AuthorizeRequest) -> Result<AuthorizeResponse>;
+
+    /// Exchange a grant (auth code, refresh token, device code) for tokens.
+    async fn token(&self, grant: TokenGrant) -> Result<TokenResponse>;
+
+    /// Register a new OAuth2 client dynamically (RFC 7591).
+    async fn register_client(&self, req: ClientRegistration) -> Result<ClientInfo>;
+}
+
+/// Resolves a platform-specific user identity to an assistant [`UserId`].
+///
+/// Used by messenger interface adapters to map e.g. a Slack user ID
+/// to the corresponding assistant user.
+#[async_trait]
+pub trait IdentityResolver: Send + Sync {
+    /// Attempt to resolve a platform user to an assistant user.
+    ///
+    /// Returns `None` if no mapping exists (the platform user has not
+    /// linked their account).
+    async fn resolve(&self, platform: &Interface, platform_user_id: &str)
+    -> Result<Option<UserId>>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_org_admin() -> AuthContext {
+        let mut space_roles = HashMap::new();
+        space_roles.insert(SpaceId::from("eng"), Role::OrgAdmin);
+        AuthContext {
+            user_id: UserId::from("alice"),
+            org_id: OrgId::from("acme"),
+            email: "alice@acme.com".into(),
+            space_roles,
+            scopes: vec![Scope::new(ResourceKind::Org, Action::Manage)],
+            client_id: "webui".into(),
+        }
+    }
+
+    fn make_member(space: &str) -> AuthContext {
+        let mut space_roles = HashMap::new();
+        space_roles.insert(SpaceId::from(space), Role::Member);
+        AuthContext {
+            user_id: UserId::from("bob"),
+            org_id: OrgId::from("acme"),
+            email: "bob@acme.com".into(),
+            space_roles,
+            scopes: vec![
+                Scope::new(ResourceKind::Personas, Action::Read),
+                Scope::new(ResourceKind::Personas, Action::Write),
+                Scope::new(ResourceKind::Conversations, Action::Read),
+                Scope::new(ResourceKind::Conversations, Action::Write),
+                Scope::new(ResourceKind::Messages, Action::Read),
+                Scope::new(ResourceKind::Messages, Action::Write),
+                Scope::new(ResourceKind::Skills, Action::Read),
+                Scope::new(ResourceKind::Skills, Action::Execute),
+                Scope::new(ResourceKind::Interfaces, Action::Read),
+                Scope::new(ResourceKind::Bindings, Action::Read),
+                Scope::new(ResourceKind::Bindings, Action::Write),
+                Scope::new(ResourceKind::ApiKeys, Action::Read),
+                Scope::new(ResourceKind::ApiKeys, Action::Write),
+            ],
+            client_id: "webui".into(),
+        }
+    }
+
+    fn make_viewer(space: &str) -> AuthContext {
+        let mut space_roles = HashMap::new();
+        space_roles.insert(SpaceId::from(space), Role::Viewer);
+        AuthContext {
+            user_id: UserId::from("charlie"),
+            org_id: OrgId::from("acme"),
+            email: "charlie@acme.com".into(),
+            space_roles,
+            scopes: vec![
+                Scope::new(ResourceKind::Personas, Action::Read),
+                Scope::new(ResourceKind::Conversations, Action::Read),
+                Scope::new(ResourceKind::Messages, Action::Read),
+                Scope::new(ResourceKind::Skills, Action::Read),
+                Scope::new(ResourceKind::Interfaces, Action::Read),
+                Scope::new(ResourceKind::Bindings, Action::Read),
+                Scope::new(ResourceKind::ApiKeys, Action::Read),
+                Scope::new(ResourceKind::ApiKeys, Action::Write),
+            ],
+            client_id: "webui".into(),
+        }
+    }
+
+    fn make_api_key_restricted() -> AuthContext {
+        let mut space_roles = HashMap::new();
+        space_roles.insert(SpaceId::from("eng"), Role::Member);
+        AuthContext {
+            user_id: UserId::from("bob"),
+            org_id: OrgId::from("acme"),
+            email: "bob@acme.com".into(),
+            space_roles,
+            scopes: vec![Scope::restricted(
+                ResourceKind::Personas,
+                Action::Read,
+                vec!["deploy-bot".into()],
+            )],
+            client_id: "api_key".into(),
+        }
+    }
+
+    // -- is_org_admin --
+
+    #[test]
+    fn org_admin_is_detected() {
+        let ctx = make_org_admin();
+        assert!(ctx.is_org_admin());
+    }
+
+    #[test]
+    fn member_is_not_org_admin() {
+        let ctx = make_member("eng");
+        assert!(!ctx.is_org_admin());
+    }
+
+    // -- role_in --
+
+    #[test]
+    fn role_in_returns_correct_role() {
+        let ctx = make_member("eng");
+        assert_eq!(ctx.role_in(&SpaceId::from("eng")), Some(&Role::Member));
+        assert_eq!(ctx.role_in(&SpaceId::from("mktg")), None);
+    }
+
+    // -- org admin bypasses --
+
+    #[test]
+    fn org_admin_can_do_anything_in_any_space() {
+        let ctx = make_org_admin();
+        let space = SpaceId::from("random-space");
+        assert!(ctx.can(&space, &ResourceKind::Users, &Action::Manage, None));
+        assert!(ctx.can(&space, &ResourceKind::Org, &Action::Delete, None));
+    }
+
+    // -- member permissions --
+
+    #[test]
+    fn member_can_read_and_write_conversations() {
+        let ctx = make_member("eng");
+        let space = SpaceId::from("eng");
+        assert!(ctx.can(&space, &ResourceKind::Conversations, &Action::Read, None));
+        assert!(ctx.can(&space, &ResourceKind::Conversations, &Action::Write, None));
+    }
+
+    #[test]
+    fn member_cannot_manage_users() {
+        let ctx = make_member("eng");
+        let space = SpaceId::from("eng");
+        assert!(!ctx.can(&space, &ResourceKind::Users, &Action::Manage, None));
+    }
+
+    #[test]
+    fn member_cannot_manage_org() {
+        let ctx = make_member("eng");
+        let space = SpaceId::from("eng");
+        assert!(!ctx.can(&space, &ResourceKind::Org, &Action::Manage, None));
+    }
+
+    #[test]
+    fn member_has_no_access_to_other_space() {
+        let ctx = make_member("eng");
+        let space = SpaceId::from("mktg");
+        assert!(!ctx.can(&space, &ResourceKind::Conversations, &Action::Read, None));
+    }
+
+    // -- viewer permissions --
+
+    #[test]
+    fn viewer_can_read_conversations() {
+        let ctx = make_viewer("eng");
+        let space = SpaceId::from("eng");
+        assert!(ctx.can(&space, &ResourceKind::Conversations, &Action::Read, None));
+    }
+
+    #[test]
+    fn viewer_cannot_write_conversations() {
+        let ctx = make_viewer("eng");
+        let space = SpaceId::from("eng");
+        assert!(!ctx.can(&space, &ResourceKind::Conversations, &Action::Write, None));
+    }
+
+    #[test]
+    fn viewer_cannot_write_messages() {
+        let ctx = make_viewer("eng");
+        let space = SpaceId::from("eng");
+        assert!(!ctx.can(&space, &ResourceKind::Messages, &Action::Write, None));
+    }
+
+    // -- API key scope restriction --
+
+    #[test]
+    fn api_key_restricted_to_specific_persona() {
+        let ctx = make_api_key_restricted();
+        let space = SpaceId::from("eng");
+        // Can read the specific persona.
+        assert!(ctx.can(
+            &space,
+            &ResourceKind::Personas,
+            &Action::Read,
+            Some("deploy-bot"),
+        ));
+        // Cannot read a different persona.
+        assert!(!ctx.can(
+            &space,
+            &ResourceKind::Personas,
+            &Action::Read,
+            Some("other-bot"),
+        ));
+    }
+
+    #[test]
+    fn api_key_without_scope_denies_action() {
+        let ctx = make_api_key_restricted();
+        let space = SpaceId::from("eng");
+        // The key only has personas:read, not conversations:read.
+        assert!(!ctx.can(&space, &ResourceKind::Conversations, &Action::Read, None,));
+    }
+
+    // -- SpaceAdmin --
+
+    #[test]
+    fn space_admin_can_manage_within_space() {
+        let mut space_roles = HashMap::new();
+        space_roles.insert(SpaceId::from("eng"), Role::SpaceAdmin);
+        let ctx = AuthContext {
+            user_id: UserId::from("dana"),
+            org_id: OrgId::from("acme"),
+            email: "dana@acme.com".into(),
+            space_roles,
+            scopes: vec![
+                Scope::new(ResourceKind::Users, Action::Manage),
+                Scope::new(ResourceKind::Interfaces, Action::Manage),
+            ],
+            client_id: "webui".into(),
+        };
+        let space = SpaceId::from("eng");
+        assert!(ctx.can(&space, &ResourceKind::Users, &Action::Manage, None));
+        assert!(ctx.can(&space, &ResourceKind::Interfaces, &Action::Manage, None));
+    }
+
+    #[test]
+    fn space_admin_has_no_access_to_other_space() {
+        let mut space_roles = HashMap::new();
+        space_roles.insert(SpaceId::from("eng"), Role::SpaceAdmin);
+        let ctx = AuthContext {
+            user_id: UserId::from("dana"),
+            org_id: OrgId::from("acme"),
+            email: "dana@acme.com".into(),
+            space_roles,
+            scopes: vec![Scope::new(ResourceKind::Users, Action::Manage)],
+            client_id: "webui".into(),
+        };
+        let space = SpaceId::from("mktg");
+        assert!(!ctx.can(&space, &ResourceKind::Users, &Action::Manage, None));
+    }
+}

--- a/crates/core/src/catalog.rs
+++ b/crates/core/src/catalog.rs
@@ -1,0 +1,68 @@
+//! Resource catalog abstraction.
+//!
+//! Organizations maintain a catalog of shared resources (skills, templates,
+//! interfaces). Spaces explicitly subscribe to catalog entries to make them
+//! available. The [`CatalogResolver`] trait handles resolution:
+//! space-local first, then catalog subscriptions, then not found.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::identity::SpaceId;
+
+/// The type of resource in the catalog.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CatalogResourceType {
+    Skill,
+    Template,
+    Interface,
+}
+
+impl std::fmt::Display for CatalogResourceType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Skill => f.write_str("skill"),
+            Self::Template => f.write_str("template"),
+            Self::Interface => f.write_str("interface"),
+        }
+    }
+}
+
+/// A reference to a catalog resource.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CatalogEntry {
+    /// The resource identifier (e.g., skill name).
+    pub resource_id: String,
+    /// The type of resource.
+    pub resource_type: CatalogResourceType,
+    /// Whether this entry comes from the org catalog (vs. space-local).
+    pub from_catalog: bool,
+}
+
+/// Resolves resources by checking space-local first, then catalog subscriptions.
+///
+/// Implemented in the storage layer where both the filesystem (space-local
+/// resources) and database (catalog subscriptions) are accessible.
+#[async_trait]
+pub trait CatalogResolver: Send + Sync {
+    /// Resolve a skill by name within a space.
+    ///
+    /// Resolution order:
+    /// 1. Space-local skill directory
+    /// 2. Org catalog (if the space has subscribed)
+    /// 3. `None` (not available)
+    async fn resolve_skill(&self, space: &SpaceId, name: &str) -> Result<Option<CatalogEntry>>;
+
+    /// Resolve a persona template by name within a space.
+    async fn resolve_template(&self, space: &SpaceId, name: &str) -> Result<Option<CatalogEntry>>;
+
+    /// List all available resources of the given type for a space,
+    /// combining space-local and subscribed catalog entries.
+    async fn list_available(
+        &self,
+        space: &SpaceId,
+        resource_type: &CatalogResourceType,
+    ) -> Result<Vec<CatalogEntry>>;
+}

--- a/crates/core/src/identity.rs
+++ b/crates/core/src/identity.rs
@@ -1,0 +1,325 @@
+//! Identity types for multi-user, multi-org operation.
+//!
+//! These newtypes provide type-safe identifiers for organizations, spaces,
+//! and users. They are used throughout the system wherever identity context
+//! is required.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+// -- Newtypes --
+
+/// Unique identifier for an organization (top-level namespace).
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct OrgId(pub String);
+
+/// Unique identifier for a space within an organization.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct SpaceId(pub String);
+
+/// Unique identifier for a user.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct UserId(pub String);
+
+// -- Display impls --
+
+impl fmt::Display for OrgId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl fmt::Display for SpaceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl fmt::Display for UserId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+// -- From<String> / AsRef<str> convenience --
+
+impl From<String> for OrgId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for OrgId {
+    fn from(s: &str) -> Self {
+        Self(s.to_owned())
+    }
+}
+
+impl AsRef<str> for OrgId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for SpaceId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for SpaceId {
+    fn from(s: &str) -> Self {
+        Self(s.to_owned())
+    }
+}
+
+impl AsRef<str> for SpaceId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for UserId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for UserId {
+    fn from(s: &str) -> Self {
+        Self(s.to_owned())
+    }
+}
+
+impl AsRef<str> for UserId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+// -- Role --
+
+/// Predefined roles that control access within the system.
+///
+/// Roles form a hierarchy: `OrgAdmin` > `SpaceAdmin` > `Member` > `Viewer`.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Role {
+    /// Full control over the organization: manages spaces, users, config.
+    OrgAdmin,
+    /// Manages resources within a specific space: personas, interfaces, grants.
+    SpaceAdmin,
+    /// Can create personas (within quota) and use granted personas.
+    Member,
+    /// Read-only access to granted personas.
+    Viewer,
+}
+
+impl Role {
+    /// Returns the privilege level (higher = more access).
+    pub fn privilege_level(&self) -> u8 {
+        match self {
+            Self::OrgAdmin => 3,
+            Self::SpaceAdmin => 2,
+            Self::Member => 1,
+            Self::Viewer => 0,
+        }
+    }
+
+    /// Returns `true` if this role has at least the same privilege as `other`.
+    pub fn has_at_least(&self, other: &Role) -> bool {
+        self.privilege_level() >= other.privilege_level()
+    }
+}
+
+impl fmt::Display for Role {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::OrgAdmin => f.write_str("org_admin"),
+            Self::SpaceAdmin => f.write_str("space_admin"),
+            Self::Member => f.write_str("member"),
+            Self::Viewer => f.write_str("viewer"),
+        }
+    }
+}
+
+// -- Scope & Permission types --
+
+/// A resource kind that can be acted upon.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResourceKind {
+    Personas,
+    Conversations,
+    Messages,
+    Skills,
+    Interfaces,
+    Bindings,
+    Users,
+    Org,
+    ApiKeys,
+    Spaces,
+}
+
+impl fmt::Display for ResourceKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Self::Personas => "personas",
+            Self::Conversations => "conversations",
+            Self::Messages => "messages",
+            Self::Skills => "skills",
+            Self::Interfaces => "interfaces",
+            Self::Bindings => "bindings",
+            Self::Users => "users",
+            Self::Org => "org",
+            Self::ApiKeys => "api_keys",
+            Self::Spaces => "spaces",
+        };
+        f.write_str(s)
+    }
+}
+
+/// An action that can be performed on a resource.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Action {
+    Read,
+    Write,
+    Delete,
+    Execute,
+    Manage,
+}
+
+impl fmt::Display for Action {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Self::Read => "read",
+            Self::Write => "write",
+            Self::Delete => "delete",
+            Self::Execute => "execute",
+            Self::Manage => "manage",
+        };
+        f.write_str(s)
+    }
+}
+
+/// A scope grants permission to perform an action on a resource kind,
+/// optionally restricted to specific resource IDs.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Scope {
+    pub resource: ResourceKind,
+    pub action: Action,
+    /// When `Some`, only the listed resource IDs are accessible.
+    /// `None` means all resources of this kind.
+    pub resource_ids: Option<Vec<String>>,
+}
+
+impl Scope {
+    /// Create a scope for all resources of the given kind and action.
+    pub fn new(resource: ResourceKind, action: Action) -> Self {
+        Self {
+            resource,
+            action,
+            resource_ids: None,
+        }
+    }
+
+    /// Create a scope restricted to specific resource IDs.
+    pub fn restricted(resource: ResourceKind, action: Action, ids: Vec<String>) -> Self {
+        Self {
+            resource,
+            action,
+            resource_ids: Some(ids),
+        }
+    }
+
+    /// Returns `true` if this scope covers the given resource, action, and
+    /// optional target ID.
+    pub fn covers(
+        &self,
+        resource: &ResourceKind,
+        action: &Action,
+        target_id: Option<&str>,
+    ) -> bool {
+        if self.resource != *resource || self.action != *action {
+            return false;
+        }
+        match (&self.resource_ids, target_id) {
+            // Unrestricted scope covers everything.
+            (None, _) => true,
+            // Restricted scope but no target → allow (listing).
+            (Some(_), None) => true,
+            // Restricted scope with target → must be in the list.
+            (Some(ids), Some(id)) => ids.iter().any(|s| s == id),
+        }
+    }
+}
+
+impl fmt::Display for Scope {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.resource, self.action)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn role_privilege_ordering() {
+        assert!(Role::OrgAdmin.has_at_least(&Role::SpaceAdmin));
+        assert!(Role::SpaceAdmin.has_at_least(&Role::Member));
+        assert!(Role::Member.has_at_least(&Role::Viewer));
+        assert!(!Role::Viewer.has_at_least(&Role::Member));
+        assert!(Role::OrgAdmin.has_at_least(&Role::OrgAdmin));
+    }
+
+    #[test]
+    fn scope_covers_unrestricted() {
+        let scope = Scope::new(ResourceKind::Personas, Action::Read);
+        assert!(scope.covers(&ResourceKind::Personas, &Action::Read, None));
+        assert!(scope.covers(&ResourceKind::Personas, &Action::Read, Some("p1")));
+        assert!(!scope.covers(&ResourceKind::Personas, &Action::Write, None));
+        assert!(!scope.covers(&ResourceKind::Conversations, &Action::Read, None));
+    }
+
+    #[test]
+    fn scope_covers_restricted() {
+        let scope = Scope::restricted(
+            ResourceKind::Personas,
+            Action::Read,
+            vec!["p1".into(), "p2".into()],
+        );
+        assert!(scope.covers(&ResourceKind::Personas, &Action::Read, Some("p1")));
+        assert!(scope.covers(&ResourceKind::Personas, &Action::Read, Some("p2")));
+        assert!(!scope.covers(&ResourceKind::Personas, &Action::Read, Some("p3")));
+        // Listing (no target) allowed even with restriction.
+        assert!(scope.covers(&ResourceKind::Personas, &Action::Read, None));
+    }
+
+    #[test]
+    fn role_display() {
+        assert_eq!(Role::OrgAdmin.to_string(), "org_admin");
+        assert_eq!(Role::Viewer.to_string(), "viewer");
+    }
+
+    #[test]
+    fn scope_display() {
+        let scope = Scope::new(ResourceKind::Messages, Action::Execute);
+        assert_eq!(scope.to_string(), "messages:execute");
+    }
+
+    #[test]
+    fn newtype_from_and_display() {
+        let org = OrgId::from("acme");
+        assert_eq!(org.to_string(), "acme");
+        assert_eq!(org.as_ref(), "acme");
+
+        let space = SpaceId::from("engineering".to_owned());
+        assert_eq!(space.to_string(), "engineering");
+
+        let user = UserId::from("alice");
+        assert_eq!(user.as_ref(), "alice");
+    }
+}

--- a/crates/core/src/identity.rs
+++ b/crates/core/src/identity.rs
@@ -234,6 +234,14 @@ impl Scope {
         }
     }
 
+    /// If this scope restricts access to specific resource IDs, returns them.
+    ///
+    /// Callers should use this to filter listing results when `covers()`
+    /// returns `false` due to a missing `target_id`.
+    pub fn visible_ids(&self) -> Option<&[String]> {
+        self.resource_ids.as_deref()
+    }
+
     /// Returns `true` if this scope covers the given resource, action, and
     /// optional target ID.
     pub fn covers(
@@ -248,8 +256,9 @@ impl Scope {
         match (&self.resource_ids, target_id) {
             // Unrestricted scope covers everything.
             (None, _) => true,
-            // Restricted scope but no target → allow (listing).
-            (Some(_), None) => true,
+            // Restricted scope but no target → deny (caller must use
+            // `visible_ids()` to filter listings).
+            (Some(_), None) => false,
             // Restricted scope with target → must be in the list.
             (Some(ids), Some(id)) => ids.iter().any(|s| s == id),
         }
@@ -294,8 +303,14 @@ mod tests {
         assert!(scope.covers(&ResourceKind::Personas, &Action::Read, Some("p1")));
         assert!(scope.covers(&ResourceKind::Personas, &Action::Read, Some("p2")));
         assert!(!scope.covers(&ResourceKind::Personas, &Action::Read, Some("p3")));
-        // Listing (no target) allowed even with restriction.
-        assert!(scope.covers(&ResourceKind::Personas, &Action::Read, None));
+        // Listing (no target) denied — callers must use visible_ids() to filter.
+        assert!(!scope.covers(&ResourceKind::Personas, &Action::Read, None));
+        // visible_ids() returns the restriction set.
+        assert_eq!(
+            scope.visible_ids(),
+            Some(vec!["p1".to_string(), "p2".to_string()].as_slice()),
+            "restricted scope should expose allowed IDs"
+        );
     }
 
     #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -18,11 +18,11 @@ pub mod types;
 pub mod upload;
 
 pub use allowlist::AllowlistFilter;
-// -- Auth & identity (multi-user) --
 pub use attachment::{
     AttachmentMeta, MAX_ATTACHMENT_SIZE, RESIZABLE_MIME_TYPES, SUPPORTED_MIME_TYPES,
     extension_for_mime, is_resizable_mime_type, is_supported_mime_type, is_text_mime_type,
 };
+// -- Auth & identity (multi-user) --
 pub use auth::{
     AuthContext, AuthProvider, AuthorizeRequest, AuthorizeResponse, ClientInfo, ClientRegistration,
     IdentityResolver, TokenGrant, TokenResponse,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,11 +1,14 @@
 pub mod allowlist;
 pub mod attachment;
+pub mod auth;
 pub mod bus;
 pub mod bus_messages;
+pub mod catalog;
 pub mod channel;
 pub mod command;
 pub mod config;
 pub mod context;
+pub mod identity;
 pub mod llm;
 pub mod memory;
 pub mod subagent;
@@ -15,15 +18,21 @@ pub mod types;
 pub mod upload;
 
 pub use allowlist::AllowlistFilter;
+// -- Auth & identity (multi-user) --
 pub use attachment::{
     AttachmentMeta, MAX_ATTACHMENT_SIZE, RESIZABLE_MIME_TYPES, SUPPORTED_MIME_TYPES,
     extension_for_mime, is_resizable_mime_type, is_supported_mime_type, is_text_mime_type,
+};
+pub use auth::{
+    AuthContext, AuthProvider, AuthorizeRequest, AuthorizeResponse, ClientInfo, ClientRegistration,
+    IdentityResolver, TokenGrant, TokenResponse,
 };
 pub use bus::{BusMessage, ClaimFilter, MessageBus, MessageStatus, PublishRequest};
 pub use bus_messages::{
     AgentReport, AgentReportStatus, AgentSpawn, ToolExecute, ToolResult, TurnPhase, TurnRequest,
     TurnResult, TurnStatus, topic,
 };
+pub use catalog::{CatalogEntry, CatalogResolver, CatalogResourceType};
 pub use channel::{ChannelAdapter, ChannelContent, ChannelMessage, ChannelUser};
 pub use command::{CommandArg, CommandDef, CommandResult, ConversationConfig};
 pub use config::{default_config_path, load_config};
@@ -32,6 +41,7 @@ pub use context::{
     runtime_agent_root, runtime_workspace_dir, set_runtime_agent_root, set_runtime_workspace_dir,
     validate_agent_id,
 };
+pub use identity::{Action, OrgId, ResourceKind, Role, Scope, SpaceId, UserId};
 // -- LLM abstractions (types, traits, streaming) --
 pub use llm::embedding::{EmbeddingProvider, LlmEmbedder, WithEmbeddingOverride};
 pub use llm::provider::{Capabilities, HostedTool, LlmProvider, ToolSupport};

--- a/openspec/changes/multi-user-orgs/.openspec.yaml
+++ b/openspec/changes/multi-user-orgs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-23

--- a/openspec/changes/multi-user-orgs/design.md
+++ b/openspec/changes/multi-user-orgs/design.md
@@ -1,0 +1,450 @@
+## Context
+
+The assistant is currently single-user. Authentication is a single shared token (`ASSISTANT_WEB_TOKEN`) validated in `crates/web-ui/src/auth.rs`. There is no user, organization, or workspace model. All data lives under `~/.assistant/` with one SQLite database (`assistant.db`). Personas are the primary scoping mechanism — conversations, tasks, and webhooks are indexed by `agent_id` — but there is no user dimension.
+
+The codebase follows a clean "trait in core, implementation elsewhere" pattern: `LlmProvider` in core with implementations in `assistant-llm-provider`, `ChannelAdapter` in core with implementations in `assistant-interfaces`, `ToolHandler` in core with implementations in `assistant-tool-executor`. The new auth system follows this same pattern.
+
+Interface adapters (Slack, Matrix, Mattermost, Signal, Nextcloud) are currently singleton configurations in `config.toml` with one instance per interface type. The adapter registry keys by interface name, preventing multiple instances. Persona-to-interface binding is limited to a single optional `home_channel` per persona, used only by the scheduler.
+
+## Goals
+
+- Multi-user access with per-user data isolation within a shared organizational context
+- OAuth2-based authentication for all clients, replacing the single shared token
+- Support both self-managed credentials (password) and federated identity (OIDC)
+- Physical data isolation at the org and space level (separate databases and disk partitions)
+- Org-level resource catalog with explicit space subscription (no implicit inheritance)
+- Flexible interface ownership (org or user) with user-defined persona bindings
+- Backward-compatible migration for existing single-user installations
+
+## Non-Goals
+
+- Custom role definitions beyond the four predefined roles
+- Fine-grained field-level permissions (row-level via scoping is sufficient)
+- Real-time collaboration on shared conversations
+- Cross-org federation or multi-org user membership
+
+---
+
+## Decisions
+
+### D1: The assistant is always the OAuth2 Authorization Server
+
+In both password and OIDC mode, the assistant server issues its own JWTs. In OIDC mode, the external IdP handles authentication (proving who the user is), but the assistant handles authorization (what the user can do). This means all downstream code sees the same token format regardless of auth mode.
+
+**Why:** The assistant needs claims the IdP doesn't know about — org membership, space roles, persona access grants, API key scopes. Issuing our own tokens lets us embed these claims and validate them statelessly. It also means dynamic client registration, token refresh, and revocation are always under our control.
+
+**Alternative considered:** Pass through IdP tokens directly and look up permissions on every request. Rejected because it couples every API request to the IdP's availability, prevents offline validation, and means our tokens can't carry authorization claims.
+
+### D2: One SQLite database per org + one per space (physical isolation)
+
+Organization-level data (users, roles, space memberships, API keys, catalog) lives in `org.db`. Space-level data (conversations, messages, memory chunks, attachments, scheduled tasks, personas) lives in `space.db` per space.
+
+**Why:** Physical database separation provides hard isolation between orgs and between spaces. No query can accidentally leak data across boundaries without explicitly opening the wrong database file. It also enables independent backup/restore, independent migrations, and prevents one noisy space from affecting another's performance. This is consistent with the user's stated goal of spaces as "isolated chunks."
+
+**Alternative considered:** Single database with `org_id`/`space_id` columns on all tables. Simpler operationally but relies on every query including the right WHERE clause — a single missing filter is a data leak. Also makes independent backup and space-level operations harder.
+
+**Trade-off:** Cross-space queries (org admin dashboards, global search) require opening multiple databases. Acceptable because these are admin-only operations and SQLite supports `ATTACH DATABASE`.
+
+### D3: Three-tier resource model (Org > Space > User) with explicit catalog subscription
+
+Resources live at three levels. Org-level resources (skills, templates, LLM configs, interfaces) are maintained centrally in a catalog. Spaces explicitly subscribe to catalog resources to make them available. Space-local resources exist independently. User-private resources (personas, conversations) are scoped within a space.
+
+**Why:** Explicit subscription prevents surprise resource availability and keeps space isolation meaningful. The org team can update a skill once and all subscribed spaces get the update, but a space admin must opt in. This matches how real organizations manage shared tooling — a central team maintains it, teams adopt it.
+
+**Alternative considered:** Automatic inheritance (spaces see all org resources). Rejected because it breaks isolation semantics and makes it impossible for a space admin to control their environment.
+
+### D4: Predefined roles with per-role quotas and template access
+
+Four roles: `org-admin`, `space-admin`, `member`, `viewer`. Each role has associated privilege definitions. Org admins can adjust quotas (max personas, template access list) per role at the org level.
+
+**Why:** Predefined roles are simpler to implement, reason about, and explain to users. Custom roles add significant UX complexity (role editor, permission matrix UI) with limited value in v1 when most deployments will be small-to-medium teams.
+
+**Role definitions:**
+
+| Capability              | org-admin | space-admin     | member       | viewer    |
+| ----------------------- | --------- | --------------- | ------------ | --------- |
+| Manage org settings     | yes       | no              | no           | no        |
+| Create/delete spaces    | yes       | no              | no           | no        |
+| Manage all users        | yes       | no              | no           | no        |
+| Manage space personas   | yes       | yes (own space) | no           | no        |
+| Manage space interfaces | yes       | yes (own space) | no           | no        |
+| Grant space access      | yes       | yes (own space) | no           | no        |
+| Create private personas | yes       | yes             | within quota | no        |
+| Use granted personas    | yes       | yes             | yes          | yes       |
+| Send messages           | yes       | yes             | yes          | no        |
+| View conversations      | yes       | yes             | yes          | yes (own) |
+| Manage own API keys     | yes       | yes             | yes          | yes       |
+
+### D5: User-created personas are private within their space
+
+When a member creates a persona (within their quota), it is visible only to them, scoped to the space they created it in. An org-admin or space-admin can see all personas in their scope. Admins create org-wide personas that are granted to users by role or individually.
+
+**Why:** Private-by-default is safer and more intuitive. Users expect their custom assistant configurations to be personal. Admin-created org personas serve the shared use case. If a user loses access to a space, their private personas in that space become inaccessible — this is correct because work-context personas shouldn't outlive the work context.
+
+**Alternative considered:** User personas float above spaces (org-level). Rejected because it breaks the space isolation model and creates ambiguity about which space's resources (skills, interfaces) the persona can access.
+
+### D6: OAuth2 dynamic client registration (RFC 7591)
+
+The assistant's OAuth2 server supports dynamic client registration at `POST /oauth/register`. Any application can register as an OAuth2 client without manual admin configuration.
+
+**Why:** Essential for ecosystem growth. Third-party integrations, custom CLIs, MCP servers, and automation tools need to authenticate. Manual client registration by an admin doesn't scale. First-party clients (web-ui, CLI, Flutter app) use pre-configured client IDs but the mechanism is the same.
+
+**Consideration:** Dynamic registration is open by default. Org admins can restrict it (require admin approval for new clients) if needed for security-sensitive deployments.
+
+### D7: API keys use GitHub-style scoped access
+
+API keys are owned by a user, carry explicit scopes (`resource:action`), and can optionally be restricted to specific resource IDs (e.g., a single persona). They resolve to the same `AuthContext` as OAuth tokens.
+
+**Why:** Scoped keys follow the principle of least privilege. A CI integration that only needs to send messages to one persona shouldn't have access to user management. The GitHub model is well-understood by developers.
+
+**Scope hierarchy:**
+
+```
+personas:read, personas:write, personas:delete
+conversations:read, conversations:write, conversations:delete
+messages:send, messages:read
+skills:read, skills:execute, skills:write
+interfaces:read, interfaces:manage
+bindings:read, bindings:write
+users:read, users:manage
+org:read, org:manage
+api_keys:read, api_keys:write, api_keys:revoke
+spaces:read, spaces:manage
+```
+
+### D8: Interface instances are named, typed, owned resources with persona bindings
+
+Interface connections are promoted from singleton config sections to first-class named resources with ownership (org or user) and explicit persona bindings. V1 supports one binding per interface instance (1:1 persona mapping).
+
+**Why:** The current model (one `[slack]` section in config.toml) can't support multiple Slack workspaces, shared vs. private interfaces, or user-defined routing. Named instances with ownership and bindings solve all three. The 1:1 binding keeps routing unambiguous in v1 — if you want the same Slack workspace to serve two personas, create two Slack apps.
+
+**Alternative considered:** Channel-based routing (one interface instance, multiple bindings filtered by channel). Deferred to v2 — adds routing complexity and ambiguity (what happens when no channel matches?).
+
+### D9: Auth abstractions in core, implementations in assistant-auth
+
+`AuthProvider`, `AuthContext`, `IdentityResolver`, and all identity types (`UserId`, `OrgId`, `SpaceId`, `Role`, `Scope`) are defined in `assistant-core`. The `assistant-auth` crate provides concrete implementations: password auth, OIDC federation, API key validation, JWT issuance, OAuth2 server logic, session management.
+
+**Why:** Follows the established crate pattern (LlmProvider in core, implementations in llm-provider). Keeps core free of heavy dependencies (OIDC, JWT, argon2) while letting all other crates depend on core for the auth types. Any crate that needs to check permissions imports `AuthContext` from core — no dependency on the auth implementation.
+
+### D10: Existing installations migrate to a "default" org
+
+On first startup after upgrade, the assistant detects the legacy `~/.assistant/` layout and migrates it: creates a "default" org, moves agents/skills/database into `~/.assistant/orgs/default/spaces/default/`, and prompts for the first admin user's credentials.
+
+**Why:** Zero-friction upgrade path. Users don't lose data or need to re-configure. The single-user experience continues to work — it's just now the "default" org with one admin user. The legacy `ASSISTANT_WEB_TOKEN` env var is accepted during migration as a temporary credential until the admin sets up proper auth.
+
+---
+
+## Entity Model
+
+```
+Organization
+├── id: Uuid
+├── name: String
+├── slug: String              (filesystem-safe, used in paths)
+├── auth_mode: Password | Oidc { issuer_url, client_id, client_secret }
+├── created_at, updated_at
+│
+├── has many → Users
+│   ├── id: Uuid
+│   ├── org_id: Uuid
+│   ├── email: String
+│   ├── name: String
+│   ├── password_hash: Option<String>     (password mode only)
+│   ├── idp_issuer: Option<String>        (OIDC mode only)
+│   ├── idp_subject: Option<String>       (OIDC mode only)
+│   ├── created_at, updated_at
+│   │
+│   ├── has many → SpaceMemberships
+│   │   ├── user_id, space_id, role
+│   │   └── quotas: { max_personas, allowed_templates }
+│   │
+│   └── has many → ApiKeys
+│       ├── id, user_id, name
+│       ├── key_hash: String
+│       ├── key_prefix: String            (for display: "ask_live_abc...")
+│       ├── scopes: Vec<Scope>
+│       ├── resource_restrictions: Option<Vec<ResourceRestriction>>
+│       └── expires_at: Option<DateTime>
+│
+├── has many → Spaces
+│   ├── id: Uuid
+│   ├── org_id: Uuid
+│   ├── name: String
+│   ├── slug: String
+│   ├── created_at, updated_at
+│   │
+│   ├── has many → Personas (org-created or user-private)
+│   ├── has many → InterfaceInstances (org-owned or user-owned)
+│   ├── has many → Bindings (persona_id, interface_instance_id)
+│   ├── has many → Skills (space-local)
+│   └── subscribes to → CatalogResources
+│
+├── has → Catalog
+│   ├── Skills (org-maintained)
+│   ├── PersonaTemplates (org-maintained)
+│   └── InterfaceInstances (org-owned)
+│
+└── has → OAuthClients (dynamically registered)
+    ├── client_id, client_name
+    ├── redirect_uris, grant_types
+    ├── token_endpoint_auth_method
+    └── created_at
+```
+
+## Disk Layout
+
+```
+~/.assistant/
+├── server.toml                              # global: listen addr, log level
+└── orgs/
+    └── {org-slug}/
+        ├── org.toml                         # auth mode, LLM providers, catalog config
+        ├── org.db                           # users, roles, memberships, API keys,
+        │                                    # OAuth clients, catalog subscriptions
+        ├── catalog/
+        │   ├── skills/
+        │   │   └── {skill-name}/SKILL.md
+        │   ├── templates/
+        │   │   └── {template-name}/
+        │   │       ├── SOUL.md
+        │   │       ├── IDENTITY.md
+        │   │       └── template.toml        # pre-wired skills, tools, config
+        │   └── interfaces/
+        │       └── {instance-name}.toml
+        │
+        └── spaces/
+            └── {space-slug}/
+                ├── space.db                 # conversations, messages, memory,
+                │                            # attachments metadata, personas,
+                │                            # scheduled tasks, webhooks, metrics
+                ├── agents/
+                │   └── {persona-id}/
+                │       ├── SOUL.md
+                │       ├── IDENTITY.md
+                │       ├── MEMORY.md
+                │       ├── memory/
+                │       ├── attachments/{conv_id}/{att_id}.ext
+                │       └── workspace/
+                ├── skills/                  # space-local skills
+                └── interfaces/              # space-local interface configs
+```
+
+## Auth Flows
+
+### Password Mode — Web UI Login
+
+```
+Browser                    Assistant Server               org.db
+   │                            │                           │
+   │  GET /oauth/authorize      │                           │
+   │  ?client_id=webui          │                           │
+   │  &response_type=code       │                           │
+   │  &code_challenge=xxx       │                           │
+   │  &redirect_uri=/callback   │                           │
+   ├───────────────────────────▶│                           │
+   │                            │                           │
+   │  ◀── 200 Login Form ──────│                           │
+   │                            │                           │
+   │  POST /oauth/authorize     │                           │
+   │  { email, password }       │                           │
+   ├───────────────────────────▶│                           │
+   │                            │  verify password_hash     │
+   │                            ├──────────────────────────▶│
+   │                            │  ◀── user record ─────────│
+   │                            │                           │
+   │                            │  generate auth code       │
+   │  ◀── 302 /callback?code=  │                           │
+   │                            │                           │
+   │  POST /oauth/token         │                           │
+   │  { code, code_verifier }   │                           │
+   ├───────────────────────────▶│                           │
+   │                            │  validate code + PKCE     │
+   │                            │  build AuthContext         │
+   │                            │  sign JWT                 │
+   │  ◀── { access_token,      │                           │
+   │        refresh_token }     │                           │
+   │                            │                           │
+```
+
+### OIDC Mode — Web UI Login
+
+```
+Browser                  Assistant Server             External IdP
+   │                          │                           │
+   │  GET /oauth/authorize    │                           │
+   │  ?client_id=webui        │                           │
+   ├─────────────────────────▶│                           │
+   │                          │                           │
+   │  ◀── 302 to IdP ────────│                           │
+   │     /authorize?client_id=assistant&...               │
+   │                          │                           │
+   │  ── authenticate at IdP ────────────────────────────▶│
+   │  ◀── 302 /callback?code=idp_code ──────────────────│
+   │                          │                           │
+   │  GET /oauth/callback     │                           │
+   │  ?code=idp_code          │                           │
+   ├─────────────────────────▶│                           │
+   │                          │  POST /token              │
+   │                          │  { code=idp_code }        │
+   │                          ├──────────────────────────▶│
+   │                          │  ◀── { id_token } ────────│
+   │                          │                           │
+   │                          │  validate id_token         │
+   │                          │  extract sub, email        │
+   │                          │  lookup/create local user  │
+   │                          │  build AuthContext          │
+   │                          │  sign OUR JWT              │
+   │                          │                           │
+   │  ◀── 302 /callback      │                           │
+   │     ?code=our_auth_code  │                           │
+   │                          │                           │
+   │  POST /oauth/token       │                           │
+   │  { code=our_auth_code }  │                           │
+   ├─────────────────────────▶│                           │
+   │  ◀── { access_token,    │                           │
+   │        refresh_token }   │                           │
+```
+
+### CLI — Device Code Flow
+
+```
+CLI                      Assistant Server
+ │                            │
+ │  POST /oauth/device        │
+ │  { client_id=cli }         │
+ ├───────────────────────────▶│
+ │                            │
+ │  ◀── { device_code,       │
+ │        user_code: "ABCD", │
+ │        verification_uri }  │
+ │                            │
+ │  Display: "Visit https://assistant.local/device        │
+ │            and enter code: ABCD"                        │
+ │                            │
+ │  POST /oauth/token         │    (poll)
+ │  { grant_type=             │
+ │    device_code,            │
+ │    device_code=xxx }       │
+ ├───────────────────────────▶│
+ │  ◀── { "pending" }        │
+ │         ...                │    (user completes login in browser)
+ │  POST /oauth/token         │
+ ├───────────────────────────▶│
+ │  ◀── { access_token,      │
+ │        refresh_token }     │
+```
+
+## Token Structure
+
+```json
+{
+  "iss": "https://assistant.example.com",
+  "sub": "usr_abc123",
+  "aud": "https://assistant.example.com",
+  "exp": 1750000000,
+  "iat": 1749996400,
+  "jti": "tok_unique_id",
+
+  "org_id": "org_acme",
+  "org_slug": "acme",
+  "email": "alice@acme.com",
+  "name": "Alice",
+
+  "spaces": {
+    "spc_eng": "admin",
+    "spc_mktg": "member"
+  },
+
+  "client_id": "webui",
+  "scope": "personas:read conversations:read conversations:write messages:send skills:execute"
+}
+```
+
+## Resource Resolution
+
+When a persona in a space needs a resource (e.g., a skill):
+
+1. Check space-local resources first
+2. Check catalog subscriptions (org resources explicitly subscribed by this space)
+3. Not found = not available (no implicit inheritance)
+
+The catalog subscription table in `org.db`:
+
+```sql
+CREATE TABLE catalog_subscriptions (
+    space_id      TEXT NOT NULL,
+    resource_type TEXT NOT NULL,     -- 'skill', 'template', 'interface'
+    resource_id   TEXT NOT NULL,     -- name/id of the catalog resource
+    subscribed_at DATETIME NOT NULL,
+    PRIMARY KEY (space_id, resource_type, resource_id)
+);
+```
+
+## Crate Architecture
+
+```
+assistant-core (extended)
+├── src/auth.rs          NEW  AuthProvider trait, AuthContext, TokenGrant, etc.
+├── src/identity.rs      NEW  UserId, OrgId, SpaceId, Role, Scope, Action, ResourceKind
+├── src/catalog.rs       NEW  CatalogResolver trait
+└── src/channel.rs       MOD  ChannelAdapter receives identity context
+
+assistant-auth (NEW CRATE)
+├── src/lib.rs                 Public API: create_auth_provider(config) → Arc<dyn AuthProvider>
+├── src/password.rs            Password hashing (argon2), credential verification
+├── src/oidc.rs                OIDC discovery, id_token validation, claim mapping
+├── src/oauth2/
+│   ├── server.rs              Authorization + token endpoints
+│   ├── clients.rs             Dynamic client registration (RFC 7591)
+│   ├── device.rs              Device code flow
+│   └── pkce.rs                PKCE challenge/verifier
+├── src/jwt.rs                 JWT signing, validation, claim building
+├── src/api_keys.rs            API key generation, hashing, scope resolution
+└── src/middleware.rs          Axum extractors: AuthContext from request
+
+assistant-storage (extended)
+├── src/org.rs           NEW  OrgStore: organizations, users, memberships, API keys
+├── src/spaces.rs        NEW  SpaceStore: space CRUD, catalog subscriptions
+├── src/migration.rs     NEW  Legacy layout detection + migration to org structure
+└── src/lib.rs           MOD  Database pool factory: org_pool(slug), space_pool(slug, space)
+
+assistant-web-ui (extended)
+├── src/auth.rs          MOD  Replace single-token with AuthContext middleware
+├── src/oauth/           NEW  OAuth2 route handlers
+│   ├── authorize.rs
+│   ├── token.rs
+│   ├── register.rs
+│   ├── device.rs
+│   └── revoke.rs
+├── src/api/             MOD  All handlers receive AuthContext, enforce permissions
+└── src/main.rs          MOD  Multi-org startup, database pool management
+
+assistant-runtime (extended)
+├── src/channel_runner.rs  MOD  Thread AuthContext through turns
+└── src/scheduler.rs       MOD  Run scheduled tasks with persona identity
+
+assistant-interfaces (extended)
+└── src/*/adapter.rs       MOD  Receive identity context, support instance naming
+```
+
+## Risks / Trade-offs
+
+**[Risk] JWT signing key management.** The assistant server needs a signing key for JWTs. If the key is lost, all tokens are invalidated. Mitigation: generate and persist the key in `org.toml` on first startup; support key rotation with a grace period for old keys.
+
+**[Risk] OIDC provider outage blocks login.** In OIDC mode, if the external IdP is down, users can't authenticate. Mitigation: existing sessions (refresh tokens) continue to work; API keys are validated locally. Document this as an operational consideration.
+
+**[Trade-off] Per-space databases increase operational complexity.** More database files means more migrations to run, more files to back up. Acceptable because the isolation guarantee is worth it, and the backup system already archives the entire `~/.assistant/` tree.
+
+**[Trade-off] No cross-space resource sharing without the catalog.** A skill in Space A can't be used in Space B unless it's promoted to the org catalog first. This is intentional — it prevents ad-hoc coupling between spaces — but may feel restrictive for small orgs. Small orgs can use a single space.
+
+**[Risk] Migration from single-user could fail mid-way.** File moves + database restructuring is non-atomic. Mitigation: create the new structure alongside the old one (copy, don't move), verify integrity, then remove the old layout. Keep a backup archive as a safety net.
+
+## Open Questions
+
+**OIDC user auto-provisioning policy.** When a user authenticates via OIDC for the first time, should they be auto-provisioned into the org (by email domain match), or require admin pre-approval? Likely an org-level setting with both options.
+
+**Token lifetime tuning.** Access token TTL (1 hour default), refresh token TTL (30 days default), and session cookie TTL (7 days default) should be configurable per org. Need to decide sensible defaults.
+
+**Org-level LLM provider restrictions.** The proposal mentions orgs can restrict which models users access. The mechanism (allowlist on the LLM config, quota-based, or per-role) is deferred to implementation.
+
+**Interface instance migration.** Existing `[slack]`/`[matrix]` config sections need to become named interface instances. The migration tool needs to generate instance names from the config (e.g., `[slack]` becomes instance `slack-default`).

--- a/openspec/changes/multi-user-orgs/design.md
+++ b/openspec/changes/multi-user-orgs/design.md
@@ -102,14 +102,14 @@ API keys are owned by a user, carry explicit scopes (`resource:action`), and can
 ```
 personas:read, personas:write, personas:delete
 conversations:read, conversations:write, conversations:delete
-messages:send, messages:read
+messages:read, messages:write
 skills:read, skills:execute, skills:write
-interfaces:read, interfaces:manage
+interfaces:read, interfaces:write
 bindings:read, bindings:write
-users:read, users:manage
+users:read, users:write, users:manage
 org:read, org:manage
-api_keys:read, api_keys:write, api_keys:revoke
-spaces:read, spaces:manage
+api_keys:read, api_keys:write, api_keys:delete
+spaces:read, spaces:write, spaces:manage
 ```
 
 ### D8: Interface instances are named, typed, owned resources with persona bindings
@@ -356,7 +356,7 @@ CLI                      Assistant Server
   },
 
   "client_id": "webui",
-  "scope": "personas:read conversations:read conversations:write messages:send skills:execute"
+  "scope": "personas:read conversations:read conversations:write messages:write skills:execute"
 }
 ```
 

--- a/openspec/changes/multi-user-orgs/proposal.md
+++ b/openspec/changes/multi-user-orgs/proposal.md
@@ -1,0 +1,62 @@
+## Why
+
+The assistant is currently a single-user system. One shared token gates all access, there is no concept of user identity, and all clients share a single global persona context. This blocks adoption in any team or organizational setting where multiple people need isolated access to their own agents, conversations, and configurations. Organizations also need to partition their business into smaller isolated units (spaces), control which resources users can access, and integrate with existing identity providers.
+
+## What Changes
+
+- Introduce a three-tier resource model: **Organization > Space > User** with per-org and per-space disk and database isolation
+- Add an **OAuth2 Authorization Server** to the assistant (new `assistant-auth` crate) that supports two authentication modes: local username/password or external OIDC — both issue the assistant's own JWTs
+- Support **dynamic OAuth2 client registration** (RFC 7591) so CLIs, mobile apps, and third-party integrations can register as OAuth clients
+- All apps (CLI, web-ui, Flutter) authenticate via **OAuth2 flows** (Authorization Code + PKCE for public clients, client credentials for server integrations), replacing the single shared token
+- Add **GitHub-style scoped API keys** as a parallel auth path, resolving to the same `AuthContext` as OAuth tokens
+- Define **auth abstractions in `assistant-core`** (`AuthProvider`, `AuthContext`, identity types) with implementations in `assistant-auth`, following the existing trait-in-core pattern
+- Remove the global default persona. Users create their first persona at onboarding, within admin-defined quotas and template restrictions
+- Personas, skills, and interface instances are **space-scoped**. Org-level resources (skills, templates, LLM configs, interfaces) live in a **catalog** that spaces explicitly subscribe to
+- Interface instances can be **org-owned** (shared, e.g. company Slack) or **user-owned** (private, e.g. personal Signal). Users define **bindings** between personas and interface instances
+- Predefined roles (**org-admin, space-admin, member, viewer**) with admin-configurable quotas (max personas, template access) per role
+- Migrate existing single-user installations to a **"default" org** with the first user as admin
+
+## Non-goals
+
+- Custom/dynamic role definitions (v1 uses predefined roles only)
+- Channel-based routing within a single interface instance (v1: one binding per interface instance)
+- Slack/platform-specific user identity mapping (deferred, solve per-platform later)
+- Multi-org membership for a single user (one user belongs to exactly one org)
+- Billing, subscription, or payment integration
+- SCIM provisioning or directory sync
+- End-to-end encryption of conversations
+
+## Capabilities
+
+### New Capabilities
+
+- `org-management`: Create and configure organizations with auth mode (password or OIDC), LLM providers, and resource catalog
+- `space-management`: Create isolated spaces within an org; subscribe to org catalog resources
+- `user-management`: Invite users to an org, assign space memberships and roles, set quotas
+- `oauth2-server`: Full OAuth2 Authorization Server with authorize, token, revoke, and dynamic client registration endpoints
+- `oidc-federation`: Delegate authentication to an external OIDC provider while retaining local authorization
+- `api-key-management`: Create, list, revoke scoped API keys with resource-level restrictions
+- `persona-templates`: Org-maintained persona blueprints (SOUL.md, IDENTITY.md, pre-wired skills/tools) that users instantiate within quota
+- `interface-bindings`: User-defined mappings between personas and interface instances (org-owned or user-owned)
+- `catalog-subscription`: Org publishes resources (skills, templates, interfaces) to a catalog; spaces subscribe to consume them
+- `install-migration`: Automatic migration of single-user installations to a default org
+
+### Modified Capabilities
+
+- `persona-lifecycle`: Personas are now space-scoped, created by users (private) or admins (org-shared), no global default
+- `conversation-scoping`: Conversations scoped to (org, space, user, persona) instead of just (persona)
+- `storage-layout`: Disk layout changes from flat `~/.assistant/` to `~/.assistant/orgs/{slug}/spaces/{name}/`
+- `interface-config`: Interface instances become named, typed resources with ownership instead of singleton config sections
+- `auth-flow`: All apps authenticate via OAuth2 instead of a single shared token
+
+## Impact
+
+- **New crate: `assistant-auth`** — OAuth2 server, password/OIDC providers, API key management, JWT issuance/validation, dynamic client registration
+- **`assistant-core`** — New auth abstractions (`AuthProvider`, `AuthContext`, `IdentityResolver`), identity types (`UserId`, `OrgId`, `SpaceId`, `Role`, `Scope`), permission checking
+- **`assistant-storage`** — New tables (organizations, spaces, users, roles, api_keys, catalog_subscriptions, interface_instances, bindings); per-org and per-space database files; migration logic for existing installs
+- **`assistant-web-ui`** — OAuth2 endpoints, auth middleware rewrite (token → AuthContext), all API handlers receive and enforce AuthContext, per-user persona/conversation scoping
+- **`assistant-runtime`** — AuthContext threaded through orchestrator, channel runner uses IdentityResolver, scheduler runs with persona identity
+- **`assistant-interfaces`** — Interface instances become first-class resources; ChannelAdapter receives identity context
+- **`assistant-cli`** — OAuth2 device code or Authorization Code + PKCE login flow, token storage
+- **Flutter app** — OAuth2 login flow, org/space navigation, persona creation from templates, API key management UI
+- **Dependencies**: `jsonwebtoken`, `openidconnect`, `argon2` (password hashing), `oauth2` crate

--- a/openspec/changes/multi-user-orgs/tasks.md
+++ b/openspec/changes/multi-user-orgs/tasks.md
@@ -1,0 +1,596 @@
+## Definition of Done
+
+- [ ] `cargo check --workspace` passes
+- [ ] `cargo test --workspace` passes
+- [ ] `cargo clippy --workspace -- -D warnings` passes
+- [ ] `cargo fmt --all --check` passes
+- [ ] OAuth2 flows work for web-ui, CLI, and Flutter app
+- [ ] Existing single-user install migrates to default org without data loss
+- [ ] OIDC mode tested against at least one provider (Keycloak or Auth0)
+- [ ] API keys with scoped access work end-to-end
+- [ ] Multi-user conversations are isolated (user A cannot see user B's conversations)
+- [ ] Space isolation verified (space A data not accessible from space B)
+- [ ] OpenAPI spec updated with all new endpoints
+
+---
+
+## PR Strategy
+
+This change is broken into **10 PRs**, each independently mergeable into `main`.
+Every PR leaves the workspace in a green, releasable state. Later PRs build on
+earlier ones but each is a coherent, reviewable unit. Within each PR, commits are
+atomic — one logical change per commit, compiles and passes tests at every point.
+
+```
+PR 1  ─── Core identity types & auth abstractions (pure additive, no behavior change)
+PR 2  ─── assistant-auth crate: JWT + password (new crate, nothing depends on it yet)
+PR 3  ──�� assistant-auth crate: OAuth2 server + PKCE + device code + dynamic client reg
+PR 4  ──��� assistant-auth crate: OIDC federation + API keys
+PR 5  ─── Storage: org/space database layer (new stores, no migration yet)
+PR 6  ─── Storage: conversation/persona user-scoping + remove default persona
+PR 7  ─── Web-UI: OAuth2 endpoints + auth middleware rewrite (apps can authenticate)
+PR 8  ─── Web-UI: org/space/user management APIs + interface bindings + catalog
+PR 9  ─── Storage migration: legacy → default org + runtime AuthContext threading
+PR 10 ─── CLI OAuth2 login + Flutter OAuth2 + docs
+```
+
+---
+
+## PR 1: Core identity types and auth abstractions
+
+> Pure type definitions and traits. No behavior change, no new dependencies.
+> Everything compiles, existing tests pass unchanged.
+
+**Commits:**
+
+- [x] `feat(core): add identity newtypes (UserId, OrgId, SpaceId)`
+  - Create `crates/core/src/identity.rs`
+  - `UserId`, `OrgId`, `SpaceId` as newtype wrappers over `String`
+  - `Role` enum: `OrgAdmin`, `SpaceAdmin`, `Member`, `Viewer`
+  - Derive: `Clone`, `Debug`, `PartialEq`, `Eq`, `Hash`, `Serialize`, `Deserialize`
+
+- [x] `feat(core): add scope and permission types`
+  - Add to `crates/core/src/identity.rs`: `Scope` struct, `ResourceKind` enum (`Personas`, `Conversations`, `Messages`, `Skills`, `Interfaces`, `Bindings`, `Users`, `Org`, `ApiKeys`, `Spaces`), `Action` enum (`Read`, `Write`, `Delete`, `Execute`, `Manage`)
+
+- [x] `feat(core): add AuthContext with permission checking`
+  - Create `crates/core/src/auth.rs`
+  - `AuthContext` struct: `user_id`, `org_id`, `email`, `space_roles: HashMap<SpaceId, Role>`, `scopes: Vec<Scope>`, `client_id`
+  - Implement `can(&self, space, resource, action) -> bool`
+  - Implement `is_org_admin(&self) -> bool`, `role_in(&self, space) -> Option<&Role>`
+
+- [x] `test(core): permission logic for AuthContext`
+  - Tests in `crates/core/src/auth.rs` `#[cfg(test)] mod tests`
+  - Cover: org-admin bypasses space checks, space-admin within own space, member scoped by grants, viewer read-only, scope filtering for API keys
+
+- [x] `feat(core): add AuthProvider and IdentityResolver traits`
+  - `AuthProvider` trait in `crates/core/src/auth.rs`: `authenticate()`, `authorize()`, `token()`, `register_client()`
+  - `IdentityResolver` trait: `resolve(platform, platform_user_id) -> Option<UserId>`
+  - Supporting request/response types: `AuthorizeRequest`, `AuthorizeResponse`, `TokenGrant`, `TokenResponse`, `ClientRegistration`, `ClientInfo`
+
+- [x] `feat(core): add CatalogResolver trait`
+  - Create `crates/core/src/catalog.rs`
+  - `CatalogResolver` trait: `resolve_skill(space, name)`, `resolve_template(space, name)`, `list_available(space, resource_type)`
+
+- [x] `chore(core): export auth, identity, and catalog modules`
+  - Update `crates/core/src/lib.rs` with re-exports
+
+---
+
+## PR 2: assistant-auth crate — JWT and password fundamentals
+
+> New crate with zero consumers. Ships JWT signing/validation and password hashing.
+> Workspace compiles, new crate has its own test suite.
+
+**Commits:**
+
+- [x] `feat(auth): scaffold assistant-auth crate`
+  - Create `crates/auth/Cargo.toml` with deps: `jsonwebtoken`, `argon2`, `rand`, `uuid`, `chrono`, `async-trait`, `anyhow`, `tracing`, `serde`, `serde_json`
+  - Add to workspace `Cargo.toml` members and `[workspace.dependencies]`
+  - Create `crates/auth/src/lib.rs` with module declarations
+
+- [x] `feat(auth): JWT signing and validation`
+  - Create `crates/auth/src/jwt.rs`
+  - Key generation (EdDSA or RS256), key persistence (load from file or generate)
+  - `sign(claims: &AuthContext, expiry: Duration) -> Result<String>`
+  - `validate(token: &str) -> Result<AuthContext>`
+  - Claim mapping: AuthContext fields ↔ JWT registered + custom claims
+
+- [x] `test(auth): JWT round-trip sign/validate/extract`
+  - Generate key, sign token, validate, assert claims match
+  - Test expired token rejection
+  - Test tampered token rejection
+
+- [x] `feat(auth): argon2 password hashing`
+  - Create `crates/auth/src/password.rs`
+  - `hash_password(plain: &str) -> Result<String>`
+  - `verify_password(plain: &str, hash: &str) -> Result<bool>`
+  - Use argon2id with sensible defaults
+
+- [x] `test(auth): password hash and verify`
+  - Hash → verify matches
+  - Wrong password → verify fails
+  - Different hashes for same input (salt)
+
+---
+
+## PR 3: assistant-auth crate — OAuth2 server, PKCE, device code, dynamic client registration
+
+> Adds the OAuth2 authorization server logic. Still no consumers — pure library code
+> with its own tests. Can be reviewed independently of any web-ui wiring.
+
+**Commits:**
+
+- [ ] `feat(auth): PKCE challenge and verification`
+  - Create `crates/auth/src/oauth2/pkce.rs`
+  - `generate_verifier() -> String`, `challenge_from_verifier(verifier) -> String`
+  - `verify(verifier, challenge) -> bool`
+  - S256 method per RFC 7636
+
+- [ ] `test(auth): PKCE challenge round-trip`
+
+- [ ] `feat(auth): authorization code grant logic`
+  - Create `crates/auth/src/oauth2/server.rs`
+  - `AuthCodeStore` (in-memory or DB-backed): generate, store, exchange, expire
+  - `generate_auth_code(user_id, client_id, redirect_uri, pkce_challenge, scopes) -> String`
+  - `exchange_auth_code(code, client_id, redirect_uri, pkce_verifier) -> Result<(AccessToken, RefreshToken)>`
+
+- [ ] `feat(auth): refresh token management`
+  - Add to `crates/auth/src/oauth2/server.rs`
+  - `RefreshTokenStore`: generate, store, rotate, revoke
+  - `refresh(token, client_id) -> Result<(AccessToken, RefreshToken)>` with rotation
+
+- [ ] `test(auth): authorization code flow end-to-end (in-memory)`
+  - Full flow: generate code → exchange with PKCE → get tokens → refresh → revoke
+
+- [ ] `feat(auth): device code flow`
+  - Create `crates/auth/src/oauth2/device.rs`
+  - `initiate(client_id) -> DeviceCodeResponse { device_code, user_code, verification_uri, interval }`
+  - `poll(device_code) -> PollResult { Pending | Authorized(tokens) | Expired }`
+  - `complete(user_code, user_id)` — called when user approves in browser
+
+- [ ] `test(auth): device code flow lifecycle`
+
+- [ ] `feat(auth): dynamic client registration (RFC 7591)`
+  - Create `crates/auth/src/oauth2/clients.rs`
+  - `ClientStore`: register, lookup, list
+  - `register(req: ClientRegistration) -> Result<ClientInfo>`
+  - Validate redirect_uris, grant_types, response_types
+  - Generate `client_id`, optional `client_secret` for confidential clients
+
+- [ ] `test(auth): dynamic client registration and lookup`
+
+---
+
+## PR 4: assistant-auth crate — OIDC federation and API keys
+
+> Completes the auth crate. After this PR, all auth mechanisms are implemented
+> as library code with tests. Still no web-ui wiring.
+
+**Commits:**
+
+- [ ] `feat(auth): OIDC discovery and id_token validation`
+  - Create `crates/auth/src/oidc.rs`
+  - Add `openidconnect` to crate deps
+  - `OidcProvider::discover(issuer_url) -> Result<Self>` — fetch .well-known/openid-configuration
+  - `validate_id_token(token: &str) -> Result<IdTokenClaims>` — verify signature, issuer, audience, expiry
+  - `extract_user_info(claims: &IdTokenClaims) -> (sub, email, name)`
+
+- [ ] `feat(auth): OIDC user provisioning logic`
+  - Add to `crates/auth/src/oidc.rs`
+  - `provision_or_lookup(idp_issuer, idp_subject, email, name) -> Result<UserId>` — find existing user by (issuer, subject) or create new one
+  - Auto-provision setting (org-level): auto-create or require admin pre-approval
+  - Email domain matching for org assignment
+
+- [ ] `test(auth): OIDC token validation with mocked provider (wiremock)`
+
+- [ ] `feat(auth): scoped API key generation and resolution`
+  - Create `crates/auth/src/api_keys.rs`
+  - `generate_key(user_id, name, scopes, resource_restrictions, expires_at) -> (key_plaintext, key_hash, key_prefix)`
+  - Key format: `ask_live_{32 random chars}` (prefix `ask_live_` for identification)
+  - `resolve_key(key_plaintext) -> Result<AuthContext>` — hash, lookup, check expiry, build AuthContext from stored scopes
+  - Constant-time comparison for key hash
+
+- [ ] `test(auth): API key generation, scoping, and resolution`
+  - Create key with limited scopes → resolve → AuthContext has those scopes
+  - Expired key → rejection
+  - Resource restrictions honored
+
+- [ ] `feat(auth): Axum auth middleware extractors`
+  - Create `crates/auth/src/middleware.rs`
+  - `AuthExtractor` implements `FromRequestParts`: checks `Authorization: Bearer <jwt>`, falls back to session cookie, falls back to API key prefix detection
+  - Returns `AuthContext` or 401
+  - `RequireScope(resource, action)` — Axum layer that checks `ctx.can()` after extraction
+
+- [ ] `test(auth): middleware extraction from various token types`
+
+- [ ] `feat(auth): AuthProvider implementations (password + OIDC)`
+  - Implement `AuthProvider` trait in `crates/auth/src/lib.rs`
+  - `PasswordAuthProvider`: delegates to password.rs + jwt.rs + oauth2/server.rs
+  - `OidcAuthProvider`: delegates to oidc.rs + jwt.rs + oauth2/server.rs
+  - Factory: `create_auth_provider(config) -> Arc<dyn AuthProvider>`
+
+---
+
+## PR 5: Storage — org and space database layer
+
+> New storage modules for org-level and space-level data. Additive only — existing
+> storage code unchanged. New stores have their own in-memory test suites.
+
+**Commits:**
+
+- [ ] `feat(storage): org.db migration — organizations and users tables`
+  - New migration files for org database
+  - Tables: `organizations` (id, name, slug, auth_mode, created_at, updated_at), `users` (id, org_id, email, name, password_hash, idp_issuer, idp_subject, created_at, updated_at)
+
+- [ ] `feat(storage): org.db migration — memberships, API keys, OAuth clients`
+  - Tables: `space_memberships` (user_id, space_id, role, max_personas, allowed_templates_json, created_at), `api_keys` (id, user_id, name, key_hash, key_prefix, scopes_json, resource_restrictions_json, expires_at, created_at), `oauth_clients` (client_id, client_name, redirect_uris_json, grant_types_json, token_endpoint_auth_method, client_secret_hash, created_at)
+
+- [ ] `feat(storage): org.db migration — auth state tables`
+  - Tables: `auth_codes` (code_hash, user_id, client_id, redirect_uri, pkce_challenge, scopes_json, expires_at), `refresh_tokens` (token_hash, user_id, client_id, scopes_json, expires_at, revoked_at), `device_codes` (device_code_hash, user_code, client_id, user_id, scopes_json, status, expires_at), `catalog_subscriptions` (space_id, resource_type, resource_id, subscribed_at)
+
+- [ ] `feat(storage): OrgStore — organization and user CRUD`
+  - Create `crates/storage/src/org.rs`
+  - `OrgStore::new(pool)` — takes org.db pool
+  - CRUD: `create_org`, `get_org`, `update_org`, `create_user`, `get_user_by_email`, `get_user_by_idp`, `list_users`, `update_user`, `delete_user`
+
+- [ ] `test(storage): OrgStore organization and user CRUD`
+  - In-memory org.db, create org, create users, query, update, delete
+
+- [ ] `feat(storage): OrgStore — space memberships and API keys`
+  - Add to `crates/storage/src/org.rs`
+  - `add_space_membership`, `remove_space_membership`, `get_memberships_for_user`, `get_members_of_space`
+  - `create_api_key`, `list_api_keys`, `get_api_key_by_hash`, `revoke_api_key`
+
+- [ ] `test(storage): space memberships and API key CRUD`
+
+- [ ] `feat(storage): OrgStore — OAuth client and auth state storage`
+  - `register_client`, `get_client`, `list_clients`
+  - `store_auth_code`, `consume_auth_code`, `store_refresh_token`, `consume_refresh_token`, `revoke_refresh_token`
+  - `store_device_code`, `get_device_code`, `complete_device_code`
+
+- [ ] `test(storage): OAuth client registration and auth code lifecycle`
+
+- [ ] `feat(storage): SpaceStore — space CRUD and catalog subscriptions`
+  - Create `crates/storage/src/spaces.rs`
+  - Operates on org.db (spaces table) + creates/opens space.db files
+  - `create_space`, `list_spaces`, `get_space`, `delete_space`
+  - `subscribe_catalog_resource`, `unsubscribe`, `list_subscriptions`
+
+- [ ] `test(storage): SpaceStore CRUD and catalog subscriptions`
+
+- [ ] `feat(storage): database pool factory for org/space resolution`
+  - Modify `crates/storage/src/lib.rs`
+  - `OrgPoolFactory::org_pool(org_slug) -> Result<SqlitePool>` — resolves `~/.assistant/orgs/{slug}/org.db`
+  - `OrgPoolFactory::space_pool(org_slug, space_slug) -> Result<SqlitePool>` — resolves `~/.assistant/orgs/{slug}/spaces/{space}/space.db`
+  - Directory creation on first access
+
+---
+
+## PR 6: Storage — conversation/persona user-scoping, remove default persona
+
+> Modifies existing storage code. This is the riskiest storage PR — existing tests
+> must be updated. The default persona model is removed here.
+
+**Commits:**
+
+- [ ] `feat(storage): add user_id scoping to ConversationStore`
+  - Modify `crates/storage/src/conversations.rs`
+  - Add `user_id: Option<String>` field to `ConversationStore` (Option for backward compat during migration)
+  - When `user_id` is set, all queries add `AND user_id = ?` filter
+  - `create_conversation` writes `user_id` into the row
+  - New space.db migration: `ALTER TABLE conversations ADD COLUMN user_id TEXT`
+
+- [ ] `test(storage): conversation user isolation`
+  - Create conversations as user A and user B on same persona
+  - Assert user A's store only returns user A's conversations
+  - Assert user B cannot access user A's conversation by ID
+
+- [ ] `feat(storage): add owner_user_id to personas, remove is_default`
+  - Modify `crates/storage/src/personas.rs`
+  - New migration: `ALTER TABLE personas ADD COLUMN owner_user_id TEXT` (null = org-owned)
+  - Remove `is_default` column (migration: `ALTER TABLE personas DROP COLUMN is_default` or mark deprecated)
+  - Remove `get_default_persona`, `set_default_persona` methods
+  - Add `list_accessible_personas(user_id, role)` — returns org personas the user has access to + user's private personas
+
+- [ ] `test(storage): persona ownership and access filtering`
+  - Org-owned persona visible to granted users
+  - User-private persona visible only to owner
+  - Admin sees all personas in space
+
+- [ ] `refactor(storage): update callers of removed default persona API`
+  - Grep for `is_default`, `get_default_persona`, `set_default_persona`
+  - Update runtime bootstrap, web-ui persona endpoints, CLI persona selection
+  - Where a default was assumed, require explicit persona selection
+
+- [ ] `feat(storage): add sender_user_id to messages`
+  - New migration: `ALTER TABLE messages ADD COLUMN sender_user_id TEXT`
+  - Modify `crates/storage/src/conversations.rs` message insertion to accept optional `sender_user_id`
+  - For `role = 'user'` messages, populate sender_user_id from AuthContext
+
+- [ ] `test(storage): messages carry sender identity`
+
+---
+
+## PR 7: Web-UI — OAuth2 endpoints and auth middleware rewrite
+
+> This is the "big flip" — the web-ui starts accepting OAuth2 tokens instead of the
+> single shared token. Legacy token support is retained as fallback. After this PR,
+> apps can authenticate via OAuth2.
+
+**Commits:**
+
+- [ ] `feat(web-ui): OAuth2 route module scaffold`
+  - Create `crates/web-ui/src/oauth/mod.rs` with sub-modules and route registration
+  - Wire into main router at `/oauth/*`
+
+- [ ] `feat(web-ui): GET /oauth/authorize endpoint`
+  - Password mode: render login form (HTML or redirect to SPA login page)
+  - OIDC mode: redirect to external IdP with state + PKCE
+  - Validate `client_id`, `redirect_uri`, `response_type`, `code_challenge`
+
+- [ ] `feat(web-ui): POST /oauth/authorize — password credential validation`
+  - Accept email + password form submission
+  - Validate via `AuthProvider`, generate auth code, redirect to `redirect_uri?code=`
+
+- [ ] `feat(web-ui): GET /oauth/callback — OIDC IdP callback`
+  - Exchange IdP auth code for id_token
+  - Validate id_token, provision/lookup user
+  - Generate our auth code, redirect to original client's redirect_uri
+
+- [ ] `feat(web-ui): POST /oauth/token endpoint`
+  - Grant types: `authorization_code` (with PKCE), `refresh_token`, `urn:ietf:params:oauth:grant-type:device_code`
+  - Returns `{ access_token, token_type, expires_in, refresh_token }`
+
+- [ ] `feat(web-ui): POST /oauth/register — dynamic client registration`
+  - Accept `ClientRegistration`, validate, store, return `ClientInfo`
+  - Optionally gate behind org admin approval (org setting)
+
+- [ ] `feat(web-ui): POST /oauth/device — device code initiation`
+  - Generate device_code + user_code, return verification_uri
+  - `GET /oauth/device/verify` — browser page where user enters code and approves
+
+- [ ] `feat(web-ui): POST /oauth/revoke + server metadata`
+  - Token revocation (access or refresh)
+  - `GET /.well-known/oauth-authorization-server` — RFC 8414 metadata document
+
+- [ ] `test(web-ui): OAuth2 endpoint integration tests`
+  - Full authorization code + PKCE flow via HTTP
+  - Device code flow via HTTP
+  - Token refresh and revocation
+  - Invalid client_id, bad PKCE, expired code
+
+- [ ] `feat(web-ui): rewrite auth middleware — JWT + API key + legacy fallback`
+  - Replace `crates/web-ui/src/auth.rs` internals
+  - Extract `AuthContext` from: Bearer JWT → session cookie → API key → legacy `ASSISTANT_WEB_TOKEN`
+  - Legacy token maps to default org admin AuthContext (migration bridge)
+  - `AuthContext` available as Axum extractor in all handlers
+
+- [ ] `feat(web-ui): permission guard middleware`
+  - `RequireScope` layer: checks `ctx.can(space, resource, action)` before handler
+  - Returns 403 with scope information on denial
+
+- [ ] `feat(web-ui): session cookie management`
+  - On OAuth2 login completion: set `HttpOnly`, `Secure`, `SameSite=Lax` cookie
+  - Cookie contains encrypted reference to refresh token
+  - Silent refresh on access token expiry
+
+- [ ] `feat(web-ui): update CSRF protection for new session model`
+
+- [ ] `test(web-ui): auth middleware with JWT, API key, legacy token, expired JWT, invalid token`
+
+- [ ] `chore(web-ui): update OpenAPI spec with OAuth2 endpoints`
+
+---
+
+## PR 8: Web-UI — org/space/user management APIs, interface bindings, catalog
+
+> Management API surface. After this PR, orgs, spaces, users, interfaces, and
+> catalog resources can be managed via the API.
+
+**Commits:**
+
+- [ ] `feat(web-ui): organization management endpoints`
+  - `POST /api/orgs` — create org (bootstrapping / super-admin)
+  - `GET /api/orgs` — list orgs (filtered by user access)
+  - `GET /api/orgs/{org_id}` — read org details
+  - `PATCH /api/orgs/{org_id}` — update org settings (auth mode, LLM config)
+  - Requires `org:manage` scope or org-admin role
+
+- [ ] `feat(web-ui): space management endpoints`
+  - `POST /api/orgs/{org_id}/spaces` — create space
+  - `GET /api/orgs/{org_id}/spaces` — list spaces (filtered by membership)
+  - `GET /api/orgs/{org_id}/spaces/{space_id}` — read space
+  - `PATCH /api/orgs/{org_id}/spaces/{space_id}` — update space
+  - `DELETE /api/orgs/{org_id}/spaces/{space_id}` — delete space (org-admin only)
+
+- [ ] `feat(web-ui): user management endpoints`
+  - `POST /api/orgs/{org_id}/users` — invite user (creates account, sends invite or returns credentials)
+  - `GET /api/orgs/{org_id}/users` — list users
+  - `GET /api/orgs/{org_id}/users/{user_id}` — read user
+  - `PATCH /api/orgs/{org_id}/users/{user_id}` — update user (name, role)
+  - `DELETE /api/orgs/{org_id}/users/{user_id}` — remove user
+
+- [ ] `feat(web-ui): space membership endpoints`
+  - `POST /api/orgs/{org_id}/spaces/{space_id}/members` — add user to space with role
+  - `GET /api/orgs/{org_id}/spaces/{space_id}/members` — list space members
+  - `PATCH /api/orgs/{org_id}/spaces/{space_id}/members/{user_id}` — change role
+  - `DELETE /api/orgs/{org_id}/spaces/{space_id}/members/{user_id}` — remove from space
+
+- [ ] `feat(web-ui): API key management endpoints`
+  - `POST /api/users/me/api-keys` — create scoped API key (returns plaintext once)
+  - `GET /api/users/me/api-keys` — list keys (prefix + name + scopes, no secrets)
+  - `DELETE /api/users/me/api-keys/{key_id}` — revoke key
+
+- [ ] `test(web-ui): org/space/user/membership/api-key endpoint tests`
+  - CRUD happy paths
+  - Permission enforcement: member can't create spaces, viewer can't invite users
+
+- [ ] `feat(web-ui): catalog management endpoints`
+  - `POST /api/orgs/{org_id}/catalog/skills` — publish skill to catalog
+  - `POST /api/orgs/{org_id}/catalog/templates` — publish template to catalog
+  - `GET /api/orgs/{org_id}/catalog/{type}` — list catalog resources
+  - `DELETE /api/orgs/{org_id}/catalog/{type}/{id}` — remove from catalog
+
+- [ ] `feat(web-ui): catalog subscription endpoints`
+  - `POST /api/orgs/{org_id}/spaces/{space_id}/subscriptions` — subscribe space to catalog resource
+  - `GET /api/orgs/{org_id}/spaces/{space_id}/subscriptions` — list subscriptions
+  - `DELETE /api/orgs/{org_id}/spaces/{space_id}/subscriptions/{id}` — unsubscribe
+
+- [ ] `feat(web-ui): interface instance endpoints`
+  - `POST /api/orgs/{org_id}/spaces/{space_id}/interfaces` — create interface instance (type, config, owner: org|user)
+  - `GET /api/orgs/{org_id}/spaces/{space_id}/interfaces` — list instances
+  - `DELETE /api/orgs/{org_id}/spaces/{space_id}/interfaces/{id}` — remove instance
+
+- [ ] `feat(web-ui): persona ↔ interface binding endpoints`
+  - `POST /api/orgs/{org_id}/spaces/{space_id}/bindings` — bind persona to interface instance
+  - `GET /api/orgs/{org_id}/spaces/{space_id}/bindings` — list bindings
+  - `DELETE /api/orgs/{org_id}/spaces/{space_id}/bindings/{id}` — unbind
+
+- [ ] `feat(web-ui): persona template instantiation and onboarding`
+  - `GET /api/orgs/{org_id}/catalog/templates` — list templates (filtered by user's allowed_templates quota)
+  - `POST /api/orgs/{org_id}/spaces/{space_id}/personas/from-template` — create persona from template, enforce max_personas quota
+  - `GET /api/users/me/onboarding-status` — has user created at least one persona?
+
+- [ ] `test(web-ui): catalog, subscriptions, interfaces, bindings, and template instantiation`
+
+- [ ] `refactor(web-ui): update existing API handlers to enforce AuthContext`
+  - Conversations, messages, personas, skills endpoints
+  - Scope queries by user_id + space from AuthContext
+  - Return 403 when user lacks access
+
+- [ ] `chore(web-ui): update OpenAPI spec with management endpoints`
+
+---
+
+## PR 9: Storage migration + runtime AuthContext threading
+
+> The migration path for existing installs, and the runtime plumbing that threads
+> identity through the orchestrator and channel runner.
+
+**Commits:**
+
+- [ ] `feat(storage): detect legacy layout`
+  - Create `crates/storage/src/migration.rs`
+  - `is_legacy_layout(base_path) -> bool` — checks for `assistant.db` without `orgs/` directory
+
+- [ ] `feat(storage): create backup before migration`
+  - `backup_legacy(base_path) -> Result<PathBuf>` — tar.gz of entire `~/.assistant/`
+  - Reuse existing backup logic from `crates/backup/`
+
+- [ ] `feat(storage): migrate filesystem layout to default org`
+  - Create `orgs/default/spaces/default/` structure
+  - Copy `agents/` → `orgs/default/spaces/default/agents/`
+  - Copy `skills/` → `orgs/default/spaces/default/skills/`
+  - Split `config.toml` → `server.toml` + `orgs/default/org.toml`
+  - Convert interface config sections to instance files in `orgs/default/spaces/default/interfaces/`
+
+- [ ] `feat(storage): migrate database to org/space split`
+  - Copy `assistant.db` → `orgs/default/spaces/default/space.db`
+  - Create `orgs/default/org.db` with schema, populate with default org + initial admin user
+  - Assign all existing conversations to admin user
+
+- [ ] `feat(storage): initial admin user creation during migration`
+  - If `ASSISTANT_WEB_TOKEN` is set: create admin user with that as temporary password
+  - Otherwise: generate random password, print to stdout
+  - Log clear instructions for the operator
+
+- [ ] `test(storage): full migration round-trip on fixture data`
+  - Create a fixture legacy layout (db + files)
+  - Run migration
+  - Verify: all conversations accessible, personas intact, skills present, org.db has admin user
+
+- [ ] `feat(runtime): extend ExecutionContext with identity fields`
+  - Add `user_id: Option<UserId>`, `org_id: Option<OrgId>`, `space_id: Option<SpaceId>` to `ExecutionContext`
+
+- [ ] `feat(runtime): thread AuthContext through Orchestrator.run_turn_with_tools()`
+  - Accept `AuthContext` parameter (or extract from ExecutionContext)
+  - Pass through to tool handlers via execution context
+
+- [ ] `feat(runtime): ChannelRunner resolves platform identity before dispatch`
+  - On incoming message: call `IdentityResolver::resolve(platform, sender_id)`
+  - If resolved: build AuthContext for that user, dispatch with identity
+  - If unresolved: reject or prompt for identity linking (configurable)
+
+- [ ] `feat(runtime): adapter registry keyed by instance ID`
+  - Change `AdapterRegistry` key from interface type name to instance ID string
+  - `ChannelRunner` looks up persona via binding table instead of global `agent_id`
+
+- [ ] `feat(runtime): scheduler runs with persona identity`
+  - Scheduled tasks look up the persona's owning user (or system identity for org tasks)
+  - Build AuthContext for the task's execution
+
+- [ ] `test(runtime): turn execution carries user identity to tool handlers`
+
+---
+
+## PR 10: CLI OAuth2 login, Flutter OAuth2, documentation
+
+> Final PR: all client apps can authenticate, documentation is updated.
+> After this merges, the full multi-user system is operational.
+
+**Commits:**
+
+- [ ] `feat(cli): assistant login command — device code flow`
+  - `assistant login --server <url>` — initiates device code flow
+  - Displays user_code and verification URL
+  - Polls for completion, stores tokens on success
+
+- [ ] `feat(cli): token storage and automatic refresh`
+  - Store access + refresh tokens in `~/.assistant/credentials.json` (mode 0600)
+  - On 401: attempt silent refresh, retry request
+  - Clear tokens on refresh failure (re-login required)
+
+- [ ] `feat(cli): assistant logout and api-keys commands`
+  - `assistant logout` — revoke tokens, delete credentials.json
+  - `assistant api-keys create --name <n> --scopes <s>` — create and display key (once)
+  - `assistant api-keys list` — table of keys (prefix, name, scopes, expiry)
+  - `assistant api-keys revoke <id>` — revoke key
+
+- [ ] `feat(cli): --api-key flag for non-interactive use`
+  - Accept `--api-key` or `ASSISTANT_API_KEY` env var
+  - Skip device code flow, authenticate directly with key
+
+- [ ] `test(cli): login flow mocked end-to-end`
+
+- [ ] `feat(app): OAuth2 Authorization Code + PKCE login in Flutter`
+  - Replace single-token entry with OAuth2 flow
+  - Use `url_launcher` to open browser for auth, listen on localhost callback
+  - Store tokens securely (macOS keychain via `flutter_secure_storage`)
+
+- [ ] `feat(app): org/space selector after login`
+  - Fetch user's orgs and spaces from API
+  - Display space picker, persist selection
+
+- [ ] `feat(app): persona creation from template during onboarding`
+  - Check onboarding status on first load
+  - Show template picker, create persona, navigate to chat
+
+- [ ] `feat(app): space switcher in navigation`
+  - Dropdown/drawer for switching active space
+  - Refreshes persona list, conversation list on switch
+
+- [ ] `feat(app): update conversation and persona lists for multi-user scoping`
+  - Conversation list filtered by current user + space + persona
+  - Persona picker shows granted org personas + own private personas
+
+- [ ] `feat(app): API key management screen`
+  - Create, list, revoke API keys
+  - Copy-to-clipboard on creation
+
+- [ ] `feat(app): admin screens (user, space, catalog management)`
+  - Behind org-admin / space-admin role check
+  - User management: invite, list, assign roles
+  - Space management: create, list, manage memberships
+  - Catalog: publish skills/templates, manage subscriptions
+
+- [ ] `test(app): widget tests for login, space switching, persona scoping`
+
+- [ ] `docs: update authentication.md with OAuth2 flows and API keys`
+
+- [ ] `docs: add multi-user.md — org/space/user model, roles, setup guide`
+
+- [ ] `docs: add ADR for multi-user-orgs architectural decision`
+
+- [ ] `docs: update CLAUDE.md workspace structure with assistant-auth crate`
+
+- [ ] `chore: final OpenAPI spec update with all new endpoints`

--- a/openspec/changes/multi-user-orgs/tasks.md
+++ b/openspec/changes/multi-user-orgs/tasks.md
@@ -90,7 +90,7 @@ PR 10 ─── CLI OAuth2 login + Flutter OAuth2 + docs
 
 - [x] `feat(auth): JWT signing and validation`
   - Create `crates/auth/src/jwt.rs`
-  - Key generation (EdDSA or RS256), key persistence (load from file or generate)
+  - HS256 shared-secret generation, key persistence (load from file or generate)
   - `sign(claims: &AuthContext, expiry: Duration) -> Result<String>`
   - `validate(token: &str) -> Result<AuthContext>`
   - Claim mapping: AuthContext fields ↔ JWT registered + custom claims


### PR DESCRIPTION
## Summary

- Add identity newtypes (`OrgId`, `SpaceId`, `UserId`), role hierarchy (`OrgAdmin`/`SpaceAdmin`/`Member`/`Viewer`), and permission scope model to `assistant-core`
- Add `AuthContext` struct with `can()` permission checking, `AuthProvider` trait (OAuth2 flows), `IdentityResolver` trait, and `CatalogResolver` trait
- Scaffold `assistant-auth` crate with JWT signing/validation (HS256, custom claims for org/space/roles) and argon2id password hashing
- Include OpenSpec proposal, design doc, and task breakdown for the full multi-user-orgs initiative (10 PRs, 118 tasks)

This is PRs 1+2 of the multi-user organizations effort. All new code has full test coverage (14 auth tests + 18 core tests). No existing code is modified beyond adding `pub mod` declarations in `core/lib.rs`.

## Test plan

- [x] `cargo test -p assistant-core` — 18 new identity/auth/permission tests pass
- [x] `cargo test -p assistant-auth` — 14 JWT + password tests pass  
- [x] `cargo test --workspace` — all 163 tests pass, no regressions
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo machete` — no unused dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Comprehensive authentication and authorization framework with OAuth2 support
  * Multi-user and organization architecture with role-based access control
  * JWT and API key authentication mechanisms
  * Secure password hashing capabilities
  * Granular permission scoping system for fine-grained access control

* **Documentation**
  * Detailed design specification for multi-user organization model and migration strategy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->