### PR TITLE
ci(release): upload openapi.json to GitHub release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,6 +25,15 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+      - uses: actions/checkout@v6
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+
+      - name: Upload openapi.json to GitHub Release
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload ${{ steps.release.outputs.tag_name }} openapi.json
+
   build-flutter-web:
     name: Build Flutter web
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds `openapi.json` as a release asset in the release-please workflow
- Uploads immediately after the release is created, before any build jobs run

## Test plan
- [ ] Verify the workflow YAML is valid
- [ ] Confirm `openapi.json` appears as a release asset on the next release