### PR TITLE
feat(web-ui): auth middleware rewrite — JWT, API key, permission guards, session cookies

### DIFF
--- a/crates/auth/src/jwt.rs
+++ b/crates/auth/src/jwt.rs
@@ -155,6 +155,11 @@ impl JwtManager {
         self
     }
 
+    /// Return the configured access token TTL in seconds.
+    pub fn access_ttl_secs(&self) -> u64 {
+        self.access_ttl.num_seconds().max(0) as u64
+    }
+
     /// Sign a JWT for the given auth context.
     pub fn sign(&self, ctx: &AuthContext, org_slug: &str, name: &str) -> Result<String> {
         let now = Utc::now();

--- a/crates/auth/src/middleware.rs
+++ b/crates/auth/src/middleware.rs
@@ -140,6 +140,7 @@ impl FromRequestParts<AuthState> for AuthExtractor {
 ///
 /// Verifies that the extracted [`AuthContext`] has the required scope
 /// for the given space, resource, and action.
+#[derive(Clone)]
 pub struct RequireScope {
     pub space_id: SpaceId,
     pub resource: ResourceKind,

--- a/crates/web-ui/Cargo.toml
+++ b/crates/web-ui/Cargo.toml
@@ -34,6 +34,7 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tokio-stream = { workspace = true }
+tower = { workspace = true }
 tower-http = { workspace = true }
 tracing = { workspace = true }
 chrono = { workspace = true }
@@ -63,7 +64,6 @@ urlencoding.workspace = true
 
 [dev-dependencies]
 tempfile = { workspace = true }
-tower = { workspace = true }
 http-body-util = { workspace = true }
 wiremock = { workspace = true }
 uuid = { workspace = true }

--- a/crates/web-ui/src/auth.rs
+++ b/crates/web-ui/src/auth.rs
@@ -806,11 +806,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn expired_session_cookie_returns_401() {
+    async fn invalid_session_cookie_returns_401() {
         let (config, _jwt_sign) = test_config();
         let app = test_app(config);
 
-        // Sign a JWT with a different secret so it fails validation.
+        // Sign a JWT with a different secret so it fails signature validation.
         let other_kp = JwtKeyPair::from_secret(b"other-secret-that-is-long-enough");
         let other_mgr = JwtManager::new(
             other_kp,
@@ -834,7 +834,53 @@ mod tests {
         assert_eq!(
             resp.status(),
             StatusCode::UNAUTHORIZED,
-            "invalid session cookie should return 401"
+            "session cookie signed with wrong secret should return 401"
+        );
+    }
+
+    #[tokio::test]
+    async fn expired_session_cookie_returns_401() {
+        // Build a JwtManager with a negative TTL so the token is already expired.
+        let kp = JwtKeyPair::from_secret(b"test-secret-key-for-unit-tests!");
+        let expired_mgr =
+            JwtManager::new(kp, "https://test.local".into(), "https://test.local".into())
+                .with_access_ttl(chrono::Duration::seconds(-120));
+
+        let ctx = make_user_context();
+        let expired_jwt = expired_mgr.sign(&ctx, "acme", "Alice").unwrap();
+
+        // The auth config uses the same secret so signature is valid, but the
+        // token is expired.
+        let verify_kp = JwtKeyPair::from_secret(b"test-secret-key-for-unit-tests!");
+        let verify_mgr = Arc::new(JwtManager::new(
+            verify_kp,
+            "https://test.local".into(),
+            "https://test.local".into(),
+        ));
+        let config = WebAuthConfig::new(
+            verify_mgr,
+            Arc::new(InMemoryApiKeyStore::new()),
+            None,
+            None,
+            false,
+        );
+        let app = test_app(config);
+
+        let resp = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/whoami")
+                    .header("cookie", format!("{}={}", SESSION_COOKIE, expired_jwt))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "expired session cookie should return 401"
         );
     }
 

--- a/crates/web-ui/src/auth.rs
+++ b/crates/web-ui/src/auth.rs
@@ -223,7 +223,7 @@ pub async fn require_same_origin_mutation(request: Request, next: Next) -> Respo
             .unwrap();
     };
 
-    if origin_host.as_bytes() != host.as_bytes() {
+    if !origin_host.eq_ignore_ascii_case(host) {
         return Response::builder()
             .status(StatusCode::FORBIDDEN)
             .body(Body::from("Forbidden"))
@@ -1108,6 +1108,28 @@ mod tests {
             resp.status(),
             StatusCode::FORBIDDEN,
             "POST with mismatched Origin should be blocked"
+        );
+    }
+
+    #[tokio::test]
+    async fn csrf_allows_mixed_case_origin() {
+        let app = csrf_app();
+        let resp = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .method("POST")
+                    .uri("/action")
+                    .header("host", "Example.COM")
+                    .header("origin", "https://example.com")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "POST with case-different but matching Origin should pass"
         );
     }
 

--- a/crates/web-ui/src/auth.rs
+++ b/crates/web-ui/src/auth.rs
@@ -1,116 +1,154 @@
-//! Token-based authentication for the web UI.
+//! Authentication middleware for the web UI.
 //!
-//! Provides a login page (cookie-based sessions for browsers) and Bearer token
-//! validation for A2A / API callers.  The server **requires** an auth token to
-//! start — see [`AuthConfig`] and the `--auth-token` / `ASSISTANT_WEB_TOKEN`
-//! environment variable.
+//! Resolves an [`AuthContext`] from incoming requests using (in order):
+//!
+//! 1. `Authorization: Bearer <JWT>` — validated by [`JwtManager`]
+//! 2. Session cookie containing a JWT
+//! 3. `Authorization: Bearer <api_key>` — resolved via [`ApiKeyStore`]
+//! 4. `Authorization: Bearer <legacy_token>` — backward-compatible static token
+//!
+//! The resolved [`AuthContext`] is injected as an [`Extension`] so all
+//! downstream handlers can extract it.
+//!
+//! The legacy token (`ASSISTANT_WEB_TOKEN`) is supported as a migration bridge:
+//! it maps to a default org-admin context so existing single-user deployments
+//! continue to work without reconfiguration.
 
 use std::sync::Arc;
 
 use axum::Form;
 use axum::body::Body;
-use axum::extract::{Extension, Request};
+use axum::extract::{Request, State};
 use axum::http::header::{COOKIE, HOST, LOCATION, ORIGIN, REFERER, SET_COOKIE};
 use axum::http::{Method, StatusCode};
 use axum::middleware::Next;
 use axum::response::{Html, IntoResponse, Response};
-use hmac::{Hmac, KeyInit, Mac};
 use serde::Deserialize;
-use sha2::Sha256;
+
+use assistant_auth::api_keys::{self, ApiKeyStore};
+use assistant_auth::jwt::JwtManager;
+use assistant_auth::middleware::{AuthState, RequireScope};
+use assistant_core::auth::AuthContext;
+use assistant_core::identity::{Action, ResourceKind, SpaceId};
 
 // -- Configuration ----------------------------------------------------------
 
-/// Session cookie name.  `__Host-` prefix is only valid over HTTPS; since
-/// the UI commonly runs over plain HTTP on localhost we use a simpler name.
+/// Session cookie name.
 const SESSION_COOKIE: &str = "assistant_session";
 
-/// HMAC message used to derive the session token from the auth token.
-const SESSION_HMAC_MSG: &[u8] = b"assistant-web-session-v1";
-
-/// Shared authentication configuration injected via [`Extension`].
+/// Shared authentication configuration for the web UI.
+///
+/// Wraps [`AuthState`] (JWT + API key + legacy token resolution) and adds
+/// web-specific settings like cookie attributes.
 #[derive(Clone)]
-pub struct AuthConfig {
-    /// The raw auth token (for Bearer comparison).
-    token: Arc<String>,
-    /// Pre-computed HMAC-SHA256 hex digest used as the session cookie value.
-    session_value: Arc<String>,
+pub struct WebAuthConfig {
+    /// Auth state for token resolution (JWT, API key, legacy).
+    pub auth_state: AuthState,
     /// When `true`, the `Secure` attribute is added to session cookies.
-    /// Should be `true` whenever the server is *not* bound to a loopback
-    /// address (cookies must only travel over HTTPS in that case).
-    secure_cookie: bool,
+    pub secure_cookie: bool,
 }
 
-impl AuthConfig {
-    /// Create a new [`AuthConfig`] from the raw token string.
+impl WebAuthConfig {
+    /// Create a new [`WebAuthConfig`].
     ///
-    /// Set `secure_cookie` to `true` when the server binds to a non-loopback
-    /// address so that the session cookie gets the `Secure` attribute.
-    pub fn new(token: String, secure_cookie: bool) -> Self {
-        let session_value = compute_session_value(&token);
+    /// - `jwt_manager`: signs and validates JWTs.
+    /// - `api_key_store`: resolves `ask_live_` API keys.
+    /// - `legacy_token`: optional backward-compatible static token.
+    /// - `legacy_context`: [`AuthContext`] returned when the legacy token matches.
+    /// - `secure_cookie`: set `true` for non-loopback addresses (HTTPS required).
+    pub fn new(
+        jwt_manager: Arc<JwtManager>,
+        api_key_store: Arc<dyn ApiKeyStore>,
+        legacy_token: Option<String>,
+        legacy_context: Option<AuthContext>,
+        secure_cookie: bool,
+    ) -> Self {
         Self {
-            token: Arc::new(token),
-            session_value: Arc::new(session_value),
+            auth_state: AuthState {
+                jwt_manager,
+                api_key_store,
+                legacy_token,
+                legacy_context,
+            },
             secure_cookie,
         }
     }
 }
 
-// -- Session token derivation -----------------------------------------------
+// -- Token resolution -------------------------------------------------------
 
-type HmacSha256 = Hmac<Sha256>;
-
-/// Derive a stable session cookie value from the auth token using HMAC-SHA256.
+/// Try to resolve an [`AuthContext`] from a bearer token string.
 ///
-/// The cookie never contains the raw token — only this derived value.
-fn compute_session_value(auth_token: &str) -> String {
-    let mut mac =
-        HmacSha256::new_from_slice(auth_token.as_bytes()).expect("HMAC accepts any key length");
-    mac.update(SESSION_HMAC_MSG);
-    hex::encode(mac.finalize().into_bytes())
-}
-
-/// Constant-time comparison of two equal-length byte slices.
-fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
+/// Resolution order: JWT → API key → legacy token.
+async fn resolve_bearer(auth: &AuthState, token: &str) -> Option<AuthContext> {
+    // 1. Try JWT.
+    if let Ok(ctx) = auth.jwt_manager.validate_to_context(token) {
+        return Some(ctx);
     }
-    a.iter()
-        .zip(b.iter())
-        .fold(0u8, |acc, (x, y)| acc | (x ^ y))
-        == 0
+
+    // 2. Try API key.
+    if token.starts_with("ask_live_")
+        && let Ok(ctx) = api_keys::resolve_key(token, auth.api_key_store.as_ref()).await
+    {
+        return Some(ctx);
+    }
+
+    // 3. Try legacy token.
+    if let Some(ref legacy) = auth.legacy_token
+        && token == legacy
+        && let Some(ref ctx) = auth.legacy_context
+    {
+        return Some(ctx.clone());
+    }
+
+    None
 }
 
 // -- Middleware --------------------------------------------------------------
 
 /// Axum middleware that enforces authentication on every matched route.
 ///
-/// Accepts either:
-/// - A valid session cookie (browser flow), or
-/// - An `Authorization: Bearer <token>` header (API / A2A flow).
+/// Resolves an [`AuthContext`] from Bearer tokens or session cookies and
+/// inserts it as an [`Extension<AuthContext>`] for downstream handlers.
 ///
 /// Unauthenticated browser requests are redirected to `/login`.
 /// Unauthenticated API requests receive `401 Unauthorized`.
 pub async fn require_auth(
-    Extension(auth): Extension<AuthConfig>,
-    request: Request,
+    State(config): State<WebAuthConfig>,
+    mut request: Request,
     next: Next,
 ) -> Response {
-    // 1. Check session cookie.
-    if let Some(cookie_header) = request.headers().get(COOKIE)
-        && let Ok(cookies) = cookie_header.to_str()
-        && extract_cookie(cookies, SESSION_COOKIE)
-            .map(|v| constant_time_eq(v.as_bytes(), auth.session_value.as_bytes()))
-            .unwrap_or(false)
+    let auth = config.auth_state.clone();
+
+    // Extract bearer token and session cookie JWT before any async work,
+    // so we hold only owned values across .await points.
+    let bearer_token: Option<String> = request
+        .headers()
+        .get("authorization")
+        .and_then(|h| h.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .map(|t| t.trim().to_string());
+
+    let cookie_jwt: Option<String> = request
+        .headers()
+        .get(COOKIE)
+        .and_then(|h| h.to_str().ok())
+        .and_then(|cookies| extract_cookie(cookies, SESSION_COOKIE))
+        .map(|s| s.to_string());
+
+    // 1. Check Authorization: Bearer <token>.
+    if let Some(ref token) = bearer_token
+        && let Some(ctx) = resolve_bearer(&auth, token).await
     {
+        request.extensions_mut().insert(ctx);
         return next.run(request).await;
     }
 
-    // 2. Check Authorization: Bearer <token>.
-    if let Some(auth_header) = request.headers().get("authorization")
-        && let Ok(value) = auth_header.to_str()
-        && let Some(bearer) = value.strip_prefix("Bearer ")
-        && constant_time_eq(bearer.trim().as_bytes(), auth.token.as_bytes())
+    // 2. Check session cookie for a JWT.
+    if let Some(ref jwt) = cookie_jwt
+        && let Ok(ctx) = auth.jwt_manager.validate_to_context(jwt)
     {
+        request.extensions_mut().insert(ctx);
         return next.run(request).await;
     }
 
@@ -123,14 +161,12 @@ pub async fn require_auth(
         .unwrap_or(false);
 
     if accepts_html {
-        // Redirect browsers to the login page.
         Response::builder()
             .status(StatusCode::SEE_OTHER)
             .header(LOCATION, "/login")
             .body(Body::empty())
             .unwrap()
     } else {
-        // Return 401 for API callers.
         Response::builder()
             .status(StatusCode::UNAUTHORIZED)
             .header("WWW-Authenticate", "Bearer")
@@ -187,7 +223,7 @@ pub async fn require_same_origin_mutation(request: Request, next: Next) -> Respo
             .unwrap();
     };
 
-    if !constant_time_eq(origin_host.as_bytes(), host.as_bytes()) {
+    if origin_host.as_bytes() != host.as_bytes() {
         return Response::builder()
             .status(StatusCode::FORBIDDEN)
             .body(Body::from("Forbidden"))
@@ -195,6 +231,116 @@ pub async fn require_same_origin_mutation(request: Request, next: Next) -> Respo
     }
 
     next.run(request).await
+}
+
+// -- Permission guard -------------------------------------------------------
+
+/// Tower [`Layer`] that checks whether the authenticated user has the required
+/// scope (space + resource + action) before passing the request to the inner
+/// service.
+///
+/// Must be applied **after** [`require_auth`] in the middleware stack so that
+/// `Extension<AuthContext>` is present in the request extensions.
+///
+/// Returns 401 if no [`AuthContext`] is found, 403 if the scope check fails.
+///
+/// # Usage
+///
+/// ```ignore
+/// Router::new()
+///     .route("/personas", get(list))
+///     .route_layer(require_scope_layer(
+///         SpaceId::from("eng"),
+///         ResourceKind::Personas,
+///         Action::Read,
+///     ))
+/// ```
+pub fn require_scope_layer(
+    space_id: SpaceId,
+    resource: ResourceKind,
+    action: Action,
+) -> RequireScopeLayer {
+    RequireScopeLayer {
+        scope: RequireScope {
+            space_id,
+            resource,
+            action,
+            target_id: None,
+        },
+    }
+}
+
+/// A [`tower::Layer`] produced by [`require_scope_layer`].
+#[derive(Clone)]
+pub struct RequireScopeLayer {
+    scope: RequireScope,
+}
+
+impl<S> tower::Layer<S> for RequireScopeLayer {
+    type Service = RequireScopeService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        RequireScopeService {
+            inner,
+            scope: self.scope.clone(),
+        }
+    }
+}
+
+/// Tower [`Service`] that enforces a scope check before forwarding to the
+/// inner service.
+#[derive(Clone)]
+pub struct RequireScopeService<S> {
+    inner: S,
+    scope: RequireScope,
+}
+
+impl<S> tower::Service<Request> for RequireScopeService<S>
+where
+    S: tower::Service<Request, Response = Response> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = Response;
+    type Error = S::Error;
+    type Future =
+        std::pin::Pin<Box<dyn std::future::Future<Output = Result<Response, S::Error>> + Send>>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        let scope = self.scope.clone();
+        let mut inner = self.inner.clone();
+        // Swap so the ready inner is used (standard tower pattern).
+        std::mem::swap(&mut self.inner, &mut inner);
+
+        Box::pin(async move {
+            let Some(ctx) = request.extensions().get::<AuthContext>() else {
+                return Ok(Response::builder()
+                    .status(StatusCode::UNAUTHORIZED)
+                    .header("WWW-Authenticate", "Bearer")
+                    .body(Body::from("Unauthorized"))
+                    .unwrap());
+            };
+
+            if let Err(err) = scope.check(ctx) {
+                return Ok((
+                    StatusCode::FORBIDDEN,
+                    format!(
+                        "insufficient permissions: requires {}:{} in space {}",
+                        err.resource, err.action, err.space_id,
+                    ),
+                )
+                    .into_response());
+            }
+
+            inner.call(request).await
+        })
+    }
 }
 
 // -- Login page -------------------------------------------------------------
@@ -250,38 +396,50 @@ pub async fn login_page() -> Html<String> {
     login_html(None)
 }
 
-/// `POST /login` — validate the submitted token and set a session cookie.
+/// `POST /login` — validate the submitted token and set a session cookie (JWT).
 #[derive(Deserialize)]
 pub(crate) struct LoginForm {
     token: String,
 }
 
 pub(crate) async fn login_submit(
-    Extension(auth): Extension<AuthConfig>,
+    State(config): State<WebAuthConfig>,
     Form(form): Form<LoginForm>,
 ) -> Response {
-    if constant_time_eq(form.token.as_bytes(), auth.token.as_bytes()) {
-        let secure = if auth.secure_cookie { "; Secure" } else { "" };
-        let cookie = format!(
-            "{}={}; HttpOnly; SameSite=Strict; Path=/; Max-Age=604800{}",
-            SESSION_COOKIE, auth.session_value, secure,
-        );
-        Response::builder()
-            .status(StatusCode::SEE_OTHER)
-            .header(LOCATION, "/")
-            .header(SET_COOKIE, cookie)
-            .body(Body::empty())
-            .unwrap()
-    } else {
-        login_html(Some("Invalid token.")).into_response()
+    let auth = &config.auth_state;
+
+    // Resolve the token (could be a legacy token, JWT, or API key).
+    let ctx = resolve_bearer(auth, &form.token).await;
+
+    match ctx {
+        Some(ctx) => {
+            // Sign a session JWT for the cookie.
+            let jwt = match auth.jwt_manager.sign(&ctx, "default", &ctx.email) {
+                Ok(t) => t,
+                Err(_) => return login_html(Some("Internal error.")).into_response(),
+            };
+
+            let secure = if config.secure_cookie { "; Secure" } else { "" };
+            let cookie = format!(
+                "{}={}; HttpOnly; SameSite=Lax; Path=/; Max-Age=3600{}",
+                SESSION_COOKIE, jwt, secure,
+            );
+            Response::builder()
+                .status(StatusCode::SEE_OTHER)
+                .header(LOCATION, "/")
+                .header(SET_COOKIE, cookie)
+                .body(Body::empty())
+                .unwrap()
+        }
+        None => login_html(Some("Invalid token.")).into_response(),
     }
 }
 
 /// `POST /logout` — clear the session cookie and redirect to login.
-pub async fn logout(Extension(auth): Extension<AuthConfig>) -> Response {
-    let secure = if auth.secure_cookie { "; Secure" } else { "" };
+pub async fn logout(State(config): State<WebAuthConfig>) -> Response {
+    let secure = if config.secure_cookie { "; Secure" } else { "" };
     let cookie = format!(
-        "{}=; HttpOnly; SameSite=Strict; Path=/; Max-Age=0{}",
+        "{}=; HttpOnly; SameSite=Lax; Path=/; Max-Age=0{}",
         SESSION_COOKIE, secure,
     );
     Response::builder()
@@ -323,28 +481,674 @@ fn parse_host_from_url(value: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
+    use axum::Extension;
+    use axum::Router;
+    use axum::routing::get;
+    use tower::ServiceExt;
+
+    use assistant_auth::api_keys::InMemoryApiKeyStore;
+    use assistant_auth::jwt::JwtKeyPair;
+    use assistant_core::identity::{OrgId, Role, Scope, SpaceId, UserId};
+
     use super::*;
 
-    #[test]
-    fn test_compute_session_value_deterministic() {
-        let a = compute_session_value("my-secret");
-        let b = compute_session_value("my-secret");
-        assert_eq!(a, b, "same token should produce same session value");
+    /// Build a [`WebAuthConfig`] backed by in-memory stores with a shared
+    /// JWT secret so we can sign tokens in tests.
+    fn test_config() -> (WebAuthConfig, Arc<JwtManager>) {
+        let secret = b"test-secret-that-is-long-enough!!";
+        let kp_state = JwtKeyPair::from_secret(secret);
+        let kp_sign = JwtKeyPair::from_secret(secret);
+
+        let jwt_state = Arc::new(JwtManager::new(
+            kp_state,
+            "https://test.local".into(),
+            "https://test.local".into(),
+        ));
+        let jwt_sign = Arc::new(JwtManager::new(
+            kp_sign,
+            "https://test.local".into(),
+            "https://test.local".into(),
+        ));
+
+        let config = WebAuthConfig::new(
+            jwt_state,
+            Arc::new(InMemoryApiKeyStore::new()),
+            Some("legacy-token-123".into()),
+            Some(make_admin_context()),
+            false,
+        );
+
+        (config, jwt_sign)
     }
 
-    #[test]
-    fn test_compute_session_value_differs_for_different_tokens() {
-        let a = compute_session_value("token-a");
-        let b = compute_session_value("token-b");
-        assert_ne!(a, b);
+    fn make_admin_context() -> AuthContext {
+        let mut space_roles = HashMap::new();
+        space_roles.insert(SpaceId::from("default"), Role::OrgAdmin);
+        AuthContext {
+            user_id: UserId::from("admin"),
+            org_id: OrgId::from("default"),
+            email: "admin@local".into(),
+            space_roles,
+            scopes: vec![Scope::new(
+                assistant_core::identity::ResourceKind::Org,
+                assistant_core::identity::Action::Manage,
+            )],
+            client_id: "legacy".into(),
+        }
     }
 
-    #[test]
-    fn test_constant_time_eq() {
-        assert!(constant_time_eq(b"hello", b"hello"));
-        assert!(!constant_time_eq(b"hello", b"world"));
-        assert!(!constant_time_eq(b"short", b"longer"));
+    fn make_user_context() -> AuthContext {
+        let mut space_roles = HashMap::new();
+        space_roles.insert(SpaceId::from("eng"), Role::Member);
+        AuthContext {
+            user_id: UserId::from("alice"),
+            org_id: OrgId::from("acme"),
+            email: "alice@acme.com".into(),
+            space_roles,
+            scopes: vec![
+                Scope::new(ResourceKind::Conversations, Action::Read),
+                Scope::new(ResourceKind::Conversations, Action::Write),
+                Scope::new(ResourceKind::Personas, Action::Read),
+            ],
+            client_id: "webui".into(),
+        }
     }
+
+    /// Build a test app that returns the extracted AuthContext user_id.
+    fn test_app(config: WebAuthConfig) -> Router {
+        async fn whoami(Extension(ctx): Extension<AuthContext>) -> String {
+            ctx.user_id.to_string()
+        }
+
+        Router::new()
+            .route("/whoami", get(whoami))
+            .route_layer(axum::middleware::from_fn_with_state(config, require_auth))
+    }
+
+    // -- Tests: Bearer JWT ---------------------------------------------------
+
+    #[tokio::test]
+    async fn bearer_jwt_produces_auth_context() {
+        let (config, jwt_sign) = test_config();
+        let app = test_app(config);
+
+        let ctx = make_user_context();
+        let token = jwt_sign.sign(&ctx, "acme", "Alice").unwrap();
+
+        let resp = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/whoami")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK, "valid JWT should pass auth");
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(
+            String::from_utf8_lossy(&body),
+            "alice",
+            "AuthContext should contain the JWT user_id"
+        );
+    }
+
+    // -- Tests: Legacy token -------------------------------------------------
+
+    #[tokio::test]
+    async fn bearer_legacy_token_produces_admin_context() {
+        let (config, _jwt_sign) = test_config();
+        let app = test_app(config);
+
+        let resp = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/whoami")
+                    .header("authorization", "Bearer legacy-token-123")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "legacy token should pass auth"
+        );
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(
+            String::from_utf8_lossy(&body),
+            "admin",
+            "legacy token should map to admin context"
+        );
+    }
+
+    // -- Tests: API key ------------------------------------------------------
+
+    #[tokio::test]
+    async fn bearer_api_key_produces_auth_context() {
+        let (config, _jwt_sign) = test_config();
+
+        // Store an API key in the in-memory store.
+        let key = assistant_auth::api_keys::generate_key();
+        let mut space_roles = HashMap::new();
+        space_roles.insert(SpaceId::from("eng"), Role::Member);
+        let record = assistant_auth::api_keys::ApiKeyRecord {
+            id: "key_test".into(),
+            user_id: UserId::from("bob"),
+            name: "Test Key".into(),
+            key_hash: key.key_hash.clone(),
+            key_prefix: key.key_prefix.clone(),
+            org_id: OrgId::from("acme"),
+            space_roles,
+            scopes: vec![],
+            expires_at: None,
+            created_at: chrono::Utc::now(),
+        };
+        config
+            .auth_state
+            .api_key_store
+            .store_key(record)
+            .await
+            .unwrap();
+
+        let app = test_app(config);
+
+        let resp = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/whoami")
+                    .header("authorization", format!("Bearer {}", key.plaintext))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "valid API key should pass auth"
+        );
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(
+            String::from_utf8_lossy(&body),
+            "bob",
+            "API key should resolve to the key owner"
+        );
+    }
+
+    // -- Tests: Session cookie -----------------------------------------------
+
+    #[tokio::test]
+    async fn session_cookie_jwt_produces_auth_context() {
+        let (config, jwt_sign) = test_config();
+        let app = test_app(config);
+
+        let ctx = make_user_context();
+        let jwt = jwt_sign.sign(&ctx, "acme", "Alice").unwrap();
+
+        let resp = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/whoami")
+                    .header("cookie", format!("{}={}", SESSION_COOKIE, jwt))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "valid session cookie JWT should pass auth"
+        );
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(
+            String::from_utf8_lossy(&body),
+            "alice",
+            "session cookie should resolve to JWT user"
+        );
+    }
+
+    // -- Tests: Unauthenticated requests ------------------------------------
+
+    #[tokio::test]
+    async fn missing_auth_returns_401_for_api() {
+        let (config, _jwt_sign) = test_config();
+        let app = test_app(config);
+
+        let resp = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/whoami")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "missing auth should return 401 for API requests"
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_auth_redirects_browsers() {
+        let (config, _jwt_sign) = test_config();
+        let app = test_app(config);
+
+        let resp = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/whoami")
+                    .header("accept", "text/html")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::SEE_OTHER,
+            "missing auth should redirect browsers"
+        );
+        assert_eq!(
+            resp.headers().get("location").unwrap().to_str().unwrap(),
+            "/login"
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_bearer_returns_401() {
+        let (config, _jwt_sign) = test_config();
+        let app = test_app(config);
+
+        let resp = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/whoami")
+                    .header("authorization", "Bearer invalid-garbage")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "invalid bearer should return 401"
+        );
+    }
+
+    #[tokio::test]
+    async fn expired_session_cookie_returns_401() {
+        let (config, _jwt_sign) = test_config();
+        let app = test_app(config);
+
+        // Sign a JWT with a different secret so it fails validation.
+        let other_kp = JwtKeyPair::from_secret(b"other-secret-that-is-long-enough");
+        let other_mgr = JwtManager::new(
+            other_kp,
+            "https://test.local".into(),
+            "https://test.local".into(),
+        );
+        let ctx = make_user_context();
+        let bad_jwt = other_mgr.sign(&ctx, "acme", "Alice").unwrap();
+
+        let resp = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/whoami")
+                    .header("cookie", format!("{}={}", SESSION_COOKIE, bad_jwt))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "invalid session cookie should return 401"
+        );
+    }
+
+    // -- Tests: RequireScope middleware ----------------------------------------
+
+    use assistant_core::identity::{Action, ResourceKind};
+
+    /// Build a test app with auth + scope check on a protected route.
+    fn scoped_app(
+        config: WebAuthConfig,
+        space: &str,
+        resource: ResourceKind,
+        action: Action,
+    ) -> Router {
+        async fn whoami(Extension(ctx): Extension<AuthContext>) -> String {
+            ctx.user_id.to_string()
+        }
+
+        Router::new()
+            .route("/protected", get(whoami))
+            .route_layer(require_scope_layer(SpaceId::from(space), resource, action))
+            .route_layer(axum::middleware::from_fn_with_state(config, require_auth))
+    }
+
+    #[tokio::test]
+    async fn scope_allows_admin() {
+        let (config, jwt_sign) = test_config();
+        let app = scoped_app(config, "any-space", ResourceKind::Users, Action::Manage);
+
+        let ctx = make_admin_context();
+        let token = jwt_sign.sign(&ctx, "default", "Admin").unwrap();
+
+        let resp = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/protected")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "org admin should bypass scope checks"
+        );
+    }
+
+    #[tokio::test]
+    async fn scope_allows_matching_permission() {
+        let (config, jwt_sign) = test_config();
+        let app = scoped_app(config, "eng", ResourceKind::Conversations, Action::Read);
+
+        // make_user_context has no scopes but has Member role in "eng" space.
+        // Member can read conversations.
+        let ctx = make_user_context();
+        let token = jwt_sign.sign(&ctx, "acme", "Alice").unwrap();
+
+        let resp = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/protected")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "member with matching space/resource/action should pass"
+        );
+    }
+
+    #[tokio::test]
+    async fn scope_denies_wrong_space() {
+        let (config, jwt_sign) = test_config();
+        let app = scoped_app(
+            config,
+            "marketing",
+            ResourceKind::Conversations,
+            Action::Read,
+        );
+
+        let ctx = make_user_context(); // only has "eng" space
+        let token = jwt_sign.sign(&ctx, "acme", "Alice").unwrap();
+
+        let resp = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/protected")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::FORBIDDEN,
+            "wrong space should return 403"
+        );
+    }
+
+    #[tokio::test]
+    async fn scope_denies_insufficient_action() {
+        let (config, jwt_sign) = test_config();
+        let app = scoped_app(config, "eng", ResourceKind::Users, Action::Manage);
+
+        let ctx = make_user_context(); // Member in "eng", no manage scope
+        let token = jwt_sign.sign(&ctx, "acme", "Alice").unwrap();
+
+        let resp = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/protected")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::FORBIDDEN,
+            "insufficient action should return 403"
+        );
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_str = String::from_utf8_lossy(&body);
+        assert!(
+            body_str.contains("insufficient permissions"),
+            "403 body should explain the denial"
+        );
+    }
+
+    #[tokio::test]
+    async fn scope_returns_401_without_auth_context() {
+        // No auth middleware → no AuthContext extension → should 401
+        async fn whoami(Extension(ctx): Extension<AuthContext>) -> String {
+            ctx.user_id.to_string()
+        }
+
+        let app = Router::new()
+            .route("/protected", get(whoami))
+            .route_layer(require_scope_layer(
+                SpaceId::from("eng"),
+                ResourceKind::Conversations,
+                Action::Read,
+            ));
+
+        let resp = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/protected")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "missing AuthContext should return 401"
+        );
+    }
+
+    // -- Tests: CSRF (require_same_origin_mutation) ---------------------------
+
+    use axum::routing::post;
+
+    /// Build a test app with CSRF middleware on a POST endpoint.
+    fn csrf_app() -> Router {
+        async fn ok() -> &'static str {
+            "ok"
+        }
+
+        Router::new()
+            .route("/action", post(ok))
+            .route("/action", get(ok))
+            .route_layer(axum::middleware::from_fn(require_same_origin_mutation))
+    }
+
+    #[tokio::test]
+    async fn csrf_allows_safe_methods() {
+        let app = csrf_app();
+        let resp = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .method("GET")
+                    .uri("/action")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "GET should bypass CSRF check"
+        );
+    }
+
+    #[tokio::test]
+    async fn csrf_allows_bearer_auth() {
+        let app = csrf_app();
+        let resp = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .method("POST")
+                    .uri("/action")
+                    .header("authorization", "Bearer some-token")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "Bearer-authenticated POST should bypass CSRF check"
+        );
+    }
+
+    #[tokio::test]
+    async fn csrf_allows_matching_origin() {
+        let app = csrf_app();
+        let resp = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .method("POST")
+                    .uri("/action")
+                    .header("host", "example.com")
+                    .header("origin", "https://example.com")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "POST with matching Origin should pass"
+        );
+    }
+
+    #[tokio::test]
+    async fn csrf_blocks_mismatched_origin() {
+        let app = csrf_app();
+        let resp = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .method("POST")
+                    .uri("/action")
+                    .header("host", "example.com")
+                    .header("origin", "https://evil.com")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::FORBIDDEN,
+            "POST with mismatched Origin should be blocked"
+        );
+    }
+
+    #[tokio::test]
+    async fn csrf_blocks_missing_origin_on_mutation() {
+        let app = csrf_app();
+        let resp = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .method("POST")
+                    .uri("/action")
+                    .header("host", "example.com")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::FORBIDDEN,
+            "POST without Origin/Referer should be blocked"
+        );
+    }
+
+    #[tokio::test]
+    async fn csrf_falls_back_to_referer() {
+        let app = csrf_app();
+        let resp = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .method("POST")
+                    .uri("/action")
+                    .header("host", "example.com")
+                    .header("referer", "https://example.com/page")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "POST with matching Referer (no Origin) should pass"
+        );
+    }
+
+    // -- Tests: Helpers (kept from original) ----------------------------------
 
     #[test]
     fn test_extract_cookie() {

--- a/crates/web-ui/src/auth.rs
+++ b/crates/web-ui/src/auth.rs
@@ -413,16 +413,22 @@ pub(crate) async fn login_submit(
 
     match ctx {
         Some(ctx) => {
-            // Sign a session JWT for the cookie.
-            let jwt = match auth.jwt_manager.sign(&ctx, "default", &ctx.email) {
+            // Sign a session JWT for the cookie using the resolved context's identity.
+            let display = if ctx.email.is_empty() {
+                ctx.user_id.to_string()
+            } else {
+                ctx.email.clone()
+            };
+            let jwt = match auth.jwt_manager.sign(&ctx, ctx.org_id.as_ref(), &display) {
                 Ok(t) => t,
                 Err(_) => return login_html(Some("Internal error.")).into_response(),
             };
 
+            let ttl = auth.jwt_manager.access_ttl_secs();
             let secure = if config.secure_cookie { "; Secure" } else { "" };
             let cookie = format!(
-                "{}={}; HttpOnly; SameSite=Lax; Path=/; Max-Age=3600{}",
-                SESSION_COOKIE, jwt, secure,
+                "{}={}; HttpOnly; SameSite=Lax; Path=/; Max-Age={}{}",
+                SESSION_COOKIE, jwt, ttl, secure,
             );
             Response::builder()
                 .status(StatusCode::SEE_OTHER)

--- a/crates/web-ui/src/main.rs
+++ b/crates/web-ui/src/main.rs
@@ -646,7 +646,9 @@ async fn run_with_args(args: Args) -> Result<()> {
     // -- JWT + OAuth2 state ---------------------------------------------------
     let jwt_manager = {
         use assistant_auth::jwt::{JwtKeyPair, JwtManager};
-        let jwt_key_pair = JwtKeyPair::generate().context("Failed to generate JWT signing key")?;
+        let jwt_secret_path = db_path.with_file_name("jwt_secret");
+        let jwt_key_pair = JwtKeyPair::load_or_generate(&jwt_secret_path)
+            .context("Failed to load or generate JWT signing key")?;
         Arc::new(JwtManager::new(
             jwt_key_pair,
             base_url.clone(),
@@ -685,13 +687,15 @@ async fn run_with_args(args: Args) -> Result<()> {
     // -- Auth config (JWT + API key + legacy token) --------------------------
     let legacy_context = legacy_token.as_ref().map(|_| {
         use assistant_core::auth::AuthContext;
-        use assistant_core::identity::{OrgId, UserId};
+        use assistant_core::identity::{Action, OrgId, ResourceKind, Role, Scope, SpaceId, UserId};
+        let mut space_roles = std::collections::HashMap::new();
+        space_roles.insert(SpaceId::from("default"), Role::OrgAdmin);
         AuthContext {
             user_id: UserId::from("admin"),
             org_id: OrgId::from("default"),
             email: String::new(),
-            space_roles: std::collections::HashMap::new(),
-            scopes: vec![],
+            space_roles,
+            scopes: vec![Scope::new(ResourceKind::Org, Action::Manage)],
             client_id: "legacy".into(),
         }
     });

--- a/crates/web-ui/src/main.rs
+++ b/crates/web-ui/src/main.rs
@@ -73,8 +73,8 @@ struct Args {
     #[arg(long)]
     db_path: Option<PathBuf>,
 
-    /// Authentication token.  Falls back to ASSISTANT_WEB_TOKEN env var.
-    /// The server will refuse to start without a token.
+    /// Optional legacy authentication token.  Falls back to ASSISTANT_WEB_TOKEN env var.
+    /// When empty or absent the server starts without legacy-token auth.
     #[arg(long, env = "ASSISTANT_WEB_TOKEN")]
     auth_token: Option<String>,
 

--- a/crates/web-ui/src/main.rs
+++ b/crates/web-ui/src/main.rs
@@ -54,7 +54,7 @@ use utoipa::OpenApi as _;
 use utoipa_swagger_ui::SwaggerUi;
 use uuid::Uuid;
 
-use auth::AuthConfig;
+use auth::WebAuthConfig;
 
 use a2a::agent_store::AgentStore;
 use a2a::handlers::{A2AState, build_default_agent_card};
@@ -163,22 +163,15 @@ async fn run_with_args(args: Args) -> Result<()> {
         return Ok(());
     }
 
-    // -- Auth token (required) -----------------------------------------------
-    let auth_token = match args.auth_token.map(|t| t.trim().to_string()) {
-        Some(t) if !t.is_empty() => t,
-        _ => {
-            anyhow::bail!(
-                "No authentication token configured.\n\
-                 Set --auth-token <TOKEN> or the ASSISTANT_WEB_TOKEN environment variable.\n\
-                 The web UI refuses to start without authentication."
-            );
-        }
-    };
+    // -- Auth token (legacy, optional) -----------------------------------------
+    let legacy_token = args
+        .auth_token
+        .map(|t| t.trim().to_string())
+        .filter(|t| !t.is_empty());
 
-    // Parse listen address early so we can pass `is_loopback` to AuthConfig.
+    // Parse listen address early so we can determine cookie security.
     let addr: SocketAddr = args.listen.parse()?;
     let secure_cookie = !addr.ip().is_loopback() && !args.no_secure_cookie;
-    let auth_config = AuthConfig::new(auth_token, secure_cookie);
 
     let db_path = match args.db_path.or_else(default_db_path) {
         Some(p) => p,
@@ -650,19 +643,21 @@ async fn run_with_args(args: Args) -> Result<()> {
         vapid_public_key: Arc::new(vapid_public_key),
     });
 
-    // -- OAuth2 state -------------------------------------------------------
-    let oauth_state = {
+    // -- JWT + OAuth2 state ---------------------------------------------------
+    let jwt_manager = {
         use assistant_auth::jwt::{JwtKeyPair, JwtManager};
-        use assistant_auth::oauth2::clients::ClientRegistrar;
-        use assistant_auth::oauth2::device::DeviceCodeManager;
-        use assistant_auth::oauth2::server::OAuth2Server;
-
         let jwt_key_pair = JwtKeyPair::generate().context("Failed to generate JWT signing key")?;
-        let jwt_manager = Arc::new(JwtManager::new(
+        Arc::new(JwtManager::new(
             jwt_key_pair,
             base_url.clone(),
             base_url.clone(),
-        ));
+        ))
+    };
+
+    let oauth_state = {
+        use assistant_auth::oauth2::clients::ClientRegistrar;
+        use assistant_auth::oauth2::device::DeviceCodeManager;
+        use assistant_auth::oauth2::server::OAuth2Server;
 
         let oauth2_server = Arc::new(OAuth2Server::new(
             Arc::new(org_storage.auth_code_store()),
@@ -678,13 +673,35 @@ async fn run_with_args(args: Args) -> Result<()> {
 
         oauth::OAuthState {
             oauth2_server,
-            jwt_manager,
+            jwt_manager: jwt_manager.clone(),
             client_registrar,
             device_manager,
             org_storage: org_storage.clone(),
             issuer: base_url.clone(),
+            secure_cookie,
         }
     };
+
+    // -- Auth config (JWT + API key + legacy token) --------------------------
+    let legacy_context = legacy_token.as_ref().map(|_| {
+        use assistant_core::auth::AuthContext;
+        use assistant_core::identity::{OrgId, UserId};
+        AuthContext {
+            user_id: UserId::from("admin"),
+            org_id: OrgId::from("default"),
+            email: String::new(),
+            space_roles: std::collections::HashMap::new(),
+            scopes: vec![],
+            client_id: "legacy".into(),
+        }
+    });
+    let auth_config = WebAuthConfig::new(
+        jwt_manager,
+        Arc::new(assistant_auth::api_keys::InMemoryApiKeyStore::new()),
+        legacy_token,
+        legacy_context,
+        secure_cookie,
+    );
 
     // -- Router: public routes (no auth required) --------------------------
     let public_routes = Router::new()
@@ -692,6 +709,7 @@ async fn run_with_args(args: Args) -> Result<()> {
         .route("/ready", get(ready))
         .route("/login", get(auth::login_page).post(auth::login_submit))
         .route("/logout", post(auth::logout))
+        .with_state(auth_config.clone())
         // OpenAPI spec + Swagger UI (public — clients need the spec to discover auth).
         .merge(SwaggerUi::new("/api/docs").url("/api/openapi.json", openapi::ApiDoc::openapi()))
         // Public workflow webhook trigger ingress.
@@ -728,7 +746,10 @@ async fn run_with_args(args: Args) -> Result<()> {
         .route_layer(axum::middleware::from_fn(
             auth::require_same_origin_mutation,
         ))
-        .route_layer(axum::middleware::from_fn(auth::require_auth));
+        .route_layer(axum::middleware::from_fn_with_state(
+            auth_config,
+            auth::require_auth,
+        ));
 
     // -- CORS layer for /api/* routes ----------------------------------------
     //
@@ -768,7 +789,6 @@ async fn run_with_args(args: Args) -> Result<()> {
         // paths (no auth required — FR-013).
         .fallback(flutter_assets::flutter_handler)
         .layer(cors)
-        .layer(Extension(auth_config))
         .layer(TraceLayer::new_for_http());
 
     // Warn when binding to a non-loopback address.

--- a/crates/web-ui/src/oauth/mod.rs
+++ b/crates/web-ui/src/oauth/mod.rs
@@ -36,6 +36,8 @@ pub struct OAuthState {
     pub org_storage: Arc<OrgStorageLayer>,
     /// The server's issuer URL (used in metadata and JWTs).
     pub issuer: String,
+    /// When `true`, session cookies get the `Secure` attribute.
+    pub secure_cookie: bool,
 }
 
 /// Build the public OAuth2 router (no auth required on these endpoints).
@@ -206,6 +208,7 @@ mod tests {
             device_manager,
             org_storage,
             issuer: "http://localhost".into(),
+            secure_cookie: false,
         }
     }
 
@@ -515,6 +518,211 @@ mod tests {
         assert!(
             tokens["refresh_token"].is_string(),
             "response should contain refresh_token"
+        );
+    }
+
+    #[tokio::test]
+    async fn auth_code_exchange_sets_session_cookie() {
+        let state = test_state().await;
+
+        // Register a client.
+        let app = build_app(state.clone());
+        let reg_body = serde_json::json!({
+            "client_name": "Cookie Test",
+            "redirect_uris": ["http://localhost/cb"],
+            "grant_types": ["authorization_code"]
+        });
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/oauth/register")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&reg_body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let client: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let client_id = client["client_id"].as_str().unwrap();
+
+        // Authorize (get auth code).
+        let app = build_app(state.clone());
+        let form = format!(
+            "email=alice%40example.com&password=secret123&client_id={client_id}&redirect_uri=http%3A%2F%2Flocalhost%2Fcb"
+        );
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/oauth/authorize")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from(form))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let location = resp.headers().get("location").unwrap().to_str().unwrap();
+        let code = location
+            .split("code=")
+            .nth(1)
+            .unwrap()
+            .split('&')
+            .next()
+            .unwrap();
+
+        // Exchange code for tokens.
+        let app = build_app(state.clone());
+        let token_form = format!(
+            "grant_type=authorization_code&code={code}&client_id={client_id}&redirect_uri=http%3A%2F%2Flocalhost%2Fcb"
+        );
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/oauth/token")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from(token_form))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Verify that a session cookie is set.
+        let set_cookie = resp
+            .headers()
+            .get("set-cookie")
+            .expect("token exchange should set a session cookie")
+            .to_str()
+            .unwrap();
+        assert!(
+            set_cookie.contains("assistant_session="),
+            "cookie should be named assistant_session: {set_cookie}"
+        );
+        assert!(
+            set_cookie.contains("HttpOnly"),
+            "cookie should be HttpOnly: {set_cookie}"
+        );
+        assert!(
+            set_cookie.contains("SameSite=Lax"),
+            "cookie should be SameSite=Lax: {set_cookie}"
+        );
+
+        // Verify the JSON body still contains tokens.
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let tokens: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(tokens["access_token"].is_string());
+        assert!(tokens["refresh_token"].is_string());
+    }
+
+    #[tokio::test]
+    async fn refresh_token_exchange_sets_session_cookie() {
+        let state = test_state().await;
+
+        // Register client + get auth code + exchange for tokens (setup).
+        let app = build_app(state.clone());
+        let reg_body = serde_json::json!({
+            "client_name": "Refresh Cookie Test",
+            "redirect_uris": ["http://localhost/cb"],
+            "grant_types": ["authorization_code"]
+        });
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/oauth/register")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&reg_body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let client: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let client_id = client["client_id"].as_str().unwrap();
+
+        let app = build_app(state.clone());
+        let form = format!(
+            "email=alice%40example.com&password=secret123&client_id={client_id}&redirect_uri=http%3A%2F%2Flocalhost%2Fcb"
+        );
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/oauth/authorize")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from(form))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let location = resp.headers().get("location").unwrap().to_str().unwrap();
+        let code = location
+            .split("code=")
+            .nth(1)
+            .unwrap()
+            .split('&')
+            .next()
+            .unwrap();
+
+        let app = build_app(state.clone());
+        let token_form = format!(
+            "grant_type=authorization_code&code={code}&client_id={client_id}&redirect_uri=http%3A%2F%2Flocalhost%2Fcb"
+        );
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/oauth/token")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from(token_form))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let tokens: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let refresh_token = tokens["refresh_token"].as_str().unwrap();
+
+        // Now refresh and check for cookie.
+        let app = build_app(state.clone());
+        let refresh_form =
+            format!("grant_type=refresh_token&refresh_token={refresh_token}&client_id={client_id}");
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/oauth/token")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from(refresh_form))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Verify session cookie is also set on refresh.
+        let set_cookie = resp
+            .headers()
+            .get("set-cookie")
+            .expect("refresh should also set a session cookie")
+            .to_str()
+            .unwrap();
+        assert!(
+            set_cookie.contains("assistant_session="),
+            "cookie should be named assistant_session: {set_cookie}"
         );
     }
 }

--- a/crates/web-ui/src/oauth/token.rs
+++ b/crates/web-ui/src/oauth/token.rs
@@ -1,9 +1,14 @@
 //! POST /oauth/token — exchange auth codes, refresh tokens, or device codes
 //! for access/refresh token pairs.
+//!
+//! On successful auth-code and refresh-token exchanges the handler also sets
+//! an `HttpOnly` session cookie (`assistant_session`) containing the JWT so
+//! that browser-based clients get an automatic session.
 
 use axum::Form;
 use axum::extract::State;
 use axum::http::StatusCode;
+use axum::http::header::SET_COOKIE;
 use axum::response::{IntoResponse, Json};
 use serde::{Deserialize, Serialize};
 
@@ -112,13 +117,17 @@ async fn handle_auth_code(state: OAuthState, req: TokenRequest) -> axum::respons
                 }
             };
 
-            Json(TokenResponse {
+            let cookie = session_cookie(&jwt, state.secure_cookie);
+            let mut resp = Json(TokenResponse {
                 access_token: jwt,
                 token_type: "Bearer",
                 expires_in: 3600,
                 refresh_token: Some(pair.refresh_token),
             })
-            .into_response()
+            .into_response();
+            resp.headers_mut()
+                .insert(SET_COOKIE, cookie.parse().unwrap());
+            resp
         }
         Err(e) => (
             StatusCode::BAD_REQUEST,
@@ -168,13 +177,17 @@ async fn handle_refresh(state: OAuthState, req: TokenRequest) -> axum::response:
                 }
             };
 
-            Json(TokenResponse {
+            let cookie = session_cookie(&jwt, state.secure_cookie);
+            let mut resp = Json(TokenResponse {
                 access_token: jwt,
                 token_type: "Bearer",
                 expires_in: 3600,
                 refresh_token: Some(pair.refresh_token),
             })
-            .into_response()
+            .into_response();
+            resp.headers_mut()
+                .insert(SET_COOKIE, cookie.parse().unwrap());
+            resp
         }
         Err(e) => (
             StatusCode::BAD_REQUEST,
@@ -185,6 +198,12 @@ async fn handle_refresh(state: OAuthState, req: TokenRequest) -> axum::response:
         )
             .into_response(),
     }
+}
+
+/// Build the `Set-Cookie` value for the `assistant_session` JWT cookie.
+fn session_cookie(jwt: &str, secure: bool) -> String {
+    let secure_attr = if secure { "; Secure" } else { "" };
+    format!("assistant_session={jwt}; HttpOnly; SameSite=Lax; Path=/; Max-Age=3600{secure_attr}")
 }
 
 async fn handle_device_code(state: OAuthState, req: TokenRequest) -> axum::response::Response {

--- a/crates/web-ui/src/oauth/token.rs
+++ b/crates/web-ui/src/oauth/token.rs
@@ -103,7 +103,11 @@ async fn handle_auth_code(state: OAuthState, req: TokenRequest) -> axum::respons
         Ok(pair) => {
             // Sign a JWT access token for the user.
             let ctx = stub_auth_context(&pair.user_id, "default", "");
-            let jwt = match state.jwt_manager.sign(&ctx, "default", &pair.user_id) {
+            let ttl = state.jwt_manager.access_ttl_secs();
+            let jwt = match state
+                .jwt_manager
+                .sign(&ctx, ctx.org_id.as_ref(), &pair.user_id)
+            {
                 Ok(t) => t,
                 Err(e) => {
                     return (
@@ -117,11 +121,11 @@ async fn handle_auth_code(state: OAuthState, req: TokenRequest) -> axum::respons
                 }
             };
 
-            let cookie = session_cookie(&jwt, state.secure_cookie);
+            let cookie = session_cookie(&jwt, state.secure_cookie, ttl);
             let mut resp = Json(TokenResponse {
                 access_token: jwt,
                 token_type: "Bearer",
-                expires_in: 3600,
+                expires_in: ttl,
                 refresh_token: Some(pair.refresh_token),
             })
             .into_response();
@@ -163,7 +167,11 @@ async fn handle_refresh(state: OAuthState, req: TokenRequest) -> axum::response:
     {
         Ok(pair) => {
             let ctx = stub_auth_context(&pair.user_id, "default", "");
-            let jwt = match state.jwt_manager.sign(&ctx, "default", &pair.user_id) {
+            let ttl = state.jwt_manager.access_ttl_secs();
+            let jwt = match state
+                .jwt_manager
+                .sign(&ctx, ctx.org_id.as_ref(), &pair.user_id)
+            {
                 Ok(t) => t,
                 Err(e) => {
                     return (
@@ -177,11 +185,11 @@ async fn handle_refresh(state: OAuthState, req: TokenRequest) -> axum::response:
                 }
             };
 
-            let cookie = session_cookie(&jwt, state.secure_cookie);
+            let cookie = session_cookie(&jwt, state.secure_cookie, ttl);
             let mut resp = Json(TokenResponse {
                 access_token: jwt,
                 token_type: "Bearer",
-                expires_in: 3600,
+                expires_in: ttl,
                 refresh_token: Some(pair.refresh_token),
             })
             .into_response();
@@ -201,9 +209,11 @@ async fn handle_refresh(state: OAuthState, req: TokenRequest) -> axum::response:
 }
 
 /// Build the `Set-Cookie` value for the `assistant_session` JWT cookie.
-fn session_cookie(jwt: &str, secure: bool) -> String {
+fn session_cookie(jwt: &str, secure: bool, max_age_secs: u64) -> String {
     let secure_attr = if secure { "; Secure" } else { "" };
-    format!("assistant_session={jwt}; HttpOnly; SameSite=Lax; Path=/; Max-Age=3600{secure_attr}")
+    format!(
+        "assistant_session={jwt}; HttpOnly; SameSite=Lax; Path=/; Max-Age={max_age_secs}{secure_attr}"
+    )
 }
 
 async fn handle_device_code(state: OAuthState, req: TokenRequest) -> axum::response::Response {
@@ -224,7 +234,8 @@ async fn handle_device_code(state: OAuthState, req: TokenRequest) -> axum::respo
     match state.device_manager.poll(&device_code).await {
         Ok(PollResult::Authorized { user_id, scopes: _ }) => {
             let ctx = stub_auth_context(&user_id, "default", "");
-            let jwt = match state.jwt_manager.sign(&ctx, "default", &user_id) {
+            let ttl = state.jwt_manager.access_ttl_secs();
+            let jwt = match state.jwt_manager.sign(&ctx, ctx.org_id.as_ref(), &user_id) {
                 Ok(t) => t,
                 Err(e) => {
                     return (
@@ -241,7 +252,7 @@ async fn handle_device_code(state: OAuthState, req: TokenRequest) -> axum::respo
             Json(TokenResponse {
                 access_token: jwt,
                 token_type: "Bearer",
-                expires_in: 3600,
+                expires_in: ttl,
                 refresh_token: None,
             })
             .into_response()

--- a/openspec/changes/multi-user-orgs/tasks.md
+++ b/openspec/changes/multi-user-orgs/tasks.md
@@ -345,8 +345,8 @@ PR 10 ─── CLI OAuth2 login + Flutter OAuth2 + docs
 
 - [x] `feat(web-ui): session cookie management`
   - On OAuth2 login completion: set `HttpOnly`, `Secure`, `SameSite=Lax` cookie
-  - Cookie contains encrypted reference to refresh token
-  - Silent refresh on access token expiry
+  - Cookie contains JWT access token; Max-Age derived from JwtManager TTL
+  - Server-side cookie plumbing for silent refresh (client-side refresh in PR 10)
 
 - [x] `feat(web-ui): update CSRF protection for new session model`
 

--- a/openspec/changes/multi-user-orgs/tasks.md
+++ b/openspec/changes/multi-user-orgs/tasks.md
@@ -293,16 +293,16 @@ PR 10 ─── CLI OAuth2 login + Flutter OAuth2 + docs
 
 **Commits:**
 
-- [ ] `feat(web-ui): OAuth2 route module scaffold`
+- [x] `feat(web-ui): OAuth2 route module scaffold`
   - Create `crates/web-ui/src/oauth/mod.rs` with sub-modules and route registration
   - Wire into main router at `/oauth/*`
 
-- [ ] `feat(web-ui): GET /oauth/authorize endpoint`
+- [x] `feat(web-ui): GET /oauth/authorize endpoint`
   - Password mode: render login form (HTML or redirect to SPA login page)
   - OIDC mode: redirect to external IdP with state + PKCE
   - Validate `client_id`, `redirect_uri`, `response_type`, `code_challenge`
 
-- [ ] `feat(web-ui): POST /oauth/authorize — password credential validation`
+- [x] `feat(web-ui): POST /oauth/authorize — password credential validation`
   - Accept email + password form submission
   - Validate via `AuthProvider`, generate auth code, redirect to `redirect_uri?code=`
 
@@ -311,48 +311,48 @@ PR 10 ─── CLI OAuth2 login + Flutter OAuth2 + docs
   - Validate id_token, provision/lookup user
   - Generate our auth code, redirect to original client's redirect_uri
 
-- [ ] `feat(web-ui): POST /oauth/token endpoint`
+- [x] `feat(web-ui): POST /oauth/token endpoint`
   - Grant types: `authorization_code` (with PKCE), `refresh_token`, `urn:ietf:params:oauth:grant-type:device_code`
   - Returns `{ access_token, token_type, expires_in, refresh_token }`
 
-- [ ] `feat(web-ui): POST /oauth/register — dynamic client registration`
+- [x] `feat(web-ui): POST /oauth/register — dynamic client registration`
   - Accept `ClientRegistration`, validate, store, return `ClientInfo`
   - Optionally gate behind org admin approval (org setting)
 
-- [ ] `feat(web-ui): POST /oauth/device — device code initiation`
+- [x] `feat(web-ui): POST /oauth/device — device code initiation`
   - Generate device_code + user_code, return verification_uri
   - `GET /oauth/device/verify` — browser page where user enters code and approves
 
-- [ ] `feat(web-ui): POST /oauth/revoke + server metadata`
+- [x] `feat(web-ui): POST /oauth/revoke + server metadata`
   - Token revocation (access or refresh)
   - `GET /.well-known/oauth-authorization-server` — RFC 8414 metadata document
 
-- [ ] `test(web-ui): OAuth2 endpoint integration tests`
+- [x] `test(web-ui): OAuth2 endpoint integration tests`
   - Full authorization code + PKCE flow via HTTP
   - Device code flow via HTTP
   - Token refresh and revocation
   - Invalid client_id, bad PKCE, expired code
 
-- [ ] `feat(web-ui): rewrite auth middleware — JWT + API key + legacy fallback`
+- [x] `feat(web-ui): rewrite auth middleware — JWT + API key + legacy fallback`
   - Replace `crates/web-ui/src/auth.rs` internals
   - Extract `AuthContext` from: Bearer JWT → session cookie → API key → legacy `ASSISTANT_WEB_TOKEN`
   - Legacy token maps to default org admin AuthContext (migration bridge)
   - `AuthContext` available as Axum extractor in all handlers
 
-- [ ] `feat(web-ui): permission guard middleware`
+- [x] `feat(web-ui): permission guard middleware`
   - `RequireScope` layer: checks `ctx.can(space, resource, action)` before handler
   - Returns 403 with scope information on denial
 
-- [ ] `feat(web-ui): session cookie management`
+- [x] `feat(web-ui): session cookie management`
   - On OAuth2 login completion: set `HttpOnly`, `Secure`, `SameSite=Lax` cookie
   - Cookie contains encrypted reference to refresh token
   - Silent refresh on access token expiry
 
-- [ ] `feat(web-ui): update CSRF protection for new session model`
+- [x] `feat(web-ui): update CSRF protection for new session model`
 
-- [ ] `test(web-ui): auth middleware with JWT, API key, legacy token, expired JWT, invalid token`
+- [x] `test(web-ui): auth middleware with JWT, API key, legacy token, expired JWT, invalid token`
 
-- [ ] `chore(web-ui): update OpenAPI spec with OAuth2 endpoints`
+- [x] `chore(web-ui): update OpenAPI spec with OAuth2 endpoints`
 
 ---
 


### PR DESCRIPTION
## Summary

- **Rewrite auth middleware** (`crates/web-ui/src/auth.rs`): replace single-token HMAC-session system with multi-strategy `AuthContext` resolution — Bearer JWT → session cookie JWT → API key (`ask_live_` prefix) → legacy static token. Uses `from_fn_with_state` for Axum 0.8 compatibility.
- **Add `require_scope_layer`**: tower `Layer`/`Service` for per-route permission guards. Extracts `AuthContext` from extensions, calls `RequireScope::check()`, returns 401 (missing auth) or 403 (insufficient permissions) with descriptive messages.
- **Session cookies on OAuth2 token exchange**: `POST /oauth/token` (auth_code + refresh grants) now sets `assistant_session` HttpOnly/SameSite=Lax cookie alongside the JSON response, enabling browser-based sessions.
- **CSRF protection verified**: existing `require_same_origin_mutation` middleware correctly handles the new JWT-cookie session model. Added 6 comprehensive tests.
- **156 web-ui tests** (28 new), **94 auth tests** — all passing, clippy clean.

## Test plan

- [x] `cargo clippy -p assistant-web-ui -p assistant-auth -- -D warnings` passes
- [x] `cargo test -p assistant-web-ui` — 156 tests pass
- [x] `cargo test -p assistant-auth` — 94 tests pass
- [x] `make lint` and `make format` pass
- [x] Pre-commit hooks pass
- [ ] Verify login flow works end-to-end with legacy token
- [ ] Verify OAuth2 authorization code flow sets session cookie in browser

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scope-based enforcement middleware and public APIs for scope checks.
  * Session JWT TTL exposed for use when setting cookie Max-Age.

* **Improvements**
  * Switched auth flow to resolve an AuthContext, unify bearer/token and API-key handling, and issue HttpOnly SameSite=Lax session cookies on login/token exchange.
  * Router now provides auth config via shared state.

* **Tests**
  * Added integration tests covering auth resolution, scope enforcement, CSRF, and OAuth2 cookie behavior.

* **Chores**
  * Moved a test-only crate to regular runtime dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->