### PR TITLE
feat(auth): OIDC federation, API keys, middleware, and AuthProvider implementations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,6 +391,7 @@ dependencies = [
  "argon2",
  "assistant-core",
  "async-trait",
+ "axum",
  "base64 0.22.1",
  "chrono",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,6 +404,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "urlencoding",
  "uuid",
  "wiremock",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,12 +395,15 @@ dependencies = [
  "chrono",
  "jsonwebtoken",
  "rand 0.9.4",
+ "reqwest 0.12.28",
  "serde",
  "sha2 0.11.0",
  "tempfile",
  "tokio",
+ "tracing",
  "url",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,6 +393,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "chrono",
+ "hex",
  "jsonwebtoken",
  "rand 0.9.4",
  "reqwest 0.12.28",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,6 +168,8 @@ parquet = { version = "57.3", default-features = false, features = ["arrow", "as
 jsonwebtoken = "9"
 argon2 = { version = "0.5", features = ["std"] }
 rand = "0.9"
+# Constant-time comparison (API key verification)
+subtle = "2"
 # Internal crates
 opentelemetry-exporter-sqlite = { path = "crates/opentelemetry-exporter-sqlite" }
 opentelemetry-exporter-iceberg = { path = "crates/opentelemetry-exporter-iceberg" }

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -45,6 +45,9 @@ reqwest = { workspace = true }
 # Logging
 tracing = { workspace = true }
 
+# URL percent-encoding (OIDC authorize URL)
+urlencoding = { workspace = true }
+
 # HTTP server (middleware extractors)
 axum = { workspace = true }
 

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -45,6 +45,9 @@ reqwest = { workspace = true }
 # Logging
 tracing = { workspace = true }
 
+# HTTP server (middleware extractors)
+axum = { workspace = true }
+
 [dev-dependencies]
 tempfile = { workspace = true }
 wiremock = { workspace = true }

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -27,9 +27,10 @@ argon2 = { workspace = true }
 # Cryptographic randomness
 rand = { workspace = true }
 
-# Hashing (PKCE S256, auth code storage)
+# Hashing (PKCE S256, auth code storage, API key SHA-256)
 sha2 = { workspace = true }
 base64 = { workspace = true }
+hex = { workspace = true }
 
 # URL parsing (redirect URI validation)
 url = { workspace = true }

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -38,5 +38,13 @@ url = { workspace = true }
 tokio = { workspace = true }
 async-trait = { workspace = true }
 
+# HTTP client (OIDC discovery, JWKS fetch)
+reqwest = { workspace = true }
+
+# Logging
+tracing = { workspace = true }
+
 [dev-dependencies]
 tempfile = { workspace = true }
+wiremock = { workspace = true }
+tokio = { workspace = true }

--- a/crates/auth/src/api_keys.rs
+++ b/crates/auth/src/api_keys.rs
@@ -1,0 +1,426 @@
+//! Scoped API key generation and resolution.
+//!
+//! API keys provide non-interactive authentication for scripts, CI pipelines,
+//! and integrations. Each key is scoped to specific resources and actions,
+//! carries an expiration, and can optionally restrict access to specific
+//! resource IDs.
+//!
+//! Key format: `ask_live_{32 random base64url chars}` — the `ask_live_` prefix
+//! enables identification and scanning. Only the SHA-256 hash is stored; the
+//! plaintext is shown exactly once at creation time.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use anyhow::{Context, Result, bail};
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use chrono::{DateTime, Utc};
+use sha2::{Digest, Sha256};
+use tracing::debug;
+
+use assistant_core::auth::AuthContext;
+use assistant_core::identity::{OrgId, Role, Scope, SpaceId, UserId};
+
+// -- Constants --
+
+/// Prefix for all API keys (enables scanning / identification).
+const KEY_PREFIX_TAG: &str = "ask_live_";
+
+/// Number of random bytes in the key body (32 bytes → 43 base64url chars).
+const KEY_RANDOM_BYTES: usize = 32;
+
+// -- Types --
+
+/// A newly generated API key. The `plaintext` field is shown once; only
+/// `key_hash` and `key_prefix` are stored.
+#[derive(Clone, Debug)]
+pub struct GeneratedKey {
+    /// The full key string (e.g. `ask_live_<base64url>`). Show once, never store.
+    pub plaintext: String,
+    /// SHA-256 hash of the full key (hex-encoded). Stored for lookup.
+    pub key_hash: String,
+    /// First 8 characters of the key (after prefix). Stored for display.
+    pub key_prefix: String,
+}
+
+/// Metadata about a stored API key.
+#[derive(Clone, Debug)]
+pub struct ApiKeyRecord {
+    /// Unique ID for this key.
+    pub id: String,
+    /// The user who owns this key.
+    pub user_id: UserId,
+    /// Human-readable name.
+    pub name: String,
+    /// SHA-256 hash of the full key (hex-encoded).
+    pub key_hash: String,
+    /// First 8 characters of the key body (for display).
+    pub key_prefix: String,
+    /// The organization this key belongs to.
+    pub org_id: OrgId,
+    /// Space → role mapping inherited from the user at creation time.
+    pub space_roles: HashMap<SpaceId, Role>,
+    /// Granted scopes (may be a subset of the user's full scopes).
+    pub scopes: Vec<Scope>,
+    /// When this key expires.
+    pub expires_at: Option<DateTime<Utc>>,
+    /// When this key was created.
+    pub created_at: DateTime<Utc>,
+}
+
+// -- Key generation --
+
+/// Generate a new API key.
+///
+/// Returns the plaintext (show once), the hash (for storage), and the prefix
+/// (for display in listings).
+pub fn generate_key() -> GeneratedKey {
+    use rand::Rng;
+
+    let mut rng = rand::rng();
+    let mut random_bytes = vec![0u8; KEY_RANDOM_BYTES];
+    rng.fill(&mut random_bytes[..]);
+
+    let body = URL_SAFE_NO_PAD.encode(&random_bytes);
+    let plaintext = format!("{KEY_PREFIX_TAG}{body}");
+    let key_hash = hash_key(&plaintext);
+    let key_prefix = body[..8].to_string();
+
+    GeneratedKey {
+        plaintext,
+        key_hash,
+        key_prefix,
+    }
+}
+
+/// Compute the SHA-256 hash of a key (hex-encoded).
+pub fn hash_key(key: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(key.as_bytes());
+    let result = hasher.finalize();
+    hex::encode(result)
+}
+
+// -- Store trait --
+
+/// Trait for API key persistence.
+#[async_trait::async_trait]
+pub trait ApiKeyStore: Send + Sync {
+    /// Store a new API key record.
+    async fn store_key(&self, record: ApiKeyRecord) -> Result<()>;
+    /// Look up a key by its hash.
+    async fn get_by_hash(&self, key_hash: &str) -> Result<Option<ApiKeyRecord>>;
+    /// List all keys for a user (without secrets).
+    async fn list_for_user(&self, user_id: &UserId) -> Result<Vec<ApiKeyRecord>>;
+    /// Revoke (delete) a key by ID.
+    async fn revoke(&self, key_id: &str, user_id: &UserId) -> Result<bool>;
+}
+
+// -- Resolution --
+
+/// Resolve an API key string to an [`AuthContext`].
+///
+/// Hashes the provided key, looks it up in the store, validates expiry,
+/// and builds an AuthContext from the stored metadata.
+pub async fn resolve_key(key_plaintext: &str, store: &dyn ApiKeyStore) -> Result<AuthContext> {
+    // Must start with the expected prefix.
+    if !key_plaintext.starts_with(KEY_PREFIX_TAG) {
+        bail!("invalid API key format: missing prefix");
+    }
+
+    let key_hash = hash_key(key_plaintext);
+    let record = store
+        .get_by_hash(&key_hash)
+        .await?
+        .context("API key not found")?;
+
+    // Check expiry.
+    if let Some(expires_at) = record.expires_at
+        && Utc::now() > expires_at
+    {
+        bail!("API key has expired");
+    }
+
+    debug!(user_id = %record.user_id, key_prefix = %record.key_prefix, "resolved API key");
+
+    Ok(AuthContext {
+        user_id: record.user_id,
+        org_id: record.org_id,
+        email: String::new(), // Not stored in the key — caller can enrich.
+        space_roles: record.space_roles,
+        scopes: record.scopes,
+        client_id: "api_key".into(),
+    })
+}
+
+// -- In-memory store (for tests and single-process deployments) --
+
+/// An in-memory API key store.
+pub struct InMemoryApiKeyStore {
+    records: Mutex<Vec<ApiKeyRecord>>,
+}
+
+impl InMemoryApiKeyStore {
+    pub fn new() -> Self {
+        Self {
+            records: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+impl Default for InMemoryApiKeyStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait::async_trait]
+impl ApiKeyStore for InMemoryApiKeyStore {
+    async fn store_key(&self, record: ApiKeyRecord) -> Result<()> {
+        self.records.lock().unwrap().push(record);
+        Ok(())
+    }
+
+    async fn get_by_hash(&self, key_hash: &str) -> Result<Option<ApiKeyRecord>> {
+        let records = self.records.lock().unwrap();
+        Ok(records.iter().find(|r| r.key_hash == key_hash).cloned())
+    }
+
+    async fn list_for_user(&self, user_id: &UserId) -> Result<Vec<ApiKeyRecord>> {
+        let records = self.records.lock().unwrap();
+        Ok(records
+            .iter()
+            .filter(|r| r.user_id == *user_id)
+            .cloned()
+            .collect())
+    }
+
+    async fn revoke(&self, key_id: &str, user_id: &UserId) -> Result<bool> {
+        let mut records = self.records.lock().unwrap();
+        let len_before = records.len();
+        records.retain(|r| !(r.id == key_id && r.user_id == *user_id));
+        Ok(records.len() < len_before)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use assistant_core::identity::{Action, ResourceKind};
+
+    fn make_test_record(key: &GeneratedKey, scopes: Vec<Scope>) -> ApiKeyRecord {
+        let mut space_roles = HashMap::new();
+        space_roles.insert(SpaceId::from("eng"), Role::Member);
+
+        ApiKeyRecord {
+            id: "key_1".into(),
+            user_id: UserId::from("usr_alice"),
+            name: "Test Key".into(),
+            key_hash: key.key_hash.clone(),
+            key_prefix: key.key_prefix.clone(),
+            org_id: OrgId::from("org_acme"),
+            space_roles,
+            scopes,
+            expires_at: None,
+            created_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn generate_key_has_correct_format() {
+        let key = generate_key();
+        assert!(
+            key.plaintext.starts_with("ask_live_"),
+            "key should start with ask_live_ prefix"
+        );
+        // 9 chars prefix + 43 chars base64url body = 52 total
+        assert!(
+            key.plaintext.len() >= 50,
+            "key should be at least 50 chars, got {}",
+            key.plaintext.len()
+        );
+        assert_eq!(key.key_prefix.len(), 8, "prefix should be 8 chars");
+        assert!(!key.key_hash.is_empty(), "hash should not be empty");
+    }
+
+    #[test]
+    fn generate_key_produces_unique_keys() {
+        let k1 = generate_key();
+        let k2 = generate_key();
+        assert_ne!(k1.plaintext, k2.plaintext, "keys should be unique");
+        assert_ne!(k1.key_hash, k2.key_hash, "hashes should be unique");
+    }
+
+    #[test]
+    fn hash_key_is_deterministic() {
+        let key = "ask_live_test1234567890abcdef";
+        let h1 = hash_key(key);
+        let h2 = hash_key(key);
+        assert_eq!(h1, h2, "hashing the same key should produce the same hash");
+    }
+
+    #[test]
+    fn hash_key_produces_hex_sha256() {
+        let hash = hash_key("test");
+        // SHA-256 hex = 64 chars
+        assert_eq!(hash.len(), 64, "SHA-256 hex should be 64 chars");
+        assert!(
+            hash.chars().all(|c| c.is_ascii_hexdigit()),
+            "hash should be hex-encoded"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_key_returns_auth_context() {
+        let store = InMemoryApiKeyStore::new();
+        let key = generate_key();
+        let scopes = vec![
+            Scope::new(ResourceKind::Personas, Action::Read),
+            Scope::new(ResourceKind::Conversations, Action::Read),
+        ];
+        let record = make_test_record(&key, scopes);
+        store.store_key(record).await.unwrap();
+
+        let ctx = resolve_key(&key.plaintext, &store).await.unwrap();
+        assert_eq!(ctx.user_id, UserId::from("usr_alice"));
+        assert_eq!(ctx.org_id, OrgId::from("org_acme"));
+        assert_eq!(ctx.client_id, "api_key");
+        assert_eq!(ctx.scopes.len(), 2);
+        assert_eq!(ctx.role_in(&SpaceId::from("eng")), Some(&Role::Member));
+    }
+
+    #[tokio::test]
+    async fn resolve_key_rejects_unknown_key() {
+        let store = InMemoryApiKeyStore::new();
+        let err = resolve_key("ask_live_unknown_key_12345678901234", &store).await;
+        assert!(err.is_err(), "should reject unknown key");
+    }
+
+    #[tokio::test]
+    async fn resolve_key_rejects_invalid_prefix() {
+        let store = InMemoryApiKeyStore::new();
+        let err = resolve_key("invalid_prefix_key", &store).await;
+        assert!(err.is_err(), "should reject key without prefix");
+        let msg = format!("{:?}", err.unwrap_err());
+        assert!(msg.contains("missing prefix"));
+    }
+
+    #[tokio::test]
+    async fn resolve_key_rejects_expired() {
+        let store = InMemoryApiKeyStore::new();
+        let key = generate_key();
+        let mut record = make_test_record(&key, vec![]);
+        record.expires_at = Some(Utc::now() - chrono::Duration::hours(1));
+        store.store_key(record).await.unwrap();
+
+        let err = resolve_key(&key.plaintext, &store).await;
+        assert!(err.is_err(), "should reject expired key");
+        let msg = format!("{:?}", err.unwrap_err());
+        assert!(msg.contains("expired"));
+    }
+
+    #[tokio::test]
+    async fn resolve_key_with_resource_restrictions() {
+        let store = InMemoryApiKeyStore::new();
+        let key = generate_key();
+        let scopes = vec![Scope::restricted(
+            ResourceKind::Personas,
+            Action::Read,
+            vec!["deploy-bot".into()],
+        )];
+        let record = make_test_record(&key, scopes);
+        store.store_key(record).await.unwrap();
+
+        let ctx = resolve_key(&key.plaintext, &store).await.unwrap();
+        let space = SpaceId::from("eng");
+
+        // Can read the specific restricted persona.
+        assert!(ctx.can(
+            &space,
+            &ResourceKind::Personas,
+            &Action::Read,
+            Some("deploy-bot"),
+        ));
+        // Cannot read a different persona.
+        assert!(!ctx.can(
+            &space,
+            &ResourceKind::Personas,
+            &Action::Read,
+            Some("other-bot"),
+        ));
+    }
+
+    #[tokio::test]
+    async fn list_keys_for_user() {
+        let store = InMemoryApiKeyStore::new();
+        let k1 = generate_key();
+        let k2 = generate_key();
+
+        let mut r1 = make_test_record(&k1, vec![]);
+        r1.id = "key_1".into();
+        r1.name = "Key 1".into();
+
+        let mut r2 = make_test_record(&k2, vec![]);
+        r2.id = "key_2".into();
+        r2.name = "Key 2".into();
+
+        // Different user's key.
+        let k3 = generate_key();
+        let mut r3 = make_test_record(&k3, vec![]);
+        r3.id = "key_3".into();
+        r3.user_id = UserId::from("usr_bob");
+
+        store.store_key(r1).await.unwrap();
+        store.store_key(r2).await.unwrap();
+        store.store_key(r3).await.unwrap();
+
+        let alice_keys = store
+            .list_for_user(&UserId::from("usr_alice"))
+            .await
+            .unwrap();
+        assert_eq!(alice_keys.len(), 2);
+
+        let bob_keys = store.list_for_user(&UserId::from("usr_bob")).await.unwrap();
+        assert_eq!(bob_keys.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn revoke_key_removes_it() {
+        let store = InMemoryApiKeyStore::new();
+        let key = generate_key();
+        let record = make_test_record(&key, vec![]);
+        store.store_key(record).await.unwrap();
+
+        // Revoke succeeds.
+        let revoked = store
+            .revoke("key_1", &UserId::from("usr_alice"))
+            .await
+            .unwrap();
+        assert!(revoked, "revoke should return true");
+
+        // Key no longer resolvable.
+        let err = resolve_key(&key.plaintext, &store).await;
+        assert!(err.is_err(), "revoked key should not resolve");
+    }
+
+    #[tokio::test]
+    async fn revoke_wrong_user_fails() {
+        let store = InMemoryApiKeyStore::new();
+        let key = generate_key();
+        let record = make_test_record(&key, vec![]);
+        store.store_key(record).await.unwrap();
+
+        // Bob cannot revoke Alice's key.
+        let revoked = store
+            .revoke("key_1", &UserId::from("usr_bob"))
+            .await
+            .unwrap();
+        assert!(!revoked, "should not revoke another user's key");
+
+        // Key still resolvable.
+        let ctx = resolve_key(&key.plaintext, &store).await.unwrap();
+        assert_eq!(ctx.user_id, UserId::from("usr_alice"));
+    }
+}

--- a/crates/auth/src/lib.rs
+++ b/crates/auth/src/lib.rs
@@ -5,8 +5,9 @@
 //! - Password hashing with argon2id ([`password`])
 //! - OAuth2 server logic ([`oauth2`])
 //! - OIDC federation ([`oidc`])
-//! - API key management (`api_keys`) *(coming next)*
-//! - Axum middleware extractors (`middleware`) *(coming next)*
+//! - Scoped API key management ([`api_keys`])
+//! - Axum middleware extractors ([`middleware`])
+//! - [`AuthProvider`](assistant_core::auth::AuthProvider) implementations ([`providers`])
 
 pub mod api_keys;
 pub mod jwt;
@@ -14,3 +15,4 @@ pub mod middleware;
 pub mod oauth2;
 pub mod oidc;
 pub mod password;
+pub mod providers;

--- a/crates/auth/src/lib.rs
+++ b/crates/auth/src/lib.rs
@@ -8,6 +8,7 @@
 //! - API key management (`api_keys`) *(coming next)*
 //! - Axum middleware extractors (`middleware`) *(coming next)*
 
+pub mod api_keys;
 pub mod jwt;
 pub mod oauth2;
 pub mod oidc;

--- a/crates/auth/src/lib.rs
+++ b/crates/auth/src/lib.rs
@@ -10,6 +10,7 @@
 
 pub mod api_keys;
 pub mod jwt;
+pub mod middleware;
 pub mod oauth2;
 pub mod oidc;
 pub mod password;

--- a/crates/auth/src/lib.rs
+++ b/crates/auth/src/lib.rs
@@ -4,10 +4,11 @@
 //! - JWT signing and validation ([`jwt`])
 //! - Password hashing with argon2id ([`password`])
 //! - OAuth2 server logic ([`oauth2`])
-//! - API key management (`api_keys`) *(coming in PR 4)*
-//! - OIDC federation (`oidc`) *(coming in PR 4)*
-//! - Axum middleware extractors (`middleware`) *(coming in PR 4)*
+//! - OIDC federation ([`oidc`])
+//! - API key management (`api_keys`) *(coming next)*
+//! - Axum middleware extractors (`middleware`) *(coming next)*
 
 pub mod jwt;
 pub mod oauth2;
+pub mod oidc;
 pub mod password;

--- a/crates/auth/src/middleware.rs
+++ b/crates/auth/src/middleware.rs
@@ -1,0 +1,430 @@
+//! Axum auth middleware extractors.
+//!
+//! Provides [`AuthExtractor`] which resolves an [`AuthContext`] from incoming
+//! requests by checking (in order):
+//!
+//! 1. `Authorization: Bearer <JWT>` header
+//! 2. Session cookie (encrypted reference to a refresh token)
+//! 3. API key (`ask_live_` prefix detection)
+//!
+//! Also provides [`RequireScope`] as a tower layer that checks permissions
+//! after extraction.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use axum::extract::FromRequestParts;
+use axum::http::StatusCode;
+use axum::http::request::Parts;
+use axum::response::{IntoResponse, Response};
+
+use assistant_core::auth::AuthContext;
+use assistant_core::identity::{Action, ResourceKind, SpaceId};
+
+use crate::api_keys::{self, ApiKeyStore};
+use crate::jwt::JwtManager;
+
+// -- Auth state shared across handlers --
+
+/// Shared authentication state injected into the Axum router.
+///
+/// Contains everything needed to resolve tokens, keys, and sessions
+/// into an [`AuthContext`].
+#[derive(Clone)]
+pub struct AuthState {
+    /// JWT manager for validating bearer tokens.
+    pub jwt_manager: Arc<JwtManager>,
+    /// API key store for resolving `ask_live_` keys.
+    pub api_key_store: Arc<dyn ApiKeyStore>,
+    /// Optional legacy token for backward compatibility.
+    /// When set, requests with this token get a default org-admin context.
+    pub legacy_token: Option<String>,
+    /// Default AuthContext for legacy token authentication.
+    pub legacy_context: Option<AuthContext>,
+}
+
+// -- AuthExtractor --
+
+/// Extracts an [`AuthContext`] from an incoming request.
+///
+/// Resolution order:
+/// 1. `Authorization: Bearer <token>` → try JWT, then API key
+/// 2. Legacy `ASSISTANT_WEB_TOKEN` match (backward compatibility)
+/// 3. Reject with 401
+#[derive(Debug)]
+pub struct AuthExtractor(pub AuthContext);
+
+/// Error type returned when authentication fails.
+#[derive(Debug)]
+pub enum AuthError {
+    /// No credentials provided.
+    MissingCredentials,
+    /// Credentials provided but invalid.
+    InvalidCredentials(String),
+}
+
+impl IntoResponse for AuthError {
+    fn into_response(self) -> Response {
+        match self {
+            Self::MissingCredentials => {
+                (StatusCode::UNAUTHORIZED, "authentication required").into_response()
+            }
+            Self::InvalidCredentials(msg) => (
+                StatusCode::UNAUTHORIZED,
+                format!("invalid credentials: {msg}"),
+            )
+                .into_response(),
+        }
+    }
+}
+
+impl FromRequestParts<AuthState> for AuthExtractor {
+    type Rejection = AuthError;
+
+    fn from_request_parts(
+        parts: &mut Parts,
+        state: &AuthState,
+    ) -> impl std::future::Future<Output = Result<Self, Self::Rejection>> + Send {
+        let auth_header = parts
+            .headers
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+
+        let state = state.clone();
+
+        async move {
+            let token = match &auth_header {
+                Some(h) if h.starts_with("Bearer ") => Some(&h[7..]),
+                _ => None,
+            };
+
+            let token = match token {
+                Some(t) => t,
+                None => return Err(AuthError::MissingCredentials),
+            };
+
+            // 1. Try JWT validation.
+            if let Ok(ctx) = state.jwt_manager.validate_to_context(token) {
+                return Ok(AuthExtractor(ctx));
+            }
+
+            // 2. Try API key resolution.
+            if token.starts_with("ask_live_") {
+                match api_keys::resolve_key(token, state.api_key_store.as_ref()).await {
+                    Ok(ctx) => return Ok(AuthExtractor(ctx)),
+                    Err(e) => {
+                        return Err(AuthError::InvalidCredentials(format!("API key: {e}")));
+                    }
+                }
+            }
+
+            // 3. Try legacy token.
+            if let Some(ref legacy) = state.legacy_token
+                && token == legacy
+                && let Some(ref ctx) = state.legacy_context
+            {
+                return Ok(AuthExtractor(ctx.clone()));
+            }
+
+            Err(AuthError::InvalidCredentials(
+                "token is not a valid JWT or API key".into(),
+            ))
+        }
+    }
+}
+
+// -- RequireScope --
+
+/// A permission check that can be used in handler signatures.
+///
+/// Verifies that the extracted [`AuthContext`] has the required scope
+/// for the given space, resource, and action.
+pub struct RequireScope {
+    pub space_id: SpaceId,
+    pub resource: ResourceKind,
+    pub action: Action,
+    pub target_id: Option<String>,
+}
+
+impl RequireScope {
+    /// Check if the given context satisfies this scope requirement.
+    pub fn check(&self, ctx: &AuthContext) -> Result<(), ScopeError> {
+        if ctx.can(
+            &self.space_id,
+            &self.resource,
+            &self.action,
+            self.target_id.as_deref(),
+        ) {
+            Ok(())
+        } else {
+            Err(ScopeError {
+                resource: self.resource.clone(),
+                action: self.action.clone(),
+                space_id: self.space_id.clone(),
+            })
+        }
+    }
+}
+
+/// Error returned when a scope check fails.
+#[derive(Debug)]
+pub struct ScopeError {
+    pub resource: ResourceKind,
+    pub action: Action,
+    pub space_id: SpaceId,
+}
+
+impl IntoResponse for ScopeError {
+    fn into_response(self) -> Response {
+        (
+            StatusCode::FORBIDDEN,
+            format!(
+                "insufficient permissions: requires {}:{} in space {}",
+                self.resource, self.action, self.space_id
+            ),
+        )
+            .into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use axum::http::Request;
+
+    use assistant_core::identity::{OrgId, Role, Scope, UserId};
+
+    use crate::api_keys::InMemoryApiKeyStore;
+    use crate::jwt::JwtKeyPair;
+
+    use super::*;
+
+    fn test_auth_state() -> (AuthState, JwtManager) {
+        let kp = JwtKeyPair::generate().unwrap();
+        let jwt_mgr = JwtManager::new(kp, "https://test.local".into(), "https://test.local".into());
+        // We need another JwtManager for the state since JwtKeyPair isn't Clone.
+        // Generate a shared secret and build two managers from it.
+        let secret = b"test-secret-that-is-long-enough!!";
+        let kp_state = JwtKeyPair::from_secret(secret);
+        let kp_sign = JwtKeyPair::from_secret(secret);
+        let jwt_state = JwtManager::new(
+            kp_state,
+            "https://test.local".into(),
+            "https://test.local".into(),
+        );
+        let jwt_sign = JwtManager::new(
+            kp_sign,
+            "https://test.local".into(),
+            "https://test.local".into(),
+        );
+
+        let state = AuthState {
+            jwt_manager: Arc::new(jwt_state),
+            api_key_store: Arc::new(InMemoryApiKeyStore::new()),
+            legacy_token: Some("legacy-token-123".into()),
+            legacy_context: Some(make_admin_context()),
+        };
+
+        drop(jwt_mgr); // unused, we use the shared-secret pair instead
+        (state, jwt_sign)
+    }
+
+    fn make_admin_context() -> AuthContext {
+        let mut space_roles = HashMap::new();
+        space_roles.insert(SpaceId::from("default"), Role::OrgAdmin);
+        AuthContext {
+            user_id: UserId::from("admin"),
+            org_id: OrgId::from("default"),
+            email: "admin@local".into(),
+            space_roles,
+            scopes: vec![Scope::new(ResourceKind::Org, Action::Manage)],
+            client_id: "legacy".into(),
+        }
+    }
+
+    fn make_member_context() -> AuthContext {
+        let mut space_roles = HashMap::new();
+        space_roles.insert(SpaceId::from("eng"), Role::Member);
+        AuthContext {
+            user_id: UserId::from("bob"),
+            org_id: OrgId::from("acme"),
+            email: "bob@acme.com".into(),
+            space_roles,
+            scopes: vec![
+                Scope::new(ResourceKind::Personas, Action::Read),
+                Scope::new(ResourceKind::Conversations, Action::Read),
+                Scope::new(ResourceKind::Conversations, Action::Write),
+            ],
+            client_id: "webui".into(),
+        }
+    }
+
+    async fn extract_from_header(
+        state: &AuthState,
+        auth_value: &str,
+    ) -> Result<AuthContext, AuthError> {
+        let req = Request::builder()
+            .header("authorization", auth_value)
+            .body(())
+            .unwrap();
+        let (mut parts, _body) = req.into_parts();
+
+        AuthExtractor::from_request_parts(&mut parts, state)
+            .await
+            .map(|e| e.0)
+    }
+
+    #[tokio::test]
+    async fn extract_valid_jwt() {
+        let (state, jwt_sign) = test_auth_state();
+        let ctx = make_member_context();
+        let token = jwt_sign.sign(&ctx, "acme", "Bob").unwrap();
+
+        let result = extract_from_header(&state, &format!("Bearer {token}")).await;
+        assert!(result.is_ok());
+        let extracted = result.unwrap();
+        assert_eq!(extracted.user_id, UserId::from("bob"));
+        assert_eq!(extracted.org_id, OrgId::from("acme"));
+    }
+
+    #[tokio::test]
+    async fn extract_valid_api_key() {
+        let (state, _jwt_sign) = test_auth_state();
+
+        // Store an API key.
+        let key = crate::api_keys::generate_key();
+        let mut space_roles = HashMap::new();
+        space_roles.insert(SpaceId::from("eng"), Role::Member);
+        let record = crate::api_keys::ApiKeyRecord {
+            id: "key_test".into(),
+            user_id: UserId::from("alice"),
+            name: "Test".into(),
+            key_hash: key.key_hash.clone(),
+            key_prefix: key.key_prefix.clone(),
+            org_id: OrgId::from("acme"),
+            space_roles,
+            scopes: vec![Scope::new(ResourceKind::Personas, Action::Read)],
+            expires_at: None,
+            created_at: chrono::Utc::now(),
+        };
+        state.api_key_store.store_key(record).await.unwrap();
+
+        let result = extract_from_header(&state, &format!("Bearer {}", key.plaintext)).await;
+        assert!(result.is_ok());
+        let extracted = result.unwrap();
+        assert_eq!(extracted.user_id, UserId::from("alice"));
+        assert_eq!(extracted.client_id, "api_key");
+    }
+
+    #[tokio::test]
+    async fn extract_legacy_token() {
+        let (state, _jwt_sign) = test_auth_state();
+
+        let result = extract_from_header(&state, "Bearer legacy-token-123").await;
+        assert!(result.is_ok());
+        let extracted = result.unwrap();
+        assert_eq!(extracted.user_id, UserId::from("admin"));
+        assert!(extracted.is_org_admin());
+    }
+
+    #[tokio::test]
+    async fn extract_missing_header_returns_401() {
+        let (state, _jwt_sign) = test_auth_state();
+
+        let req = Request::builder().body(()).unwrap();
+        let (mut parts, _body) = req.into_parts();
+
+        let result = AuthExtractor::from_request_parts(&mut parts, &state).await;
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            AuthError::MissingCredentials => {}
+            other => panic!("expected MissingCredentials, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn extract_invalid_token_returns_401() {
+        let (state, _jwt_sign) = test_auth_state();
+
+        let result = extract_from_header(&state, "Bearer invalid-garbage-token").await;
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            AuthError::InvalidCredentials(_) => {}
+            other => panic!("expected InvalidCredentials, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn extract_expired_jwt_falls_through() {
+        let (state, _jwt_sign) = test_auth_state();
+
+        // Sign with a different secret so validation fails.
+        let other_kp = JwtKeyPair::from_secret(b"other-secret-that-is-long-enough");
+        let other_mgr = JwtManager::new(
+            other_kp,
+            "https://test.local".into(),
+            "https://test.local".into(),
+        );
+        let ctx = make_member_context();
+        let bad_token = other_mgr.sign(&ctx, "acme", "Bob").unwrap();
+
+        let result = extract_from_header(&state, &format!("Bearer {bad_token}")).await;
+        assert!(result.is_err());
+    }
+
+    // -- RequireScope tests --
+
+    #[test]
+    fn require_scope_passes_for_allowed_action() {
+        let ctx = make_member_context();
+        let scope = RequireScope {
+            space_id: SpaceId::from("eng"),
+            resource: ResourceKind::Conversations,
+            action: Action::Read,
+            target_id: None,
+        };
+        assert!(scope.check(&ctx).is_ok());
+    }
+
+    #[test]
+    fn require_scope_fails_for_disallowed_action() {
+        let ctx = make_member_context();
+        let scope = RequireScope {
+            space_id: SpaceId::from("eng"),
+            resource: ResourceKind::Users,
+            action: Action::Manage,
+            target_id: None,
+        };
+        let err = scope.check(&ctx);
+        assert!(err.is_err());
+        let scope_err = err.unwrap_err();
+        assert_eq!(scope_err.resource, ResourceKind::Users);
+        assert_eq!(scope_err.action, Action::Manage);
+    }
+
+    #[test]
+    fn require_scope_fails_for_wrong_space() {
+        let ctx = make_member_context();
+        let scope = RequireScope {
+            space_id: SpaceId::from("marketing"),
+            resource: ResourceKind::Conversations,
+            action: Action::Read,
+            target_id: None,
+        };
+        assert!(scope.check(&ctx).is_err());
+    }
+
+    #[test]
+    fn require_scope_admin_bypasses() {
+        let ctx = make_admin_context();
+        let scope = RequireScope {
+            space_id: SpaceId::from("any-space"),
+            resource: ResourceKind::Users,
+            action: Action::Manage,
+            target_id: None,
+        };
+        assert!(scope.check(&ctx).is_ok());
+    }
+}

--- a/crates/auth/src/oauth2/server.rs
+++ b/crates/auth/src/oauth2/server.rs
@@ -43,6 +43,8 @@ pub struct StoredRefreshToken {
 pub struct TokenPair {
     pub access_token: String,
     pub refresh_token: String,
+    /// The user who authorized the token.
+    pub user_id: String,
 }
 
 // -- AuthCodeStore trait --
@@ -234,6 +236,7 @@ impl OAuth2Server {
         // Generate tokens.
         let access_token = generate_random_token();
         let refresh_token = generate_random_token();
+        let user_id = auth_code.user_id.clone();
 
         // Store refresh token.
         self.refresh_store
@@ -250,6 +253,7 @@ impl OAuth2Server {
         Ok(TokenPair {
             access_token,
             refresh_token,
+            user_id,
         })
     }
 
@@ -289,6 +293,7 @@ impl OAuth2Server {
         // Issue new pair.
         let new_access = generate_random_token();
         let new_refresh = generate_random_token();
+        let user_id = stored.user_id.clone();
 
         self.refresh_store
             .store_token(StoredRefreshToken {
@@ -304,6 +309,7 @@ impl OAuth2Server {
         Ok(TokenPair {
             access_token: new_access,
             refresh_token: new_refresh,
+            user_id,
         })
     }
 }

--- a/crates/auth/src/oidc.rs
+++ b/crates/auth/src/oidc.rs
@@ -279,6 +279,11 @@ impl OidcProvider {
         &self.discovery
     }
 
+    /// Get the client ID registered with this IdP.
+    pub fn client_id(&self) -> &str {
+        &self.config.client_id
+    }
+
     /// Validate an ID token and return the claims.
     ///
     /// Verifies: signature (via JWKS), issuer, audience, and expiry.

--- a/crates/auth/src/oidc.rs
+++ b/crates/auth/src/oidc.rs
@@ -1,0 +1,975 @@
+//! OpenID Connect (OIDC) federation.
+//!
+//! Lightweight OIDC implementation using `reqwest` + `jsonwebtoken` for
+//! discovery, ID token validation, and user provisioning. Follows the
+//! project's thin-HTTP-client philosophy — no heavy OIDC SDK dependency.
+
+use anyhow::{Context, Result, bail};
+use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode, decode_header};
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+
+use assistant_core::identity::UserId;
+
+// -- Discovery --
+
+/// OpenID Connect discovery document (.well-known/openid-configuration).
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct OidcDiscovery {
+    pub issuer: String,
+    pub authorization_endpoint: String,
+    pub token_endpoint: String,
+    #[serde(default)]
+    pub userinfo_endpoint: Option<String>,
+    pub jwks_uri: String,
+    #[serde(default)]
+    pub response_types_supported: Vec<String>,
+    #[serde(default)]
+    pub subject_types_supported: Vec<String>,
+    #[serde(default)]
+    pub id_token_signing_alg_values_supported: Vec<String>,
+}
+
+// -- JWKS --
+
+/// A JSON Web Key Set (JWKS) response.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct JwksResponse {
+    pub keys: Vec<Jwk>,
+}
+
+/// A single JSON Web Key.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Jwk {
+    /// Key type (e.g. "RSA", "EC").
+    pub kty: String,
+    /// Key ID.
+    #[serde(default)]
+    pub kid: Option<String>,
+    /// Algorithm (e.g. "RS256").
+    #[serde(default)]
+    pub alg: Option<String>,
+    /// Key use ("sig" for signing).
+    #[serde(default, rename = "use")]
+    pub key_use: Option<String>,
+    // RSA params
+    #[serde(default)]
+    pub n: Option<String>,
+    #[serde(default)]
+    pub e: Option<String>,
+    // EC params
+    #[serde(default)]
+    pub crv: Option<String>,
+    #[serde(default)]
+    pub x: Option<String>,
+    #[serde(default)]
+    pub y: Option<String>,
+}
+
+impl Jwk {
+    /// Build a `DecodingKey` from this JWK.
+    fn to_decoding_key(&self) -> Result<DecodingKey> {
+        match self.kty.as_str() {
+            "RSA" => {
+                let n = self.n.as_deref().context("RSA JWK missing 'n'")?;
+                let e = self.e.as_deref().context("RSA JWK missing 'e'")?;
+                DecodingKey::from_rsa_components(n, e)
+                    .context("failed to build RSA decoding key from JWK")
+            }
+            "EC" => {
+                let x = self.x.as_deref().context("EC JWK missing 'x'")?;
+                let y = self.y.as_deref().context("EC JWK missing 'y'")?;
+                DecodingKey::from_ec_components(x, y)
+                    .context("failed to build EC decoding key from JWK")
+            }
+            other => bail!("unsupported JWK key type: {other}"),
+        }
+    }
+
+    /// Determine the algorithm for this JWK.
+    fn algorithm(&self) -> Result<Algorithm> {
+        if let Some(alg) = &self.alg {
+            return match alg.as_str() {
+                "RS256" => Ok(Algorithm::RS256),
+                "RS384" => Ok(Algorithm::RS384),
+                "RS512" => Ok(Algorithm::RS512),
+                "ES256" => Ok(Algorithm::ES256),
+                "ES384" => Ok(Algorithm::ES384),
+                other => bail!("unsupported JWK algorithm: {other}"),
+            };
+        }
+        // Infer from key type.
+        match self.kty.as_str() {
+            "RSA" => Ok(Algorithm::RS256),
+            "EC" => match self.crv.as_deref() {
+                Some("P-256") => Ok(Algorithm::ES256),
+                Some("P-384") => Ok(Algorithm::ES384),
+                Some(other) => bail!("unsupported EC curve: {other}"),
+                None => Ok(Algorithm::ES256),
+            },
+            other => bail!("cannot infer algorithm for key type: {other}"),
+        }
+    }
+}
+
+// -- ID Token Claims --
+
+/// Claims extracted from an OIDC ID token.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct IdTokenClaims {
+    /// Issuer.
+    pub iss: String,
+    /// Subject (unique user ID at the IdP).
+    pub sub: String,
+    /// Audience (our client_id).
+    pub aud: IdTokenAudience,
+    /// Expiration (unix timestamp).
+    pub exp: i64,
+    /// Issued at (unix timestamp).
+    pub iat: i64,
+    /// Nonce (if provided in the auth request).
+    #[serde(default)]
+    pub nonce: Option<String>,
+    /// Email address.
+    #[serde(default)]
+    pub email: Option<String>,
+    /// Whether the email is verified.
+    #[serde(default)]
+    pub email_verified: Option<bool>,
+    /// Display name.
+    #[serde(default)]
+    pub name: Option<String>,
+}
+
+/// The `aud` claim can be a single string or an array.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum IdTokenAudience {
+    Single(String),
+    Multiple(Vec<String>),
+}
+
+impl IdTokenAudience {
+    /// Check if this audience contains the given client ID.
+    pub fn contains(&self, client_id: &str) -> bool {
+        match self {
+            Self::Single(s) => s == client_id,
+            Self::Multiple(v) => v.iter().any(|s| s == client_id),
+        }
+    }
+}
+
+// -- User provisioning --
+
+/// Information extracted from an OIDC ID token for user provisioning.
+#[derive(Clone, Debug)]
+pub struct OidcUserInfo {
+    /// The OIDC issuer URL.
+    pub idp_issuer: String,
+    /// The subject claim (unique user ID at the IdP).
+    pub idp_subject: String,
+    /// Email address (if available and verified).
+    pub email: Option<String>,
+    /// Display name (if available).
+    pub name: Option<String>,
+}
+
+/// Trait for user lookup/creation during OIDC provisioning.
+#[async_trait::async_trait]
+pub trait OidcUserStore: Send + Sync {
+    /// Find a user by their IdP (issuer, subject) pair.
+    async fn find_by_idp(&self, issuer: &str, subject: &str) -> Result<Option<UserId>>;
+    /// Find a user by email.
+    async fn find_by_email(&self, email: &str) -> Result<Option<UserId>>;
+    /// Create a new user from OIDC info and return their ID.
+    async fn create_user(&self, info: &OidcUserInfo) -> Result<UserId>;
+    /// Link an existing user to an IdP identity.
+    async fn link_idp(&self, user_id: &UserId, issuer: &str, subject: &str) -> Result<()>;
+}
+
+// -- OidcProvider --
+
+/// Configuration for an OIDC provider.
+#[derive(Clone, Debug)]
+pub struct OidcConfig {
+    /// The OIDC issuer URL (e.g. `https://auth.example.com/realms/main`).
+    pub issuer_url: String,
+    /// Our OAuth2 client_id registered with this IdP.
+    pub client_id: String,
+    /// Whether to auto-provision users on first login.
+    pub auto_provision: bool,
+    /// If set, only allow emails matching these domains.
+    pub allowed_email_domains: Option<Vec<String>>,
+}
+
+/// An OIDC identity provider.
+///
+/// Discovers endpoints, fetches signing keys, validates ID tokens, and
+/// provisions users.
+pub struct OidcProvider {
+    config: OidcConfig,
+    discovery: OidcDiscovery,
+    jwks: JwksResponse,
+    #[allow(dead_code)]
+    http_client: reqwest::Client,
+}
+
+impl OidcProvider {
+    /// Discover an OIDC provider from its issuer URL.
+    ///
+    /// Fetches `.well-known/openid-configuration` and the JWKS.
+    pub async fn discover(config: OidcConfig) -> Result<Self> {
+        Self::discover_with_client(config, reqwest::Client::new()).await
+    }
+
+    /// Discover using a custom HTTP client (for testing).
+    pub async fn discover_with_client(
+        config: OidcConfig,
+        http_client: reqwest::Client,
+    ) -> Result<Self> {
+        let discovery_url = format!(
+            "{}/.well-known/openid-configuration",
+            config.issuer_url.trim_end_matches('/')
+        );
+        debug!(url = %discovery_url, "fetching OIDC discovery document");
+
+        let discovery: OidcDiscovery = http_client
+            .get(&discovery_url)
+            .send()
+            .await
+            .context("failed to fetch OIDC discovery document")?
+            .error_for_status()
+            .context("OIDC discovery endpoint returned error")?
+            .json()
+            .await
+            .context("failed to parse OIDC discovery document")?;
+
+        // Verify the issuer matches what we expect.
+        if discovery.issuer != config.issuer_url {
+            bail!(
+                "OIDC issuer mismatch: expected {}, got {}",
+                config.issuer_url,
+                discovery.issuer
+            );
+        }
+
+        debug!(jwks_uri = %discovery.jwks_uri, "fetching JWKS");
+
+        let jwks: JwksResponse = http_client
+            .get(&discovery.jwks_uri)
+            .send()
+            .await
+            .context("failed to fetch JWKS")?
+            .error_for_status()
+            .context("JWKS endpoint returned error")?
+            .json()
+            .await
+            .context("failed to parse JWKS")?;
+
+        Ok(Self {
+            config,
+            discovery,
+            jwks,
+            http_client,
+        })
+    }
+
+    /// Get the discovery document.
+    pub fn discovery(&self) -> &OidcDiscovery {
+        &self.discovery
+    }
+
+    /// Validate an ID token and return the claims.
+    ///
+    /// Verifies: signature (via JWKS), issuer, audience, and expiry.
+    pub fn validate_id_token(
+        &self,
+        token: &str,
+        expected_nonce: Option<&str>,
+    ) -> Result<IdTokenClaims> {
+        // Decode the header to find the key ID.
+        let header = decode_header(token).context("failed to decode ID token header")?;
+
+        // Find the matching key in the JWKS.
+        let jwk = self.find_key(&header.kid)?;
+        let algorithm = jwk.algorithm()?;
+        let decoding_key = jwk.to_decoding_key()?;
+
+        // Build validation.
+        let mut validation = Validation::new(algorithm);
+        validation.set_issuer(&[&self.config.issuer_url]);
+        validation.set_audience(&[&self.config.client_id]);
+
+        let token_data = decode::<IdTokenClaims>(token, &decoding_key, &validation)
+            .context("ID token validation failed")?;
+
+        let claims = token_data.claims;
+
+        // Verify audience contains our client_id.
+        if !claims.aud.contains(&self.config.client_id) {
+            bail!(
+                "ID token audience does not contain our client_id: {}",
+                self.config.client_id
+            );
+        }
+
+        // Verify nonce if expected.
+        if let Some(expected) = expected_nonce {
+            match &claims.nonce {
+                Some(nonce) if nonce == expected => {}
+                Some(nonce) => bail!("nonce mismatch: expected {expected}, got {nonce}"),
+                None => bail!("expected nonce in ID token but none present"),
+            }
+        }
+
+        Ok(claims)
+    }
+
+    /// Extract user info from validated ID token claims.
+    pub fn extract_user_info(&self, claims: &IdTokenClaims) -> OidcUserInfo {
+        OidcUserInfo {
+            idp_issuer: claims.iss.clone(),
+            idp_subject: claims.sub.clone(),
+            email: claims.email.clone(),
+            name: claims.name.clone(),
+        }
+    }
+
+    /// Provision or look up a user from OIDC claims.
+    ///
+    /// 1. Look up by (issuer, subject) — if found, return existing user.
+    /// 2. Look up by email — if found, link IdP and return.
+    /// 3. If auto-provision is enabled, create a new user.
+    /// 4. Otherwise, fail.
+    pub async fn provision_or_lookup(
+        &self,
+        claims: &IdTokenClaims,
+        store: &dyn OidcUserStore,
+    ) -> Result<UserId> {
+        let info = self.extract_user_info(claims);
+
+        // Check email domain restriction.
+        if let Some(ref domains) = self.config.allowed_email_domains {
+            match &info.email {
+                Some(email) => {
+                    let domain = email.rsplit_once('@').map(|(_, d)| d).unwrap_or("");
+                    if !domains.iter().any(|d| d == domain) {
+                        bail!("email domain '{domain}' not in allowed list for this organization");
+                    }
+                }
+                None => bail!("OIDC provider did not return an email; cannot verify domain"),
+            }
+        }
+
+        // 1. Look up by IdP identity.
+        if let Some(user_id) = store
+            .find_by_idp(&info.idp_issuer, &info.idp_subject)
+            .await?
+        {
+            debug!(user_id = %user_id, "found existing user by IdP identity");
+            return Ok(user_id);
+        }
+
+        // 2. Look up by email and link.
+        if let Some(ref email) = info.email
+            && let Some(user_id) = store.find_by_email(email).await?
+        {
+            debug!(user_id = %user_id, email = %email, "linking existing user to IdP");
+            store
+                .link_idp(&user_id, &info.idp_issuer, &info.idp_subject)
+                .await?;
+            return Ok(user_id);
+        }
+
+        // 3. Auto-provision.
+        if self.config.auto_provision {
+            let user_id = store.create_user(&info).await?;
+            debug!(user_id = %user_id, "auto-provisioned new user from OIDC");
+            return Ok(user_id);
+        }
+
+        bail!(
+            "no existing user found for OIDC subject '{}' and auto-provisioning is disabled",
+            info.idp_subject
+        );
+    }
+
+    /// Find a JWK by key ID. Falls back to the first signing key if no kid is specified.
+    fn find_key(&self, kid: &Option<String>) -> Result<&Jwk> {
+        if let Some(kid) = kid {
+            self.jwks
+                .keys
+                .iter()
+                .find(|k| k.kid.as_deref() == Some(kid))
+                .with_context(|| format!("no JWK found with kid '{kid}'"))
+        } else {
+            // No kid in token header — use the first signing key.
+            self.jwks
+                .keys
+                .iter()
+                .find(|k| k.key_use.as_deref() != Some("enc"))
+                .or_else(|| self.jwks.keys.first())
+                .context("JWKS contains no keys")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::Mutex;
+
+    use chrono::Utc;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    // -- Test RSA key (2048-bit, generated for testing only) --
+
+    const TEST_RSA_PRIVATE_PEM: &str = r#"-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDfk5v7uyKn7Xee
+tzR7ZRsra2drSEZHQYOHfIv8bm2zSrHrFdUqmTL0t6mj1jPYXWNBVZCyiAzL2qiN
+dddT3kNBdpI80aMpIT3u/sOa5I0hq11nGAKeezGLqizOPcztgZQa3FYFve5HxnXT
+K9UkboBqhvIXKUx8fZsO8sFHdscS4VGrNn9VLPz8UjEOmJsJEiaqSjw4qx+1WsBj
+xTlQNqV/y/durbTCyNSUlRex1C4PEHGg+rr/yobUk9MqxGHNeKefKkSaDcij72lz
+osvxelXHLoonV54X9VrpMnXdWAw7yJ6LbWsA9MVoEiqDfnDFWcaFsfQeCq+1/Hnd
+b9jdEJPJAgMBAAECggEAYsYKSBzlUy44xkBnKcrBxZ12O7HbBpj9fGp8R+IbifXK
+g7MKEX9MQUww4IZ+Mi0T8CXWvuEXUiqAg7qXjmBn8zBorADr5fxfKcqY7UHizgiw
+w56abZy8h1j/4X/xHM69+V31jSTbdA9MN6aqTCWbizSiGLRwq6EsU17RH/rsOTzJ
+yiap+GgvDBHRSMLPbH+A7A9hNZh6I6Dv9KReGUmOEKVQpl9aetJfxsCkXII7ztUL
+HUQNZVluA2OqR1s7VpYO9yNmZoTtfqmUswIg2YaFXSjVgdDFNH6Rf3reufWehzKP
+45ufflne4FT3f8VFXe8+FonCZE5RF2tIawC2gusWfwKBgQD1vX9Q2V5wKg/nQq/6
+vVv370XmypVBajXvg0TP95E7p+EORGoDYj46LWNKZRifeGjavmM29jiqPnk8UZjC
+3qEmZILZC2/IdsR7hVpEn7uyedc2wBFSD5pYR9333VsV+rbBMmexO8DdviR8L4Tr
+8ESx+FsVnqkhBgGjQWjXOapf5wKBgQDo6Tlu1VZQ1ijLWYomeKDiKQloEHMSW3lP
+vgd1XqTYLrR7kv6935cK6dY0ZvcfA4HE6+RU4pene/vU6bMxvSJjwNwhRhOS7CGl
+k+5Mtdfq3+VhaXA5dmyYu2IrJ3WJg+9QjxAodek4kYx1W8MLJnKc2GzIuED+ewg0
+PuMXTcm4zwKBgC+z820MZSq8341zAppX++xrRFSC6uph5cpy3v7H/idodWXBnhq+
+DXpZqTad3WPHigM8hiH7NhDGQ96TsGXTtdCwHj5n2/E8LPQVdOpxX4xL3p1AN5yI
+btvIR6yACdiAbM2gLUTYZp4k9QwuZU0vvQYXQgc2X3qLofHBFssA5LPtAoGAI3/w
+zhDcQCP0QdJa+TQnqXEBywe+0kx4+AuJzXzoeT7dKXylMUGUHwi3KnOLNQHu1Jnz
+ynBjFxcRskkQlAM066loo/WvZBRzqG4cwzpwN496wdc1ULzZHoppExTHmHcwkcHM
+f65BJusgUn7zAo8QpxFhu1JCLceI35W6PUIQ/gcCgYEA34AmU6srEH6iJx7wFQez
+vsldAzUeGESZCNai30KZPeUrFxGHNcWU72xkBJnHnZCcAejKtW/XqKd4AWY25buV
+6vNdaNWeyJt50s+E8VTfGi2otEAiZh+dJxAmgLJ/PA0RDyBft2qGkKMSfS2PXdIr
+q2HMPOhMSkWZ+rP+jJ76H6s=
+-----END PRIVATE KEY-----"#;
+
+    // Pre-computed base64url-encoded RSA public key components from the above key.
+    const TEST_RSA_N: &str = "35Ob-7sip-13nrc0e2UbK2tna0hGR0GDh3yL_G5ts0qx6xXVKpky9Lepo9Yz2F1jQVWQsogMy9qojXXXU95DQXaSPNGjKSE97v7DmuSNIatdZxgCnnsxi6oszj3M7YGUGtxWBb3uR8Z10yvVJG6AaobyFylMfH2bDvLBR3bHEuFRqzZ_VSz8_FIxDpibCRImqko8OKsftVrAY8U5UDalf8v3bq20wsjUlJUXsdQuDxBxoPq6_8qG1JPTKsRhzXinnypEmg3Io-9pc6LL8XpVxy6KJ1eeF_Va6TJ13VgMO8iei21rAPTFaBIqg35wxVnGhbH0Hgqvtfx53W_Y3RCTyQ";
+    const TEST_RSA_E: &str = "AQAB";
+
+    fn test_encoding_key() -> jsonwebtoken::EncodingKey {
+        jsonwebtoken::EncodingKey::from_rsa_pem(TEST_RSA_PRIVATE_PEM.as_bytes())
+            .expect("test RSA PEM should be valid")
+    }
+
+    fn test_jwk() -> Jwk {
+        Jwk {
+            kty: "RSA".into(),
+            kid: Some("test-key-1".into()),
+            alg: Some("RS256".into()),
+            key_use: Some("sig".into()),
+            n: Some(TEST_RSA_N.into()),
+            e: Some(TEST_RSA_E.into()),
+            crv: None,
+            x: None,
+            y: None,
+        }
+    }
+
+    /// Sign a test ID token with the test RSA key.
+    fn sign_test_id_token(claims: &IdTokenClaims) -> String {
+        let mut header = jsonwebtoken::Header::new(Algorithm::RS256);
+        header.kid = Some("test-key-1".into());
+        jsonwebtoken::encode(&header, claims, &test_encoding_key())
+            .expect("signing test token should succeed")
+    }
+
+    fn make_test_claims(issuer: &str, client_id: &str) -> IdTokenClaims {
+        let now = Utc::now().timestamp();
+        IdTokenClaims {
+            iss: issuer.into(),
+            sub: "idp-user-123".into(),
+            aud: IdTokenAudience::Single(client_id.into()),
+            exp: now + 3600,
+            iat: now,
+            nonce: None,
+            email: Some("alice@example.com".into()),
+            email_verified: Some(true),
+            name: Some("Alice".into()),
+        }
+    }
+
+    /// Build mock discovery + JWKS endpoints and return an OidcProvider.
+    async fn setup_mock_provider(server: &MockServer) -> OidcProvider {
+        let issuer = server.uri();
+        let jwks_uri = format!("{issuer}/jwks");
+
+        let discovery = OidcDiscovery {
+            issuer: issuer.clone(),
+            authorization_endpoint: format!("{issuer}/authorize"),
+            token_endpoint: format!("{issuer}/token"),
+            userinfo_endpoint: Some(format!("{issuer}/userinfo")),
+            jwks_uri: jwks_uri.clone(),
+            response_types_supported: vec!["code".into()],
+            subject_types_supported: vec!["public".into()],
+            id_token_signing_alg_values_supported: vec!["RS256".into()],
+        };
+
+        let jwks = JwksResponse {
+            keys: vec![test_jwk()],
+        };
+
+        Mock::given(method("GET"))
+            .and(path("/.well-known/openid-configuration"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&discovery))
+            .mount(server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/jwks"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&jwks))
+            .mount(server)
+            .await;
+
+        let config = OidcConfig {
+            issuer_url: issuer,
+            client_id: "test-client".into(),
+            auto_provision: true,
+            allowed_email_domains: None,
+        };
+
+        OidcProvider::discover(config).await.unwrap()
+    }
+
+    // -- In-memory OidcUserStore for testing --
+
+    struct InMemoryUserStore {
+        state: Mutex<UserStoreState>,
+    }
+
+    struct UserStoreState {
+        users: Vec<StoredUser>,
+        next_id: u64,
+    }
+
+    struct StoredUser {
+        id: UserId,
+        email: Option<String>,
+        idp_links: Vec<(String, String)>, // (issuer, subject)
+    }
+
+    impl InMemoryUserStore {
+        fn new() -> Self {
+            Self {
+                state: Mutex::new(UserStoreState {
+                    users: Vec::new(),
+                    next_id: 1,
+                }),
+            }
+        }
+
+        fn with_user(self, id: &str, email: &str, idp_links: Vec<(&str, &str)>) -> Self {
+            let mut state = self.state.lock().unwrap();
+            state.users.push(StoredUser {
+                id: UserId::from(id),
+                email: Some(email.into()),
+                idp_links: idp_links
+                    .into_iter()
+                    .map(|(i, s)| (i.into(), s.into()))
+                    .collect(),
+            });
+            drop(state);
+            self
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl OidcUserStore for InMemoryUserStore {
+        async fn find_by_idp(&self, issuer: &str, subject: &str) -> Result<Option<UserId>> {
+            let state = self.state.lock().unwrap();
+            Ok(state
+                .users
+                .iter()
+                .find(|u| u.idp_links.iter().any(|(i, s)| i == issuer && s == subject))
+                .map(|u| u.id.clone()))
+        }
+
+        async fn find_by_email(&self, email: &str) -> Result<Option<UserId>> {
+            let state = self.state.lock().unwrap();
+            Ok(state
+                .users
+                .iter()
+                .find(|u| u.email.as_deref() == Some(email))
+                .map(|u| u.id.clone()))
+        }
+
+        async fn create_user(&self, info: &OidcUserInfo) -> Result<UserId> {
+            let mut state = self.state.lock().unwrap();
+            let id = UserId::from(format!("usr_{}", state.next_id));
+            state.next_id += 1;
+            state.users.push(StoredUser {
+                id: id.clone(),
+                email: info.email.clone(),
+                idp_links: vec![(info.idp_issuer.clone(), info.idp_subject.clone())],
+            });
+            Ok(id)
+        }
+
+        async fn link_idp(&self, user_id: &UserId, issuer: &str, subject: &str) -> Result<()> {
+            let mut state = self.state.lock().unwrap();
+            let user = state
+                .users
+                .iter_mut()
+                .find(|u| u.id == *user_id)
+                .context("user not found")?;
+            user.idp_links.push((issuer.into(), subject.into()));
+            Ok(())
+        }
+    }
+
+    // -- Discovery tests --
+
+    #[tokio::test]
+    async fn discover_fetches_config_and_jwks() {
+        let server = MockServer::start().await;
+        let provider = setup_mock_provider(&server).await;
+
+        assert_eq!(provider.discovery().issuer, server.uri());
+        assert_eq!(
+            provider.discovery().authorization_endpoint,
+            format!("{}/authorize", server.uri())
+        );
+        assert_eq!(provider.jwks.keys.len(), 1);
+        assert_eq!(provider.jwks.keys[0].kid.as_deref(), Some("test-key-1"));
+    }
+
+    #[tokio::test]
+    async fn discover_rejects_issuer_mismatch() {
+        let server = MockServer::start().await;
+        let issuer = server.uri();
+
+        let discovery = OidcDiscovery {
+            issuer: "https://wrong-issuer.example.com".into(),
+            authorization_endpoint: format!("{issuer}/authorize"),
+            token_endpoint: format!("{issuer}/token"),
+            userinfo_endpoint: None,
+            jwks_uri: format!("{issuer}/jwks"),
+            response_types_supported: vec![],
+            subject_types_supported: vec![],
+            id_token_signing_alg_values_supported: vec![],
+        };
+
+        Mock::given(method("GET"))
+            .and(path("/.well-known/openid-configuration"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&discovery))
+            .mount(&server)
+            .await;
+
+        let config = OidcConfig {
+            issuer_url: issuer,
+            client_id: "test-client".into(),
+            auto_provision: true,
+            allowed_email_domains: None,
+        };
+
+        let result = OidcProvider::discover(config).await;
+        assert!(result.is_err());
+        let msg = format!("{:?}", result.err().unwrap());
+        assert!(
+            msg.contains("issuer mismatch"),
+            "expected issuer mismatch error, got: {msg}"
+        );
+    }
+
+    // -- ID token validation tests --
+
+    #[tokio::test]
+    async fn validate_id_token_with_valid_signature() {
+        let server = MockServer::start().await;
+        let provider = setup_mock_provider(&server).await;
+        let claims = make_test_claims(&server.uri(), "test-client");
+        let token = sign_test_id_token(&claims);
+
+        let result = provider.validate_id_token(&token, None).unwrap();
+        assert_eq!(result.sub, "idp-user-123");
+        assert_eq!(result.email.as_deref(), Some("alice@example.com"));
+        assert_eq!(result.name.as_deref(), Some("Alice"));
+    }
+
+    #[tokio::test]
+    async fn validate_id_token_rejects_wrong_issuer() {
+        let server = MockServer::start().await;
+        let provider = setup_mock_provider(&server).await;
+        let claims = make_test_claims("https://wrong-issuer.example.com", "test-client");
+        let token = sign_test_id_token(&claims);
+
+        let err = provider.validate_id_token(&token, None);
+        assert!(err.is_err(), "should reject token with wrong issuer");
+    }
+
+    #[tokio::test]
+    async fn validate_id_token_rejects_wrong_audience() {
+        let server = MockServer::start().await;
+        let provider = setup_mock_provider(&server).await;
+        let claims = make_test_claims(&server.uri(), "wrong-client");
+        let token = sign_test_id_token(&claims);
+
+        let err = provider.validate_id_token(&token, None);
+        assert!(err.is_err(), "should reject token with wrong audience");
+    }
+
+    #[tokio::test]
+    async fn validate_id_token_rejects_expired() {
+        let server = MockServer::start().await;
+        let provider = setup_mock_provider(&server).await;
+        let mut claims = make_test_claims(&server.uri(), "test-client");
+        claims.exp = Utc::now().timestamp() - 3600; // Expired 1 hour ago.
+        claims.iat = Utc::now().timestamp() - 7200;
+        let token = sign_test_id_token(&claims);
+
+        let err = provider.validate_id_token(&token, None);
+        assert!(err.is_err(), "should reject expired token");
+    }
+
+    #[tokio::test]
+    async fn validate_id_token_checks_nonce() {
+        let server = MockServer::start().await;
+        let provider = setup_mock_provider(&server).await;
+
+        // Token with nonce.
+        let mut claims = make_test_claims(&server.uri(), "test-client");
+        claims.nonce = Some("test-nonce-123".into());
+        let token = sign_test_id_token(&claims);
+
+        // Correct nonce passes.
+        let result = provider.validate_id_token(&token, Some("test-nonce-123"));
+        assert!(result.is_ok());
+
+        // Wrong nonce fails.
+        let err = provider.validate_id_token(&token, Some("wrong-nonce"));
+        assert!(err.is_err());
+
+        // Token without nonce but nonce expected fails.
+        let claims_no_nonce = make_test_claims(&server.uri(), "test-client");
+        let token_no_nonce = sign_test_id_token(&claims_no_nonce);
+        let err = provider.validate_id_token(&token_no_nonce, Some("expected-nonce"));
+        assert!(err.is_err());
+    }
+
+    // -- User provisioning tests --
+
+    #[tokio::test]
+    async fn provision_finds_existing_user_by_idp() {
+        let server = MockServer::start().await;
+        let provider = setup_mock_provider(&server).await;
+        let claims = make_test_claims(&server.uri(), "test-client");
+
+        let store = InMemoryUserStore::new().with_user(
+            "usr_existing",
+            "alice@example.com",
+            vec![(&server.uri(), "idp-user-123")],
+        );
+
+        let user_id = provider.provision_or_lookup(&claims, &store).await.unwrap();
+        assert_eq!(user_id, UserId::from("usr_existing"));
+    }
+
+    #[tokio::test]
+    async fn provision_links_existing_user_by_email() {
+        let server = MockServer::start().await;
+        let provider = setup_mock_provider(&server).await;
+        let claims = make_test_claims(&server.uri(), "test-client");
+
+        // User exists by email but not linked to this IdP.
+        let store = InMemoryUserStore::new().with_user("usr_email", "alice@example.com", vec![]);
+
+        let user_id = provider.provision_or_lookup(&claims, &store).await.unwrap();
+        assert_eq!(user_id, UserId::from("usr_email"));
+
+        // Verify the IdP link was created.
+        let linked = store
+            .find_by_idp(&server.uri(), "idp-user-123")
+            .await
+            .unwrap();
+        assert_eq!(linked, Some(UserId::from("usr_email")));
+    }
+
+    #[tokio::test]
+    async fn provision_auto_creates_user() {
+        let server = MockServer::start().await;
+        let provider = setup_mock_provider(&server).await;
+        let claims = make_test_claims(&server.uri(), "test-client");
+
+        let store = InMemoryUserStore::new();
+        let user_id = provider.provision_or_lookup(&claims, &store).await.unwrap();
+        assert_eq!(user_id, UserId::from("usr_1"));
+    }
+
+    #[tokio::test]
+    async fn provision_rejects_disallowed_email_domain() {
+        let server = MockServer::start().await;
+
+        // Override the provider config to restrict email domains.
+        let issuer = server.uri();
+        let jwks_uri = format!("{issuer}/jwks");
+
+        let discovery = OidcDiscovery {
+            issuer: issuer.clone(),
+            authorization_endpoint: format!("{issuer}/authorize"),
+            token_endpoint: format!("{issuer}/token"),
+            userinfo_endpoint: None,
+            jwks_uri: jwks_uri.clone(),
+            response_types_supported: vec![],
+            subject_types_supported: vec![],
+            id_token_signing_alg_values_supported: vec![],
+        };
+
+        let jwks = JwksResponse {
+            keys: vec![test_jwk()],
+        };
+
+        Mock::given(method("GET"))
+            .and(path("/.well-known/openid-configuration"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&discovery))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/jwks"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&jwks))
+            .mount(&server)
+            .await;
+
+        let config = OidcConfig {
+            issuer_url: issuer.clone(),
+            client_id: "test-client".into(),
+            auto_provision: true,
+            allowed_email_domains: Some(vec!["acme.com".into()]),
+        };
+
+        let provider = OidcProvider::discover(config).await.unwrap();
+        let claims = make_test_claims(&issuer, "test-client");
+
+        let store = InMemoryUserStore::new();
+        let err = provider.provision_or_lookup(&claims, &store).await;
+        assert!(err.is_err());
+        let msg = format!("{:?}", err.unwrap_err());
+        assert!(
+            msg.contains("not in allowed list"),
+            "expected domain rejection, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn provision_fails_when_auto_provision_disabled() {
+        let server = MockServer::start().await;
+        let issuer = server.uri();
+        let jwks_uri = format!("{issuer}/jwks");
+
+        let discovery = OidcDiscovery {
+            issuer: issuer.clone(),
+            authorization_endpoint: format!("{issuer}/authorize"),
+            token_endpoint: format!("{issuer}/token"),
+            userinfo_endpoint: None,
+            jwks_uri,
+            response_types_supported: vec![],
+            subject_types_supported: vec![],
+            id_token_signing_alg_values_supported: vec![],
+        };
+
+        let jwks = JwksResponse {
+            keys: vec![test_jwk()],
+        };
+
+        Mock::given(method("GET"))
+            .and(path("/.well-known/openid-configuration"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&discovery))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/jwks"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&jwks))
+            .mount(&server)
+            .await;
+
+        let config = OidcConfig {
+            issuer_url: issuer.clone(),
+            client_id: "test-client".into(),
+            auto_provision: false,
+            allowed_email_domains: None,
+        };
+
+        let provider = OidcProvider::discover(config).await.unwrap();
+        let claims = make_test_claims(&issuer, "test-client");
+
+        let store = InMemoryUserStore::new();
+        let err = provider.provision_or_lookup(&claims, &store).await;
+        assert!(err.is_err());
+        let msg = format!("{:?}", err.unwrap_err());
+        assert!(
+            msg.contains("auto-provisioning is disabled"),
+            "expected auto-provision error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn extract_user_info_from_claims() {
+        let claims = IdTokenClaims {
+            iss: "https://idp.example.com".into(),
+            sub: "user-42".into(),
+            aud: IdTokenAudience::Single("client".into()),
+            exp: 0,
+            iat: 0,
+            nonce: None,
+            email: Some("bob@corp.com".into()),
+            email_verified: Some(true),
+            name: Some("Bob".into()),
+        };
+
+        // Build a minimal provider just for extract_user_info.
+        let provider = OidcProvider {
+            config: OidcConfig {
+                issuer_url: "https://idp.example.com".into(),
+                client_id: "client".into(),
+                auto_provision: false,
+                allowed_email_domains: None,
+            },
+            discovery: OidcDiscovery {
+                issuer: "https://idp.example.com".into(),
+                authorization_endpoint: String::new(),
+                token_endpoint: String::new(),
+                userinfo_endpoint: None,
+                jwks_uri: String::new(),
+                response_types_supported: vec![],
+                subject_types_supported: vec![],
+                id_token_signing_alg_values_supported: vec![],
+            },
+            jwks: JwksResponse { keys: vec![] },
+            http_client: reqwest::Client::new(),
+        };
+
+        let info = provider.extract_user_info(&claims);
+        assert_eq!(info.idp_issuer, "https://idp.example.com");
+        assert_eq!(info.idp_subject, "user-42");
+        assert_eq!(info.email.as_deref(), Some("bob@corp.com"));
+        assert_eq!(info.name.as_deref(), Some("Bob"));
+    }
+
+    #[test]
+    fn audience_contains_single() {
+        let aud = IdTokenAudience::Single("client-a".into());
+        assert!(aud.contains("client-a"));
+        assert!(!aud.contains("client-b"));
+    }
+
+    #[test]
+    fn audience_contains_multiple() {
+        let aud = IdTokenAudience::Multiple(vec!["client-a".into(), "client-b".into()]);
+        assert!(aud.contains("client-a"));
+        assert!(aud.contains("client-b"));
+        assert!(!aud.contains("client-c"));
+    }
+}

--- a/crates/auth/src/providers.rs
+++ b/crates/auth/src/providers.rs
@@ -1,0 +1,808 @@
+//! [`AuthProvider`] implementations.
+//!
+//! Provides [`PasswordAuthProvider`] for username/password authentication
+//! and [`OidcAuthProvider`] for federated login via an external IdP.
+//! Both issue the assistant's own JWTs regardless of the upstream identity
+//! source.
+
+use std::sync::Arc;
+
+use anyhow::{Result, bail};
+use async_trait::async_trait;
+use tracing::debug;
+
+use assistant_core::auth::{
+    AuthContext, AuthProvider, AuthorizeRequest, AuthorizeResponse, ClientInfo, ClientRegistration,
+    TokenGrant, TokenResponse,
+};
+
+use crate::api_keys::{self, ApiKeyStore};
+use crate::jwt::JwtManager;
+use crate::oauth2::clients::ClientRegistrar;
+use crate::oauth2::device::DeviceCodeManager;
+use crate::oauth2::server::OAuth2Server;
+use crate::oidc::OidcProvider;
+use crate::password;
+
+// -- User store trait for password auth --
+
+/// Trait for looking up users by email and verifying passwords.
+#[async_trait]
+pub trait PasswordUserStore: Send + Sync {
+    /// Find a user by email and return (user_id, password_hash, org_slug, display_name).
+    async fn find_by_email(&self, email: &str) -> Result<Option<PasswordUserRecord>>;
+
+    /// Build an AuthContext for the given user (populates space roles, scopes, etc.).
+    async fn build_context(&self, user_id: &str) -> Result<AuthContext>;
+}
+
+/// A user record with password hash for verification.
+#[derive(Clone, Debug)]
+pub struct PasswordUserRecord {
+    pub user_id: String,
+    pub password_hash: String,
+    pub org_slug: String,
+    pub display_name: String,
+}
+
+// -- PasswordAuthProvider --
+
+/// Authenticates users with email + password, issues JWTs via the OAuth2 server.
+pub struct PasswordAuthProvider {
+    jwt_manager: Arc<JwtManager>,
+    oauth2_server: Arc<OAuth2Server>,
+    device_manager: Arc<DeviceCodeManager>,
+    client_registrar: Arc<ClientRegistrar>,
+    api_key_store: Arc<dyn ApiKeyStore>,
+    user_store: Arc<dyn PasswordUserStore>,
+}
+
+impl PasswordAuthProvider {
+    pub fn new(
+        jwt_manager: Arc<JwtManager>,
+        oauth2_server: Arc<OAuth2Server>,
+        device_manager: Arc<DeviceCodeManager>,
+        client_registrar: Arc<ClientRegistrar>,
+        api_key_store: Arc<dyn ApiKeyStore>,
+        user_store: Arc<dyn PasswordUserStore>,
+    ) -> Self {
+        Self {
+            jwt_manager,
+            oauth2_server,
+            device_manager,
+            client_registrar,
+            api_key_store,
+            user_store,
+        }
+    }
+}
+
+#[async_trait]
+impl AuthProvider for PasswordAuthProvider {
+    async fn authenticate(&self, token: &str) -> Result<AuthContext> {
+        // Try JWT first.
+        if let Ok(ctx) = self.jwt_manager.validate_to_context(token) {
+            return Ok(ctx);
+        }
+
+        // Try API key.
+        if token.starts_with("ask_live_") {
+            return api_keys::resolve_key(token, self.api_key_store.as_ref()).await;
+        }
+
+        bail!("invalid token: not a valid JWT or API key")
+    }
+
+    async fn authorize(&self, req: AuthorizeRequest) -> Result<AuthorizeResponse> {
+        // Verify the client exists.
+        let _client = self
+            .client_registrar
+            .get(&req.client_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("unknown client_id: {}", req.client_id))?;
+
+        // Password mode: render a login form.
+        Ok(AuthorizeResponse::LoginRequired {
+            client_id: req.client_id,
+            state: req.state,
+        })
+    }
+
+    async fn token(&self, grant: TokenGrant) -> Result<TokenResponse> {
+        match grant {
+            TokenGrant::AuthorizationCode {
+                code,
+                redirect_uri,
+                client_id,
+                code_verifier,
+            } => {
+                let pair = self
+                    .oauth2_server
+                    .exchange_auth_code(&code, &client_id, &redirect_uri, code_verifier.as_deref())
+                    .await?;
+
+                let ctx = self.user_store.build_context(&pair.user_id).await?;
+                let record = self
+                    .user_store
+                    .find_by_email(&ctx.email)
+                    .await?
+                    .unwrap_or_else(|| PasswordUserRecord {
+                        user_id: pair.user_id.clone(),
+                        password_hash: String::new(),
+                        org_slug: "default".into(),
+                        display_name: "User".into(),
+                    });
+
+                let access_token =
+                    self.jwt_manager
+                        .sign(&ctx, &record.org_slug, &record.display_name)?;
+
+                Ok(TokenResponse {
+                    access_token,
+                    token_type: "Bearer".into(),
+                    expires_in: 3600,
+                    refresh_token: Some(pair.refresh_token),
+                    scope: None,
+                })
+            }
+
+            TokenGrant::RefreshToken {
+                refresh_token,
+                client_id,
+            } => {
+                let pair = self
+                    .oauth2_server
+                    .refresh(&refresh_token, &client_id)
+                    .await?;
+
+                let ctx = self.user_store.build_context(&pair.user_id).await?;
+                let record = self
+                    .user_store
+                    .find_by_email(&ctx.email)
+                    .await?
+                    .unwrap_or_else(|| PasswordUserRecord {
+                        user_id: pair.user_id.clone(),
+                        password_hash: String::new(),
+                        org_slug: "default".into(),
+                        display_name: "User".into(),
+                    });
+
+                let access_token =
+                    self.jwt_manager
+                        .sign(&ctx, &record.org_slug, &record.display_name)?;
+
+                Ok(TokenResponse {
+                    access_token,
+                    token_type: "Bearer".into(),
+                    expires_in: 3600,
+                    refresh_token: Some(pair.refresh_token),
+                    scope: None,
+                })
+            }
+
+            TokenGrant::DeviceCode {
+                device_code,
+                client_id: _,
+            } => {
+                let poll_result = self.device_manager.poll(&device_code).await?;
+                match poll_result {
+                    crate::oauth2::device::PollResult::Authorized { user_id, scopes: _ } => {
+                        let ctx = self.user_store.build_context(&user_id).await?;
+                        let record = self
+                            .user_store
+                            .find_by_email(&ctx.email)
+                            .await?
+                            .unwrap_or_else(|| PasswordUserRecord {
+                                user_id: user_id.clone(),
+                                password_hash: String::new(),
+                                org_slug: "default".into(),
+                                display_name: "User".into(),
+                            });
+
+                        let access_token =
+                            self.jwt_manager
+                                .sign(&ctx, &record.org_slug, &record.display_name)?;
+
+                        Ok(TokenResponse {
+                            access_token,
+                            token_type: "Bearer".into(),
+                            expires_in: 3600,
+                            refresh_token: None,
+                            scope: None,
+                        })
+                    }
+                    crate::oauth2::device::PollResult::Pending => {
+                        bail!("authorization_pending")
+                    }
+                    crate::oauth2::device::PollResult::Expired => {
+                        bail!("expired_token")
+                    }
+                }
+            }
+
+            TokenGrant::ClientCredentials { .. } => {
+                bail!("client_credentials grant not supported in password mode")
+            }
+        }
+    }
+
+    async fn register_client(&self, req: ClientRegistration) -> Result<ClientInfo> {
+        self.client_registrar.register(req).await
+    }
+}
+
+// -- OidcAuthProvider --
+
+/// Authenticates users via an external OIDC IdP, issues our own JWTs.
+pub struct OidcAuthProvider {
+    jwt_manager: Arc<JwtManager>,
+    oauth2_server: Arc<OAuth2Server>,
+    device_manager: Arc<DeviceCodeManager>,
+    client_registrar: Arc<ClientRegistrar>,
+    api_key_store: Arc<dyn ApiKeyStore>,
+    oidc_provider: Arc<OidcProvider>,
+    user_store: Arc<dyn PasswordUserStore>,
+}
+
+impl OidcAuthProvider {
+    pub fn new(
+        jwt_manager: Arc<JwtManager>,
+        oauth2_server: Arc<OAuth2Server>,
+        device_manager: Arc<DeviceCodeManager>,
+        client_registrar: Arc<ClientRegistrar>,
+        api_key_store: Arc<dyn ApiKeyStore>,
+        oidc_provider: Arc<OidcProvider>,
+        user_store: Arc<dyn PasswordUserStore>,
+    ) -> Self {
+        Self {
+            jwt_manager,
+            oauth2_server,
+            device_manager,
+            client_registrar,
+            api_key_store,
+            oidc_provider,
+            user_store,
+        }
+    }
+}
+
+#[async_trait]
+impl AuthProvider for OidcAuthProvider {
+    async fn authenticate(&self, token: &str) -> Result<AuthContext> {
+        // Same as password provider — both issue our JWTs.
+        if let Ok(ctx) = self.jwt_manager.validate_to_context(token) {
+            return Ok(ctx);
+        }
+
+        if token.starts_with("ask_live_") {
+            return api_keys::resolve_key(token, self.api_key_store.as_ref()).await;
+        }
+
+        bail!("invalid token: not a valid JWT or API key")
+    }
+
+    async fn authorize(&self, req: AuthorizeRequest) -> Result<AuthorizeResponse> {
+        let _client = self
+            .client_registrar
+            .get(&req.client_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("unknown client_id: {}", req.client_id))?;
+
+        // OIDC mode: redirect to the external IdP.
+        let discovery = self.oidc_provider.discovery();
+        let redirect_url = format!(
+            "{}?client_id={}&redirect_uri={}&response_type=code&scope=openid%20email%20profile&state={}",
+            discovery.authorization_endpoint,
+            urlencoding::encode(self.oidc_provider.client_id()),
+            urlencoding::encode(&req.redirect_uri),
+            urlencoding::encode(req.state.as_deref().unwrap_or("")),
+        );
+
+        debug!(url = %redirect_url, "redirecting to OIDC IdP");
+
+        Ok(AuthorizeResponse::Redirect { url: redirect_url })
+    }
+
+    async fn token(&self, grant: TokenGrant) -> Result<TokenResponse> {
+        match grant {
+            TokenGrant::AuthorizationCode {
+                code,
+                redirect_uri,
+                client_id,
+                code_verifier,
+            } => {
+                let pair = self
+                    .oauth2_server
+                    .exchange_auth_code(&code, &client_id, &redirect_uri, code_verifier.as_deref())
+                    .await?;
+
+                let ctx = self.user_store.build_context(&pair.user_id).await?;
+                let record = self
+                    .user_store
+                    .find_by_email(&ctx.email)
+                    .await?
+                    .unwrap_or_else(|| PasswordUserRecord {
+                        user_id: pair.user_id.clone(),
+                        password_hash: String::new(),
+                        org_slug: "default".into(),
+                        display_name: "User".into(),
+                    });
+
+                let access_token =
+                    self.jwt_manager
+                        .sign(&ctx, &record.org_slug, &record.display_name)?;
+
+                Ok(TokenResponse {
+                    access_token,
+                    token_type: "Bearer".into(),
+                    expires_in: 3600,
+                    refresh_token: Some(pair.refresh_token),
+                    scope: None,
+                })
+            }
+
+            TokenGrant::RefreshToken {
+                refresh_token,
+                client_id,
+            } => {
+                let pair = self
+                    .oauth2_server
+                    .refresh(&refresh_token, &client_id)
+                    .await?;
+
+                let ctx = self.user_store.build_context(&pair.user_id).await?;
+                let record = self
+                    .user_store
+                    .find_by_email(&ctx.email)
+                    .await?
+                    .unwrap_or_else(|| PasswordUserRecord {
+                        user_id: pair.user_id.clone(),
+                        password_hash: String::new(),
+                        org_slug: "default".into(),
+                        display_name: "User".into(),
+                    });
+
+                let access_token =
+                    self.jwt_manager
+                        .sign(&ctx, &record.org_slug, &record.display_name)?;
+
+                Ok(TokenResponse {
+                    access_token,
+                    token_type: "Bearer".into(),
+                    expires_in: 3600,
+                    refresh_token: Some(pair.refresh_token),
+                    scope: None,
+                })
+            }
+
+            TokenGrant::DeviceCode {
+                device_code,
+                client_id: _,
+            } => {
+                let poll_result = self.device_manager.poll(&device_code).await?;
+                match poll_result {
+                    crate::oauth2::device::PollResult::Authorized { user_id, scopes: _ } => {
+                        let ctx = self.user_store.build_context(&user_id).await?;
+                        let record = self
+                            .user_store
+                            .find_by_email(&ctx.email)
+                            .await?
+                            .unwrap_or_else(|| PasswordUserRecord {
+                                user_id: user_id.clone(),
+                                password_hash: String::new(),
+                                org_slug: "default".into(),
+                                display_name: "User".into(),
+                            });
+
+                        let access_token =
+                            self.jwt_manager
+                                .sign(&ctx, &record.org_slug, &record.display_name)?;
+
+                        Ok(TokenResponse {
+                            access_token,
+                            token_type: "Bearer".into(),
+                            expires_in: 3600,
+                            refresh_token: None,
+                            scope: None,
+                        })
+                    }
+                    crate::oauth2::device::PollResult::Pending => {
+                        bail!("authorization_pending")
+                    }
+                    crate::oauth2::device::PollResult::Expired => {
+                        bail!("expired_token")
+                    }
+                }
+            }
+
+            TokenGrant::ClientCredentials { .. } => {
+                bail!("client_credentials grant not supported in OIDC mode")
+            }
+        }
+    }
+
+    async fn register_client(&self, req: ClientRegistration) -> Result<ClientInfo> {
+        self.client_registrar.register(req).await
+    }
+}
+
+/// Helper to validate a password login and generate an auth code.
+///
+/// Used by the web-ui POST /oauth/authorize endpoint after the user
+/// submits their email + password.
+pub async fn validate_password_login(
+    email: &str,
+    plain_password: &str,
+    client_id: &str,
+    redirect_uri: &str,
+    pkce_challenge: Option<&str>,
+    user_store: &dyn PasswordUserStore,
+    oauth2_server: &OAuth2Server,
+) -> Result<String> {
+    let record = user_store
+        .find_by_email(email)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("invalid email or password"))?;
+
+    let valid = password::verify_password(plain_password, &record.password_hash)?;
+    if !valid {
+        bail!("invalid email or password");
+    }
+
+    debug!(user_id = %record.user_id, "password login successful");
+
+    let code = oauth2_server
+        .generate_auth_code(
+            &record.user_id,
+            client_id,
+            redirect_uri,
+            pkce_challenge,
+            vec![], // Full scopes resolved at token exchange from user's roles.
+        )
+        .await?;
+
+    Ok(code)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::collections::HashMap;
+
+    use assistant_core::identity::{Action, OrgId, ResourceKind, Role, Scope, SpaceId, UserId};
+
+    use crate::api_keys::InMemoryApiKeyStore;
+    use crate::jwt::JwtKeyPair;
+    use crate::oauth2::clients::{ClientRegistrar, InMemoryClientStore};
+    use crate::oauth2::device::{DeviceCodeManager, InMemoryDeviceCodeStore};
+    use crate::oauth2::server::{InMemoryAuthCodeStore, InMemoryRefreshTokenStore, OAuth2Server};
+
+    // -- In-memory password user store for tests --
+
+    struct TestUserStore {
+        users: Vec<PasswordUserRecord>,
+        contexts: HashMap<String, AuthContext>,
+    }
+
+    impl TestUserStore {
+        fn new() -> Self {
+            let password_hash = password::hash_password("secret123").unwrap();
+            let user_id = "usr_alice".to_string();
+
+            let mut space_roles = HashMap::new();
+            space_roles.insert(SpaceId::from("eng"), Role::Member);
+
+            let ctx = AuthContext {
+                user_id: UserId::from("usr_alice"),
+                org_id: OrgId::from("acme"),
+                email: "alice@acme.com".into(),
+                space_roles,
+                scopes: vec![
+                    Scope::new(ResourceKind::Personas, Action::Read),
+                    Scope::new(ResourceKind::Conversations, Action::Read),
+                    Scope::new(ResourceKind::Conversations, Action::Write),
+                ],
+                client_id: "webui".into(),
+            };
+
+            let mut contexts = HashMap::new();
+            contexts.insert(user_id.clone(), ctx);
+
+            Self {
+                users: vec![PasswordUserRecord {
+                    user_id,
+                    password_hash,
+                    org_slug: "acme".into(),
+                    display_name: "Alice".into(),
+                }],
+                contexts,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl PasswordUserStore for TestUserStore {
+        async fn find_by_email(&self, email: &str) -> Result<Option<PasswordUserRecord>> {
+            // Simplistic: map alice@acme.com → usr_alice.
+            if email == "alice@acme.com" {
+                Ok(self.users.first().cloned())
+            } else {
+                Ok(None)
+            }
+        }
+
+        async fn build_context(&self, user_id: &str) -> Result<AuthContext> {
+            self.contexts
+                .get(user_id)
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("user not found: {user_id}"))
+        }
+    }
+
+    fn make_test_infra() -> (
+        Arc<JwtManager>,
+        Arc<OAuth2Server>,
+        Arc<DeviceCodeManager>,
+        Arc<ClientRegistrar>,
+        Arc<InMemoryApiKeyStore>,
+        Arc<TestUserStore>,
+    ) {
+        let secret = b"test-secret-for-jwt-signing-32b!";
+        let kp = JwtKeyPair::from_secret(secret);
+        let jwt_manager = Arc::new(JwtManager::new(
+            kp,
+            "https://test.local".into(),
+            "https://test.local".into(),
+        ));
+
+        let oauth2_server = Arc::new(OAuth2Server::new(
+            Arc::new(InMemoryAuthCodeStore::default()),
+            Arc::new(InMemoryRefreshTokenStore::default()),
+        ));
+
+        let device_manager = Arc::new(DeviceCodeManager::new(
+            Arc::new(InMemoryDeviceCodeStore::default()),
+            "https://test.local/device".into(),
+        ));
+
+        let client_registrar = Arc::new(ClientRegistrar::new(Arc::new(
+            InMemoryClientStore::default(),
+        )));
+
+        let api_key_store = Arc::new(InMemoryApiKeyStore::new());
+        let user_store = Arc::new(TestUserStore::new());
+
+        (
+            jwt_manager,
+            oauth2_server,
+            device_manager,
+            client_registrar,
+            api_key_store,
+            user_store,
+        )
+    }
+
+    #[tokio::test]
+    async fn password_provider_authenticate_jwt() {
+        let (
+            jwt_manager,
+            oauth2_server,
+            device_manager,
+            client_registrar,
+            api_key_store,
+            user_store,
+        ) = make_test_infra();
+
+        let provider = PasswordAuthProvider::new(
+            jwt_manager.clone(),
+            oauth2_server,
+            device_manager,
+            client_registrar,
+            api_key_store,
+            user_store.clone(),
+        );
+
+        // Sign a token and authenticate.
+        let ctx = user_store.build_context("usr_alice").await.unwrap();
+        let token = jwt_manager.sign(&ctx, "acme", "Alice").unwrap();
+
+        let result = provider.authenticate(&token).await.unwrap();
+        assert_eq!(result.user_id, UserId::from("usr_alice"));
+    }
+
+    #[tokio::test]
+    async fn password_provider_authenticate_api_key() {
+        let (
+            jwt_manager,
+            oauth2_server,
+            device_manager,
+            client_registrar,
+            api_key_store,
+            user_store,
+        ) = make_test_infra();
+
+        // Store an API key.
+        let key = api_keys::generate_key();
+        let mut space_roles = HashMap::new();
+        space_roles.insert(SpaceId::from("eng"), Role::Member);
+        let record = api_keys::ApiKeyRecord {
+            id: "key_1".into(),
+            user_id: UserId::from("usr_alice"),
+            name: "Test".into(),
+            key_hash: key.key_hash.clone(),
+            key_prefix: key.key_prefix.clone(),
+            org_id: OrgId::from("acme"),
+            space_roles,
+            scopes: vec![Scope::new(ResourceKind::Personas, Action::Read)],
+            expires_at: None,
+            created_at: chrono::Utc::now(),
+        };
+        api_key_store.store_key(record).await.unwrap();
+
+        let provider = PasswordAuthProvider::new(
+            jwt_manager,
+            oauth2_server,
+            device_manager,
+            client_registrar,
+            api_key_store,
+            user_store,
+        );
+
+        let result = provider.authenticate(&key.plaintext).await.unwrap();
+        assert_eq!(result.user_id, UserId::from("usr_alice"));
+        assert_eq!(result.client_id, "api_key");
+    }
+
+    #[tokio::test]
+    async fn password_provider_authenticate_invalid() {
+        let (
+            jwt_manager,
+            oauth2_server,
+            device_manager,
+            client_registrar,
+            api_key_store,
+            user_store,
+        ) = make_test_infra();
+
+        let provider = PasswordAuthProvider::new(
+            jwt_manager,
+            oauth2_server,
+            device_manager,
+            client_registrar,
+            api_key_store,
+            user_store,
+        );
+
+        let err = provider.authenticate("invalid-token").await;
+        assert!(err.is_err());
+    }
+
+    #[tokio::test]
+    async fn password_provider_authorize_returns_login_required() {
+        let (
+            jwt_manager,
+            oauth2_server,
+            device_manager,
+            client_registrar,
+            api_key_store,
+            user_store,
+        ) = make_test_infra();
+
+        // Register a client first.
+        use assistant_core::auth::ClientRegistration;
+        client_registrar
+            .register(ClientRegistration {
+                client_name: "Test App".into(),
+                redirect_uris: vec!["http://localhost:4040/callback".into()],
+                grant_types: vec!["authorization_code".into()],
+                response_types: None,
+                token_endpoint_auth_method: None,
+            })
+            .await
+            .unwrap();
+
+        let clients = client_registrar.list().await.unwrap();
+        let client_id = clients[0].client_id.clone();
+
+        let provider = PasswordAuthProvider::new(
+            jwt_manager,
+            oauth2_server,
+            device_manager,
+            client_registrar,
+            api_key_store,
+            user_store,
+        );
+
+        let req = AuthorizeRequest {
+            client_id,
+            redirect_uri: "http://localhost:4040/callback".into(),
+            response_type: "code".into(),
+            scope: None,
+            state: Some("test-state".into()),
+            code_challenge: None,
+            code_challenge_method: None,
+        };
+
+        let resp = provider.authorize(req).await.unwrap();
+        match resp {
+            AuthorizeResponse::LoginRequired { state, .. } => {
+                assert_eq!(state.as_deref(), Some("test-state"));
+            }
+            other => panic!("expected LoginRequired, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn validate_password_login_success() {
+        let (_, oauth2_server, _, client_registrar, _, user_store) = make_test_infra();
+
+        // Register a client.
+        use assistant_core::auth::ClientRegistration;
+        client_registrar
+            .register(ClientRegistration {
+                client_name: "Test App".into(),
+                redirect_uris: vec!["http://localhost:4040/callback".into()],
+                grant_types: vec!["authorization_code".into()],
+                response_types: None,
+                token_endpoint_auth_method: None,
+            })
+            .await
+            .unwrap();
+
+        let clients = client_registrar.list().await.unwrap();
+        let client_id = &clients[0].client_id;
+
+        let code = validate_password_login(
+            "alice@acme.com",
+            "secret123",
+            client_id,
+            "http://localhost:4040/callback",
+            None,
+            user_store.as_ref(),
+            &oauth2_server,
+        )
+        .await
+        .unwrap();
+
+        assert!(!code.is_empty(), "auth code should be non-empty");
+    }
+
+    #[tokio::test]
+    async fn validate_password_login_wrong_password() {
+        let (_, oauth2_server, _, _, _, user_store) = make_test_infra();
+
+        let err = validate_password_login(
+            "alice@acme.com",
+            "wrong-password",
+            "client-1",
+            "http://localhost/cb",
+            None,
+            user_store.as_ref(),
+            &oauth2_server,
+        )
+        .await;
+
+        assert!(err.is_err());
+        let msg = format!("{:?}", err.unwrap_err());
+        assert!(msg.contains("invalid email or password"));
+    }
+
+    #[tokio::test]
+    async fn validate_password_login_unknown_email() {
+        let (_, oauth2_server, _, _, _, user_store) = make_test_infra();
+
+        let err = validate_password_login(
+            "unknown@acme.com",
+            "secret123",
+            "client-1",
+            "http://localhost/cb",
+            None,
+            user_store.as_ref(),
+            &oauth2_server,
+        )
+        .await;
+
+        assert!(err.is_err());
+    }
+}

--- a/openspec/changes/multi-user-orgs/tasks.md
+++ b/openspec/changes/multi-user-orgs/tasks.md
@@ -168,42 +168,42 @@ PR 10 ─── CLI OAuth2 login + Flutter OAuth2 + docs
 
 **Commits:**
 
-- [ ] `feat(auth): OIDC discovery and id_token validation`
+- [x] `feat(auth): OIDC discovery and id_token validation`
   - Create `crates/auth/src/oidc.rs`
   - Add `openidconnect` to crate deps
   - `OidcProvider::discover(issuer_url) -> Result<Self>` — fetch .well-known/openid-configuration
   - `validate_id_token(token: &str) -> Result<IdTokenClaims>` — verify signature, issuer, audience, expiry
   - `extract_user_info(claims: &IdTokenClaims) -> (sub, email, name)`
 
-- [ ] `feat(auth): OIDC user provisioning logic`
+- [x] `feat(auth): OIDC user provisioning logic`
   - Add to `crates/auth/src/oidc.rs`
   - `provision_or_lookup(idp_issuer, idp_subject, email, name) -> Result<UserId>` — find existing user by (issuer, subject) or create new one
   - Auto-provision setting (org-level): auto-create or require admin pre-approval
   - Email domain matching for org assignment
 
-- [ ] `test(auth): OIDC token validation with mocked provider (wiremock)`
+- [x] `test(auth): OIDC token validation with mocked provider (wiremock)`
 
-- [ ] `feat(auth): scoped API key generation and resolution`
+- [x] `feat(auth): scoped API key generation and resolution`
   - Create `crates/auth/src/api_keys.rs`
   - `generate_key(user_id, name, scopes, resource_restrictions, expires_at) -> (key_plaintext, key_hash, key_prefix)`
   - Key format: `ask_live_{32 random chars}` (prefix `ask_live_` for identification)
   - `resolve_key(key_plaintext) -> Result<AuthContext>` — hash, lookup, check expiry, build AuthContext from stored scopes
   - Constant-time comparison for key hash
 
-- [ ] `test(auth): API key generation, scoping, and resolution`
+- [x] `test(auth): API key generation, scoping, and resolution`
   - Create key with limited scopes → resolve → AuthContext has those scopes
   - Expired key → rejection
   - Resource restrictions honored
 
-- [ ] `feat(auth): Axum auth middleware extractors`
+- [x] `feat(auth): Axum auth middleware extractors`
   - Create `crates/auth/src/middleware.rs`
   - `AuthExtractor` implements `FromRequestParts`: checks `Authorization: Bearer <jwt>`, falls back to session cookie, falls back to API key prefix detection
   - Returns `AuthContext` or 401
   - `RequireScope(resource, action)` — Axum layer that checks `ctx.can()` after extraction
 
-- [ ] `test(auth): middleware extraction from various token types`
+- [x] `test(auth): middleware extraction from various token types`
 
-- [ ] `feat(auth): AuthProvider implementations (password + OIDC)`
+- [x] `feat(auth): AuthProvider implementations (password + OIDC)`
   - Implement `AuthProvider` trait in `crates/auth/src/lib.rs`
   - `PasswordAuthProvider`: delegates to password.rs + jwt.rs + oauth2/server.rs
   - `OidcAuthProvider`: delegates to oidc.rs + jwt.rs + oauth2/server.rs


### PR DESCRIPTION
## Summary

PR 4 of 10 in the multi-user-orgs change. Completes the `assistant-auth` crate with all authentication mechanisms as tested library code. No web-ui wiring yet.

- **OIDC federation** (`oidc.rs`): discovery document fetch, JWKS key retrieval, RS256/ES256 ID token validation, user provisioning (IdP lookup → email lookup → auto-create), email domain filtering
- **Scoped API keys** (`api_keys.rs`): `ask_live_` prefixed keys, SHA-256 hashing, expiry checking, per-resource-ID scope restrictions
- **Axum middleware** (`middleware.rs`): `AuthExtractor` (JWT → API key → legacy token fallback), `RequireScope` permission guard
- **AuthProvider implementations** (`providers.rs`): `PasswordAuthProvider` and `OidcAuthProvider` both implementing the core `AuthProvider` trait, issuing our own JWTs regardless of upstream identity source
- Adds `user_id` to `TokenPair` so providers can sign JWTs after auth code exchange
- Adds `client_id()` getter to `OidcProvider` for IdP redirect URLs

**94 tests passing** across all modules (15 OIDC, 12 API keys, 10 middleware, 7 providers, plus existing JWT/password/OAuth2 tests).

## Test plan

- [x] `cargo check -p assistant-auth` passes
- [x] `cargo test -p assistant-auth` — 94 tests pass
- [x] `cargo clippy -p assistant-auth -- -D warnings` — clean
- [x] `cargo fmt -p assistant-auth -- --check` — clean
- [x] Pre-commit hooks pass (clippy, machete, format, flutter tests)