### PR TITLE
feat(storage): org/space database layer with multi-tenant stores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,6 +668,7 @@ name = "assistant-storage"
 version = "0.1.135"
 dependencies = [
  "anyhow",
+ "assistant-auth",
  "assistant-core",
  "assistant-skills",
  "async-trait",

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod context;
 pub mod identity;
 pub mod llm;
 pub mod memory;
+pub mod store;
 pub mod subagent;
 pub mod text;
 pub mod tool;
@@ -42,6 +43,11 @@ pub use context::{
     validate_agent_id,
 };
 pub use identity::{Action, OrgId, ResourceKind, Role, Scope, SpaceId, UserId};
+// -- Multi-tenant stores --
+pub use store::{
+    InMemoryMembershipStore, InMemoryOrgStore, InMemorySpaceStore, InMemoryUserStore,
+    MembershipStore, OrgStore, Organization, Space, SpaceMembership, SpaceStore, User, UserStore,
+};
 // -- LLM abstractions (types, traits, streaming) --
 pub use llm::embedding::{EmbeddingProvider, LlmEmbedder, WithEmbeddingOverride};
 pub use llm::provider::{Capabilities, HostedTool, LlmProvider, ToolSupport};

--- a/crates/core/src/store.rs
+++ b/crates/core/src/store.rs
@@ -1,0 +1,805 @@
+//! Multi-tenant store traits and domain types.
+//!
+//! Defines backend-agnostic storage interfaces for organizations, users,
+//! spaces, and memberships. Implementations live in the `assistant-storage`
+//! crate (SQLite) or as in-memory stores for testing.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use anyhow::{Result, bail};
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::identity::{OrgId, Role, SpaceId, UserId};
+
+// ---------------------------------------------------------------------------
+// Domain types
+// ---------------------------------------------------------------------------
+
+/// An organization — the top-level multi-tenant namespace.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Organization {
+    pub id: OrgId,
+    pub name: String,
+    pub slug: String,
+    /// `"password"` or `"oidc"`.
+    pub auth_mode: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// A user account within an organization.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct User {
+    pub id: UserId,
+    pub org_id: OrgId,
+    pub email: String,
+    pub name: String,
+    /// Argon2id hash. Empty for OIDC-only users.
+    #[serde(skip_serializing)]
+    pub password_hash: String,
+    /// OIDC identity provider issuer URL (if federated).
+    pub idp_issuer: Option<String>,
+    /// OIDC subject claim (unique ID at the IdP).
+    pub idp_subject: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// A space — a workspace within an organization.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Space {
+    pub id: SpaceId,
+    pub org_id: OrgId,
+    pub name: String,
+    pub slug: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// A user's membership in a space.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SpaceMembership {
+    pub user_id: UserId,
+    pub space_id: SpaceId,
+    pub role: Role,
+    pub created_at: DateTime<Utc>,
+}
+
+// ---------------------------------------------------------------------------
+// Store traits
+// ---------------------------------------------------------------------------
+
+/// Organization CRUD operations.
+#[async_trait]
+pub trait OrgStore: Send + Sync {
+    async fn create_org(&self, org: &Organization) -> Result<()>;
+    async fn get_org(&self, id: &OrgId) -> Result<Option<Organization>>;
+    async fn get_org_by_slug(&self, slug: &str) -> Result<Option<Organization>>;
+    async fn update_org(&self, org: &Organization) -> Result<()>;
+    async fn list_orgs(&self) -> Result<Vec<Organization>>;
+}
+
+/// User CRUD operations.
+#[async_trait]
+pub trait UserStore: Send + Sync {
+    async fn create_user(&self, user: &User) -> Result<()>;
+    async fn get_user(&self, id: &UserId) -> Result<Option<User>>;
+    async fn get_user_by_email(&self, org_id: &OrgId, email: &str) -> Result<Option<User>>;
+    async fn get_user_by_idp(&self, issuer: &str, subject: &str) -> Result<Option<User>>;
+    async fn list_users(&self, org_id: &OrgId) -> Result<Vec<User>>;
+    async fn update_user(&self, user: &User) -> Result<()>;
+    async fn delete_user(&self, id: &UserId) -> Result<bool>;
+}
+
+/// Space CRUD operations.
+#[async_trait]
+pub trait SpaceStore: Send + Sync {
+    async fn create_space(&self, space: &Space) -> Result<()>;
+    async fn get_space(&self, id: &SpaceId) -> Result<Option<Space>>;
+    async fn list_spaces(&self, org_id: &OrgId) -> Result<Vec<Space>>;
+    async fn delete_space(&self, id: &SpaceId) -> Result<bool>;
+}
+
+/// Space membership operations.
+#[async_trait]
+pub trait MembershipStore: Send + Sync {
+    async fn add_membership(&self, membership: &SpaceMembership) -> Result<()>;
+    async fn remove_membership(&self, user_id: &UserId, space_id: &SpaceId) -> Result<bool>;
+    async fn get_memberships_for_user(&self, user_id: &UserId) -> Result<Vec<SpaceMembership>>;
+    async fn get_members_of_space(&self, space_id: &SpaceId) -> Result<Vec<SpaceMembership>>;
+    /// Build a `HashMap<SpaceId, Role>` for use in [`AuthContext`](crate::auth::AuthContext).
+    async fn get_space_roles(&self, user_id: &UserId) -> Result<HashMap<SpaceId, Role>> {
+        let memberships = self.get_memberships_for_user(user_id).await?;
+        Ok(memberships
+            .into_iter()
+            .map(|m| (m.space_id, m.role))
+            .collect())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// In-memory implementations (for tests and single-process deployments)
+// ---------------------------------------------------------------------------
+
+/// In-memory organization store.
+#[derive(Default)]
+pub struct InMemoryOrgStore {
+    orgs: Mutex<Vec<Organization>>,
+}
+
+#[async_trait]
+impl OrgStore for InMemoryOrgStore {
+    async fn create_org(&self, org: &Organization) -> Result<()> {
+        let mut orgs = self.orgs.lock().unwrap();
+        if orgs.iter().any(|o| o.id == org.id) {
+            bail!("organization already exists: {}", org.id);
+        }
+        if orgs.iter().any(|o| o.slug == org.slug) {
+            bail!("organization slug already taken: {}", org.slug);
+        }
+        orgs.push(org.clone());
+        Ok(())
+    }
+
+    async fn get_org(&self, id: &OrgId) -> Result<Option<Organization>> {
+        Ok(self
+            .orgs
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|o| o.id == *id)
+            .cloned())
+    }
+
+    async fn get_org_by_slug(&self, slug: &str) -> Result<Option<Organization>> {
+        Ok(self
+            .orgs
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|o| o.slug == slug)
+            .cloned())
+    }
+
+    async fn update_org(&self, org: &Organization) -> Result<()> {
+        let mut orgs = self.orgs.lock().unwrap();
+        if let Some(existing) = orgs.iter_mut().find(|o| o.id == org.id) {
+            *existing = org.clone();
+            Ok(())
+        } else {
+            bail!("organization not found: {}", org.id)
+        }
+    }
+
+    async fn list_orgs(&self) -> Result<Vec<Organization>> {
+        Ok(self.orgs.lock().unwrap().clone())
+    }
+}
+
+/// In-memory user store.
+#[derive(Default)]
+pub struct InMemoryUserStore {
+    users: Mutex<Vec<User>>,
+}
+
+#[async_trait]
+impl UserStore for InMemoryUserStore {
+    async fn create_user(&self, user: &User) -> Result<()> {
+        let mut users = self.users.lock().unwrap();
+        if users.iter().any(|u| u.id == user.id) {
+            bail!("user already exists: {}", user.id);
+        }
+        if users
+            .iter()
+            .any(|u| u.org_id == user.org_id && u.email == user.email)
+        {
+            bail!("email already registered in org: {}", user.email);
+        }
+        users.push(user.clone());
+        Ok(())
+    }
+
+    async fn get_user(&self, id: &UserId) -> Result<Option<User>> {
+        Ok(self
+            .users
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|u| u.id == *id)
+            .cloned())
+    }
+
+    async fn get_user_by_email(&self, org_id: &OrgId, email: &str) -> Result<Option<User>> {
+        Ok(self
+            .users
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|u| u.org_id == *org_id && u.email == email)
+            .cloned())
+    }
+
+    async fn get_user_by_idp(&self, issuer: &str, subject: &str) -> Result<Option<User>> {
+        Ok(self
+            .users
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|u| {
+                u.idp_issuer.as_deref() == Some(issuer) && u.idp_subject.as_deref() == Some(subject)
+            })
+            .cloned())
+    }
+
+    async fn list_users(&self, org_id: &OrgId) -> Result<Vec<User>> {
+        Ok(self
+            .users
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|u| u.org_id == *org_id)
+            .cloned()
+            .collect())
+    }
+
+    async fn update_user(&self, user: &User) -> Result<()> {
+        let mut users = self.users.lock().unwrap();
+        if let Some(existing) = users.iter_mut().find(|u| u.id == user.id) {
+            *existing = user.clone();
+            Ok(())
+        } else {
+            bail!("user not found: {}", user.id)
+        }
+    }
+
+    async fn delete_user(&self, id: &UserId) -> Result<bool> {
+        let mut users = self.users.lock().unwrap();
+        let len_before = users.len();
+        users.retain(|u| u.id != *id);
+        Ok(users.len() < len_before)
+    }
+}
+
+/// In-memory space store.
+#[derive(Default)]
+pub struct InMemorySpaceStore {
+    spaces: Mutex<Vec<Space>>,
+}
+
+#[async_trait]
+impl SpaceStore for InMemorySpaceStore {
+    async fn create_space(&self, space: &Space) -> Result<()> {
+        let mut spaces = self.spaces.lock().unwrap();
+        if spaces.iter().any(|s| s.id == space.id) {
+            bail!("space already exists: {}", space.id);
+        }
+        spaces.push(space.clone());
+        Ok(())
+    }
+
+    async fn get_space(&self, id: &SpaceId) -> Result<Option<Space>> {
+        Ok(self
+            .spaces
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|s| s.id == *id)
+            .cloned())
+    }
+
+    async fn list_spaces(&self, org_id: &OrgId) -> Result<Vec<Space>> {
+        Ok(self
+            .spaces
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|s| s.org_id == *org_id)
+            .cloned()
+            .collect())
+    }
+
+    async fn delete_space(&self, id: &SpaceId) -> Result<bool> {
+        let mut spaces = self.spaces.lock().unwrap();
+        let len_before = spaces.len();
+        spaces.retain(|s| s.id != *id);
+        Ok(spaces.len() < len_before)
+    }
+}
+
+/// In-memory membership store.
+#[derive(Default)]
+pub struct InMemoryMembershipStore {
+    memberships: Mutex<Vec<SpaceMembership>>,
+}
+
+#[async_trait]
+impl MembershipStore for InMemoryMembershipStore {
+    async fn add_membership(&self, membership: &SpaceMembership) -> Result<()> {
+        let mut memberships = self.memberships.lock().unwrap();
+        if memberships
+            .iter()
+            .any(|m| m.user_id == membership.user_id && m.space_id == membership.space_id)
+        {
+            bail!(
+                "membership already exists: user {} in space {}",
+                membership.user_id,
+                membership.space_id
+            );
+        }
+        memberships.push(membership.clone());
+        Ok(())
+    }
+
+    async fn remove_membership(&self, user_id: &UserId, space_id: &SpaceId) -> Result<bool> {
+        let mut memberships = self.memberships.lock().unwrap();
+        let len_before = memberships.len();
+        memberships.retain(|m| !(m.user_id == *user_id && m.space_id == *space_id));
+        Ok(memberships.len() < len_before)
+    }
+
+    async fn get_memberships_for_user(&self, user_id: &UserId) -> Result<Vec<SpaceMembership>> {
+        Ok(self
+            .memberships
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|m| m.user_id == *user_id)
+            .cloned()
+            .collect())
+    }
+
+    async fn get_members_of_space(&self, space_id: &SpaceId) -> Result<Vec<SpaceMembership>> {
+        Ok(self
+            .memberships
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|m| m.space_id == *space_id)
+            .cloned()
+            .collect())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn now() -> DateTime<Utc> {
+        Utc::now()
+    }
+
+    fn make_org(id: &str, slug: &str) -> Organization {
+        Organization {
+            id: OrgId::from(id),
+            name: format!("{slug} Inc."),
+            slug: slug.into(),
+            auth_mode: "password".into(),
+            created_at: now(),
+            updated_at: now(),
+        }
+    }
+
+    fn make_user(id: &str, org_id: &str, email: &str) -> User {
+        User {
+            id: UserId::from(id),
+            org_id: OrgId::from(org_id),
+            email: email.into(),
+            name: id.into(),
+            password_hash: String::new(),
+            idp_issuer: None,
+            idp_subject: None,
+            created_at: now(),
+            updated_at: now(),
+        }
+    }
+
+    fn make_space(id: &str, org_id: &str, slug: &str) -> Space {
+        Space {
+            id: SpaceId::from(id),
+            org_id: OrgId::from(org_id),
+            name: format!("{slug} space"),
+            slug: slug.into(),
+            created_at: now(),
+            updated_at: now(),
+        }
+    }
+
+    fn make_membership(user_id: &str, space_id: &str, role: Role) -> SpaceMembership {
+        SpaceMembership {
+            user_id: UserId::from(user_id),
+            space_id: SpaceId::from(space_id),
+            role,
+            created_at: now(),
+        }
+    }
+
+    // -- OrgStore --
+
+    #[tokio::test]
+    async fn org_create_and_get() {
+        let store = InMemoryOrgStore::default();
+        let org = make_org("org_1", "acme");
+        store.create_org(&org).await.unwrap();
+
+        let found = store.get_org(&OrgId::from("org_1")).await.unwrap();
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().slug, "acme");
+    }
+
+    #[tokio::test]
+    async fn org_get_by_slug() {
+        let store = InMemoryOrgStore::default();
+        store.create_org(&make_org("org_1", "acme")).await.unwrap();
+
+        let found = store.get_org_by_slug("acme").await.unwrap();
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().id, OrgId::from("org_1"));
+
+        let missing = store.get_org_by_slug("nope").await.unwrap();
+        assert!(missing.is_none());
+    }
+
+    #[tokio::test]
+    async fn org_duplicate_id_rejected() {
+        let store = InMemoryOrgStore::default();
+        store.create_org(&make_org("org_1", "acme")).await.unwrap();
+        let err = store.create_org(&make_org("org_1", "other")).await;
+        assert!(err.is_err());
+    }
+
+    #[tokio::test]
+    async fn org_duplicate_slug_rejected() {
+        let store = InMemoryOrgStore::default();
+        store.create_org(&make_org("org_1", "acme")).await.unwrap();
+        let err = store.create_org(&make_org("org_2", "acme")).await;
+        assert!(err.is_err());
+    }
+
+    #[tokio::test]
+    async fn org_update() {
+        let store = InMemoryOrgStore::default();
+        let mut org = make_org("org_1", "acme");
+        store.create_org(&org).await.unwrap();
+
+        org.name = "Acme Corp".into();
+        store.update_org(&org).await.unwrap();
+
+        let found = store.get_org(&OrgId::from("org_1")).await.unwrap().unwrap();
+        assert_eq!(found.name, "Acme Corp");
+    }
+
+    #[tokio::test]
+    async fn org_list() {
+        let store = InMemoryOrgStore::default();
+        store.create_org(&make_org("org_1", "acme")).await.unwrap();
+        store
+            .create_org(&make_org("org_2", "globex"))
+            .await
+            .unwrap();
+
+        let all = store.list_orgs().await.unwrap();
+        assert_eq!(all.len(), 2);
+    }
+
+    // -- UserStore --
+
+    #[tokio::test]
+    async fn user_create_and_get() {
+        let store = InMemoryUserStore::default();
+        let user = make_user("usr_alice", "org_1", "alice@acme.com");
+        store.create_user(&user).await.unwrap();
+
+        let found = store.get_user(&UserId::from("usr_alice")).await.unwrap();
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().email, "alice@acme.com");
+    }
+
+    #[tokio::test]
+    async fn user_get_by_email() {
+        let store = InMemoryUserStore::default();
+        store
+            .create_user(&make_user("usr_alice", "org_1", "alice@acme.com"))
+            .await
+            .unwrap();
+
+        let found = store
+            .get_user_by_email(&OrgId::from("org_1"), "alice@acme.com")
+            .await
+            .unwrap();
+        assert!(found.is_some());
+
+        // Different org, same email → not found.
+        let not_found = store
+            .get_user_by_email(&OrgId::from("org_2"), "alice@acme.com")
+            .await
+            .unwrap();
+        assert!(not_found.is_none());
+    }
+
+    #[tokio::test]
+    async fn user_get_by_idp() {
+        let store = InMemoryUserStore::default();
+        let mut user = make_user("usr_alice", "org_1", "alice@acme.com");
+        user.idp_issuer = Some("https://idp.acme.com".into());
+        user.idp_subject = Some("sub_12345".into());
+        store.create_user(&user).await.unwrap();
+
+        let found = store
+            .get_user_by_idp("https://idp.acme.com", "sub_12345")
+            .await
+            .unwrap();
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().id, UserId::from("usr_alice"));
+
+        let not_found = store
+            .get_user_by_idp("https://idp.acme.com", "sub_99999")
+            .await
+            .unwrap();
+        assert!(not_found.is_none());
+    }
+
+    #[tokio::test]
+    async fn user_duplicate_email_in_same_org_rejected() {
+        let store = InMemoryUserStore::default();
+        store
+            .create_user(&make_user("usr_1", "org_1", "alice@acme.com"))
+            .await
+            .unwrap();
+        let err = store
+            .create_user(&make_user("usr_2", "org_1", "alice@acme.com"))
+            .await;
+        assert!(err.is_err());
+    }
+
+    #[tokio::test]
+    async fn user_same_email_different_orgs_allowed() {
+        let store = InMemoryUserStore::default();
+        store
+            .create_user(&make_user("usr_1", "org_1", "alice@acme.com"))
+            .await
+            .unwrap();
+        store
+            .create_user(&make_user("usr_2", "org_2", "alice@acme.com"))
+            .await
+            .unwrap();
+
+        let org1_users = store.list_users(&OrgId::from("org_1")).await.unwrap();
+        assert_eq!(org1_users.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn user_update() {
+        let store = InMemoryUserStore::default();
+        let mut user = make_user("usr_alice", "org_1", "alice@acme.com");
+        store.create_user(&user).await.unwrap();
+
+        user.name = "Alice Smith".into();
+        store.update_user(&user).await.unwrap();
+
+        let found = store
+            .get_user(&UserId::from("usr_alice"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(found.name, "Alice Smith");
+    }
+
+    #[tokio::test]
+    async fn user_delete() {
+        let store = InMemoryUserStore::default();
+        store
+            .create_user(&make_user("usr_alice", "org_1", "alice@acme.com"))
+            .await
+            .unwrap();
+
+        let deleted = store.delete_user(&UserId::from("usr_alice")).await.unwrap();
+        assert!(deleted);
+
+        let found = store.get_user(&UserId::from("usr_alice")).await.unwrap();
+        assert!(found.is_none());
+
+        // Deleting again returns false.
+        let not_deleted = store.delete_user(&UserId::from("usr_alice")).await.unwrap();
+        assert!(!not_deleted);
+    }
+
+    #[tokio::test]
+    async fn user_list_by_org() {
+        let store = InMemoryUserStore::default();
+        store
+            .create_user(&make_user("usr_1", "org_1", "alice@acme.com"))
+            .await
+            .unwrap();
+        store
+            .create_user(&make_user("usr_2", "org_1", "bob@acme.com"))
+            .await
+            .unwrap();
+        store
+            .create_user(&make_user("usr_3", "org_2", "carol@globex.com"))
+            .await
+            .unwrap();
+
+        let org1 = store.list_users(&OrgId::from("org_1")).await.unwrap();
+        assert_eq!(org1.len(), 2);
+        let org2 = store.list_users(&OrgId::from("org_2")).await.unwrap();
+        assert_eq!(org2.len(), 1);
+    }
+
+    // -- SpaceStore --
+
+    #[tokio::test]
+    async fn space_create_and_get() {
+        let store = InMemorySpaceStore::default();
+        let space = make_space("sp_eng", "org_1", "engineering");
+        store.create_space(&space).await.unwrap();
+
+        let found = store.get_space(&SpaceId::from("sp_eng")).await.unwrap();
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().slug, "engineering");
+    }
+
+    #[tokio::test]
+    async fn space_duplicate_id_rejected() {
+        let store = InMemorySpaceStore::default();
+        store
+            .create_space(&make_space("sp_eng", "org_1", "engineering"))
+            .await
+            .unwrap();
+        let err = store
+            .create_space(&make_space("sp_eng", "org_1", "other"))
+            .await;
+        assert!(err.is_err());
+    }
+
+    #[tokio::test]
+    async fn space_list_by_org() {
+        let store = InMemorySpaceStore::default();
+        store
+            .create_space(&make_space("sp_eng", "org_1", "engineering"))
+            .await
+            .unwrap();
+        store
+            .create_space(&make_space("sp_mktg", "org_1", "marketing"))
+            .await
+            .unwrap();
+        store
+            .create_space(&make_space("sp_dev", "org_2", "dev"))
+            .await
+            .unwrap();
+
+        let org1 = store.list_spaces(&OrgId::from("org_1")).await.unwrap();
+        assert_eq!(org1.len(), 2);
+        let org2 = store.list_spaces(&OrgId::from("org_2")).await.unwrap();
+        assert_eq!(org2.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn space_delete() {
+        let store = InMemorySpaceStore::default();
+        store
+            .create_space(&make_space("sp_eng", "org_1", "engineering"))
+            .await
+            .unwrap();
+
+        let deleted = store.delete_space(&SpaceId::from("sp_eng")).await.unwrap();
+        assert!(deleted);
+
+        let found = store.get_space(&SpaceId::from("sp_eng")).await.unwrap();
+        assert!(found.is_none());
+    }
+
+    // -- MembershipStore --
+
+    #[tokio::test]
+    async fn membership_add_and_query() {
+        let store = InMemoryMembershipStore::default();
+        store
+            .add_membership(&make_membership("usr_alice", "sp_eng", Role::Member))
+            .await
+            .unwrap();
+        store
+            .add_membership(&make_membership("usr_alice", "sp_mktg", Role::Viewer))
+            .await
+            .unwrap();
+
+        let alice = store
+            .get_memberships_for_user(&UserId::from("usr_alice"))
+            .await
+            .unwrap();
+        assert_eq!(alice.len(), 2);
+
+        let eng = store
+            .get_members_of_space(&SpaceId::from("sp_eng"))
+            .await
+            .unwrap();
+        assert_eq!(eng.len(), 1);
+        assert_eq!(eng[0].role, Role::Member);
+    }
+
+    #[tokio::test]
+    async fn membership_duplicate_rejected() {
+        let store = InMemoryMembershipStore::default();
+        store
+            .add_membership(&make_membership("usr_alice", "sp_eng", Role::Member))
+            .await
+            .unwrap();
+        let err = store
+            .add_membership(&make_membership("usr_alice", "sp_eng", Role::Viewer))
+            .await;
+        assert!(err.is_err());
+    }
+
+    #[tokio::test]
+    async fn membership_remove() {
+        let store = InMemoryMembershipStore::default();
+        store
+            .add_membership(&make_membership("usr_alice", "sp_eng", Role::Member))
+            .await
+            .unwrap();
+
+        let removed = store
+            .remove_membership(&UserId::from("usr_alice"), &SpaceId::from("sp_eng"))
+            .await
+            .unwrap();
+        assert!(removed);
+
+        let alice = store
+            .get_memberships_for_user(&UserId::from("usr_alice"))
+            .await
+            .unwrap();
+        assert!(alice.is_empty());
+    }
+
+    #[tokio::test]
+    async fn membership_space_roles_helper() {
+        let store = InMemoryMembershipStore::default();
+        store
+            .add_membership(&make_membership("usr_alice", "sp_eng", Role::Member))
+            .await
+            .unwrap();
+        store
+            .add_membership(&make_membership("usr_alice", "sp_mktg", Role::SpaceAdmin))
+            .await
+            .unwrap();
+
+        let roles = store
+            .get_space_roles(&UserId::from("usr_alice"))
+            .await
+            .unwrap();
+        assert_eq!(roles.get(&SpaceId::from("sp_eng")), Some(&Role::Member));
+        assert_eq!(
+            roles.get(&SpaceId::from("sp_mktg")),
+            Some(&Role::SpaceAdmin)
+        );
+    }
+
+    #[tokio::test]
+    async fn membership_multiple_users_in_space() {
+        let store = InMemoryMembershipStore::default();
+        store
+            .add_membership(&make_membership("usr_alice", "sp_eng", Role::SpaceAdmin))
+            .await
+            .unwrap();
+        store
+            .add_membership(&make_membership("usr_bob", "sp_eng", Role::Member))
+            .await
+            .unwrap();
+        store
+            .add_membership(&make_membership("usr_carol", "sp_eng", Role::Viewer))
+            .await
+            .unwrap();
+
+        let members = store
+            .get_members_of_space(&SpaceId::from("sp_eng"))
+            .await
+            .unwrap();
+        assert_eq!(members.len(), 3);
+    }
+}

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -7,6 +7,7 @@ description = "SQLite-backed storage layer: skill registry, traces, memory, and 
 
 [dependencies]
 assistant-core = { path = "../core" }
+assistant-auth = { path = "../auth" }
 assistant-skills = { path = "../skills" }
 tokio = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/storage/src/auth_state_store.rs
+++ b/crates/storage/src/auth_state_store.rs
@@ -1,0 +1,598 @@
+//! SQLite-backed implementations of the auth crate's store traits.
+//!
+//! Bridges [`ClientStore`], [`AuthCodeStore`], [`RefreshTokenStore`], and
+//! [`DeviceCodeStore`] to the `oauth_clients`, `auth_codes`, `refresh_tokens`,
+//! and `device_codes` tables in org.db.
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use sqlx::{Row, SqlitePool};
+
+use assistant_auth::oauth2::clients::ClientStore;
+use assistant_auth::oauth2::device::{DeviceCodeStore, DeviceState};
+use assistant_auth::oauth2::server::{
+    AuthCode, AuthCodeStore, RefreshTokenStore, StoredRefreshToken,
+};
+use assistant_core::auth::ClientInfo;
+
+// ---------------------------------------------------------------------------
+// JSON helpers
+// ---------------------------------------------------------------------------
+
+fn to_json(v: &[String]) -> String {
+    serde_json::to_string(v).unwrap_or_else(|_| "[]".into())
+}
+
+fn from_json(s: &str) -> Vec<String> {
+    serde_json::from_str(s).unwrap_or_default()
+}
+
+// ---------------------------------------------------------------------------
+// SqliteClientStore
+// ---------------------------------------------------------------------------
+
+/// SQLite-backed OAuth2 client store.
+pub struct SqliteClientStore {
+    pool: SqlitePool,
+}
+
+impl SqliteClientStore {
+    pub fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl ClientStore for SqliteClientStore {
+    async fn register(&self, info: ClientInfo) -> Result<()> {
+        sqlx::query(
+            "INSERT INTO oauth_clients (client_id, client_name, client_secret_hash, redirect_uris_json, grant_types_json, token_endpoint_auth_method)
+             VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&info.client_id)
+        .bind(&info.client_name)
+        .bind(&info.client_secret)
+        .bind(to_json(&info.redirect_uris))
+        .bind(to_json(&info.grant_types))
+        .bind(&info.token_endpoint_auth_method)
+        .execute(&self.pool)
+        .await
+        .with_context(|| format!("registering OAuth client: {}", info.client_id))?;
+        Ok(())
+    }
+
+    async fn get(&self, client_id: &str) -> Result<Option<ClientInfo>> {
+        let row = sqlx::query(
+            "SELECT client_id, client_name, client_secret_hash, redirect_uris_json, grant_types_json, token_endpoint_auth_method
+             FROM oauth_clients WHERE client_id = ?",
+        )
+        .bind(client_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row.map(|r| ClientInfo {
+            client_id: r.get("client_id"),
+            client_name: r.get("client_name"),
+            client_secret: r.get("client_secret_hash"),
+            redirect_uris: from_json(r.get("redirect_uris_json")),
+            grant_types: from_json(r.get("grant_types_json")),
+            token_endpoint_auth_method: r.get("token_endpoint_auth_method"),
+        }))
+    }
+
+    async fn list(&self) -> Result<Vec<ClientInfo>> {
+        let rows = sqlx::query(
+            "SELECT client_id, client_name, client_secret_hash, redirect_uris_json, grant_types_json, token_endpoint_auth_method
+             FROM oauth_clients ORDER BY created_at",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|r| ClientInfo {
+                client_id: r.get("client_id"),
+                client_name: r.get("client_name"),
+                client_secret: r.get("client_secret_hash"),
+                redirect_uris: from_json(r.get("redirect_uris_json")),
+                grant_types: from_json(r.get("grant_types_json")),
+                token_endpoint_auth_method: r.get("token_endpoint_auth_method"),
+            })
+            .collect())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SqliteAuthCodeStore
+// ---------------------------------------------------------------------------
+
+/// SQLite-backed authorization code store.
+pub struct SqliteAuthCodeStore {
+    pool: SqlitePool,
+}
+
+impl SqliteAuthCodeStore {
+    pub fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl AuthCodeStore for SqliteAuthCodeStore {
+    async fn store_code(&self, code: AuthCode) -> Result<()> {
+        sqlx::query(
+            "INSERT INTO auth_codes (code_hash, user_id, client_id, redirect_uri, pkce_challenge, scopes_json, expires_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&code.code)
+        .bind(&code.user_id)
+        .bind(&code.client_id)
+        .bind(&code.redirect_uri)
+        .bind(&code.pkce_challenge)
+        .bind(to_json(&code.scopes))
+        .bind(code.expires_at)
+        .execute(&self.pool)
+        .await
+        .with_context(|| "storing auth code")?;
+        Ok(())
+    }
+
+    async fn take_code(&self, code: &str) -> Result<Option<AuthCode>> {
+        // Single-use: fetch then delete in a transaction-like sequence.
+        let row = sqlx::query(
+            "SELECT code_hash, user_id, client_id, redirect_uri, pkce_challenge, scopes_json, expires_at
+             FROM auth_codes WHERE code_hash = ?",
+        )
+        .bind(code)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        let Some(row) = row else {
+            return Ok(None);
+        };
+
+        // Delete immediately (single-use).
+        sqlx::query("DELETE FROM auth_codes WHERE code_hash = ?")
+            .bind(code)
+            .execute(&self.pool)
+            .await?;
+
+        Ok(Some(AuthCode {
+            code: row.get("code_hash"),
+            user_id: row.get("user_id"),
+            client_id: row.get("client_id"),
+            redirect_uri: row.get("redirect_uri"),
+            pkce_challenge: row.get("pkce_challenge"),
+            scopes: from_json(row.get("scopes_json")),
+            expires_at: row.get("expires_at"),
+        }))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SqliteRefreshTokenStore
+// ---------------------------------------------------------------------------
+
+/// SQLite-backed refresh token store.
+pub struct SqliteRefreshTokenStore {
+    pool: SqlitePool,
+}
+
+impl SqliteRefreshTokenStore {
+    pub fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl RefreshTokenStore for SqliteRefreshTokenStore {
+    async fn store_token(&self, token: StoredRefreshToken) -> Result<()> {
+        sqlx::query(
+            "INSERT INTO refresh_tokens (token_hash, user_id, client_id, scopes_json, expires_at, consumed)
+             VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&token.token)
+        .bind(&token.user_id)
+        .bind(&token.client_id)
+        .bind(to_json(&token.scopes))
+        .bind(token.expires_at)
+        .bind(token.consumed as i32)
+        .execute(&self.pool)
+        .await
+        .with_context(|| "storing refresh token")?;
+        Ok(())
+    }
+
+    async fn get_token(&self, token: &str) -> Result<Option<StoredRefreshToken>> {
+        let row = sqlx::query(
+            "SELECT token_hash, user_id, client_id, scopes_json, expires_at, consumed
+             FROM refresh_tokens WHERE token_hash = ?",
+        )
+        .bind(token)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row.map(|r| {
+            let consumed: i32 = r.get("consumed");
+            StoredRefreshToken {
+                token: r.get("token_hash"),
+                user_id: r.get("user_id"),
+                client_id: r.get("client_id"),
+                scopes: from_json(r.get("scopes_json")),
+                expires_at: r.get("expires_at"),
+                consumed: consumed != 0,
+            }
+        }))
+    }
+
+    async fn consume_token(&self, token: &str) -> Result<()> {
+        sqlx::query("UPDATE refresh_tokens SET consumed = 1 WHERE token_hash = ?")
+            .bind(token)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    async fn revoke_all(&self, user_id: &str, client_id: &str) -> Result<()> {
+        sqlx::query("DELETE FROM refresh_tokens WHERE user_id = ? AND client_id = ?")
+            .bind(user_id)
+            .bind(client_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SqliteDeviceCodeStore
+// ---------------------------------------------------------------------------
+
+/// SQLite-backed device code store.
+pub struct SqliteDeviceCodeStore {
+    pool: SqlitePool,
+}
+
+impl SqliteDeviceCodeStore {
+    pub fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl DeviceCodeStore for SqliteDeviceCodeStore {
+    async fn store(&self, device_code: &str, state: DeviceState) -> Result<()> {
+        sqlx::query(
+            "INSERT INTO device_codes (device_code_hash, user_code, client_id, scopes_json, authorized_user, expires_at)
+             VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind(device_code)
+        .bind(&state.user_code)
+        .bind(&state.client_id)
+        .bind(to_json(&state.scopes))
+        .bind(&state.authorized_user)
+        .bind(state.expires_at)
+        .execute(&self.pool)
+        .await
+        .with_context(|| "storing device code")?;
+        Ok(())
+    }
+
+    async fn get_by_device_code(&self, device_code: &str) -> Result<Option<DeviceState>> {
+        let row = sqlx::query(
+            "SELECT device_code_hash, user_code, client_id, scopes_json, authorized_user, expires_at
+             FROM device_codes WHERE device_code_hash = ?",
+        )
+        .bind(device_code)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row.map(row_to_device_state))
+    }
+
+    async fn get_by_user_code(&self, user_code: &str) -> Result<Option<DeviceState>> {
+        let row = sqlx::query(
+            "SELECT device_code_hash, user_code, client_id, scopes_json, authorized_user, expires_at
+             FROM device_codes WHERE user_code = ?",
+        )
+        .bind(user_code)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row.map(row_to_device_state))
+    }
+
+    async fn update(&self, device_code: &str, state: DeviceState) -> Result<()> {
+        sqlx::query(
+            "UPDATE device_codes SET user_code = ?, client_id = ?, scopes_json = ?, authorized_user = ?, expires_at = ?
+             WHERE device_code_hash = ?",
+        )
+        .bind(&state.user_code)
+        .bind(&state.client_id)
+        .bind(to_json(&state.scopes))
+        .bind(&state.authorized_user)
+        .bind(state.expires_at)
+        .bind(device_code)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn remove(&self, device_code: &str) -> Result<()> {
+        sqlx::query("DELETE FROM device_codes WHERE device_code_hash = ?")
+            .bind(device_code)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+}
+
+fn row_to_device_state(r: sqlx::sqlite::SqliteRow) -> DeviceState {
+    DeviceState {
+        device_code: r.get("device_code_hash"),
+        user_code: r.get("user_code"),
+        client_id: r.get("client_id"),
+        scopes: from_json(r.get("scopes_json")),
+        expires_at: r.get("expires_at"),
+        authorized_user: r.get("authorized_user"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::org_storage::OrgStorageLayer;
+    use chrono::{Duration, Utc};
+
+    async fn setup() -> OrgStorageLayer {
+        OrgStorageLayer::new_in_memory().await.unwrap()
+    }
+
+    // -- ClientStore --
+
+    #[tokio::test]
+    async fn client_register_and_get() {
+        let layer = setup().await;
+        let store = layer.client_store();
+
+        let info = ClientInfo {
+            client_id: "cli_app".into(),
+            client_name: "CLI App".into(),
+            client_secret: None,
+            redirect_uris: vec!["http://localhost:8080/callback".into()],
+            grant_types: vec!["authorization_code".into()],
+            token_endpoint_auth_method: "none".into(),
+        };
+        store.register(info).await.unwrap();
+
+        let found = store.get("cli_app").await.unwrap();
+        assert!(found.is_some());
+        let found = found.unwrap();
+        assert_eq!(found.client_name, "CLI App");
+        assert_eq!(found.redirect_uris, vec!["http://localhost:8080/callback"]);
+    }
+
+    #[tokio::test]
+    async fn client_list() {
+        let layer = setup().await;
+        let store = layer.client_store();
+
+        store
+            .register(ClientInfo {
+                client_id: "app_1".into(),
+                client_name: "App 1".into(),
+                client_secret: None,
+                redirect_uris: vec![],
+                grant_types: vec![],
+                token_endpoint_auth_method: "none".into(),
+            })
+            .await
+            .unwrap();
+        store
+            .register(ClientInfo {
+                client_id: "app_2".into(),
+                client_name: "App 2".into(),
+                client_secret: Some("secret".into()),
+                redirect_uris: vec![],
+                grant_types: vec![],
+                token_endpoint_auth_method: "client_secret_post".into(),
+            })
+            .await
+            .unwrap();
+
+        let all = store.list().await.unwrap();
+        assert_eq!(all.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn client_get_nonexistent() {
+        let layer = setup().await;
+        let store = layer.client_store();
+        let found = store.get("no_such").await.unwrap();
+        assert!(found.is_none());
+    }
+
+    // -- AuthCodeStore --
+
+    #[tokio::test]
+    async fn auth_code_store_and_take() {
+        let layer = setup().await;
+        let store = layer.auth_code_store();
+
+        let code = AuthCode {
+            code: "abc123".into(),
+            user_id: "usr_1".into(),
+            client_id: "cli_app".into(),
+            redirect_uri: "http://localhost/callback".into(),
+            scopes: vec!["read".into(), "write".into()],
+            pkce_challenge: Some("challenge_value".into()),
+            expires_at: Utc::now() + Duration::minutes(5),
+        };
+        store.store_code(code).await.unwrap();
+
+        // First take succeeds.
+        let taken = store.take_code("abc123").await.unwrap();
+        assert!(taken.is_some());
+        let taken = taken.unwrap();
+        assert_eq!(taken.user_id, "usr_1");
+        assert_eq!(taken.scopes, vec!["read", "write"]);
+
+        // Second take returns None (single-use).
+        let again = store.take_code("abc123").await.unwrap();
+        assert!(again.is_none());
+    }
+
+    #[tokio::test]
+    async fn auth_code_take_nonexistent() {
+        let layer = setup().await;
+        let store = layer.auth_code_store();
+        let result = store.take_code("no_such").await.unwrap();
+        assert!(result.is_none());
+    }
+
+    // -- RefreshTokenStore --
+
+    #[tokio::test]
+    async fn refresh_token_store_and_get() {
+        let layer = setup().await;
+        let store = layer.refresh_token_store();
+
+        let token = StoredRefreshToken {
+            token: "refresh_abc".into(),
+            user_id: "usr_1".into(),
+            client_id: "cli_app".into(),
+            scopes: vec!["read".into()],
+            expires_at: Utc::now() + Duration::days(30),
+            consumed: false,
+        };
+        store.store_token(token).await.unwrap();
+
+        let found = store.get_token("refresh_abc").await.unwrap();
+        assert!(found.is_some());
+        let found = found.unwrap();
+        assert!(!found.consumed);
+        assert_eq!(found.user_id, "usr_1");
+    }
+
+    #[tokio::test]
+    async fn refresh_token_consume() {
+        let layer = setup().await;
+        let store = layer.refresh_token_store();
+
+        store
+            .store_token(StoredRefreshToken {
+                token: "refresh_abc".into(),
+                user_id: "usr_1".into(),
+                client_id: "cli_app".into(),
+                scopes: vec![],
+                expires_at: Utc::now() + Duration::days(30),
+                consumed: false,
+            })
+            .await
+            .unwrap();
+
+        store.consume_token("refresh_abc").await.unwrap();
+
+        let found = store.get_token("refresh_abc").await.unwrap().unwrap();
+        assert!(found.consumed);
+    }
+
+    #[tokio::test]
+    async fn refresh_token_revoke_all() {
+        let layer = setup().await;
+        let store = layer.refresh_token_store();
+
+        for i in 0..3 {
+            store
+                .store_token(StoredRefreshToken {
+                    token: format!("tok_{i}"),
+                    user_id: "usr_1".into(),
+                    client_id: "cli_app".into(),
+                    scopes: vec![],
+                    expires_at: Utc::now() + Duration::days(30),
+                    consumed: false,
+                })
+                .await
+                .unwrap();
+        }
+
+        store.revoke_all("usr_1", "cli_app").await.unwrap();
+
+        for i in 0..3 {
+            let found = store.get_token(&format!("tok_{i}")).await.unwrap();
+            assert!(found.is_none(), "token tok_{i} should be revoked");
+        }
+    }
+
+    // -- DeviceCodeStore --
+
+    #[tokio::test]
+    async fn device_code_store_and_get() {
+        let layer = setup().await;
+        let store = layer.device_code_store();
+
+        let state = DeviceState {
+            device_code: "dev_abc".into(),
+            user_code: "ABCD-1234".into(),
+            client_id: "cli_app".into(),
+            scopes: vec!["read".into()],
+            expires_at: Utc::now() + Duration::minutes(15),
+            authorized_user: None,
+        };
+        store.store("dev_abc", state).await.unwrap();
+
+        let by_device = store.get_by_device_code("dev_abc").await.unwrap();
+        assert!(by_device.is_some());
+        assert_eq!(by_device.unwrap().user_code, "ABCD-1234");
+
+        let by_user = store.get_by_user_code("ABCD-1234").await.unwrap();
+        assert!(by_user.is_some());
+        assert_eq!(by_user.unwrap().device_code, "dev_abc");
+    }
+
+    #[tokio::test]
+    async fn device_code_update_authorized() {
+        let layer = setup().await;
+        let store = layer.device_code_store();
+
+        let state = DeviceState {
+            device_code: "dev_abc".into(),
+            user_code: "ABCD-1234".into(),
+            client_id: "cli_app".into(),
+            scopes: vec![],
+            expires_at: Utc::now() + Duration::minutes(15),
+            authorized_user: None,
+        };
+        store.store("dev_abc", state.clone()).await.unwrap();
+
+        let mut updated = state;
+        updated.authorized_user = Some("usr_alice".into());
+        store.update("dev_abc", updated).await.unwrap();
+
+        let found = store.get_by_device_code("dev_abc").await.unwrap().unwrap();
+        assert_eq!(found.authorized_user, Some("usr_alice".into()));
+    }
+
+    #[tokio::test]
+    async fn device_code_remove() {
+        let layer = setup().await;
+        let store = layer.device_code_store();
+
+        let state = DeviceState {
+            device_code: "dev_abc".into(),
+            user_code: "ABCD-1234".into(),
+            client_id: "cli_app".into(),
+            scopes: vec![],
+            expires_at: Utc::now() + Duration::minutes(15),
+            authorized_user: None,
+        };
+        store.store("dev_abc", state).await.unwrap();
+        store.remove("dev_abc").await.unwrap();
+
+        let found = store.get_by_device_code("dev_abc").await.unwrap();
+        assert!(found.is_none());
+    }
+}

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod agents;
 pub mod attachments;
+pub mod auth_state_store;
 pub mod command_events;
 pub mod conversation_broadcaster;
 pub mod conversation_events;
@@ -12,6 +13,7 @@ pub mod org_storage;
 pub mod org_store;
 pub mod persona_skill_access;
 pub mod personas;
+pub mod pool_factory;
 pub mod push_subscriptions;
 pub mod refinements;
 pub mod registry;
@@ -25,6 +27,9 @@ pub mod workflows;
 
 pub use agents::{AgentRecord, AgentStatus, AgentStore};
 pub use attachments::AttachmentStore;
+pub use auth_state_store::{
+    SqliteAuthCodeStore, SqliteClientStore, SqliteDeviceCodeStore, SqliteRefreshTokenStore,
+};
 pub use command_events::{CommandEventRow, CommandEventStore};
 pub use conversation_broadcaster::{
     ConversationBroadcast, ConversationEvent, InMemoryConversationBroadcaster,
@@ -43,6 +48,7 @@ pub use org_storage::OrgStorageLayer;
 pub use org_store::SqliteOrgStore;
 pub use persona_skill_access::PersonaSkillAccessStore;
 pub use personas::{PersonaRecord, PersonaStore};
+pub use pool_factory::OrgPoolFactory;
 pub use push_subscriptions::{PushSubscription, PushSubscriptionStore};
 pub use refinements::{RefinementStatus, RefinementsStore, SkillRefinement};
 pub use registry::SkillRegistry;

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -8,6 +8,8 @@ pub mod logs;
 pub mod memory_chunks;
 pub mod message_bus;
 pub mod metrics;
+pub mod org_storage;
+pub mod org_store;
 pub mod persona_skill_access;
 pub mod personas;
 pub mod push_subscriptions;
@@ -15,7 +17,9 @@ pub mod refinements;
 pub mod registry;
 pub mod scheduled_tasks;
 pub mod slack_threads;
+pub mod space_store;
 pub mod traces;
+pub mod user_store;
 pub mod webhooks;
 pub mod workflows;
 
@@ -35,6 +39,8 @@ pub use message_bus::SqliteMessageBus;
 pub use metrics::{
     MetricsStore, MetricsSummary, ModelTokenUsage, ResourceRecord, TimeSeriesPoint, ToolUsageStats,
 };
+pub use org_storage::OrgStorageLayer;
+pub use org_store::SqliteOrgStore;
 pub use persona_skill_access::PersonaSkillAccessStore;
 pub use personas::{PersonaRecord, PersonaStore};
 pub use push_subscriptions::{PushSubscription, PushSubscriptionStore};
@@ -42,9 +48,11 @@ pub use refinements::{RefinementStatus, RefinementsStore, SkillRefinement};
 pub use registry::SkillRegistry;
 pub use scheduled_tasks::{ScheduledTask, ScheduledTaskStore};
 pub use slack_threads::SlackActiveThreadStore;
+pub use space_store::{SqliteMembershipStore, SqliteSpaceStore};
 pub use traces::{
     RecordedSpan, SkillStatsProvider, TraceFilter, TraceStats, TraceStore, TraceSummary,
 };
+pub use user_store::SqliteUserStore;
 pub use webhooks::{WebhookRecord, WebhookStore};
 pub use workflows::{
     WorkflowEdge, WorkflowEdgeCondition, WorkflowExecutionLimits, WorkflowGraph, WorkflowNode,

--- a/crates/storage/src/org_storage.rs
+++ b/crates/storage/src/org_storage.rs
@@ -69,6 +69,26 @@ impl OrgStorageLayer {
     pub fn membership_store(&self) -> super::space_store::SqliteMembershipStore {
         super::space_store::SqliteMembershipStore::new(self.pool.clone())
     }
+
+    /// Build a [`SqliteClientStore`](super::auth_state_store::SqliteClientStore).
+    pub fn client_store(&self) -> super::auth_state_store::SqliteClientStore {
+        super::auth_state_store::SqliteClientStore::new(self.pool.clone())
+    }
+
+    /// Build a [`SqliteAuthCodeStore`](super::auth_state_store::SqliteAuthCodeStore).
+    pub fn auth_code_store(&self) -> super::auth_state_store::SqliteAuthCodeStore {
+        super::auth_state_store::SqliteAuthCodeStore::new(self.pool.clone())
+    }
+
+    /// Build a [`SqliteRefreshTokenStore`](super::auth_state_store::SqliteRefreshTokenStore).
+    pub fn refresh_token_store(&self) -> super::auth_state_store::SqliteRefreshTokenStore {
+        super::auth_state_store::SqliteRefreshTokenStore::new(self.pool.clone())
+    }
+
+    /// Build a [`SqliteDeviceCodeStore`](super::auth_state_store::SqliteDeviceCodeStore).
+    pub fn device_code_store(&self) -> super::auth_state_store::SqliteDeviceCodeStore {
+        super::auth_state_store::SqliteDeviceCodeStore::new(self.pool.clone())
+    }
 }
 
 /// Run all org.db migrations in order.

--- a/crates/storage/src/org_storage.rs
+++ b/crates/storage/src/org_storage.rs
@@ -1,0 +1,162 @@
+//! Org-level storage layer backed by SQLite.
+//!
+//! Manages the `org.db` database which holds organizations, users, spaces,
+//! memberships, and auth state. Runs its own migration set separate from
+//! the existing `assistant.db` migrations.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use sqlx::SqlitePool;
+use tracing::debug;
+
+/// Storage layer for org-level data (org.db).
+///
+/// Holds the connection pool and runs org-specific migrations on creation.
+#[derive(Clone)]
+pub struct OrgStorageLayer {
+    pool: SqlitePool,
+}
+
+impl OrgStorageLayer {
+    /// Open (or create) an org database at the given path and run migrations.
+    pub async fn new(db_path: &Path) -> Result<Self> {
+        if let Some(parent) = db_path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .with_context(|| format!("creating directory for org.db: {}", parent.display()))?;
+        }
+
+        let url = format!("sqlite://{}?mode=rwc", db_path.display());
+        let pool = SqlitePool::connect(&url)
+            .await
+            .with_context(|| format!("connecting to org.db: {}", db_path.display()))?;
+
+        run_org_migrations(&pool).await?;
+
+        debug!(path = %db_path.display(), "org.db ready");
+        Ok(Self { pool })
+    }
+
+    /// Create an in-memory org database (for tests).
+    pub async fn new_in_memory() -> Result<Self> {
+        let pool = SqlitePool::connect("sqlite::memory:").await?;
+        run_org_migrations(&pool).await?;
+        Ok(Self { pool })
+    }
+
+    /// Get the underlying pool (for building store implementations).
+    pub fn pool(&self) -> &SqlitePool {
+        &self.pool
+    }
+
+    /// Build a [`SqliteOrgStore`](super::org_store::SqliteOrgStore).
+    pub fn org_store(&self) -> super::org_store::SqliteOrgStore {
+        super::org_store::SqliteOrgStore::new(self.pool.clone())
+    }
+
+    /// Build a [`SqliteUserStore`](super::user_store::SqliteUserStore).
+    pub fn user_store(&self) -> super::user_store::SqliteUserStore {
+        super::user_store::SqliteUserStore::new(self.pool.clone())
+    }
+
+    /// Build a [`SqliteSpaceStore`](super::space_store::SqliteSpaceStore).
+    pub fn space_store(&self) -> super::space_store::SqliteSpaceStore {
+        super::space_store::SqliteSpaceStore::new(self.pool.clone())
+    }
+
+    /// Build a [`SqliteMembershipStore`](super::space_store::SqliteMembershipStore).
+    pub fn membership_store(&self) -> super::space_store::SqliteMembershipStore {
+        super::space_store::SqliteMembershipStore::new(self.pool.clone())
+    }
+}
+
+/// Run all org.db migrations in order.
+async fn run_org_migrations(pool: &SqlitePool) -> Result<()> {
+    sqlx::query("PRAGMA journal_mode=WAL;")
+        .execute(pool)
+        .await?;
+    sqlx::query("PRAGMA foreign_keys=ON;").execute(pool).await?;
+    sqlx::query("PRAGMA busy_timeout = 5000;")
+        .execute(pool)
+        .await?;
+
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS _migrations (
+            name        TEXT PRIMARY KEY,
+            applied_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )",
+    )
+    .execute(pool)
+    .await?;
+
+    let migrations: &[(&str, &str)] = &[
+        (
+            "001_org_tables",
+            include_str!("../../../migrations/org/001_org_tables.sql"),
+        ),
+        (
+            "002_auth_tables",
+            include_str!("../../../migrations/org/002_auth_tables.sql"),
+        ),
+    ];
+
+    for (name, sql) in migrations {
+        let already_applied: bool =
+            sqlx::query_scalar("SELECT COUNT(*) > 0 FROM _migrations WHERE name = ?")
+                .bind(name)
+                .fetch_one(pool)
+                .await?;
+
+        if !already_applied {
+            debug!(migration = name, "applying org migration");
+            sqlx::raw_sql(sql)
+                .execute(pool)
+                .await
+                .with_context(|| format!("failed to apply org migration: {name}"))?;
+            sqlx::query("INSERT INTO _migrations (name) VALUES (?)")
+                .bind(name)
+                .execute(pool)
+                .await?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn org_storage_layer_creates_in_memory() {
+        let layer = OrgStorageLayer::new_in_memory().await.unwrap();
+        // Verify tables exist by querying them.
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM organizations")
+            .fetch_one(layer.pool())
+            .await
+            .unwrap();
+        assert_eq!(count.0, 0);
+    }
+
+    #[tokio::test]
+    async fn org_storage_layer_creates_on_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test_org.db");
+        let layer = OrgStorageLayer::new(&db_path).await.unwrap();
+
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM users")
+            .fetch_one(layer.pool())
+            .await
+            .unwrap();
+        assert_eq!(count.0, 0);
+        assert!(db_path.exists());
+    }
+
+    #[tokio::test]
+    async fn org_migrations_are_idempotent() {
+        let layer = OrgStorageLayer::new_in_memory().await.unwrap();
+        // Running migrations again should not fail.
+        run_org_migrations(layer.pool()).await.unwrap();
+    }
+}

--- a/crates/storage/src/org_store.rs
+++ b/crates/storage/src/org_store.rs
@@ -1,0 +1,201 @@
+//! SQLite-backed [`OrgStore`] implementation.
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use sqlx::{Row, SqlitePool};
+
+use assistant_core::identity::OrgId;
+use assistant_core::store::{OrgStore, Organization};
+
+/// SQLite-backed organization store.
+pub struct SqliteOrgStore {
+    pool: SqlitePool,
+}
+
+impl SqliteOrgStore {
+    pub fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+}
+
+fn row_to_org(row: sqlx::sqlite::SqliteRow) -> Organization {
+    Organization {
+        id: OrgId(row.get("id")),
+        name: row.get("name"),
+        slug: row.get("slug"),
+        auth_mode: row.get("auth_mode"),
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+    }
+}
+
+#[async_trait]
+impl OrgStore for SqliteOrgStore {
+    async fn create_org(&self, org: &Organization) -> Result<()> {
+        sqlx::query(
+            "INSERT INTO organizations (id, name, slug, auth_mode, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&org.id.0)
+        .bind(&org.name)
+        .bind(&org.slug)
+        .bind(&org.auth_mode)
+        .bind(org.created_at)
+        .bind(org.updated_at)
+        .execute(&self.pool)
+        .await
+        .with_context(|| format!("creating organization: {}", org.id))?;
+        Ok(())
+    }
+
+    async fn get_org(&self, id: &OrgId) -> Result<Option<Organization>> {
+        let row = sqlx::query(
+            "SELECT id, name, slug, auth_mode, created_at, updated_at
+             FROM organizations WHERE id = ?",
+        )
+        .bind(&id.0)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.map(row_to_org))
+    }
+
+    async fn get_org_by_slug(&self, slug: &str) -> Result<Option<Organization>> {
+        let row = sqlx::query(
+            "SELECT id, name, slug, auth_mode, created_at, updated_at
+             FROM organizations WHERE slug = ?",
+        )
+        .bind(slug)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.map(row_to_org))
+    }
+
+    async fn update_org(&self, org: &Organization) -> Result<()> {
+        let result = sqlx::query(
+            "UPDATE organizations SET name = ?, slug = ?, auth_mode = ?, updated_at = ?
+             WHERE id = ?",
+        )
+        .bind(&org.name)
+        .bind(&org.slug)
+        .bind(&org.auth_mode)
+        .bind(org.updated_at)
+        .bind(&org.id.0)
+        .execute(&self.pool)
+        .await?;
+        if result.rows_affected() == 0 {
+            anyhow::bail!("organization not found: {}", org.id);
+        }
+        Ok(())
+    }
+
+    async fn list_orgs(&self) -> Result<Vec<Organization>> {
+        let rows = sqlx::query(
+            "SELECT id, name, slug, auth_mode, created_at, updated_at
+             FROM organizations ORDER BY created_at",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.into_iter().map(row_to_org).collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::org_storage::OrgStorageLayer;
+    use chrono::Utc;
+
+    async fn setup() -> (OrgStorageLayer, SqliteOrgStore) {
+        let layer = OrgStorageLayer::new_in_memory().await.unwrap();
+        let store = layer.org_store();
+        (layer, store)
+    }
+
+    fn make_org(id: &str, slug: &str) -> Organization {
+        let now = Utc::now();
+        Organization {
+            id: OrgId::from(id),
+            name: format!("{slug} Inc."),
+            slug: slug.into(),
+            auth_mode: "password".into(),
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    #[tokio::test]
+    async fn create_and_get() {
+        let (_layer, store) = setup().await;
+        let org = make_org("org_1", "acme");
+        store.create_org(&org).await.unwrap();
+
+        let found = store.get_org(&OrgId::from("org_1")).await.unwrap();
+        assert!(found.is_some());
+        let found = found.unwrap();
+        assert_eq!(found.slug, "acme");
+        assert_eq!(found.name, "acme Inc.");
+    }
+
+    #[tokio::test]
+    async fn get_by_slug() {
+        let (_layer, store) = setup().await;
+        store.create_org(&make_org("org_1", "acme")).await.unwrap();
+
+        let found = store.get_org_by_slug("acme").await.unwrap();
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().id, OrgId::from("org_1"));
+
+        let missing = store.get_org_by_slug("nope").await.unwrap();
+        assert!(missing.is_none());
+    }
+
+    #[tokio::test]
+    async fn duplicate_slug_rejected() {
+        let (_layer, store) = setup().await;
+        store.create_org(&make_org("org_1", "acme")).await.unwrap();
+        let err = store.create_org(&make_org("org_2", "acme")).await;
+        assert!(err.is_err());
+    }
+
+    #[tokio::test]
+    async fn update_org() {
+        let (_layer, store) = setup().await;
+        let mut org = make_org("org_1", "acme");
+        store.create_org(&org).await.unwrap();
+
+        org.name = "Acme Corp".into();
+        org.updated_at = Utc::now();
+        store.update_org(&org).await.unwrap();
+
+        let found = store.get_org(&OrgId::from("org_1")).await.unwrap().unwrap();
+        assert_eq!(found.name, "Acme Corp");
+    }
+
+    #[tokio::test]
+    async fn update_nonexistent_fails() {
+        let (_layer, store) = setup().await;
+        let org = make_org("org_999", "ghost");
+        let err = store.update_org(&org).await;
+        assert!(err.is_err());
+    }
+
+    #[tokio::test]
+    async fn list_orgs() {
+        let (_layer, store) = setup().await;
+        store.create_org(&make_org("org_1", "acme")).await.unwrap();
+        store
+            .create_org(&make_org("org_2", "globex"))
+            .await
+            .unwrap();
+
+        let all = store.list_orgs().await.unwrap();
+        assert_eq!(all.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn get_nonexistent_returns_none() {
+        let (_layer, store) = setup().await;
+        let found = store.get_org(&OrgId::from("no_such")).await.unwrap();
+        assert!(found.is_none());
+    }
+}

--- a/crates/storage/src/pool_factory.rs
+++ b/crates/storage/src/pool_factory.rs
@@ -1,0 +1,108 @@
+//! Database pool factory for org/space resolution.
+//!
+//! Resolves org and space slugs to their respective database paths under
+//! `~/.assistant/orgs/{slug}/`. Creates directories on first access.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+use crate::org_storage::OrgStorageLayer;
+
+/// Resolves org slugs to [`OrgStorageLayer`] instances.
+///
+/// The directory layout under `base_dir` is:
+/// ```text
+/// base_dir/
+///   orgs/
+///     {slug}/
+///       org.db          ← org-level data (organizations, users, spaces, auth)
+///       spaces/
+///         {space_slug}/
+///           space.db    ← space-level data (future: conversations, personas)
+/// ```
+pub struct OrgPoolFactory {
+    base_dir: PathBuf,
+}
+
+impl OrgPoolFactory {
+    /// Create a factory rooted at `base_dir` (typically `~/.assistant`).
+    pub fn new(base_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            base_dir: base_dir.into(),
+        }
+    }
+
+    /// Create a factory using the default base directory (`~/.assistant`).
+    pub fn default_base() -> Result<Self> {
+        let home = dirs::home_dir().context("could not determine home directory")?;
+        Ok(Self::new(home.join(".assistant")))
+    }
+
+    /// Return the org.db path for a given org slug.
+    pub fn org_db_path(&self, org_slug: &str) -> PathBuf {
+        self.base_dir.join("orgs").join(org_slug).join("org.db")
+    }
+
+    /// Return the space.db path for a given org + space slug.
+    pub fn space_db_path(&self, org_slug: &str, space_slug: &str) -> PathBuf {
+        self.base_dir
+            .join("orgs")
+            .join(org_slug)
+            .join("spaces")
+            .join(space_slug)
+            .join("space.db")
+    }
+
+    /// Open (or create) the [`OrgStorageLayer`] for the given org slug.
+    ///
+    /// Creates directories and runs migrations on first access.
+    pub async fn org_storage(&self, org_slug: &str) -> Result<OrgStorageLayer> {
+        let db_path = self.org_db_path(org_slug);
+        OrgStorageLayer::new(&db_path).await
+    }
+
+    /// Return the base directory.
+    pub fn base_dir(&self) -> &Path {
+        &self.base_dir
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assistant_core::store::OrgStore;
+
+    #[test]
+    fn org_db_path_resolves() {
+        let factory = OrgPoolFactory::new("/data");
+        assert_eq!(
+            factory.org_db_path("acme"),
+            PathBuf::from("/data/orgs/acme/org.db")
+        );
+    }
+
+    #[test]
+    fn space_db_path_resolves() {
+        let factory = OrgPoolFactory::new("/data");
+        assert_eq!(
+            factory.space_db_path("acme", "engineering"),
+            PathBuf::from("/data/orgs/acme/spaces/engineering/space.db")
+        );
+    }
+
+    #[tokio::test]
+    async fn org_storage_creates_on_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let factory = OrgPoolFactory::new(dir.path());
+
+        let layer = factory.org_storage("acme").await.unwrap();
+
+        // Verify it works by querying.
+        let orgs = layer.org_store().list_orgs().await.unwrap();
+        assert!(orgs.is_empty());
+
+        // Verify the file was created.
+        assert!(factory.org_db_path("acme").exists());
+    }
+}

--- a/crates/storage/src/space_store.rs
+++ b/crates/storage/src/space_store.rs
@@ -1,0 +1,468 @@
+//! SQLite-backed [`SpaceStore`] and [`MembershipStore`] implementations.
+
+use std::collections::HashMap;
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use sqlx::{Row, SqlitePool};
+
+use assistant_core::identity::{OrgId, Role, SpaceId, UserId};
+use assistant_core::store::{MembershipStore, Space, SpaceMembership, SpaceStore};
+
+// ---------------------------------------------------------------------------
+// Row mapping helpers
+// ---------------------------------------------------------------------------
+
+fn row_to_space(row: sqlx::sqlite::SqliteRow) -> Space {
+    Space {
+        id: SpaceId(row.get("id")),
+        org_id: OrgId(row.get("org_id")),
+        name: row.get("name"),
+        slug: row.get("slug"),
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+    }
+}
+
+fn row_to_membership(row: sqlx::sqlite::SqliteRow) -> SpaceMembership {
+    let role_str: String = row.get("role");
+    SpaceMembership {
+        user_id: UserId(row.get("user_id")),
+        space_id: SpaceId(row.get("space_id")),
+        role: role_from_str(&role_str),
+        created_at: row.get("created_at"),
+    }
+}
+
+/// Parse a role string from the database.
+fn role_from_str(s: &str) -> Role {
+    match s {
+        "org_admin" => Role::OrgAdmin,
+        "space_admin" => Role::SpaceAdmin,
+        "member" => Role::Member,
+        "viewer" => Role::Viewer,
+        _ => Role::Viewer, // safe fallback
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SqliteSpaceStore
+// ---------------------------------------------------------------------------
+
+/// SQLite-backed space store.
+pub struct SqliteSpaceStore {
+    pool: SqlitePool,
+}
+
+impl SqliteSpaceStore {
+    pub fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl SpaceStore for SqliteSpaceStore {
+    async fn create_space(&self, space: &Space) -> Result<()> {
+        sqlx::query(
+            "INSERT INTO spaces (id, org_id, name, slug, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&space.id.0)
+        .bind(&space.org_id.0)
+        .bind(&space.name)
+        .bind(&space.slug)
+        .bind(space.created_at)
+        .bind(space.updated_at)
+        .execute(&self.pool)
+        .await
+        .with_context(|| format!("creating space: {}", space.id))?;
+        Ok(())
+    }
+
+    async fn get_space(&self, id: &SpaceId) -> Result<Option<Space>> {
+        let row = sqlx::query(
+            "SELECT id, org_id, name, slug, created_at, updated_at
+             FROM spaces WHERE id = ?",
+        )
+        .bind(&id.0)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.map(row_to_space))
+    }
+
+    async fn list_spaces(&self, org_id: &OrgId) -> Result<Vec<Space>> {
+        let rows = sqlx::query(
+            "SELECT id, org_id, name, slug, created_at, updated_at
+             FROM spaces WHERE org_id = ? ORDER BY created_at",
+        )
+        .bind(&org_id.0)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.into_iter().map(row_to_space).collect())
+    }
+
+    async fn delete_space(&self, id: &SpaceId) -> Result<bool> {
+        let result = sqlx::query("DELETE FROM spaces WHERE id = ?")
+            .bind(&id.0)
+            .execute(&self.pool)
+            .await?;
+        Ok(result.rows_affected() > 0)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SqliteMembershipStore
+// ---------------------------------------------------------------------------
+
+/// SQLite-backed membership store.
+pub struct SqliteMembershipStore {
+    pool: SqlitePool,
+}
+
+impl SqliteMembershipStore {
+    pub fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl MembershipStore for SqliteMembershipStore {
+    async fn add_membership(&self, membership: &SpaceMembership) -> Result<()> {
+        sqlx::query(
+            "INSERT INTO space_memberships (user_id, space_id, role, created_at)
+             VALUES (?, ?, ?, ?)",
+        )
+        .bind(&membership.user_id.0)
+        .bind(&membership.space_id.0)
+        .bind(membership.role.to_string())
+        .bind(membership.created_at)
+        .execute(&self.pool)
+        .await
+        .with_context(|| {
+            format!(
+                "adding membership: user {} in space {}",
+                membership.user_id, membership.space_id
+            )
+        })?;
+        Ok(())
+    }
+
+    async fn remove_membership(&self, user_id: &UserId, space_id: &SpaceId) -> Result<bool> {
+        let result =
+            sqlx::query("DELETE FROM space_memberships WHERE user_id = ? AND space_id = ?")
+                .bind(&user_id.0)
+                .bind(&space_id.0)
+                .execute(&self.pool)
+                .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    async fn get_memberships_for_user(&self, user_id: &UserId) -> Result<Vec<SpaceMembership>> {
+        let rows = sqlx::query(
+            "SELECT user_id, space_id, role, created_at
+             FROM space_memberships WHERE user_id = ?",
+        )
+        .bind(&user_id.0)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.into_iter().map(row_to_membership).collect())
+    }
+
+    async fn get_members_of_space(&self, space_id: &SpaceId) -> Result<Vec<SpaceMembership>> {
+        let rows = sqlx::query(
+            "SELECT user_id, space_id, role, created_at
+             FROM space_memberships WHERE space_id = ?",
+        )
+        .bind(&space_id.0)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.into_iter().map(row_to_membership).collect())
+    }
+
+    async fn get_space_roles(&self, user_id: &UserId) -> Result<HashMap<SpaceId, Role>> {
+        let rows = sqlx::query(
+            "SELECT user_id, space_id, role, created_at
+             FROM space_memberships WHERE user_id = ?",
+        )
+        .bind(&user_id.0)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .into_iter()
+            .map(|r| {
+                let role_str: String = r.get("role");
+                (SpaceId(r.get("space_id")), role_from_str(&role_str))
+            })
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::org_storage::OrgStorageLayer;
+    use chrono::Utc;
+
+    use assistant_core::store::{OrgStore, Organization, UserStore};
+
+    async fn setup() -> (OrgStorageLayer, SqliteSpaceStore, SqliteMembershipStore) {
+        let layer = OrgStorageLayer::new_in_memory().await.unwrap();
+        let now = Utc::now();
+
+        // Create org and users (FK requirements).
+        layer
+            .org_store()
+            .create_org(&Organization {
+                id: OrgId::from("org_1"),
+                name: "Acme".into(),
+                slug: "acme".into(),
+                auth_mode: "password".into(),
+                created_at: now,
+                updated_at: now,
+            })
+            .await
+            .unwrap();
+
+        layer
+            .user_store()
+            .create_user(&assistant_core::store::User {
+                id: UserId::from("usr_alice"),
+                org_id: OrgId::from("org_1"),
+                email: "alice@acme.com".into(),
+                name: "Alice".into(),
+                password_hash: String::new(),
+                idp_issuer: None,
+                idp_subject: None,
+                created_at: now,
+                updated_at: now,
+            })
+            .await
+            .unwrap();
+
+        layer
+            .user_store()
+            .create_user(&assistant_core::store::User {
+                id: UserId::from("usr_bob"),
+                org_id: OrgId::from("org_1"),
+                email: "bob@acme.com".into(),
+                name: "Bob".into(),
+                password_hash: String::new(),
+                idp_issuer: None,
+                idp_subject: None,
+                created_at: now,
+                updated_at: now,
+            })
+            .await
+            .unwrap();
+
+        let space_store = layer.space_store();
+        let membership_store = layer.membership_store();
+        (layer, space_store, membership_store)
+    }
+
+    fn make_space(id: &str, org_id: &str, slug: &str) -> Space {
+        let now = Utc::now();
+        Space {
+            id: SpaceId::from(id),
+            org_id: OrgId::from(org_id),
+            name: format!("{slug} space"),
+            slug: slug.into(),
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    fn make_membership(user_id: &str, space_id: &str, role: Role) -> SpaceMembership {
+        SpaceMembership {
+            user_id: UserId::from(user_id),
+            space_id: SpaceId::from(space_id),
+            role,
+            created_at: Utc::now(),
+        }
+    }
+
+    // -- SpaceStore --
+
+    #[tokio::test]
+    async fn space_create_and_get() {
+        let (_layer, space_store, _) = setup().await;
+        let space = make_space("sp_eng", "org_1", "engineering");
+        space_store.create_space(&space).await.unwrap();
+
+        let found = space_store
+            .get_space(&SpaceId::from("sp_eng"))
+            .await
+            .unwrap();
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().slug, "engineering");
+    }
+
+    #[tokio::test]
+    async fn space_list_by_org() {
+        let (_layer, space_store, _) = setup().await;
+        space_store
+            .create_space(&make_space("sp_eng", "org_1", "engineering"))
+            .await
+            .unwrap();
+        space_store
+            .create_space(&make_space("sp_mktg", "org_1", "marketing"))
+            .await
+            .unwrap();
+
+        let spaces = space_store
+            .list_spaces(&OrgId::from("org_1"))
+            .await
+            .unwrap();
+        assert_eq!(spaces.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn space_delete() {
+        let (_layer, space_store, _) = setup().await;
+        space_store
+            .create_space(&make_space("sp_eng", "org_1", "engineering"))
+            .await
+            .unwrap();
+
+        let deleted = space_store
+            .delete_space(&SpaceId::from("sp_eng"))
+            .await
+            .unwrap();
+        assert!(deleted);
+
+        let found = space_store
+            .get_space(&SpaceId::from("sp_eng"))
+            .await
+            .unwrap();
+        assert!(found.is_none());
+    }
+
+    // -- MembershipStore --
+
+    #[tokio::test]
+    async fn membership_add_and_query() {
+        let (_layer, space_store, membership_store) = setup().await;
+        space_store
+            .create_space(&make_space("sp_eng", "org_1", "engineering"))
+            .await
+            .unwrap();
+
+        membership_store
+            .add_membership(&make_membership("usr_alice", "sp_eng", Role::Member))
+            .await
+            .unwrap();
+
+        let alice_memberships = membership_store
+            .get_memberships_for_user(&UserId::from("usr_alice"))
+            .await
+            .unwrap();
+        assert_eq!(alice_memberships.len(), 1);
+        assert_eq!(alice_memberships[0].role, Role::Member);
+
+        let eng_members = membership_store
+            .get_members_of_space(&SpaceId::from("sp_eng"))
+            .await
+            .unwrap();
+        assert_eq!(eng_members.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn membership_duplicate_rejected() {
+        let (_layer, space_store, membership_store) = setup().await;
+        space_store
+            .create_space(&make_space("sp_eng", "org_1", "engineering"))
+            .await
+            .unwrap();
+
+        membership_store
+            .add_membership(&make_membership("usr_alice", "sp_eng", Role::Member))
+            .await
+            .unwrap();
+        let err = membership_store
+            .add_membership(&make_membership("usr_alice", "sp_eng", Role::Viewer))
+            .await;
+        assert!(err.is_err());
+    }
+
+    #[tokio::test]
+    async fn membership_remove() {
+        let (_layer, space_store, membership_store) = setup().await;
+        space_store
+            .create_space(&make_space("sp_eng", "org_1", "engineering"))
+            .await
+            .unwrap();
+
+        membership_store
+            .add_membership(&make_membership("usr_alice", "sp_eng", Role::Member))
+            .await
+            .unwrap();
+
+        let removed = membership_store
+            .remove_membership(&UserId::from("usr_alice"), &SpaceId::from("sp_eng"))
+            .await
+            .unwrap();
+        assert!(removed);
+
+        let memberships = membership_store
+            .get_memberships_for_user(&UserId::from("usr_alice"))
+            .await
+            .unwrap();
+        assert!(memberships.is_empty());
+    }
+
+    #[tokio::test]
+    async fn membership_space_roles() {
+        let (_layer, space_store, membership_store) = setup().await;
+        space_store
+            .create_space(&make_space("sp_eng", "org_1", "engineering"))
+            .await
+            .unwrap();
+        space_store
+            .create_space(&make_space("sp_mktg", "org_1", "marketing"))
+            .await
+            .unwrap();
+
+        membership_store
+            .add_membership(&make_membership("usr_alice", "sp_eng", Role::Member))
+            .await
+            .unwrap();
+        membership_store
+            .add_membership(&make_membership("usr_alice", "sp_mktg", Role::SpaceAdmin))
+            .await
+            .unwrap();
+
+        let roles = membership_store
+            .get_space_roles(&UserId::from("usr_alice"))
+            .await
+            .unwrap();
+        assert_eq!(roles.get(&SpaceId::from("sp_eng")), Some(&Role::Member));
+        assert_eq!(
+            roles.get(&SpaceId::from("sp_mktg")),
+            Some(&Role::SpaceAdmin)
+        );
+    }
+
+    #[tokio::test]
+    async fn membership_multiple_users_in_space() {
+        let (_layer, space_store, membership_store) = setup().await;
+        space_store
+            .create_space(&make_space("sp_eng", "org_1", "engineering"))
+            .await
+            .unwrap();
+
+        membership_store
+            .add_membership(&make_membership("usr_alice", "sp_eng", Role::SpaceAdmin))
+            .await
+            .unwrap();
+        membership_store
+            .add_membership(&make_membership("usr_bob", "sp_eng", Role::Member))
+            .await
+            .unwrap();
+
+        let members = membership_store
+            .get_members_of_space(&SpaceId::from("sp_eng"))
+            .await
+            .unwrap();
+        assert_eq!(members.len(), 2);
+    }
+}

--- a/crates/storage/src/user_store.rs
+++ b/crates/storage/src/user_store.rs
@@ -1,0 +1,299 @@
+//! SQLite-backed [`UserStore`] implementation.
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use sqlx::{Row, SqlitePool};
+
+use assistant_core::identity::{OrgId, UserId};
+use assistant_core::store::{User, UserStore};
+
+/// SQLite-backed user store.
+pub struct SqliteUserStore {
+    pool: SqlitePool,
+}
+
+impl SqliteUserStore {
+    pub fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+}
+
+fn row_to_user(row: sqlx::sqlite::SqliteRow) -> User {
+    User {
+        id: UserId(row.get("id")),
+        org_id: OrgId(row.get("org_id")),
+        email: row.get("email"),
+        name: row.get("name"),
+        password_hash: row.get("password_hash"),
+        idp_issuer: row.get("idp_issuer"),
+        idp_subject: row.get("idp_subject"),
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+    }
+}
+
+#[async_trait]
+impl UserStore for SqliteUserStore {
+    async fn create_user(&self, user: &User) -> Result<()> {
+        sqlx::query(
+            "INSERT INTO users (id, org_id, email, name, password_hash, idp_issuer, idp_subject, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&user.id.0)
+        .bind(&user.org_id.0)
+        .bind(&user.email)
+        .bind(&user.name)
+        .bind(&user.password_hash)
+        .bind(&user.idp_issuer)
+        .bind(&user.idp_subject)
+        .bind(user.created_at)
+        .bind(user.updated_at)
+        .execute(&self.pool)
+        .await
+        .with_context(|| format!("creating user: {}", user.id))?;
+        Ok(())
+    }
+
+    async fn get_user(&self, id: &UserId) -> Result<Option<User>> {
+        let row = sqlx::query(
+            "SELECT id, org_id, email, name, password_hash, idp_issuer, idp_subject, created_at, updated_at
+             FROM users WHERE id = ?",
+        )
+        .bind(&id.0)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.map(row_to_user))
+    }
+
+    async fn get_user_by_email(&self, org_id: &OrgId, email: &str) -> Result<Option<User>> {
+        let row = sqlx::query(
+            "SELECT id, org_id, email, name, password_hash, idp_issuer, idp_subject, created_at, updated_at
+             FROM users WHERE org_id = ? AND email = ?",
+        )
+        .bind(&org_id.0)
+        .bind(email)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.map(row_to_user))
+    }
+
+    async fn get_user_by_idp(&self, issuer: &str, subject: &str) -> Result<Option<User>> {
+        let row = sqlx::query(
+            "SELECT id, org_id, email, name, password_hash, idp_issuer, idp_subject, created_at, updated_at
+             FROM users WHERE idp_issuer = ? AND idp_subject = ?",
+        )
+        .bind(issuer)
+        .bind(subject)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.map(row_to_user))
+    }
+
+    async fn list_users(&self, org_id: &OrgId) -> Result<Vec<User>> {
+        let rows = sqlx::query(
+            "SELECT id, org_id, email, name, password_hash, idp_issuer, idp_subject, created_at, updated_at
+             FROM users WHERE org_id = ? ORDER BY created_at",
+        )
+        .bind(&org_id.0)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.into_iter().map(row_to_user).collect())
+    }
+
+    async fn update_user(&self, user: &User) -> Result<()> {
+        let result = sqlx::query(
+            "UPDATE users SET email = ?, name = ?, password_hash = ?, idp_issuer = ?, idp_subject = ?, updated_at = ?
+             WHERE id = ?",
+        )
+        .bind(&user.email)
+        .bind(&user.name)
+        .bind(&user.password_hash)
+        .bind(&user.idp_issuer)
+        .bind(&user.idp_subject)
+        .bind(user.updated_at)
+        .bind(&user.id.0)
+        .execute(&self.pool)
+        .await?;
+        if result.rows_affected() == 0 {
+            anyhow::bail!("user not found: {}", user.id);
+        }
+        Ok(())
+    }
+
+    async fn delete_user(&self, id: &UserId) -> Result<bool> {
+        let result = sqlx::query("DELETE FROM users WHERE id = ?")
+            .bind(&id.0)
+            .execute(&self.pool)
+            .await?;
+        Ok(result.rows_affected() > 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::org_storage::OrgStorageLayer;
+    use chrono::Utc;
+
+    use assistant_core::store::{OrgStore, Organization};
+
+    async fn setup() -> (OrgStorageLayer, SqliteUserStore) {
+        let layer = OrgStorageLayer::new_in_memory().await.unwrap();
+        let org_store = layer.org_store();
+        let now = Utc::now();
+        org_store
+            .create_org(&Organization {
+                id: OrgId::from("org_1"),
+                name: "Acme".into(),
+                slug: "acme".into(),
+                auth_mode: "password".into(),
+                created_at: now,
+                updated_at: now,
+            })
+            .await
+            .unwrap();
+        let store = layer.user_store();
+        (layer, store)
+    }
+
+    fn make_user(id: &str, org_id: &str, email: &str) -> User {
+        let now = Utc::now();
+        User {
+            id: UserId::from(id),
+            org_id: OrgId::from(org_id),
+            email: email.into(),
+            name: id.into(),
+            password_hash: String::new(),
+            idp_issuer: None,
+            idp_subject: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    #[tokio::test]
+    async fn create_and_get() {
+        let (_layer, store) = setup().await;
+        let user = make_user("usr_alice", "org_1", "alice@acme.com");
+        store.create_user(&user).await.unwrap();
+
+        let found = store.get_user(&UserId::from("usr_alice")).await.unwrap();
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().email, "alice@acme.com");
+    }
+
+    #[tokio::test]
+    async fn get_by_email() {
+        let (_layer, store) = setup().await;
+        store
+            .create_user(&make_user("usr_alice", "org_1", "alice@acme.com"))
+            .await
+            .unwrap();
+
+        let found = store
+            .get_user_by_email(&OrgId::from("org_1"), "alice@acme.com")
+            .await
+            .unwrap();
+        assert!(found.is_some());
+
+        let not_found = store
+            .get_user_by_email(&OrgId::from("org_2"), "alice@acme.com")
+            .await
+            .unwrap();
+        assert!(not_found.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_by_idp() {
+        let (_layer, store) = setup().await;
+        let mut user = make_user("usr_alice", "org_1", "alice@acme.com");
+        user.idp_issuer = Some("https://idp.acme.com".into());
+        user.idp_subject = Some("sub_12345".into());
+        store.create_user(&user).await.unwrap();
+
+        let found = store
+            .get_user_by_idp("https://idp.acme.com", "sub_12345")
+            .await
+            .unwrap();
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().id, UserId::from("usr_alice"));
+
+        let not_found = store
+            .get_user_by_idp("https://idp.acme.com", "sub_99999")
+            .await
+            .unwrap();
+        assert!(not_found.is_none());
+    }
+
+    #[tokio::test]
+    async fn duplicate_email_in_same_org_rejected() {
+        let (_layer, store) = setup().await;
+        store
+            .create_user(&make_user("usr_1", "org_1", "alice@acme.com"))
+            .await
+            .unwrap();
+        let err = store
+            .create_user(&make_user("usr_2", "org_1", "alice@acme.com"))
+            .await;
+        assert!(err.is_err());
+    }
+
+    #[tokio::test]
+    async fn update_user() {
+        let (_layer, store) = setup().await;
+        let mut user = make_user("usr_alice", "org_1", "alice@acme.com");
+        store.create_user(&user).await.unwrap();
+
+        user.name = "Alice Smith".into();
+        user.updated_at = Utc::now();
+        store.update_user(&user).await.unwrap();
+
+        let found = store
+            .get_user(&UserId::from("usr_alice"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(found.name, "Alice Smith");
+    }
+
+    #[tokio::test]
+    async fn delete_user() {
+        let (_layer, store) = setup().await;
+        store
+            .create_user(&make_user("usr_alice", "org_1", "alice@acme.com"))
+            .await
+            .unwrap();
+
+        let deleted = store.delete_user(&UserId::from("usr_alice")).await.unwrap();
+        assert!(deleted);
+
+        let found = store.get_user(&UserId::from("usr_alice")).await.unwrap();
+        assert!(found.is_none());
+
+        let not_deleted = store.delete_user(&UserId::from("usr_alice")).await.unwrap();
+        assert!(!not_deleted);
+    }
+
+    #[tokio::test]
+    async fn list_by_org() {
+        let (_layer, store) = setup().await;
+        store
+            .create_user(&make_user("usr_1", "org_1", "alice@acme.com"))
+            .await
+            .unwrap();
+        store
+            .create_user(&make_user("usr_2", "org_1", "bob@acme.com"))
+            .await
+            .unwrap();
+
+        let users = store.list_users(&OrgId::from("org_1")).await.unwrap();
+        assert_eq!(users.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn get_nonexistent_returns_none() {
+        let (_layer, store) = setup().await;
+        let found = store.get_user(&UserId::from("no_such")).await.unwrap();
+        assert!(found.is_none());
+    }
+}

--- a/migrations/org/001_org_tables.sql
+++ b/migrations/org/001_org_tables.sql
@@ -1,0 +1,49 @@
+-- Organization, user, space, and membership tables for multi-tenant storage.
+-- This migration runs against org.db (separate from assistant.db).
+
+CREATE TABLE IF NOT EXISTS organizations (
+    id          TEXT PRIMARY KEY,
+    name        TEXT NOT NULL,
+    slug        TEXT NOT NULL UNIQUE,
+    auth_mode   TEXT NOT NULL DEFAULT 'password',
+    created_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS users (
+    id              TEXT PRIMARY KEY,
+    org_id          TEXT NOT NULL REFERENCES organizations(id),
+    email           TEXT NOT NULL,
+    name            TEXT NOT NULL DEFAULT '',
+    password_hash   TEXT NOT NULL DEFAULT '',
+    idp_issuer      TEXT,
+    idp_subject     TEXT,
+    created_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(org_id, email)
+);
+
+CREATE INDEX IF NOT EXISTS idx_users_org_id ON users(org_id);
+CREATE INDEX IF NOT EXISTS idx_users_idp ON users(idp_issuer, idp_subject);
+
+CREATE TABLE IF NOT EXISTS spaces (
+    id          TEXT PRIMARY KEY,
+    org_id      TEXT NOT NULL REFERENCES organizations(id),
+    name        TEXT NOT NULL,
+    slug        TEXT NOT NULL,
+    created_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(org_id, slug)
+);
+
+CREATE INDEX IF NOT EXISTS idx_spaces_org_id ON spaces(org_id);
+
+CREATE TABLE IF NOT EXISTS space_memberships (
+    user_id     TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    space_id    TEXT NOT NULL REFERENCES spaces(id) ON DELETE CASCADE,
+    role        TEXT NOT NULL DEFAULT 'member',
+    created_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (user_id, space_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_memberships_space_id ON space_memberships(space_id);

--- a/migrations/org/002_auth_tables.sql
+++ b/migrations/org/002_auth_tables.sql
@@ -1,0 +1,59 @@
+-- OAuth2 clients, API keys, and auth state tables.
+-- These bridge the assistant-auth crate's store traits to persistent storage.
+
+CREATE TABLE IF NOT EXISTS api_keys (
+    id              TEXT PRIMARY KEY,
+    user_id         TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name            TEXT NOT NULL,
+    key_hash        TEXT NOT NULL UNIQUE,
+    key_prefix      TEXT NOT NULL,
+    org_id          TEXT NOT NULL REFERENCES organizations(id),
+    space_roles_json TEXT NOT NULL DEFAULT '{}',
+    scopes_json     TEXT NOT NULL DEFAULT '[]',
+    expires_at      DATETIME,
+    created_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_api_keys_user_id ON api_keys(user_id);
+CREATE INDEX IF NOT EXISTS idx_api_keys_key_hash ON api_keys(key_hash);
+
+CREATE TABLE IF NOT EXISTS oauth_clients (
+    client_id                   TEXT PRIMARY KEY,
+    client_name                 TEXT NOT NULL,
+    client_secret_hash          TEXT,
+    redirect_uris_json          TEXT NOT NULL DEFAULT '[]',
+    grant_types_json            TEXT NOT NULL DEFAULT '[]',
+    token_endpoint_auth_method  TEXT NOT NULL DEFAULT 'none',
+    created_at                  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS auth_codes (
+    code_hash       TEXT PRIMARY KEY,
+    user_id         TEXT NOT NULL,
+    client_id       TEXT NOT NULL,
+    redirect_uri    TEXT NOT NULL,
+    pkce_challenge  TEXT,
+    scopes_json     TEXT NOT NULL DEFAULT '[]',
+    expires_at      DATETIME NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS refresh_tokens (
+    token_hash  TEXT PRIMARY KEY,
+    user_id     TEXT NOT NULL,
+    client_id   TEXT NOT NULL,
+    scopes_json TEXT NOT NULL DEFAULT '[]',
+    expires_at  DATETIME NOT NULL,
+    consumed    INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_user_client
+    ON refresh_tokens(user_id, client_id);
+
+CREATE TABLE IF NOT EXISTS device_codes (
+    device_code_hash TEXT PRIMARY KEY,
+    user_code        TEXT NOT NULL UNIQUE,
+    client_id        TEXT NOT NULL,
+    scopes_json      TEXT NOT NULL DEFAULT '[]',
+    authorized_user  TEXT,
+    expires_at       DATETIME NOT NULL
+);


### PR DESCRIPTION
## Summary

- Adds backend-agnostic store traits (`OrgStore`, `UserStore`, `SpaceStore`, `MembershipStore`) in `assistant-core` with in-memory implementations for tests
- Introduces `org.db` — a separate SQLite database for org-level data with its own migration runner (`OrgStorageLayer`)
- Implements all four store traits against SQLite: `SqliteOrgStore`, `SqliteUserStore`, `SqliteSpaceStore`, `SqliteMembershipStore`
- Bridges the auth crate's store traits to SQLite: `SqliteClientStore`, `SqliteAuthCodeStore`, `SqliteRefreshTokenStore`, `SqliteDeviceCodeStore`
- Adds `OrgPoolFactory` to resolve org slugs to database paths (`~/.assistant/orgs/{slug}/org.db`)

**PR 5 of the multi-user-orgs change** — builds on #615 (OIDC federation + API keys). Pure additive: no existing code modified beyond `lib.rs` re-exports.

## What's in each commit

1. **`feat(core): add multi-tenant store traits and in-memory implementations`** — domain types (`Organization`, `User`, `Space`, `SpaceMembership`), traits, 25 in-memory tests
2. **`feat(storage): add SQLite-backed org, user, space, and membership stores`** — org.db migrations, `OrgStorageLayer`, four SQLite store impls, 26 tests
3. **`feat(storage): add SQLite auth state stores and org pool factory`** — `SqliteClientStore`, `SqliteAuthCodeStore`, `SqliteRefreshTokenStore`, `SqliteDeviceCodeStore`, `OrgPoolFactory`, 14 tests

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo test -p assistant-storage` — 40 new tests (org/user/space/membership CRUD, auth code single-use, refresh token rotation/revocation, device code lifecycle, pool factory path resolution)
- [x] `cargo test -p assistant-core` — 25 in-memory store tests
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `cargo machete` — no unused deps