### PR TITLE
feat(auth): OAuth2 server — PKCE, auth code grant, device code, client registration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,11 +390,16 @@ dependencies = [
  "anyhow",
  "argon2",
  "assistant-core",
+ "async-trait",
+ "base64 0.22.1",
  "chrono",
  "jsonwebtoken",
  "rand 0.9.4",
  "serde",
+ "sha2 0.11.0",
  "tempfile",
+ "tokio",
+ "url",
  "uuid",
 ]
 

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -27,5 +27,16 @@ argon2 = { workspace = true }
 # Cryptographic randomness
 rand = { workspace = true }
 
+# Hashing (PKCE S256, auth code storage)
+sha2 = { workspace = true }
+base64 = { workspace = true }
+
+# URL parsing (redirect URI validation)
+url = { workspace = true }
+
+# Async runtime (for token store traits)
+tokio = { workspace = true }
+async-trait = { workspace = true }
+
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/auth/src/oauth2/clients.rs
+++ b/crates/auth/src/oauth2/clients.rs
@@ -1,0 +1,337 @@
+//! Dynamic client registration (RFC 7591).
+//!
+//! Manages OAuth2 client registration, lookup, and validation.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::{Result, bail};
+use tokio::sync::RwLock;
+
+use assistant_core::auth::{ClientInfo, ClientRegistration};
+
+// -- ClientStore trait --
+
+/// Storage backend for registered OAuth2 clients.
+#[async_trait::async_trait]
+pub trait ClientStore: Send + Sync {
+    /// Register a new client.
+    async fn register(&self, info: ClientInfo) -> Result<()>;
+
+    /// Look up a client by ID.
+    async fn get(&self, client_id: &str) -> Result<Option<ClientInfo>>;
+
+    /// List all registered clients.
+    async fn list(&self) -> Result<Vec<ClientInfo>>;
+}
+
+// -- In-memory implementation --
+
+/// In-memory client store for testing and single-server deployments.
+#[derive(Clone, Default)]
+pub struct InMemoryClientStore {
+    clients: Arc<RwLock<HashMap<String, ClientInfo>>>,
+}
+
+#[async_trait::async_trait]
+impl ClientStore for InMemoryClientStore {
+    async fn register(&self, info: ClientInfo) -> Result<()> {
+        self.clients
+            .write()
+            .await
+            .insert(info.client_id.clone(), info);
+        Ok(())
+    }
+
+    async fn get(&self, client_id: &str) -> Result<Option<ClientInfo>> {
+        Ok(self.clients.read().await.get(client_id).cloned())
+    }
+
+    async fn list(&self) -> Result<Vec<ClientInfo>> {
+        Ok(self.clients.read().await.values().cloned().collect())
+    }
+}
+
+// -- Client registrar --
+
+/// Validates and registers OAuth2 clients per RFC 7591.
+pub struct ClientRegistrar {
+    store: Arc<dyn ClientStore>,
+}
+
+/// Allowed grant types for validation.
+const ALLOWED_GRANT_TYPES: &[&str] = &[
+    "authorization_code",
+    "refresh_token",
+    "client_credentials",
+    "urn:ietf:params:oauth:grant-type:device_code",
+];
+
+/// Allowed response types for validation.
+const ALLOWED_RESPONSE_TYPES: &[&str] = &["code"];
+
+impl ClientRegistrar {
+    /// Create a new client registrar.
+    pub fn new(store: Arc<dyn ClientStore>) -> Self {
+        Self { store }
+    }
+
+    /// Register a new OAuth2 client.
+    ///
+    /// Validates the registration request, generates a `client_id`, and
+    /// optionally generates a `client_secret` for confidential clients.
+    pub async fn register(&self, req: ClientRegistration) -> Result<ClientInfo> {
+        // Validate client name.
+        if req.client_name.trim().is_empty() {
+            bail!("client_name must not be empty");
+        }
+
+        // Validate redirect URIs.
+        if req.redirect_uris.is_empty() {
+            bail!("at least one redirect_uri is required");
+        }
+        for uri in &req.redirect_uris {
+            validate_redirect_uri(uri)?;
+        }
+
+        // Validate grant types.
+        if req.grant_types.is_empty() {
+            bail!("at least one grant_type is required");
+        }
+        for gt in &req.grant_types {
+            if !ALLOWED_GRANT_TYPES.contains(&gt.as_str()) {
+                bail!("unsupported grant_type: {gt}");
+            }
+        }
+
+        // Validate response types if provided.
+        if let Some(ref rts) = req.response_types {
+            for rt in rts {
+                if !ALLOWED_RESPONSE_TYPES.contains(&rt.as_str()) {
+                    bail!("unsupported response_type: {rt}");
+                }
+            }
+        }
+
+        // Determine auth method.
+        let auth_method = req.token_endpoint_auth_method.as_deref().unwrap_or("none");
+        let is_confidential =
+            auth_method == "client_secret_post" || auth_method == "client_secret_basic";
+
+        // Generate client_id.
+        let client_id = format!("cid_{}", uuid::Uuid::new_v4().as_simple());
+
+        // Generate client_secret for confidential clients.
+        let client_secret = if is_confidential {
+            Some(generate_client_secret())
+        } else {
+            None
+        };
+
+        let info = ClientInfo {
+            client_id,
+            client_name: req.client_name,
+            client_secret,
+            redirect_uris: req.redirect_uris,
+            grant_types: req.grant_types,
+            token_endpoint_auth_method: auth_method.to_owned(),
+        };
+
+        self.store.register(info.clone()).await?;
+        Ok(info)
+    }
+
+    /// Look up a registered client by ID.
+    pub async fn get(&self, client_id: &str) -> Result<Option<ClientInfo>> {
+        self.store.get(client_id).await
+    }
+
+    /// List all registered clients.
+    pub async fn list(&self) -> Result<Vec<ClientInfo>> {
+        self.store.list().await
+    }
+}
+
+/// Validate a redirect URI.
+fn validate_redirect_uri(uri: &str) -> Result<()> {
+    // Must be a valid absolute URI.
+    let parsed: url::Url = uri
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid redirect_uri '{uri}': {e}"))?;
+
+    // Must use HTTPS or localhost HTTP.
+    match parsed.scheme() {
+        "https" => {}
+        "http" => {
+            let host = parsed.host_str().unwrap_or("");
+            if host != "localhost" && host != "127.0.0.1" && host != "[::1]" {
+                bail!("redirect_uri with http:// is only allowed for localhost, got: {uri}");
+            }
+        }
+        other => bail!("redirect_uri must use https:// or http://localhost, got scheme: {other}"),
+    }
+
+    // Must not contain a fragment.
+    if parsed.fragment().is_some() {
+        bail!("redirect_uri must not contain a fragment: {uri}");
+    }
+
+    Ok(())
+}
+
+/// Generate a cryptographically random client secret.
+fn generate_client_secret() -> String {
+    use base64::Engine;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use rand::Rng;
+
+    let mut rng = rand::rng();
+    let mut bytes = [0u8; 32];
+    rng.fill(&mut bytes);
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_registrar() -> ClientRegistrar {
+        ClientRegistrar::new(Arc::new(InMemoryClientStore::default()))
+    }
+
+    fn valid_registration() -> ClientRegistration {
+        ClientRegistration {
+            client_name: "Test App".into(),
+            redirect_uris: vec!["https://example.com/callback".into()],
+            grant_types: vec!["authorization_code".into()],
+            response_types: Some(vec!["code".into()]),
+            token_endpoint_auth_method: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn register_public_client() {
+        let reg = make_registrar();
+        let info = reg.register(valid_registration()).await.unwrap();
+
+        assert!(
+            info.client_id.starts_with("cid_"),
+            "should have cid_ prefix"
+        );
+        assert_eq!(info.client_name, "Test App");
+        assert!(info.client_secret.is_none(), "public client has no secret");
+        assert_eq!(info.token_endpoint_auth_method, "none");
+    }
+
+    #[tokio::test]
+    async fn register_confidential_client() {
+        let reg = make_registrar();
+        let mut req = valid_registration();
+        req.token_endpoint_auth_method = Some("client_secret_post".into());
+
+        let info = reg.register(req).await.unwrap();
+        assert!(
+            info.client_secret.is_some(),
+            "confidential client should have a secret"
+        );
+    }
+
+    #[tokio::test]
+    async fn lookup_registered_client() {
+        let reg = make_registrar();
+        let info = reg.register(valid_registration()).await.unwrap();
+
+        let found = reg.get(&info.client_id).await.unwrap();
+        assert!(found.is_some(), "should find registered client");
+        assert_eq!(found.unwrap().client_name, "Test App");
+    }
+
+    #[tokio::test]
+    async fn lookup_unknown_client_returns_none() {
+        let reg = make_registrar();
+        let found = reg.get("nonexistent").await.unwrap();
+        assert!(found.is_none(), "unknown client should return None");
+    }
+
+    #[tokio::test]
+    async fn list_clients() {
+        let reg = make_registrar();
+        reg.register(valid_registration()).await.unwrap();
+
+        let mut req2 = valid_registration();
+        req2.client_name = "Second App".into();
+        reg.register(req2).await.unwrap();
+
+        let all = reg.list().await.unwrap();
+        assert_eq!(all.len(), 2, "should have 2 registered clients");
+    }
+
+    #[tokio::test]
+    async fn empty_client_name_is_rejected() {
+        let reg = make_registrar();
+        let mut req = valid_registration();
+        req.client_name = "  ".into();
+        assert!(reg.register(req).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn empty_redirect_uris_is_rejected() {
+        let reg = make_registrar();
+        let mut req = valid_registration();
+        req.redirect_uris = vec![];
+        assert!(reg.register(req).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn http_non_localhost_redirect_is_rejected() {
+        let reg = make_registrar();
+        let mut req = valid_registration();
+        req.redirect_uris = vec!["http://evil.com/callback".into()];
+        assert!(reg.register(req).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn http_localhost_redirect_is_allowed() {
+        let reg = make_registrar();
+        let mut req = valid_registration();
+        req.redirect_uris = vec!["http://localhost:8080/callback".into()];
+        assert!(reg.register(req).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn fragment_in_redirect_is_rejected() {
+        let reg = make_registrar();
+        let mut req = valid_registration();
+        req.redirect_uris = vec!["https://example.com/callback#fragment".into()];
+        assert!(reg.register(req).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn unsupported_grant_type_is_rejected() {
+        let reg = make_registrar();
+        let mut req = valid_registration();
+        req.grant_types = vec!["implicit".into()];
+        assert!(reg.register(req).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn unsupported_response_type_is_rejected() {
+        let reg = make_registrar();
+        let mut req = valid_registration();
+        req.response_types = Some(vec!["token".into()]);
+        assert!(reg.register(req).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn device_code_grant_type_is_allowed() {
+        let reg = make_registrar();
+        let mut req = valid_registration();
+        req.grant_types = vec!["urn:ietf:params:oauth:grant-type:device_code".into()];
+        let info = reg.register(req).await.unwrap();
+        assert!(
+            info.grant_types
+                .contains(&"urn:ietf:params:oauth:grant-type:device_code".to_string()),
+            "device code grant should be allowed"
+        );
+    }
+}

--- a/crates/auth/src/oauth2/device.rs
+++ b/crates/auth/src/oauth2/device.rs
@@ -1,0 +1,347 @@
+//! Device authorization grant (RFC 8628).
+//!
+//! Enables CLI and other input-constrained clients to authenticate by
+//! displaying a user code that the user enters in a browser.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::{Result, bail};
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+
+// -- Types --
+
+/// Response to a device authorization request.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DeviceCodeResponse {
+    /// Opaque device code used for polling.
+    pub device_code: String,
+    /// Short human-readable code the user enters in a browser.
+    pub user_code: String,
+    /// URL where the user should go to enter the code.
+    pub verification_uri: String,
+    /// Recommended polling interval in seconds.
+    pub interval: u64,
+    /// When this device code expires.
+    pub expires_in: u64,
+}
+
+/// The result of polling for device authorization.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PollResult {
+    /// The user hasn't authorized yet — keep polling.
+    Pending,
+    /// The user authorized — here are the tokens.
+    Authorized {
+        user_id: String,
+        scopes: Vec<String>,
+    },
+    /// The device code has expired.
+    Expired,
+}
+
+// -- DeviceCodeStore trait --
+
+/// Storage backend for device code flow state.
+#[async_trait::async_trait]
+pub trait DeviceCodeStore: Send + Sync {
+    /// Store a new pending device authorization.
+    async fn store(&self, device_code: &str, state: DeviceState) -> Result<()>;
+
+    /// Look up a pending device authorization by device code.
+    async fn get_by_device_code(&self, device_code: &str) -> Result<Option<DeviceState>>;
+
+    /// Look up a pending device authorization by user code.
+    async fn get_by_user_code(&self, user_code: &str) -> Result<Option<DeviceState>>;
+
+    /// Update the state (e.g., mark as authorized).
+    async fn update(&self, device_code: &str, state: DeviceState) -> Result<()>;
+
+    /// Remove a device code entry.
+    async fn remove(&self, device_code: &str) -> Result<()>;
+}
+
+/// Externalized device flow state for storage backends.
+#[derive(Clone, Debug)]
+pub struct DeviceState {
+    pub device_code: String,
+    pub user_code: String,
+    pub client_id: String,
+    pub scopes: Vec<String>,
+    pub expires_at: DateTime<Utc>,
+    pub authorized_user: Option<String>,
+}
+
+// -- In-memory implementation --
+
+/// In-memory device code store for testing and single-server deployments.
+#[derive(Clone, Default)]
+pub struct InMemoryDeviceCodeStore {
+    entries: Arc<RwLock<HashMap<String, DeviceState>>>,
+}
+
+#[async_trait::async_trait]
+impl DeviceCodeStore for InMemoryDeviceCodeStore {
+    async fn store(&self, device_code: &str, state: DeviceState) -> Result<()> {
+        self.entries
+            .write()
+            .await
+            .insert(device_code.to_owned(), state);
+        Ok(())
+    }
+
+    async fn get_by_device_code(&self, device_code: &str) -> Result<Option<DeviceState>> {
+        Ok(self.entries.read().await.get(device_code).cloned())
+    }
+
+    async fn get_by_user_code(&self, user_code: &str) -> Result<Option<DeviceState>> {
+        Ok(self
+            .entries
+            .read()
+            .await
+            .values()
+            .find(|s| s.user_code == user_code)
+            .cloned())
+    }
+
+    async fn update(&self, device_code: &str, state: DeviceState) -> Result<()> {
+        self.entries
+            .write()
+            .await
+            .insert(device_code.to_owned(), state);
+        Ok(())
+    }
+
+    async fn remove(&self, device_code: &str) -> Result<()> {
+        self.entries.write().await.remove(device_code);
+        Ok(())
+    }
+}
+
+// -- Device code manager --
+
+/// Manages the device authorization grant flow.
+pub struct DeviceCodeManager {
+    store: Arc<dyn DeviceCodeStore>,
+    verification_uri: String,
+    code_ttl: Duration,
+    poll_interval: u64,
+}
+
+impl DeviceCodeManager {
+    /// Create a new device code manager.
+    pub fn new(store: Arc<dyn DeviceCodeStore>, verification_uri: String) -> Self {
+        Self {
+            store,
+            verification_uri,
+            code_ttl: Duration::minutes(15),
+            poll_interval: 5,
+        }
+    }
+
+    /// Override the device code TTL.
+    pub fn with_code_ttl(mut self, ttl: Duration) -> Self {
+        self.code_ttl = ttl;
+        self
+    }
+
+    /// Initiate a new device authorization flow.
+    pub async fn initiate(
+        &self,
+        client_id: &str,
+        scopes: Vec<String>,
+    ) -> Result<DeviceCodeResponse> {
+        let device_code = generate_random_token();
+        let user_code = generate_user_code();
+        let expires_at = Utc::now() + self.code_ttl;
+
+        let state = DeviceState {
+            device_code: device_code.clone(),
+            user_code: user_code.clone(),
+            client_id: client_id.to_owned(),
+            scopes,
+            expires_at,
+            authorized_user: None,
+        };
+
+        self.store.store(&device_code, state).await?;
+
+        Ok(DeviceCodeResponse {
+            device_code,
+            user_code,
+            verification_uri: self.verification_uri.clone(),
+            interval: self.poll_interval,
+            expires_in: self.code_ttl.num_seconds() as u64,
+        })
+    }
+
+    /// Poll for the result of a device authorization.
+    pub async fn poll(&self, device_code: &str) -> Result<PollResult> {
+        let state = self
+            .store
+            .get_by_device_code(device_code)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("unknown device code"))?;
+
+        if Utc::now() > state.expires_at {
+            self.store.remove(device_code).await?;
+            return Ok(PollResult::Expired);
+        }
+
+        match state.authorized_user {
+            Some(user_id) => {
+                self.store.remove(device_code).await?;
+                Ok(PollResult::Authorized {
+                    user_id,
+                    scopes: state.scopes,
+                })
+            }
+            None => Ok(PollResult::Pending),
+        }
+    }
+
+    /// Complete the device flow — called when the user approves in the browser.
+    pub async fn complete(&self, user_code: &str, user_id: &str) -> Result<()> {
+        let state = self
+            .store
+            .get_by_user_code(user_code)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("unknown user code"))?;
+
+        if Utc::now() > state.expires_at {
+            self.store.remove(&state.device_code).await?;
+            bail!("device code expired");
+        }
+
+        let device_code = state.device_code.clone();
+        let updated = DeviceState {
+            authorized_user: Some(user_id.to_owned()),
+            ..state
+        };
+        self.store.update(&device_code, updated).await?;
+        Ok(())
+    }
+}
+
+/// Generate a URL-safe random token.
+fn generate_random_token() -> String {
+    use base64::Engine;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use rand::Rng;
+
+    let mut rng = rand::rng();
+    let mut bytes = [0u8; 32];
+    rng.fill(&mut bytes);
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+
+/// Generate a short, human-friendly user code (e.g., "ABCD-EFGH").
+fn generate_user_code() -> String {
+    use rand::Rng;
+
+    // Use uppercase letters excluding easily confused chars (0/O, 1/I/L).
+    const ALPHABET: &[u8] = b"ABCDEFGHJKMNPQRSTUVWXYZ";
+    let mut rng = rand::rng();
+    let left: String = (0..4)
+        .map(|_| ALPHABET[rng.random_range(0..ALPHABET.len())] as char)
+        .collect();
+    let right: String = (0..4)
+        .map(|_| ALPHABET[rng.random_range(0..ALPHABET.len())] as char)
+        .collect();
+    format!("{left}-{right}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_manager() -> DeviceCodeManager {
+        DeviceCodeManager::new(
+            Arc::new(InMemoryDeviceCodeStore::default()),
+            "https://example.com/device".into(),
+        )
+    }
+
+    #[tokio::test]
+    async fn initiate_returns_valid_response() {
+        let mgr = make_manager();
+        let resp = mgr
+            .initiate("cli", vec!["personas:read".into()])
+            .await
+            .unwrap();
+
+        assert!(!resp.device_code.is_empty(), "should have device code");
+        assert_eq!(resp.user_code.len(), 9, "user code should be XXXX-XXXX");
+        assert!(resp.user_code.contains('-'), "user code should have dash");
+        assert_eq!(resp.verification_uri, "https://example.com/device");
+        assert_eq!(resp.interval, 5);
+    }
+
+    #[tokio::test]
+    async fn poll_returns_pending_before_approval() {
+        let mgr = make_manager();
+        let resp = mgr.initiate("cli", vec![]).await.unwrap();
+
+        let result = mgr.poll(&resp.device_code).await.unwrap();
+        assert_eq!(result, PollResult::Pending, "should be pending");
+    }
+
+    #[tokio::test]
+    async fn complete_then_poll_returns_authorized() {
+        let mgr = make_manager();
+        let resp = mgr
+            .initiate("cli", vec!["personas:read".into()])
+            .await
+            .unwrap();
+
+        mgr.complete(&resp.user_code, "usr_alice").await.unwrap();
+
+        let result = mgr.poll(&resp.device_code).await.unwrap();
+        assert_eq!(
+            result,
+            PollResult::Authorized {
+                user_id: "usr_alice".into(),
+                scopes: vec!["personas:read".into()],
+            },
+            "should be authorized after completion"
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_after_authorized_removes_entry() {
+        let mgr = make_manager();
+        let resp = mgr.initiate("cli", vec![]).await.unwrap();
+
+        mgr.complete(&resp.user_code, "usr_alice").await.unwrap();
+        mgr.poll(&resp.device_code).await.unwrap(); // consumes
+
+        let err = mgr.poll(&resp.device_code).await;
+        assert!(err.is_err(), "entry should be removed after authorization");
+    }
+
+    #[tokio::test]
+    async fn expired_code_returns_expired() {
+        let mgr = make_manager().with_code_ttl(Duration::seconds(-10));
+        let resp = mgr.initiate("cli", vec![]).await.unwrap();
+
+        let result = mgr.poll(&resp.device_code).await.unwrap();
+        assert_eq!(result, PollResult::Expired, "should be expired");
+    }
+
+    #[tokio::test]
+    async fn complete_with_unknown_user_code_fails() {
+        let mgr = make_manager();
+        let err = mgr.complete("XXXX-YYYY", "usr_alice").await;
+        assert!(err.is_err(), "unknown user code should fail");
+    }
+
+    #[tokio::test]
+    async fn user_codes_are_unique() {
+        let mgr = make_manager();
+        let r1 = mgr.initiate("cli", vec![]).await.unwrap();
+        let r2 = mgr.initiate("cli", vec![]).await.unwrap();
+        assert_ne!(r1.user_code, r2.user_code, "user codes should be unique");
+    }
+}

--- a/crates/auth/src/oauth2/mod.rs
+++ b/crates/auth/src/oauth2/mod.rs
@@ -1,7 +1,6 @@
 //! OAuth2 authorization server logic.
-//!
-//! Sub-modules are added in PR 3:
-//! - `pkce` — PKCE challenge/verification
-//! - `server` — Authorization code grant + refresh tokens
-//! - `device` — Device code flow
-//! - `clients` — Dynamic client registration (RFC 7591)
+
+pub mod clients;
+pub mod device;
+pub mod pkce;
+pub mod server;

--- a/crates/auth/src/oauth2/pkce.rs
+++ b/crates/auth/src/oauth2/pkce.rs
@@ -1,0 +1,90 @@
+//! PKCE (Proof Key for Code Exchange) per RFC 7636.
+//!
+//! Implements the S256 challenge method used to protect the authorization
+//! code grant against interception attacks.
+
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use sha2::{Digest, Sha256};
+
+/// Generate a cryptographically random code verifier (43-128 chars, URL-safe).
+pub fn generate_verifier() -> String {
+    use rand::Rng;
+    let mut rng = rand::rng();
+    let mut bytes = [0u8; 32];
+    rng.fill(&mut bytes);
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+
+/// Compute the S256 challenge from a verifier: `BASE64URL(SHA256(verifier))`.
+pub fn challenge_from_verifier(verifier: &str) -> String {
+    let hash = Sha256::digest(verifier.as_bytes());
+    URL_SAFE_NO_PAD.encode(hash)
+}
+
+/// Verify that a verifier matches a previously stored S256 challenge.
+pub fn verify(verifier: &str, challenge: &str) -> bool {
+    challenge_from_verifier(verifier) == challenge
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verifier_is_url_safe_and_correct_length() {
+        let verifier = generate_verifier();
+        // 32 bytes -> 43 base64url chars (no padding)
+        assert_eq!(verifier.len(), 43, "verifier should be 43 chars");
+        assert!(
+            verifier
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'),
+            "verifier should be URL-safe: {verifier}"
+        );
+    }
+
+    #[test]
+    fn challenge_round_trip() {
+        let verifier = generate_verifier();
+        let challenge = challenge_from_verifier(&verifier);
+        assert!(
+            verify(&verifier, &challenge),
+            "verifier should match its own challenge"
+        );
+    }
+
+    #[test]
+    fn wrong_verifier_fails() {
+        let verifier = generate_verifier();
+        let challenge = challenge_from_verifier(&verifier);
+        let wrong = generate_verifier();
+        assert!(
+            !verify(&wrong, &challenge),
+            "different verifier should not match"
+        );
+    }
+
+    #[test]
+    fn different_verifiers_produce_different_challenges() {
+        let v1 = generate_verifier();
+        let v2 = generate_verifier();
+        assert_ne!(
+            challenge_from_verifier(&v1),
+            challenge_from_verifier(&v2),
+            "different verifiers should produce different challenges"
+        );
+    }
+
+    #[test]
+    fn rfc7636_test_vector() {
+        // RFC 7636 Appendix B test vector
+        let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+        let expected = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
+        assert_eq!(
+            challenge_from_verifier(verifier),
+            expected,
+            "should match RFC 7636 Appendix B test vector"
+        );
+    }
+}

--- a/crates/auth/src/oauth2/server.rs
+++ b/crates/auth/src/oauth2/server.rs
@@ -1,0 +1,580 @@
+//! Authorization code grant and refresh token management.
+//!
+//! Implements the core OAuth2 authorization code flow with PKCE support
+//! and refresh token rotation.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::{Result, bail};
+use chrono::{DateTime, Duration, Utc};
+use tokio::sync::RwLock;
+
+use super::pkce;
+
+// -- Types --
+
+/// A pending authorization code waiting to be exchanged for tokens.
+#[derive(Clone, Debug)]
+pub struct AuthCode {
+    pub code: String,
+    pub user_id: String,
+    pub client_id: String,
+    pub redirect_uri: String,
+    pub scopes: Vec<String>,
+    pub pkce_challenge: Option<String>,
+    pub expires_at: DateTime<Utc>,
+}
+
+/// A stored refresh token.
+#[derive(Clone, Debug)]
+pub struct StoredRefreshToken {
+    pub token: String,
+    pub user_id: String,
+    pub client_id: String,
+    pub scopes: Vec<String>,
+    pub expires_at: DateTime<Utc>,
+    /// Whether this token has been consumed (for rotation detection).
+    pub consumed: bool,
+}
+
+/// The result of exchanging an auth code or refreshing tokens.
+#[derive(Clone, Debug)]
+pub struct TokenPair {
+    pub access_token: String,
+    pub refresh_token: String,
+}
+
+// -- AuthCodeStore trait --
+
+/// Storage backend for authorization codes.
+#[async_trait::async_trait]
+pub trait AuthCodeStore: Send + Sync {
+    /// Store a new authorization code.
+    async fn store_code(&self, code: AuthCode) -> Result<()>;
+
+    /// Look up and consume an authorization code (single-use).
+    async fn take_code(&self, code: &str) -> Result<Option<AuthCode>>;
+}
+
+/// Storage backend for refresh tokens.
+#[async_trait::async_trait]
+pub trait RefreshTokenStore: Send + Sync {
+    /// Store a new refresh token.
+    async fn store_token(&self, token: StoredRefreshToken) -> Result<()>;
+
+    /// Look up a refresh token without consuming it.
+    async fn get_token(&self, token: &str) -> Result<Option<StoredRefreshToken>>;
+
+    /// Mark a refresh token as consumed (for rotation).
+    async fn consume_token(&self, token: &str) -> Result<()>;
+
+    /// Revoke all refresh tokens for a user+client pair (security measure
+    /// when replay is detected).
+    async fn revoke_all(&self, user_id: &str, client_id: &str) -> Result<()>;
+}
+
+// -- In-memory implementations --
+
+/// In-memory auth code store for testing and single-server deployments.
+#[derive(Clone, Default)]
+pub struct InMemoryAuthCodeStore {
+    codes: Arc<RwLock<HashMap<String, AuthCode>>>,
+}
+
+#[async_trait::async_trait]
+impl AuthCodeStore for InMemoryAuthCodeStore {
+    async fn store_code(&self, code: AuthCode) -> Result<()> {
+        self.codes.write().await.insert(code.code.clone(), code);
+        Ok(())
+    }
+
+    async fn take_code(&self, code: &str) -> Result<Option<AuthCode>> {
+        Ok(self.codes.write().await.remove(code))
+    }
+}
+
+/// In-memory refresh token store for testing and single-server deployments.
+#[derive(Clone, Default)]
+pub struct InMemoryRefreshTokenStore {
+    tokens: Arc<RwLock<HashMap<String, StoredRefreshToken>>>,
+}
+
+#[async_trait::async_trait]
+impl RefreshTokenStore for InMemoryRefreshTokenStore {
+    async fn store_token(&self, token: StoredRefreshToken) -> Result<()> {
+        self.tokens.write().await.insert(token.token.clone(), token);
+        Ok(())
+    }
+
+    async fn get_token(&self, token: &str) -> Result<Option<StoredRefreshToken>> {
+        Ok(self.tokens.read().await.get(token).cloned())
+    }
+
+    async fn consume_token(&self, token: &str) -> Result<()> {
+        if let Some(t) = self.tokens.write().await.get_mut(token) {
+            t.consumed = true;
+        }
+        Ok(())
+    }
+
+    async fn revoke_all(&self, user_id: &str, client_id: &str) -> Result<()> {
+        self.tokens
+            .write()
+            .await
+            .retain(|_, t| !(t.user_id == user_id && t.client_id == client_id));
+        Ok(())
+    }
+}
+
+// -- OAuth2 Server --
+
+/// The OAuth2 authorization server managing auth codes and refresh tokens.
+pub struct OAuth2Server {
+    code_store: Arc<dyn AuthCodeStore>,
+    refresh_store: Arc<dyn RefreshTokenStore>,
+    /// How long an authorization code is valid.
+    code_ttl: Duration,
+    /// How long a refresh token is valid.
+    refresh_ttl: Duration,
+}
+
+impl OAuth2Server {
+    /// Create a new OAuth2 server with the given stores.
+    pub fn new(
+        code_store: Arc<dyn AuthCodeStore>,
+        refresh_store: Arc<dyn RefreshTokenStore>,
+    ) -> Self {
+        Self {
+            code_store,
+            refresh_store,
+            code_ttl: Duration::minutes(10),
+            refresh_ttl: Duration::days(30),
+        }
+    }
+
+    /// Override the authorization code TTL.
+    pub fn with_code_ttl(mut self, ttl: Duration) -> Self {
+        self.code_ttl = ttl;
+        self
+    }
+
+    /// Override the refresh token TTL.
+    pub fn with_refresh_ttl(mut self, ttl: Duration) -> Self {
+        self.refresh_ttl = ttl;
+        self
+    }
+
+    /// Generate and store a new authorization code.
+    pub async fn generate_auth_code(
+        &self,
+        user_id: &str,
+        client_id: &str,
+        redirect_uri: &str,
+        pkce_challenge: Option<&str>,
+        scopes: Vec<String>,
+    ) -> Result<String> {
+        let code = generate_random_token();
+        let auth_code = AuthCode {
+            code: code.clone(),
+            user_id: user_id.to_owned(),
+            client_id: client_id.to_owned(),
+            redirect_uri: redirect_uri.to_owned(),
+            scopes,
+            pkce_challenge: pkce_challenge.map(|s| s.to_owned()),
+            expires_at: Utc::now() + self.code_ttl,
+        };
+        self.code_store.store_code(auth_code).await?;
+        Ok(code)
+    }
+
+    /// Exchange an authorization code for an access/refresh token pair.
+    ///
+    /// The code is single-use and is consumed on success.
+    pub async fn exchange_auth_code(
+        &self,
+        code: &str,
+        client_id: &str,
+        redirect_uri: &str,
+        pkce_verifier: Option<&str>,
+    ) -> Result<TokenPair> {
+        let auth_code = self
+            .code_store
+            .take_code(code)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("invalid or expired authorization code"))?;
+
+        // Validate client_id.
+        if auth_code.client_id != client_id {
+            bail!("client_id mismatch");
+        }
+
+        // Validate redirect_uri.
+        if auth_code.redirect_uri != redirect_uri {
+            bail!("redirect_uri mismatch");
+        }
+
+        // Validate expiry.
+        if Utc::now() > auth_code.expires_at {
+            bail!("authorization code expired");
+        }
+
+        // Validate PKCE.
+        match (&auth_code.pkce_challenge, pkce_verifier) {
+            (Some(challenge), Some(verifier)) => {
+                if !pkce::verify(verifier, challenge) {
+                    bail!("PKCE verification failed");
+                }
+            }
+            (Some(_), None) => bail!("PKCE verifier required but not provided"),
+            (None, Some(_)) => { /* verifier provided but no challenge stored — ignore */ }
+            (None, None) => {}
+        }
+
+        // Generate tokens.
+        let access_token = generate_random_token();
+        let refresh_token = generate_random_token();
+
+        // Store refresh token.
+        self.refresh_store
+            .store_token(StoredRefreshToken {
+                token: refresh_token.clone(),
+                user_id: auth_code.user_id,
+                client_id: auth_code.client_id,
+                scopes: auth_code.scopes,
+                expires_at: Utc::now() + self.refresh_ttl,
+                consumed: false,
+            })
+            .await?;
+
+        Ok(TokenPair {
+            access_token,
+            refresh_token,
+        })
+    }
+
+    /// Refresh an access token using a refresh token.
+    ///
+    /// Implements refresh token rotation: the old token is consumed and a new
+    /// pair is issued. If a consumed token is reused (replay attack), all
+    /// tokens for that user+client are revoked.
+    pub async fn refresh(&self, refresh_token: &str, client_id: &str) -> Result<TokenPair> {
+        let stored = self
+            .refresh_store
+            .get_token(refresh_token)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("invalid refresh token"))?;
+
+        // Replay detection: if token was already consumed, revoke everything.
+        if stored.consumed {
+            self.refresh_store
+                .revoke_all(&stored.user_id, &stored.client_id)
+                .await?;
+            bail!("refresh token replay detected — all tokens revoked");
+        }
+
+        // Validate client_id.
+        if stored.client_id != client_id {
+            bail!("client_id mismatch on refresh");
+        }
+
+        // Validate expiry.
+        if Utc::now() > stored.expires_at {
+            bail!("refresh token expired");
+        }
+
+        // Consume old token.
+        self.refresh_store.consume_token(refresh_token).await?;
+
+        // Issue new pair.
+        let new_access = generate_random_token();
+        let new_refresh = generate_random_token();
+
+        self.refresh_store
+            .store_token(StoredRefreshToken {
+                token: new_refresh.clone(),
+                user_id: stored.user_id,
+                client_id: stored.client_id,
+                scopes: stored.scopes,
+                expires_at: Utc::now() + self.refresh_ttl,
+                consumed: false,
+            })
+            .await?;
+
+        Ok(TokenPair {
+            access_token: new_access,
+            refresh_token: new_refresh,
+        })
+    }
+}
+
+/// Generate a URL-safe random token (32 bytes → 43 base64url chars).
+fn generate_random_token() -> String {
+    use base64::Engine;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use rand::Rng;
+
+    let mut rng = rand::rng();
+    let mut bytes = [0u8; 32];
+    rng.fill(&mut bytes);
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_server() -> OAuth2Server {
+        OAuth2Server::new(
+            Arc::new(InMemoryAuthCodeStore::default()),
+            Arc::new(InMemoryRefreshTokenStore::default()),
+        )
+    }
+
+    #[tokio::test]
+    async fn auth_code_exchange_with_pkce() {
+        let server = make_server();
+        let verifier = pkce::generate_verifier();
+        let challenge = pkce::challenge_from_verifier(&verifier);
+
+        let code = server
+            .generate_auth_code(
+                "usr_alice",
+                "webui",
+                "http://localhost/callback",
+                Some(&challenge),
+                vec!["personas:read".into()],
+            )
+            .await
+            .unwrap();
+
+        let pair = server
+            .exchange_auth_code(&code, "webui", "http://localhost/callback", Some(&verifier))
+            .await
+            .unwrap();
+
+        assert!(!pair.access_token.is_empty(), "should get access token");
+        assert!(!pair.refresh_token.is_empty(), "should get refresh token");
+    }
+
+    #[tokio::test]
+    async fn auth_code_is_single_use() {
+        let server = make_server();
+
+        let code = server
+            .generate_auth_code("usr_alice", "webui", "http://localhost/cb", None, vec![])
+            .await
+            .unwrap();
+
+        // First exchange succeeds.
+        server
+            .exchange_auth_code(&code, "webui", "http://localhost/cb", None)
+            .await
+            .unwrap();
+
+        // Second exchange fails.
+        let err = server
+            .exchange_auth_code(&code, "webui", "http://localhost/cb", None)
+            .await;
+        assert!(err.is_err(), "auth code should be single-use");
+    }
+
+    #[tokio::test]
+    async fn wrong_pkce_verifier_is_rejected() {
+        let server = make_server();
+        let verifier = pkce::generate_verifier();
+        let challenge = pkce::challenge_from_verifier(&verifier);
+
+        let code = server
+            .generate_auth_code(
+                "usr_alice",
+                "webui",
+                "http://localhost/cb",
+                Some(&challenge),
+                vec![],
+            )
+            .await
+            .unwrap();
+
+        let wrong_verifier = pkce::generate_verifier();
+        let err = server
+            .exchange_auth_code(&code, "webui", "http://localhost/cb", Some(&wrong_verifier))
+            .await;
+        assert!(err.is_err(), "wrong PKCE verifier should be rejected");
+    }
+
+    #[tokio::test]
+    async fn missing_pkce_verifier_is_rejected() {
+        let server = make_server();
+        let verifier = pkce::generate_verifier();
+        let challenge = pkce::challenge_from_verifier(&verifier);
+
+        let code = server
+            .generate_auth_code(
+                "usr_alice",
+                "webui",
+                "http://localhost/cb",
+                Some(&challenge),
+                vec![],
+            )
+            .await
+            .unwrap();
+
+        let err = server
+            .exchange_auth_code(&code, "webui", "http://localhost/cb", None)
+            .await;
+        assert!(err.is_err(), "missing PKCE verifier should be rejected");
+    }
+
+    #[tokio::test]
+    async fn wrong_client_id_is_rejected() {
+        let server = make_server();
+
+        let code = server
+            .generate_auth_code("usr_alice", "webui", "http://localhost/cb", None, vec![])
+            .await
+            .unwrap();
+
+        let err = server
+            .exchange_auth_code(&code, "wrong_client", "http://localhost/cb", None)
+            .await;
+        assert!(err.is_err(), "wrong client_id should be rejected");
+    }
+
+    #[tokio::test]
+    async fn wrong_redirect_uri_is_rejected() {
+        let server = make_server();
+
+        let code = server
+            .generate_auth_code("usr_alice", "webui", "http://localhost/cb", None, vec![])
+            .await
+            .unwrap();
+
+        let err = server
+            .exchange_auth_code(&code, "webui", "http://evil.com/cb", None)
+            .await;
+        assert!(err.is_err(), "wrong redirect_uri should be rejected");
+    }
+
+    #[tokio::test]
+    async fn refresh_token_rotation() {
+        let server = make_server();
+
+        let code = server
+            .generate_auth_code("usr_alice", "webui", "http://localhost/cb", None, vec![])
+            .await
+            .unwrap();
+
+        let pair1 = server
+            .exchange_auth_code(&code, "webui", "http://localhost/cb", None)
+            .await
+            .unwrap();
+
+        // Refresh yields new tokens.
+        let pair2 = server.refresh(&pair1.refresh_token, "webui").await.unwrap();
+        assert_ne!(
+            pair1.refresh_token, pair2.refresh_token,
+            "refresh should rotate tokens"
+        );
+
+        // Old refresh token cannot be reused.
+        let err = server.refresh(&pair1.refresh_token, "webui").await;
+        assert!(err.is_err(), "reusing consumed refresh token should fail");
+    }
+
+    #[tokio::test]
+    async fn refresh_replay_revokes_all() {
+        let server = make_server();
+
+        let code = server
+            .generate_auth_code("usr_alice", "webui", "http://localhost/cb", None, vec![])
+            .await
+            .unwrap();
+
+        let pair1 = server
+            .exchange_auth_code(&code, "webui", "http://localhost/cb", None)
+            .await
+            .unwrap();
+
+        // Normal refresh.
+        let pair2 = server.refresh(&pair1.refresh_token, "webui").await.unwrap();
+
+        // Replay attack with old token — triggers revocation.
+        let err = server.refresh(&pair1.refresh_token, "webui").await;
+        assert!(err.is_err(), "replay should be detected");
+
+        // Even the new token is now revoked.
+        let err2 = server.refresh(&pair2.refresh_token, "webui").await;
+        assert!(err2.is_err(), "all tokens should be revoked after replay");
+    }
+
+    #[tokio::test]
+    async fn expired_code_is_rejected() {
+        let server = make_server().with_code_ttl(Duration::seconds(-10));
+
+        let code = server
+            .generate_auth_code("usr_alice", "webui", "http://localhost/cb", None, vec![])
+            .await
+            .unwrap();
+
+        let err = server
+            .exchange_auth_code(&code, "webui", "http://localhost/cb", None)
+            .await;
+        assert!(err.is_err(), "expired code should be rejected");
+    }
+
+    #[tokio::test]
+    async fn expired_refresh_token_is_rejected() {
+        let server = make_server().with_refresh_ttl(Duration::seconds(-10));
+
+        let code = server
+            .generate_auth_code("usr_alice", "webui", "http://localhost/cb", None, vec![])
+            .await
+            .unwrap();
+
+        let pair = server
+            .exchange_auth_code(&code, "webui", "http://localhost/cb", None)
+            .await
+            .unwrap();
+
+        let err = server.refresh(&pair.refresh_token, "webui").await;
+        assert!(err.is_err(), "expired refresh token should be rejected");
+    }
+
+    #[tokio::test]
+    async fn full_flow_generate_exchange_refresh() {
+        let server = make_server();
+        let verifier = pkce::generate_verifier();
+        let challenge = pkce::challenge_from_verifier(&verifier);
+
+        // 1. Generate auth code.
+        let code = server
+            .generate_auth_code(
+                "usr_alice",
+                "webui",
+                "http://localhost/callback",
+                Some(&challenge),
+                vec!["personas:read".into(), "conversations:write".into()],
+            )
+            .await
+            .unwrap();
+
+        // 2. Exchange with PKCE.
+        let pair1 = server
+            .exchange_auth_code(&code, "webui", "http://localhost/callback", Some(&verifier))
+            .await
+            .unwrap();
+
+        // 3. Refresh.
+        let pair2 = server.refresh(&pair1.refresh_token, "webui").await.unwrap();
+        assert_ne!(pair1.access_token, pair2.access_token, "new access token");
+        assert_ne!(
+            pair1.refresh_token, pair2.refresh_token,
+            "new refresh token"
+        );
+
+        // 4. Refresh again with new token.
+        let pair3 = server.refresh(&pair2.refresh_token, "webui").await.unwrap();
+        assert_ne!(pair2.refresh_token, pair3.refresh_token, "rotated again");
+    }
+}

--- a/openspec/changes/multi-user-orgs/tasks.md
+++ b/openspec/changes/multi-user-orgs/tasks.md
@@ -120,44 +120,44 @@ PR 10 ─── CLI OAuth2 login + Flutter OAuth2 + docs
 
 **Commits:**
 
-- [ ] `feat(auth): PKCE challenge and verification`
+- [x] `feat(auth): PKCE challenge and verification`
   - Create `crates/auth/src/oauth2/pkce.rs`
   - `generate_verifier() -> String`, `challenge_from_verifier(verifier) -> String`
   - `verify(verifier, challenge) -> bool`
   - S256 method per RFC 7636
 
-- [ ] `test(auth): PKCE challenge round-trip`
+- [x] `test(auth): PKCE challenge round-trip`
 
-- [ ] `feat(auth): authorization code grant logic`
+- [x] `feat(auth): authorization code grant logic`
   - Create `crates/auth/src/oauth2/server.rs`
   - `AuthCodeStore` (in-memory or DB-backed): generate, store, exchange, expire
   - `generate_auth_code(user_id, client_id, redirect_uri, pkce_challenge, scopes) -> String`
   - `exchange_auth_code(code, client_id, redirect_uri, pkce_verifier) -> Result<(AccessToken, RefreshToken)>`
 
-- [ ] `feat(auth): refresh token management`
+- [x] `feat(auth): refresh token management`
   - Add to `crates/auth/src/oauth2/server.rs`
   - `RefreshTokenStore`: generate, store, rotate, revoke
   - `refresh(token, client_id) -> Result<(AccessToken, RefreshToken)>` with rotation
 
-- [ ] `test(auth): authorization code flow end-to-end (in-memory)`
+- [x] `test(auth): authorization code flow end-to-end (in-memory)`
   - Full flow: generate code → exchange with PKCE → get tokens → refresh → revoke
 
-- [ ] `feat(auth): device code flow`
+- [x] `feat(auth): device code flow`
   - Create `crates/auth/src/oauth2/device.rs`
   - `initiate(client_id) -> DeviceCodeResponse { device_code, user_code, verification_uri, interval }`
   - `poll(device_code) -> PollResult { Pending | Authorized(tokens) | Expired }`
   - `complete(user_code, user_id)` — called when user approves in browser
 
-- [ ] `test(auth): device code flow lifecycle`
+- [x] `test(auth): device code flow lifecycle`
 
-- [ ] `feat(auth): dynamic client registration (RFC 7591)`
+- [x] `feat(auth): dynamic client registration (RFC 7591)`
   - Create `crates/auth/src/oauth2/clients.rs`
   - `ClientStore`: register, lookup, list
   - `register(req: ClientRegistration) -> Result<ClientInfo>`
   - Validate redirect_uris, grant_types, response_types
   - Generate `client_id`, optional `client_secret` for confidential clients
 
-- [ ] `test(auth): dynamic client registration and lookup`
+- [x] `test(auth): dynamic client registration and lookup`
 
 ---
 


### PR DESCRIPTION
## Summary

Stacked on #610. Adds the complete OAuth2 authorization server logic to `assistant-auth` as pure library code with its own tests — no web-ui consumers yet.

- **PKCE** (RFC 7636): `generate_verifier()`, `challenge_from_verifier()`, `verify()` with S256 method. Validated against RFC 7636 Appendix B test vector.
- **Authorization code grant**: `OAuth2Server` with `AuthCodeStore`/`RefreshTokenStore` traits + in-memory implementations. Single-use codes, PKCE validation, client_id/redirect_uri matching, expiry.
- **Refresh token rotation**: consumed tokens are tracked; replaying a consumed token revokes all tokens for that user+client pair (replay attack mitigation).
- **Device code flow** (RFC 8628): `DeviceCodeManager` with `DeviceCodeStore` trait. Human-readable `XXXX-XXXX` user codes, poll/complete lifecycle.
- **Dynamic client registration** (RFC 7591): `ClientRegistrar` with `ClientStore` trait. Validates redirect URIs (HTTPS or localhost HTTP, no fragments), grant types, response types. Generates `cid_`-prefixed client IDs and optional secrets for confidential clients.

36 new tests, 50 total in `assistant-auth`. Depends on #610.

## Test plan

- [x] `cargo test -p assistant-auth` — 50 tests pass (5 PKCE + 11 server + 7 device + 13 clients + 14 existing)
- [x] `cargo test --workspace` — no regressions
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo machete` — no unused dependencies