### PR TITLE
chore(deps): bump jsonwebtoken from 9.3 to 10.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -983,6 +983,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -3437,16 +3438,18 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.1"
+version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
+ "aws-lc-rs",
  "base64 0.22.1",
+ "getrandom 0.2.17",
  "js-sys",
  "pem",
- "ring",
  "serde",
  "serde_json",
+ "signature",
  "simple_asn1",
 ]
 
@@ -5070,7 +5073,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -5263,7 +5266,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -6804,6 +6807,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,7 +165,7 @@ arrow-array = "57.3"
 arrow-schema = "57.3"
 parquet = { version = "57.3", default-features = false, features = ["arrow", "async"] }
 # Authentication
-jsonwebtoken = "9"
+jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }
 argon2 = { version = "0.5", features = ["std"] }
 rand = "0.9"
 # Constant-time comparison (API key verification)


### PR DESCRIPTION
## Summary
- Bumps `jsonwebtoken` from 9.3.1 to 10.3.0 (major version)
- Only change: added `features = ["aws_lc_rs"]` to select the mandatory crypto backend — **no code changes** required
- All 97 auth tests pass, clippy clean

## Held back
The following Dependabot PRs were assessed and **cannot be applied** without further work:

| PR | Upgrade | Reason |
|---|---|---|
| #622 | rand 0.9→0.10 | Blocked by async-openai 0.35 pinning `rand = "^0.9"` |
| #624 | async-openai 0.35→0.36 | Requires reqwest 0.13 (workspace is on 0.12) |
| #572 | reqwest 0.12→0.13 | Feature rename (`rustls-tls`→`rustls`), middleware version bumps, TLS defaults change |
| #573 | arrow/parquet 57→58 | iceberg 0.9 pins arrow 57 — creates duplicate arrow versions and type mismatches |

PRs #622, #624, and #572 are chained: reqwest 0.13 → async-openai 0.36 → rand 0.10. They should be done together.
PR #573 is blocked until iceberg releases a version compatible with arrow 58.

Closes #623

## Test plan
- [x] `cargo check --workspace` — clean
- [x] `cargo test -p assistant-auth` — 97/97 pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [ ] CI validates full workspace