### PR TITLE
feat(runtime): storage migration + runtime AuthContext threading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,6 +670,7 @@ version = "0.1.135"
 dependencies = [
  "anyhow",
  "assistant-auth",
+ "assistant-backup",
  "assistant-core",
  "assistant-skills",
  "async-trait",
@@ -677,6 +678,7 @@ dependencies = [
  "cron",
  "dirs",
  "opentelemetry-semantic-conventions",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "sqlx",

--- a/crates/core/src/bus_messages.rs
+++ b/crates/core/src/bus_messages.rs
@@ -78,6 +78,17 @@ pub struct TurnRequest {
     /// [`AttachmentStore`] at LLM-call time.
     #[serde(default)]
     pub attachment_ids: Vec<Uuid>,
+
+    // -- Identity (multi-user) ------------------------------------------------
+    /// The authenticated user who initiated this turn.
+    #[serde(default)]
+    pub user_id: Option<String>,
+    /// The organisation context for this turn.
+    #[serde(default)]
+    pub org_id: Option<String>,
+    /// The space context for this turn.
+    #[serde(default)]
+    pub space_id: Option<String>,
 }
 
 /// The final result of a completed turn.
@@ -254,6 +265,9 @@ mod tests {
                 "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".to_string(),
             ),
             attachment_ids: vec![],
+            user_id: None,
+            org_id: None,
+            space_id: None,
         };
         let json = serde_json::to_value(&req).unwrap();
         let back: TurnRequest = serde_json::from_value(json).unwrap();

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -75,6 +75,6 @@ pub use types::{
     NotificationsConfig, ObservabilityConfig, OpenAIAuthMode, OpenAIOptions, OpenAIUserLocation,
     OpenAIWebSearchOptions, OpenRouterOptions, OtelExporter, PartitionGranularity, SignalConfig,
     SkillsConfig, SlackConfig, SlackListenMode, StorageConfig, TranscriptionConfig,
-    TranscriptionProviderKind, TtsConfig, TtsProviderKind,
+    TranscriptionProviderKind, TtsConfig, TtsProviderKind, TurnIdentity,
 };
 pub use upload::resolve_upload_bytes;

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -88,6 +88,59 @@ pub struct ExecutionContext {
     pub allowed_tools: Option<Vec<String>>,
     /// Current subagent nesting depth.  The root agent has depth `0`.
     pub depth: u32,
+
+    // -- Identity fields (multi-user) ----------------------------------------
+    /// The authenticated user executing this turn. `None` for legacy
+    /// single-user or system-originated turns.
+    pub user_id: Option<crate::identity::UserId>,
+    /// The organization context. `None` for legacy single-user mode.
+    pub org_id: Option<crate::identity::OrgId>,
+    /// The space context. `None` for legacy single-user mode.
+    pub space_id: Option<crate::identity::SpaceId>,
+}
+
+impl ExecutionContext {
+    /// Populate the identity fields from an [`AuthContext`](crate::auth::AuthContext).
+    ///
+    /// Copies `user_id` and `org_id` directly; leaves `space_id` as-is since
+    /// it depends on the routing context rather than the token.
+    pub fn with_auth(mut self, auth: &crate::auth::AuthContext) -> Self {
+        self.user_id = Some(auth.user_id.clone());
+        self.org_id = Some(auth.org_id.clone());
+        self
+    }
+
+    /// Populate the identity fields from a [`TurnIdentity`].
+    pub fn with_identity(mut self, id: &TurnIdentity) -> Self {
+        self.user_id = id.user_id.clone();
+        self.org_id = id.org_id.clone();
+        self.space_id = id.space_id.clone();
+        self
+    }
+}
+
+/// Lightweight bundle of optional identity fields threaded through the
+/// orchestrator turn pipeline.
+///
+/// Callers that have an authenticated user populate this from
+/// [`AuthContext`](crate::auth::AuthContext); legacy / system turns use
+/// [`Default`].
+#[derive(Debug, Clone, Default)]
+pub struct TurnIdentity {
+    pub user_id: Option<crate::identity::UserId>,
+    pub org_id: Option<crate::identity::OrgId>,
+    pub space_id: Option<crate::identity::SpaceId>,
+}
+
+impl TurnIdentity {
+    /// Build a `TurnIdentity` from an [`AuthContext`](crate::auth::AuthContext).
+    pub fn from_auth(auth: &crate::auth::AuthContext) -> Self {
+        Self {
+            user_id: Some(auth.user_id.clone()),
+            org_id: Some(auth.org_id.clone()),
+            space_id: None,
+        }
+    }
 }
 
 /// Which interface originated the request

--- a/crates/integration-tests/tests/smoke.rs
+++ b/crates/integration-tests/tests/smoke.rs
@@ -13,7 +13,9 @@ use std::sync::Arc;
 use std::{env, time::Duration};
 
 use anyhow::Result;
-use assistant_core::{AssistantConfig, ExecutionContext, MessageBus, types::Interface};
+use assistant_core::{
+    AssistantConfig, ExecutionContext, MessageBus, TurnIdentity, types::Interface,
+};
 use assistant_llm_provider::ollama::client::{LlmClient, LlmClientConfig};
 use assistant_runtime::Orchestrator;
 use assistant_skills::SkillSource;
@@ -164,6 +166,9 @@ fn exec_ctx(f: &Fixture) -> ExecutionContext {
         interactive: false,
         allowed_tools: None,
         depth: 0,
+        user_id: None,
+        org_id: None,
+        space_id: None,
     }
 }
 
@@ -246,6 +251,7 @@ async fn test_tool_loop_terminates() -> Result<()> {
                 Interface::Cli,
                 None,
                 vec![],
+                TurnIdentity::default(),
             )
             .await
     })
@@ -274,6 +280,7 @@ async fn test_self_analyze_runs() -> Result<()> {
                 Interface::Cli,
                 None,
                 vec![],
+                TurnIdentity::default(),
             )
             .await?;
 
@@ -286,6 +293,7 @@ async fn test_self_analyze_runs() -> Result<()> {
                 Interface::Cli,
                 None,
                 vec![],
+                TurnIdentity::default(),
             )
             .await?;
 

--- a/crates/mcp-server/src/server.rs
+++ b/crates/mcp-server/src/server.rs
@@ -158,6 +158,9 @@ pub async fn handle_request(
                 interactive: false,
                 allowed_tools: None,
                 depth: 0,
+                user_id: None,
+                org_id: None,
+                space_id: None,
             };
 
             match executor.execute(&tool_name, params, &ctx).await {

--- a/crates/runtime/src/channel_runner.rs
+++ b/crates/runtime/src/channel_runner.rs
@@ -160,6 +160,8 @@ impl ChannelRunner {
                 None,
                 attachments,
                 vec![],
+                // TODO: resolve platform identity → TurnIdentity once
+                // IdentityResolver is wired up (multi-user-orgs task #71).
                 assistant_core::TurnIdentity::default(),
             )
             .await;

--- a/crates/runtime/src/channel_runner.rs
+++ b/crates/runtime/src/channel_runner.rs
@@ -152,7 +152,16 @@ impl ChannelRunner {
         }
 
         let result = orchestrator
-            .run_turn_with_tools(&text, conv_id, interface, tools, None, attachments, vec![])
+            .run_turn_with_tools(
+                &text,
+                conv_id,
+                interface,
+                tools,
+                None,
+                attachments,
+                vec![],
+                assistant_core::TurnIdentity::default(),
+            )
             .await;
 
         match result {

--- a/crates/runtime/src/orchestrator/mod.rs
+++ b/crates/runtime/src/orchestrator/mod.rs
@@ -9,8 +9,8 @@ use anyhow::Result;
 use assistant_core::{
     Attachment, AttachmentMeta, ChatHistoryMessage, ChatRole, ContentBlock, ExecutionContext,
     Interface, LlmProvider, LlmResponse, MemoryLoader, Message, MessageBus, StreamChunk,
-    ToolHandler, ToolSpec, context::agent_base_dir, is_resizable_mime_type, is_supported_mime_type,
-    is_text_mime_type, strip_html_comments,
+    ToolHandler, ToolSpec, TurnIdentity, context::agent_base_dir, is_resizable_mime_type,
+    is_supported_mime_type, is_text_mime_type, strip_html_comments,
 };
 use assistant_storage::{SkillRegistry, StorageLayer, conversations::ConversationStore};
 use assistant_tool_executor::ToolExecutor;
@@ -365,6 +365,7 @@ impl Orchestrator {
         trace_cx: Option<&OtelContext>,
         attachments: Vec<ContentBlock>,
         attachment_ids: Vec<Uuid>,
+        identity: TurnIdentity,
     ) -> Result<TurnResult> {
         let turn_span = info_span!(
             "conversation_turn",
@@ -381,6 +382,7 @@ impl Orchestrator {
             attachments,
             None,
             attachment_ids,
+            identity,
         )
         .instrument(turn_span)
         .await
@@ -402,6 +404,7 @@ impl Orchestrator {
         attachments: Vec<ContentBlock>,
         token_sink: mpsc::Sender<OrchestratorEvent>,
         attachment_ids: Vec<Uuid>,
+        identity: TurnIdentity,
     ) -> Result<TurnResult> {
         let turn_span = info_span!(
             "conversation_turn",
@@ -419,6 +422,7 @@ impl Orchestrator {
             attachments,
             Some(token_sink),
             attachment_ids,
+            identity,
         )
         .instrument(turn_span)
         .await
@@ -432,6 +436,7 @@ impl Orchestrator {
         interface: Interface,
         trace_cx: Option<&OtelContext>,
         attachment_ids: Vec<Uuid>,
+        identity: TurnIdentity,
     ) -> Result<TurnResult> {
         self.run_turn_core(
             user_message,
@@ -440,11 +445,13 @@ impl Orchestrator {
             None,
             trace_cx,
             attachment_ids,
+            identity,
         )
         .await
     }
 
     /// Like [`run_turn`] but streams final-answer tokens through `token_sink`.
+    #[allow(clippy::too_many_arguments)]
     pub async fn run_turn_streaming(
         &self,
         user_message: &str,
@@ -453,6 +460,7 @@ impl Orchestrator {
         token_sink: mpsc::Sender<OrchestratorEvent>,
         trace_cx: Option<&OtelContext>,
         attachment_ids: Vec<Uuid>,
+        identity: TurnIdentity,
     ) -> Result<TurnResult> {
         self.run_turn_core(
             user_message,
@@ -461,6 +469,7 @@ impl Orchestrator {
             Some(token_sink),
             trace_cx,
             attachment_ids,
+            identity,
         )
         .await
     }
@@ -478,6 +487,7 @@ impl Orchestrator {
         attachments: Vec<ContentBlock>,
         token_sink: Option<mpsc::Sender<OrchestratorEvent>>,
         attachment_ids: Vec<Uuid>,
+        identity: TurnIdentity,
     ) -> Result<TurnResult> {
         // Clear active skill at turn boundary so stale skill context doesn't leak.
         *self.active_skill.write().await = None;
@@ -572,6 +582,9 @@ impl Orchestrator {
                 interactive: false,
                 allowed_tools: None,
                 depth: 0,
+                user_id: identity.user_id.clone(),
+                org_id: identity.org_id.clone(),
+                space_id: identity.space_id.clone(),
             };
 
             let mut llm_span = crate::otel_spans::start_llm_span(
@@ -870,6 +883,7 @@ impl Orchestrator {
     }
 
     /// Shared implementation for [`run_turn`] and [`run_turn_streaming`].
+    #[allow(clippy::too_many_arguments)]
     async fn run_turn_core(
         &self,
         user_message: &str,
@@ -878,6 +892,7 @@ impl Orchestrator {
         token_sink: Option<mpsc::Sender<OrchestratorEvent>>,
         trace_cx: Option<&OtelContext>,
         attachment_ids: Vec<Uuid>,
+        identity: TurnIdentity,
     ) -> Result<TurnResult> {
         // Clear active skill at turn boundary so stale skill context doesn't leak.
         *self.active_skill.write().await = None;
@@ -944,6 +959,9 @@ impl Orchestrator {
                 interactive: matches!(interface, Interface::Cli),
                 allowed_tools: None,
                 depth: 0,
+                user_id: identity.user_id.clone(),
+                org_id: identity.org_id.clone(),
+                space_id: identity.space_id.clone(),
             };
 
             let mut llm_span = crate::otel_spans::start_llm_span(

--- a/crates/runtime/src/orchestrator/subagent.rs
+++ b/crates/runtime/src/orchestrator/subagent.rs
@@ -448,6 +448,9 @@ impl SubagentRunner for Orchestrator {
                                 interactive: false,
                                 allowed_tools: allowed_tools.clone(),
                                 depth: new_depth,
+                                user_id: None,
+                                org_id: None,
+                                space_id: None,
                             };
 
                             let start = std::time::Instant::now();

--- a/crates/runtime/src/orchestrator/tests.rs
+++ b/crates/runtime/src/orchestrator/tests.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use assistant_core::{
     AssistantConfig, ChatHistoryMessage, ChatRole, ContentBlock, LlmProvider, MessageBus,
-    PublishRequest, ToolCallItem, bus_messages, topic, types::Interface,
+    PublishRequest, ToolCallItem, TurnIdentity, bus_messages, topic, types::Interface,
 };
 use assistant_llm_provider::ollama::client::{LlmClient, LlmClientConfig};
 use assistant_storage::{StorageLayer, registry::SkillRegistry};
@@ -95,9 +95,16 @@ async fn first_turn_sends_only_current_message() {
     let (orch, _) = build(&server.uri()).await;
     let conv_id = Uuid::new_v4();
 
-    orch.run_turn("hello", conv_id, Interface::Cli, None, vec![])
-        .await
-        .unwrap();
+    orch.run_turn(
+        "hello",
+        conv_id,
+        Interface::Cli,
+        None,
+        vec![],
+        TurnIdentity::default(),
+    )
+    .await
+    .unwrap();
 
     let reqs = server.received_requests().await.unwrap();
     assert_eq!(reqs.len(), 1);
@@ -117,12 +124,26 @@ async fn second_turn_includes_prior_history() {
     let (orch, _) = build(&server.uri()).await;
     let conv_id = Uuid::new_v4();
 
-    orch.run_turn("first message", conv_id, Interface::Cli, None, vec![])
-        .await
-        .unwrap();
-    orch.run_turn("second message", conv_id, Interface::Cli, None, vec![])
-        .await
-        .unwrap();
+    orch.run_turn(
+        "first message",
+        conv_id,
+        Interface::Cli,
+        None,
+        vec![],
+        TurnIdentity::default(),
+    )
+    .await
+    .unwrap();
+    orch.run_turn(
+        "second message",
+        conv_id,
+        Interface::Cli,
+        None,
+        vec![],
+        TurnIdentity::default(),
+    )
+    .await
+    .unwrap();
 
     let reqs = server.received_requests().await.unwrap();
     assert_eq!(reqs.len(), 2);
@@ -146,12 +167,26 @@ async fn current_message_not_duplicated() {
     let (orch, _) = build(&server.uri()).await;
     let conv_id = Uuid::new_v4();
 
-    orch.run_turn("turn one", conv_id, Interface::Cli, None, vec![])
-        .await
-        .unwrap();
-    orch.run_turn("turn two", conv_id, Interface::Cli, None, vec![])
-        .await
-        .unwrap();
+    orch.run_turn(
+        "turn one",
+        conv_id,
+        Interface::Cli,
+        None,
+        vec![],
+        TurnIdentity::default(),
+    )
+    .await
+    .unwrap();
+    orch.run_turn(
+        "turn two",
+        conv_id,
+        Interface::Cli,
+        None,
+        vec![],
+        TurnIdentity::default(),
+    )
+    .await
+    .unwrap();
 
     let reqs = server.received_requests().await.unwrap();
     let msgs = messages_in(reqs.last().unwrap());
@@ -188,9 +223,16 @@ async fn seeded_history_included_in_llm_call() {
     seed_bot.turn = 1;
     conv_store.save_message(&seed_bot).await.unwrap();
 
-    orch.run_turn("follow-up", conv_id, Interface::Slack, None, vec![])
-        .await
-        .unwrap();
+    orch.run_turn(
+        "follow-up",
+        conv_id,
+        Interface::Slack,
+        None,
+        vec![],
+        TurnIdentity::default(),
+    )
+    .await
+    .unwrap();
 
     let reqs = server.received_requests().await.unwrap();
     assert_eq!(reqs.len(), 1);
@@ -213,15 +255,36 @@ async fn three_turns_accumulate_history() {
     let (orch, _) = build(&server.uri()).await;
     let conv_id = Uuid::new_v4();
 
-    orch.run_turn("turn 1", conv_id, Interface::Cli, None, vec![])
-        .await
-        .unwrap();
-    orch.run_turn("turn 2", conv_id, Interface::Cli, None, vec![])
-        .await
-        .unwrap();
-    orch.run_turn("turn 3", conv_id, Interface::Cli, None, vec![])
-        .await
-        .unwrap();
+    orch.run_turn(
+        "turn 1",
+        conv_id,
+        Interface::Cli,
+        None,
+        vec![],
+        TurnIdentity::default(),
+    )
+    .await
+    .unwrap();
+    orch.run_turn(
+        "turn 2",
+        conv_id,
+        Interface::Cli,
+        None,
+        vec![],
+        TurnIdentity::default(),
+    )
+    .await
+    .unwrap();
+    orch.run_turn(
+        "turn 3",
+        conv_id,
+        Interface::Cli,
+        None,
+        vec![],
+        TurnIdentity::default(),
+    )
+    .await
+    .unwrap();
 
     let reqs = server.received_requests().await.unwrap();
     assert_eq!(reqs.len(), 3);
@@ -244,12 +307,26 @@ async fn different_conversations_are_isolated() {
     let conv_a = Uuid::new_v4();
     let conv_b = Uuid::new_v4();
 
-    orch.run_turn("conv-a message", conv_a, Interface::Cli, None, vec![])
-        .await
-        .unwrap();
-    orch.run_turn("conv-b message", conv_b, Interface::Cli, None, vec![])
-        .await
-        .unwrap();
+    orch.run_turn(
+        "conv-a message",
+        conv_a,
+        Interface::Cli,
+        None,
+        vec![],
+        TurnIdentity::default(),
+    )
+    .await
+    .unwrap();
+    orch.run_turn(
+        "conv-b message",
+        conv_b,
+        Interface::Cli,
+        None,
+        vec![],
+        TurnIdentity::default(),
+    )
+    .await
+    .unwrap();
 
     let reqs = server.received_requests().await.unwrap();
 
@@ -299,7 +376,14 @@ async fn single_tool_call_adds_observation_to_next_request() {
 
     let (orch, _) = build(&server.uri()).await;
     let result = orch
-        .run_turn("go", Uuid::new_v4(), Interface::Cli, None, vec![])
+        .run_turn(
+            "go",
+            Uuid::new_v4(),
+            Interface::Cli,
+            None,
+            vec![],
+            TurnIdentity::default(),
+        )
         .await
         .unwrap();
     assert_eq!(result.answer, "done");
@@ -341,9 +425,16 @@ async fn two_tool_calls_handled_in_single_iteration() {
         .await;
 
     let (orch, _) = build(&server.uri()).await;
-    orch.run_turn("go", Uuid::new_v4(), Interface::Cli, None, vec![])
-        .await
-        .unwrap();
+    orch.run_turn(
+        "go",
+        Uuid::new_v4(),
+        Interface::Cli,
+        None,
+        vec![],
+        TurnIdentity::default(),
+    )
+    .await
+    .unwrap();
 
     let reqs = server.received_requests().await.unwrap();
     assert_eq!(
@@ -374,9 +465,16 @@ async fn two_tool_calls_both_observations_sent_to_llm() {
         .await;
 
     let (orch, _) = build(&server.uri()).await;
-    orch.run_turn("go", Uuid::new_v4(), Interface::Cli, None, vec![])
-        .await
-        .unwrap();
+    orch.run_turn(
+        "go",
+        Uuid::new_v4(),
+        Interface::Cli,
+        None,
+        vec![],
+        TurnIdentity::default(),
+    )
+    .await
+    .unwrap();
 
     let reqs = server.received_requests().await.unwrap();
     let msgs = messages_in(&reqs[1]);
@@ -421,9 +519,16 @@ async fn three_tool_calls_handled_in_single_iteration() {
         .await;
 
     let (orch, _) = build(&server.uri()).await;
-    orch.run_turn("go", Uuid::new_v4(), Interface::Cli, None, vec![])
-        .await
-        .unwrap();
+    orch.run_turn(
+        "go",
+        Uuid::new_v4(),
+        Interface::Cli,
+        None,
+        vec![],
+        TurnIdentity::default(),
+    )
+    .await
+    .unwrap();
 
     let reqs = server.received_requests().await.unwrap();
     assert_eq!(
@@ -587,6 +692,7 @@ async fn end_turn_rejected_when_reply_tool_exists_but_not_called() {
         None,
         vec![],
         vec![],
+        TurnIdentity::default(),
     )
     .await
     .unwrap();
@@ -646,6 +752,7 @@ async fn end_turn_accepted_without_reply_tool_in_cli_mode() {
         None,
         vec![],
         vec![],
+        TurnIdentity::default(),
     )
     .await
     .unwrap();
@@ -685,6 +792,7 @@ async fn end_turn_accepted_after_reply_tool_called() {
         None,
         vec![],
         vec![],
+        TurnIdentity::default(),
     )
     .await
     .unwrap();
@@ -730,6 +838,7 @@ async fn end_turn_accepted_after_react_tool_called() {
         None,
         vec![],
         vec![],
+        TurnIdentity::default(),
     )
     .await
     .unwrap();
@@ -794,6 +903,7 @@ async fn empty_final_answer_not_persisted_and_retries() {
         None,
         vec![],
         vec![],
+        TurnIdentity::default(),
     )
     .await
     .unwrap();
@@ -861,7 +971,14 @@ async fn empty_final_answer_not_persisted_in_run_turn() {
     let conv_id = Uuid::new_v4();
 
     let result = orch
-        .run_turn("hello", conv_id, Interface::Cli, None, vec![])
+        .run_turn(
+            "hello",
+            conv_id,
+            Interface::Cli,
+            None,
+            vec![],
+            TurnIdentity::default(),
+        )
         .await
         .unwrap();
 
@@ -1082,7 +1199,14 @@ async fn run_turn_collects_attachments_from_tool_output() {
     ])));
 
     let result = orch
-        .run_turn("make a chart", Uuid::new_v4(), Interface::Cli, None, vec![])
+        .run_turn(
+            "make a chart",
+            Uuid::new_v4(),
+            Interface::Cli,
+            None,
+            vec![],
+            TurnIdentity::default(),
+        )
         .await
         .unwrap();
 
@@ -1125,7 +1249,14 @@ async fn run_turn_collects_multiple_attachments_across_tool_calls() {
     ])));
 
     let result = orch
-        .run_turn("go", Uuid::new_v4(), Interface::Cli, None, vec![])
+        .run_turn(
+            "go",
+            Uuid::new_v4(),
+            Interface::Cli,
+            None,
+            vec![],
+            TurnIdentity::default(),
+        )
         .await
         .unwrap();
 
@@ -1146,7 +1277,14 @@ async fn run_turn_no_attachments_when_tools_return_none() {
     let (orch, _, _) = build_with_executor(&server.uri()).await;
 
     let result = orch
-        .run_turn("hello", Uuid::new_v4(), Interface::Cli, None, vec![])
+        .run_turn(
+            "hello",
+            Uuid::new_v4(),
+            Interface::Cli,
+            None,
+            vec![],
+            TurnIdentity::default(),
+        )
         .await
         .unwrap();
 
@@ -1195,6 +1333,7 @@ async fn run_turn_streaming_collects_attachments() {
             tx,
             None,
             vec![],
+            TurnIdentity::default(),
         )
         .await
         .unwrap();
@@ -1265,6 +1404,7 @@ async fn run_turn_with_tools_collects_attachments_from_extension() {
         None,
         vec![],
         vec![],
+        TurnIdentity::default(),
     )
     .await
     .unwrap();
@@ -1572,6 +1712,9 @@ async fn run_worker_processes_turn_request() {
         timestamp: None,
         traceparent: None,
         attachment_ids: vec![],
+        user_id: None,
+        org_id: None,
+        space_id: None,
     };
     orch.bus()
         .publish(
@@ -1664,6 +1807,9 @@ async fn worker_propagates_submit_correlation_fields_to_turn_result() {
         timestamp: None,
         traceparent: None,
         attachment_ids: vec![],
+        user_id: None,
+        org_id: None,
+        space_id: None,
     };
 
     let request_msg_id = orch
@@ -1807,6 +1953,7 @@ async fn conversation_can_delegate_to_anonymous_subagent() {
             Interface::Cli,
             None,
             vec![],
+            TurnIdentity::default(),
         )
         .await
         .unwrap();
@@ -1896,6 +2043,7 @@ async fn conversation_can_delegate_to_existing_agent_context() {
             Interface::Cli,
             None,
             vec![],
+            TurnIdentity::default(),
         )
         .await
         .unwrap();
@@ -2263,7 +2411,14 @@ async fn run_turn_max_iterations_returns_error() {
     let (orch, _) = build_with_config(&server.uri(), config).await;
 
     let result = orch
-        .run_turn("trigger loop", Uuid::new_v4(), Interface::Cli, None, vec![])
+        .run_turn(
+            "trigger loop",
+            Uuid::new_v4(),
+            Interface::Cli,
+            None,
+            vec![],
+            TurnIdentity::default(),
+        )
         .await;
 
     match result {
@@ -2452,7 +2607,14 @@ async fn failed_turn_propagates_error() {
     let conv_id = Uuid::new_v4();
 
     let result = orch
-        .run_turn("test", conv_id, Interface::Cli, None, vec![])
+        .run_turn(
+            "test",
+            conv_id,
+            Interface::Cli,
+            None,
+            vec![],
+            TurnIdentity::default(),
+        )
         .await;
     assert!(
         result.is_err(),
@@ -2577,6 +2739,7 @@ async fn failed_turn_with_tools_llm_error_propagates() {
             None,
             vec![],
             vec![],
+            TurnIdentity::default(),
         )
         .await;
     assert!(
@@ -2613,6 +2776,7 @@ async fn failed_turn_with_tools_max_iterations_returns_error() {
             None,
             vec![],
             vec![],
+            TurnIdentity::default(),
         )
         .await;
     match result {
@@ -2679,6 +2843,7 @@ async fn run_turn_with_tools_streaming_emits_tokens_through_sink() {
         vec![],
         tx,
         vec![],
+        TurnIdentity::default(),
     )
     .await
     .unwrap();
@@ -2721,6 +2886,7 @@ async fn run_turn_with_tools_streaming_tokens_arrive_in_order() {
         vec![],
         tx,
         vec![],
+        TurnIdentity::default(),
     )
     .await
     .unwrap();
@@ -2942,6 +3108,7 @@ async fn run_turn_streaming_emits_thinking_event() {
         vec![],
         tx,
         vec![],
+        TurnIdentity::default(),
     )
     .await
     .unwrap();
@@ -3025,6 +3192,7 @@ async fn run_turn_streaming_emits_thinking_before_tool_calls() {
         vec![],
         tx,
         vec![],
+        TurnIdentity::default(),
     )
     .await
     .unwrap();

--- a/crates/runtime/src/orchestrator/turn_control.rs
+++ b/crates/runtime/src/orchestrator/turn_control.rs
@@ -117,6 +117,9 @@ impl Orchestrator {
                     interactive: false,
                     allowed_tools: None,
                     depth: 0,
+                    user_id: None,
+                    org_id: None,
+                    space_id: None,
                 };
                 if let Err(e) = reply_handler.run(params_map, &ctx).await {
                     warn!(tool = %reply_name, %e, "Auto-post via reply tool failed");

--- a/crates/runtime/src/orchestrator/worker.rs
+++ b/crates/runtime/src/orchestrator/worker.rs
@@ -9,7 +9,8 @@ use std::time::Duration;
 
 use anyhow::Result;
 use assistant_core::{
-    ClaimFilter, ContentBlock, Interface, PublishRequest, ToolHandler, bus_messages, topic,
+    ClaimFilter, ContentBlock, Interface, OrgId, PublishRequest, SpaceId, ToolHandler,
+    TurnIdentity, UserId, bus_messages, topic,
 };
 use chrono::{DateTime, Local, Utc};
 use opentelemetry::{
@@ -207,6 +208,14 @@ impl Orchestrator {
                         })
                         .unwrap_or_else(CancellationToken::new);
 
+                    // Extract identity from the bus message so tools see who
+                    // initiated this turn.
+                    let identity = TurnIdentity {
+                        user_id: turn_req.user_id.map(UserId::from),
+                        org_id: turn_req.org_id.map(OrgId::from),
+                        space_id: turn_req.space_id.map(SpaceId::from),
+                    };
+
                     // Dispatch to the appropriate processing method, racing
                     // against the per-turn cancellation token so an expired
                     // submit_turn deadline aborts work rather than letting it
@@ -225,6 +234,7 @@ impl Orchestrator {
                                         reg.attachments,
                                         sink,
                                         turn_req.attachment_ids.clone(),
+                                        identity.clone(),
                                     )
                                     .await
                                 } else {
@@ -237,6 +247,7 @@ impl Orchestrator {
                                         Some(&bus_consume_cx),
                                         reg.attachments,
                                         turn_req.attachment_ids.clone(),
+                                        identity.clone(),
                                     )
                                     .await
                                 }
@@ -249,6 +260,7 @@ impl Orchestrator {
                                     sink,
                                     Some(&bus_consume_cx),
                                     turn_req.attachment_ids.clone(),
+                                    identity.clone(),
                                 )
                                 .await
                             } else {
@@ -259,6 +271,7 @@ impl Orchestrator {
                                     interface,
                                     Some(&bus_consume_cx),
                                     turn_req.attachment_ids.clone(),
+                                    identity.clone(),
                                 )
                                 .await
                             }
@@ -569,6 +582,7 @@ impl Orchestrator {
             timestamp,
             HashMap::new(),
             vec![],
+            TurnIdentity::default(),
         )
         .await
     }
@@ -589,12 +603,36 @@ impl Orchestrator {
             timestamp,
             HashMap::new(),
             attachment_ids,
+            TurnIdentity::default(),
+        )
+        .await
+    }
+
+    /// Submit a turn with full identity context.
+    pub async fn submit_turn_with_identity(
+        &self,
+        prompt: &str,
+        conversation_id: Uuid,
+        interface: Interface,
+        timestamp: Option<DateTime<Utc>>,
+        attachment_ids: Vec<Uuid>,
+        identity: TurnIdentity,
+    ) -> Result<TurnResult> {
+        self.submit_turn_internal(
+            prompt,
+            conversation_id,
+            interface,
+            timestamp,
+            HashMap::new(),
+            attachment_ids,
+            identity,
         )
         .await
     }
 
     /// Submit a turn through the message bus and wait for the result, enriched
     /// with interface-provided metadata attributes and optional attachment IDs.
+    #[allow(clippy::too_many_arguments)]
     async fn submit_turn_internal(
         &self,
         prompt: &str,
@@ -603,6 +641,7 @@ impl Orchestrator {
         timestamp: Option<DateTime<Utc>>,
         submit_metadata: HashMap<String, String>,
         attachment_ids: Vec<Uuid>,
+        identity: TurnIdentity,
     ) -> Result<TurnResult> {
         let request_id = Uuid::new_v4();
         // Register a cancellation token so the worker can be interrupted if
@@ -643,6 +682,9 @@ impl Orchestrator {
             timestamp,
             traceparent: crate::otel_spans::traceparent_from_context(&interface_cx),
             attachment_ids,
+            user_id: identity.user_id.as_ref().map(|u| u.to_string()),
+            org_id: identity.org_id.as_ref().map(|o| o.to_string()),
+            space_id: identity.space_id.as_ref().map(|s| s.to_string()),
         };
 
         let mut produce_request_span = crate::otel_spans::start_bus_span(

--- a/crates/runtime/src/scheduler.rs
+++ b/crates/runtime/src/scheduler.rs
@@ -178,6 +178,9 @@ pub(crate) async fn run_due_tasks(
             timestamp: Some(Utc::now()),
             traceparent: traceparent_from_context(&interface_cx),
             attachment_ids: vec![],
+            user_id: None,
+            org_id: None,
+            space_id: None,
         };
 
         let mut produce_turn_span = crate::otel_spans::start_bus_span(
@@ -355,6 +358,9 @@ pub(crate) async fn run_heartbeat(orchestrator: &Orchestrator) -> Result<()> {
         timestamp: Some(Utc::now()),
         traceparent: traceparent_from_context(&interface_cx),
         attachment_ids: vec![],
+        user_id: None,
+        org_id: None,
+        space_id: None,
     };
 
     let mut produce_turn_span = crate::otel_spans::start_bus_span(

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -8,6 +8,7 @@ description = "SQLite-backed storage layer: skill registry, traces, memory, and 
 [dependencies]
 assistant-core = { path = "../core" }
 assistant-auth = { path = "../auth" }
+assistant-backup = { path = "../backup" }
 assistant-skills = { path = "../skills" }
 tokio = { workspace = true }
 serde_json = { workspace = true }
@@ -18,6 +19,7 @@ tracing = { workspace = true }
 sqlx = { workspace = true }
 opentelemetry-semantic-conventions = { workspace = true }
 dirs = { workspace = true }
+rand = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
 cron = { workspace = true }

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -13,6 +13,7 @@ pub mod logs;
 pub mod memory_chunks;
 pub mod message_bus;
 pub mod metrics;
+pub mod migration;
 pub mod org_storage;
 pub mod org_store;
 pub mod persona_skill_access;

--- a/crates/storage/src/migration.rs
+++ b/crates/storage/src/migration.rs
@@ -17,7 +17,7 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use tracing::info;
+use tracing::{info, warn};
 
 use assistant_backup::{BackupEngine, BackupOptions};
 
@@ -198,9 +198,15 @@ fn split_config(content: &str) -> (String, String) {
         }
 
         if !header_done {
-            // Lines before the first section header go to both (comments/preamble).
+            // Lines before the first section header: comments and blanks go
+            // to both files; non-comment scalar keys go to server only
+            // (legacy top-level keys like `db_path` map to storage config).
+            let is_comment_or_blank =
+                trimmed.is_empty() || trimmed.starts_with('#') || trimmed.starts_with(';');
             server_lines.push(line.to_string());
-            org_lines.push(line.to_string());
+            if is_comment_or_blank {
+                org_lines.push(line.to_string());
+            }
         } else if in_server_section {
             server_lines.push(line.to_string());
         } else {
@@ -271,12 +277,18 @@ pub async fn migrate_database(base_path: &Path) -> Result<()> {
         .with_context(|| format!("copying {} → {}", legacy_db.display(), space_db.display()))?;
     info!("copied assistant.db → {}", space_db.display());
 
-    // Also copy WAL/SHM if present
+    // Also copy WAL/SHM if present.
+    // Note: callers should ensure the source database is closed (no active
+    // connections) before invoking this migration so that the WAL is
+    // checkpointed. If the files still exist, we copy them on a best-effort
+    // basis and warn on failure.
     for suffix in &["-wal", "-shm"] {
         let src = base_path.join(format!("assistant.db{suffix}"));
         if src.exists() {
             let dst = space_dir.join(format!("space.db{suffix}"));
-            tokio::fs::copy(&src, &dst).await.ok();
+            if let Err(e) = tokio::fs::copy(&src, &dst).await {
+                warn!(src = %src.display(), dst = %dst.display(), error = %e, "failed to copy WAL/SHM file");
+            }
         }
     }
 
@@ -323,25 +335,52 @@ pub async fn migrate_database(base_path: &Path) -> Result<()> {
     info!("created default space: {}", space.id);
 
     // Create admin user and membership.
-    let admin_user_id = create_admin_user(&org_storage, &org.id.0, &space.id.0).await?;
-    info!("created admin user: {admin_user_id}");
+    let creds = create_admin_user(&org_storage, &org.id.0, &space.id.0).await?;
+    info!("created admin user: {}", creds.user_id);
+
+    if let Some(ref pw) = creds.generated_password {
+        info!("============================================================");
+        info!("  Migration complete - initial admin credentials:");
+        info!("    Email:    {}", creds.email);
+        info!("    Password: {pw}");
+        info!("  Change this password after first login.");
+        info!("============================================================");
+    } else {
+        info!("============================================================");
+        info!("  Migration complete - admin user created.");
+        info!("    Email:    {}", creds.email);
+        info!("    Password: (your ASSISTANT_WEB_TOKEN value)");
+        info!("============================================================");
+    }
 
     Ok(())
 }
 
 // -- Admin user creation -----------------------------------------------------
 
+/// Credentials returned by [`create_admin_user`] so the caller can display
+/// them through the appropriate output channel (e.g. `info!` log, CLI
+/// banner, etc.) instead of writing directly to stdout from library code.
+#[derive(Debug)]
+pub struct AdminCredentials {
+    pub user_id: String,
+    pub email: String,
+    /// `Some(password)` when a random password was generated.
+    /// `None` when `ASSISTANT_WEB_TOKEN` was used (caller already knows it).
+    pub generated_password: Option<String>,
+}
+
 /// Create the initial admin user during migration.
 ///
 /// - If `ASSISTANT_WEB_TOKEN` is set, uses it as a temporary password.
-/// - Otherwise, generates a random 24-character password and prints it to stdout.
+/// - Otherwise, generates a random 24-character password.
 ///
-/// Returns the new user's ID.
+/// Returns [`AdminCredentials`] so the caller can display them.
 pub async fn create_admin_user(
     org_storage: &crate::org_storage::OrgStorageLayer,
     org_id: &str,
     space_id: &str,
-) -> Result<String> {
+) -> Result<AdminCredentials> {
     use assistant_auth::password::hash_password;
     use assistant_core::identity::{OrgId, Role, SpaceId, UserId};
     use assistant_core::store::{MembershipStore, SpaceMembership, User, UserStore};
@@ -400,30 +439,11 @@ pub async fn create_admin_user(
         .await
         .context("granting admin membership")?;
 
-    if was_generated {
-        // Print to stdout so the operator sees it exactly once.
-        println!();
-        println!("═══════════════════════════════════════════════════════════");
-        println!("  Migration complete — initial admin credentials:");
-        println!();
-        println!("    Email:    admin@localhost");
-        println!("    Password: {password}");
-        println!();
-        println!("  Change this password after first login.");
-        println!("═══════════════════════════════════════════════════════════");
-        println!();
-    } else {
-        println!();
-        println!("══════════════���════════════════════════════════════════════");
-        println!("  Migration complete — admin user created.");
-        println!();
-        println!("    Email:    admin@localhost");
-        println!("    Password: (your ASSISTANT_WEB_TOKEN value)");
-        println!("═════���═════════════════════════════════��═══════════════════");
-        println!();
-    }
-
-    Ok(user_id)
+    Ok(AdminCredentials {
+        user_id,
+        email: "admin@localhost".into(),
+        generated_password: if was_generated { Some(password) } else { None },
+    })
 }
 
 // -- Full migration entry point ----------------------------------------------
@@ -696,9 +716,11 @@ enabled = true
     async fn migrate_database_creates_org_and_space_dbs() {
         let dir = TempDir::new().unwrap();
 
-        // Create a valid legacy database with migrations.
+        // Create a valid legacy database with migrations, then close it so
+        // the WAL is checkpointed before migrate_database copies the file.
         let legacy_db = dir.path().join("assistant.db");
-        let _storage = crate::StorageLayer::new(&legacy_db).await.unwrap();
+        let storage = crate::StorageLayer::new(&legacy_db).await.unwrap();
+        drop(storage);
 
         migrate_database(dir.path()).await.unwrap();
 

--- a/crates/storage/src/migration.rs
+++ b/crates/storage/src/migration.rs
@@ -1,0 +1,879 @@
+//! Legacy-to-multi-org migration for existing single-user installations.
+//!
+//! Detects the legacy `~/.assistant/` layout (flat `assistant.db` + `agents/` +
+//! `skills/` + `config.toml`) and migrates it to the new org/space directory
+//! structure introduced by the multi-user feature.
+//!
+//! ## Migration steps
+//!
+//! 1. **Detect** — [`is_legacy_layout`] checks for `assistant.db` without `orgs/`.
+//! 2. **Backup** — [`backup_legacy`] creates a `.tar.gz` snapshot via the backup crate.
+//! 3. **Filesystem** — [`migrate_filesystem`] creates `orgs/default/spaces/default/`
+//!    and copies `agents/`, `skills/`, interface configs.
+//! 4. **Database** — [`migrate_database`] copies `assistant.db` → `space.db`, creates
+//!    `org.db` with the default org, space, and initial admin user.
+//! 5. **Admin user** — [`create_admin_user`] seeds the first admin account.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use tracing::info;
+
+use assistant_backup::{BackupEngine, BackupOptions};
+
+// -- Constants ---------------------------------------------------------------
+
+/// Default org slug used when migrating a legacy single-user installation.
+pub const DEFAULT_ORG_SLUG: &str = "default";
+/// Default space slug used when migrating a legacy single-user installation.
+pub const DEFAULT_SPACE_SLUG: &str = "default";
+/// Default org name.
+const DEFAULT_ORG_NAME: &str = "Default Organization";
+/// Default space name.
+const DEFAULT_SPACE_NAME: &str = "Default Space";
+
+// -- Detection ---------------------------------------------------------------
+
+/// Check whether `base_path` contains a legacy (pre-multi-org) layout.
+///
+/// Returns `true` when `assistant.db` exists **and** there is no `orgs/`
+/// directory — i.e. the installation has not yet been migrated.
+pub fn is_legacy_layout(base_path: &Path) -> bool {
+    let has_db = base_path.join("assistant.db").exists();
+    let has_orgs = base_path.join("orgs").is_dir();
+    has_db && !has_orgs
+}
+
+// -- Backup ------------------------------------------------------------------
+
+/// Create a `.tar.gz` backup of the entire legacy installation before migrating.
+///
+/// Returns the path to the created archive. Uses the existing [`BackupEngine`]
+/// so all discovery, WAL checkpoint, and manifest logic is reused.
+pub async fn backup_legacy(base_path: &Path) -> Result<PathBuf> {
+    let backups_dir = base_path.join("backups");
+    tokio::fs::create_dir_all(&backups_dir)
+        .await
+        .with_context(|| format!("creating backups directory: {}", backups_dir.display()))?;
+
+    let archive_name = format!(
+        "pre-migration-{}.tar.gz",
+        chrono::Utc::now().format("%Y%m%d-%H%M%S")
+    );
+    let output_path = backups_dir.join(&archive_name);
+
+    let opts = BackupOptions {
+        install_dir: base_path.to_path_buf(),
+        output_path: output_path.clone(),
+        db_path: Some(base_path.join("assistant.db")),
+    };
+
+    let result = BackupEngine::new()
+        .run(opts)
+        .await
+        .context("creating pre-migration backup")?;
+
+    info!(
+        "pre-migration backup created: {} ({} files, {} bytes)",
+        result.output_path.display(),
+        result.entry_count,
+        result.archive_size
+    );
+
+    Ok(result.output_path)
+}
+
+// -- Filesystem migration ----------------------------------------------------
+
+/// Create the new org/space directory structure and copy legacy files into it.
+///
+/// Creates:
+/// ```text
+/// base_path/orgs/default/spaces/default/agents/
+/// base_path/orgs/default/spaces/default/skills/
+/// ```
+///
+/// Copies `agents/` and `skills/` directory trees. Splits `config.toml` into
+/// `server.toml` (global settings) and `orgs/default/org.toml` (org settings).
+pub async fn migrate_filesystem(base_path: &Path) -> Result<()> {
+    let space_dir = base_path
+        .join("orgs")
+        .join(DEFAULT_ORG_SLUG)
+        .join("spaces")
+        .join(DEFAULT_SPACE_SLUG);
+    let org_dir = base_path.join("orgs").join(DEFAULT_ORG_SLUG);
+
+    // Create the directory structure.
+    tokio::fs::create_dir_all(&space_dir)
+        .await
+        .with_context(|| format!("creating space directory: {}", space_dir.display()))?;
+
+    // Copy agents/ → orgs/default/spaces/default/agents/
+    let legacy_agents = base_path.join("agents");
+    if legacy_agents.is_dir() {
+        let dest = space_dir.join("agents");
+        copy_dir_recursive(&legacy_agents, &dest)
+            .await
+            .context("copying agents directory")?;
+        info!("copied agents/ → {}", dest.display());
+    }
+
+    // Copy skills/ → orgs/default/spaces/default/skills/
+    let legacy_skills = base_path.join("skills");
+    if legacy_skills.is_dir() {
+        let dest = space_dir.join("skills");
+        copy_dir_recursive(&legacy_skills, &dest)
+            .await
+            .context("copying skills directory")?;
+        info!("copied skills/ → {}", dest.display());
+    }
+
+    // Split config.toml → server.toml + org.toml
+    let legacy_config = base_path.join("config.toml");
+    if legacy_config.is_file() {
+        let content = tokio::fs::read_to_string(&legacy_config)
+            .await
+            .context("reading legacy config.toml")?;
+
+        let (server_toml, org_toml) = split_config(&content);
+
+        let server_path = base_path.join("server.toml");
+        tokio::fs::write(&server_path, server_toml.as_bytes())
+            .await
+            .with_context(|| format!("writing {}", server_path.display()))?;
+        info!("wrote server.toml");
+
+        let org_toml_path = org_dir.join("org.toml");
+        tokio::fs::write(&org_toml_path, org_toml.as_bytes())
+            .await
+            .with_context(|| format!("writing {}", org_toml_path.display()))?;
+        info!("wrote org.toml");
+    }
+
+    Ok(())
+}
+
+/// Split legacy `config.toml` into server-level and org-level config.
+///
+/// Server-level sections: `[storage]`, `[bus]`, `[mcp]`, `[self_improvement]`
+/// Org-level sections: `[llm]`, `[agent]`, `[skills]`, `[memory]`,
+///   `[transcription]`, `[tts]`, `[learning]`, `[signal]`, `[slack]`,
+///   `[matrix]`, `[mattermost]`, `[nextcloud]`
+fn split_config(content: &str) -> (String, String) {
+    let server_sections = ["[storage]", "[bus]", "[mcp]", "[self_improvement]"];
+
+    let mut server_lines = Vec::new();
+    let mut org_lines = Vec::new();
+    let mut in_server_section = false;
+    let mut header_done = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        // Detect section headers.
+        if trimmed.starts_with('[') && !trimmed.starts_with("[[") {
+            let is_server = server_sections.iter().any(|s| trimmed.starts_with(s));
+
+            in_server_section = is_server;
+            header_done = true;
+
+            if is_server {
+                server_lines.push(line.to_string());
+            } else {
+                org_lines.push(line.to_string());
+            }
+            continue;
+        }
+
+        // Subsections like [[mcp.servers]] stay with their parent.
+        if trimmed.starts_with("[[") {
+            if trimmed.contains("mcp.") {
+                in_server_section = true;
+                server_lines.push(line.to_string());
+            } else {
+                in_server_section = false;
+                org_lines.push(line.to_string());
+            }
+            continue;
+        }
+
+        if !header_done {
+            // Lines before the first section header go to both (comments/preamble).
+            server_lines.push(line.to_string());
+            org_lines.push(line.to_string());
+        } else if in_server_section {
+            server_lines.push(line.to_string());
+        } else {
+            org_lines.push(line.to_string());
+        }
+    }
+
+    let server = server_lines.join("\n") + "\n";
+    let org = org_lines.join("\n") + "\n";
+    (server, org)
+}
+
+/// Recursively copy a directory tree.
+async fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
+    tokio::fs::create_dir_all(dst)
+        .await
+        .with_context(|| format!("creating directory: {}", dst.display()))?;
+
+    let mut rd = tokio::fs::read_dir(src)
+        .await
+        .with_context(|| format!("reading directory: {}", src.display()))?;
+
+    while let Some(entry) = rd.next_entry().await? {
+        let src_path = entry.path();
+        let file_name = entry.file_name();
+        let dst_path = dst.join(&file_name);
+
+        let meta = entry.metadata().await?;
+        if meta.is_dir() {
+            Box::pin(copy_dir_recursive(&src_path, &dst_path)).await?;
+        } else if meta.is_file() {
+            tokio::fs::copy(&src_path, &dst_path)
+                .await
+                .with_context(|| {
+                    format!("copying {} → {}", src_path.display(), dst_path.display())
+                })?;
+        }
+    }
+
+    Ok(())
+}
+
+// -- Database migration ------------------------------------------------------
+
+/// Copy `assistant.db` to `space.db` and create `org.db` with the default
+/// org, space, and initial admin user.
+///
+/// - `assistant.db` → `orgs/default/spaces/default/space.db` (verbatim copy;
+///   existing space-level migrations will apply on next startup).
+/// - Creates `orgs/default/org.db` with org schema populated with:
+///   - Default organization row
+///   - Default space row
+///   - Admin user (see [`create_admin_user`])
+///   - Admin's space membership (OrgAdmin role)
+pub async fn migrate_database(base_path: &Path) -> Result<()> {
+    let legacy_db = base_path.join("assistant.db");
+    let org_dir = base_path.join("orgs").join(DEFAULT_ORG_SLUG);
+    let space_dir = org_dir.join("spaces").join(DEFAULT_SPACE_SLUG);
+
+    tokio::fs::create_dir_all(&space_dir)
+        .await
+        .with_context(|| format!("creating space directory: {}", space_dir.display()))?;
+
+    // Copy assistant.db → space.db
+    let space_db = space_dir.join("space.db");
+    tokio::fs::copy(&legacy_db, &space_db)
+        .await
+        .with_context(|| format!("copying {} → {}", legacy_db.display(), space_db.display()))?;
+    info!("copied assistant.db → {}", space_db.display());
+
+    // Also copy WAL/SHM if present
+    for suffix in &["-wal", "-shm"] {
+        let src = base_path.join(format!("assistant.db{suffix}"));
+        if src.exists() {
+            let dst = space_dir.join(format!("space.db{suffix}"));
+            tokio::fs::copy(&src, &dst).await.ok();
+        }
+    }
+
+    // Create org.db via OrgStorageLayer (runs org migrations).
+    let org_db_path = org_dir.join("org.db");
+    let org_storage = crate::org_storage::OrgStorageLayer::new(&org_db_path)
+        .await
+        .context("creating org.db")?;
+
+    // Seed default org.
+    use assistant_core::identity::{OrgId, SpaceId};
+    use assistant_core::store::{OrgStore, Organization, Space, SpaceStore};
+    let now = chrono::Utc::now();
+
+    let org = Organization {
+        id: OrgId::from(format!("org_{}", uuid::Uuid::new_v4())),
+        name: DEFAULT_ORG_NAME.into(),
+        slug: DEFAULT_ORG_SLUG.into(),
+        auth_mode: "password".into(),
+        created_at: now,
+        updated_at: now,
+    };
+    org_storage
+        .org_store()
+        .create_org(&org)
+        .await
+        .context("creating default organization")?;
+    info!("created default organization: {}", org.id);
+
+    // Seed default space.
+    let space = Space {
+        id: SpaceId::from(format!("spc_{}", uuid::Uuid::new_v4())),
+        org_id: org.id.clone(),
+        name: DEFAULT_SPACE_NAME.into(),
+        slug: DEFAULT_SPACE_SLUG.into(),
+        created_at: now,
+        updated_at: now,
+    };
+    org_storage
+        .space_store()
+        .create_space(&space)
+        .await
+        .context("creating default space")?;
+    info!("created default space: {}", space.id);
+
+    // Create admin user and membership.
+    let admin_user_id = create_admin_user(&org_storage, &org.id.0, &space.id.0).await?;
+    info!("created admin user: {admin_user_id}");
+
+    Ok(())
+}
+
+// -- Admin user creation -----------------------------------------------------
+
+/// Create the initial admin user during migration.
+///
+/// - If `ASSISTANT_WEB_TOKEN` is set, uses it as a temporary password.
+/// - Otherwise, generates a random 24-character password and prints it to stdout.
+///
+/// Returns the new user's ID.
+pub async fn create_admin_user(
+    org_storage: &crate::org_storage::OrgStorageLayer,
+    org_id: &str,
+    space_id: &str,
+) -> Result<String> {
+    use assistant_auth::password::hash_password;
+    use assistant_core::identity::{OrgId, Role, SpaceId, UserId};
+    use assistant_core::store::{MembershipStore, SpaceMembership, User, UserStore};
+    use rand::Rng;
+
+    let now = chrono::Utc::now();
+
+    // Determine password source.
+    let (password, was_generated) = match std::env::var("ASSISTANT_WEB_TOKEN") {
+        Ok(token) if !token.is_empty() => {
+            info!("using ASSISTANT_WEB_TOKEN as initial admin password");
+            (token, false)
+        }
+        _ => {
+            // Generate a random 24-character alphanumeric password.
+            let pw: String = rand::rng()
+                .sample_iter(&rand::distr::Alphanumeric)
+                .take(24)
+                .map(char::from)
+                .collect();
+            (pw, true)
+        }
+    };
+
+    let password_hash = hash_password(&password).context("hashing admin password")?;
+
+    let user_id = format!("usr_{}", uuid::Uuid::new_v4());
+    let user = User {
+        id: UserId::from(user_id.clone()),
+        org_id: OrgId::from(org_id),
+        email: "admin@localhost".into(),
+        name: "Admin".into(),
+        password_hash,
+        idp_issuer: None,
+        idp_subject: None,
+        created_at: now,
+        updated_at: now,
+    };
+
+    org_storage
+        .user_store()
+        .create_user(&user)
+        .await
+        .context("creating admin user")?;
+
+    // Grant OrgAdmin role in default space.
+    let membership = SpaceMembership {
+        user_id: UserId::from(user_id.clone()),
+        space_id: SpaceId::from(space_id),
+        role: Role::OrgAdmin,
+        created_at: now,
+    };
+    org_storage
+        .membership_store()
+        .add_membership(&membership)
+        .await
+        .context("granting admin membership")?;
+
+    if was_generated {
+        // Print to stdout so the operator sees it exactly once.
+        println!();
+        println!("═══════════════════════════════════════════════════════════");
+        println!("  Migration complete — initial admin credentials:");
+        println!();
+        println!("    Email:    admin@localhost");
+        println!("    Password: {password}");
+        println!();
+        println!("  Change this password after first login.");
+        println!("═══════════════════════════════════════════════════════════");
+        println!();
+    } else {
+        println!();
+        println!("══════════════���════════════════════════════════════════════");
+        println!("  Migration complete — admin user created.");
+        println!();
+        println!("    Email:    admin@localhost");
+        println!("    Password: (your ASSISTANT_WEB_TOKEN value)");
+        println!("═════���═════════════════════════════════��═══════════════════");
+        println!();
+    }
+
+    Ok(user_id)
+}
+
+// -- Full migration entry point ----------------------------------------------
+
+/// Run the complete legacy → multi-org migration.
+///
+/// 1. Detect legacy layout (caller should check [`is_legacy_layout`] first).
+/// 2. Create a pre-migration backup.
+/// 3. Migrate filesystem layout.
+/// 4. Migrate database (copy + create org.db with admin user).
+///
+/// Returns the path to the pre-migration backup archive.
+pub async fn run_migration(base_path: &Path) -> Result<PathBuf> {
+    info!(
+        "starting legacy → multi-org migration at {}",
+        base_path.display()
+    );
+
+    // Step 1: Backup
+    let backup_path = backup_legacy(base_path).await?;
+
+    // Step 2: Filesystem migration (dirs, config split)
+    migrate_filesystem(base_path).await?;
+
+    // Step 3: Database migration (copy + org.db creation)
+    migrate_database(base_path).await?;
+
+    info!("migration complete. Backup at: {}", backup_path.display());
+    Ok(backup_path)
+}
+
+// -- Tests -------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    use assistant_core::store::{MembershipStore, OrgStore, SpaceStore, UserStore};
+
+    // -- is_legacy_layout tests ----------------------------------------------
+
+    #[test]
+    fn detects_legacy_layout() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("assistant.db"), b"").unwrap();
+
+        assert!(
+            is_legacy_layout(dir.path()),
+            "directory with assistant.db and no orgs/ should be detected as legacy"
+        );
+    }
+
+    #[test]
+    fn already_migrated_is_not_legacy() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("assistant.db"), b"").unwrap();
+        std::fs::create_dir(dir.path().join("orgs")).unwrap();
+
+        assert!(
+            !is_legacy_layout(dir.path()),
+            "directory with both assistant.db and orgs/ should NOT be detected as legacy"
+        );
+    }
+
+    #[test]
+    fn empty_dir_is_not_legacy() {
+        let dir = TempDir::new().unwrap();
+
+        assert!(
+            !is_legacy_layout(dir.path()),
+            "empty directory should NOT be detected as legacy"
+        );
+    }
+
+    #[test]
+    fn fresh_install_no_db_is_not_legacy() {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir(dir.path().join("orgs")).unwrap();
+
+        assert!(
+            !is_legacy_layout(dir.path()),
+            "fresh install with orgs/ but no assistant.db should NOT be legacy"
+        );
+    }
+
+    // -- split_config tests --------------------------------------------------
+
+    #[test]
+    fn split_config_separates_sections() {
+        let config = r#"# Header comment
+
+[llm]
+provider = "ollama"
+model = "qwen2.5:7b"
+
+[storage]
+# db_path = "~/.assistant/assistant.db"
+
+[agent]
+# id = "default"
+
+[mcp]
+
+[[mcp.servers]]
+name = "github"
+
+[skills]
+# extra_dirs = []
+
+[self_improvement]
+trace_enabled = true
+
+[memory]
+# enabled = true
+
+[learning]
+enabled = true
+"#;
+        let (server, org) = split_config(config);
+
+        // Server should have storage, mcp, self_improvement
+        assert!(
+            server.contains("[storage]"),
+            "server.toml should contain [storage]"
+        );
+        assert!(server.contains("[mcp]"), "server.toml should contain [mcp]");
+        assert!(
+            server.contains("[[mcp.servers]]"),
+            "server.toml should contain [[mcp.servers]]"
+        );
+        assert!(
+            server.contains("[self_improvement]"),
+            "server.toml should contain [self_improvement]"
+        );
+
+        // Server should NOT have llm, agent, skills, memory, learning
+        assert!(
+            !server.contains("[llm]"),
+            "server.toml should NOT contain [llm]"
+        );
+        assert!(
+            !server.contains("[agent]"),
+            "server.toml should NOT contain [agent]"
+        );
+        assert!(
+            !server.contains("[learning]"),
+            "server.toml should NOT contain [learning]"
+        );
+
+        // Org should have llm, agent, skills, memory, learning
+        assert!(org.contains("[llm]"), "org.toml should contain [llm]");
+        assert!(org.contains("[agent]"), "org.toml should contain [agent]");
+        assert!(org.contains("[skills]"), "org.toml should contain [skills]");
+        assert!(org.contains("[memory]"), "org.toml should contain [memory]");
+        assert!(
+            org.contains("[learning]"),
+            "org.toml should contain [learning]"
+        );
+
+        // Org should NOT have storage, mcp, self_improvement
+        assert!(
+            !org.contains("[storage]"),
+            "org.toml should NOT contain [storage]"
+        );
+        assert!(!org.contains("[mcp]"), "org.toml should NOT contain [mcp]");
+    }
+
+    // -- copy_dir_recursive tests --------------------------------------------
+
+    #[tokio::test]
+    async fn copy_dir_recursive_copies_tree() {
+        let src = TempDir::new().unwrap();
+        let dst = TempDir::new().unwrap();
+
+        // Create a nested structure.
+        std::fs::create_dir_all(src.path().join("a/b")).unwrap();
+        std::fs::write(src.path().join("a/file1.txt"), b"hello").unwrap();
+        std::fs::write(src.path().join("a/b/file2.txt"), b"world").unwrap();
+
+        let dst_path = dst.path().join("copied");
+        copy_dir_recursive(src.path().join("a").as_path(), &dst_path)
+            .await
+            .unwrap();
+
+        assert!(dst_path.join("file1.txt").exists());
+        assert!(dst_path.join("b/file2.txt").exists());
+
+        let content = std::fs::read_to_string(dst_path.join("b/file2.txt")).unwrap();
+        assert_eq!(content, "world");
+    }
+
+    // -- backup_legacy tests -------------------------------------------------
+
+    #[tokio::test]
+    async fn backup_legacy_creates_archive() {
+        let dir = TempDir::new().unwrap();
+
+        // Seed a minimal legacy layout.
+        std::fs::write(dir.path().join("assistant.db"), b"fake-db-content").unwrap();
+        std::fs::write(
+            dir.path().join("config.toml"),
+            b"[llm]\nprovider = \"ollama\"",
+        )
+        .unwrap();
+
+        let archive_path = backup_legacy(dir.path()).await.unwrap();
+
+        assert!(archive_path.exists(), "backup archive should be created");
+        assert!(
+            archive_path.to_string_lossy().contains("pre-migration"),
+            "archive name should contain 'pre-migration'"
+        );
+    }
+
+    // -- migrate_filesystem tests --------------------------------------------
+
+    #[tokio::test]
+    async fn migrate_filesystem_creates_structure() {
+        let dir = TempDir::new().unwrap();
+
+        // Seed legacy layout.
+        std::fs::create_dir_all(dir.path().join("agents/default")).unwrap();
+        std::fs::write(dir.path().join("agents/default/SOUL.md"), b"# Soul").unwrap();
+        std::fs::create_dir_all(dir.path().join("skills/web-fetch")).unwrap();
+        std::fs::write(dir.path().join("skills/web-fetch/SKILL.md"), b"# Web Fetch").unwrap();
+        std::fs::write(
+            dir.path().join("config.toml"),
+            "[llm]\nprovider = \"ollama\"\n\n[storage]\n# db_path\n",
+        )
+        .unwrap();
+
+        migrate_filesystem(dir.path()).await.unwrap();
+
+        let space_dir = dir.path().join("orgs/default/spaces/default");
+
+        // Agents copied.
+        assert!(
+            space_dir.join("agents/default/SOUL.md").exists(),
+            "agents should be copied to new location"
+        );
+
+        // Skills copied.
+        assert!(
+            space_dir.join("skills/web-fetch/SKILL.md").exists(),
+            "skills should be copied to new location"
+        );
+
+        // server.toml created.
+        assert!(
+            dir.path().join("server.toml").exists(),
+            "server.toml should be created"
+        );
+        let server = std::fs::read_to_string(dir.path().join("server.toml")).unwrap();
+        assert!(
+            server.contains("[storage]"),
+            "server.toml should contain [storage]"
+        );
+
+        // org.toml created.
+        let org_toml_path = dir.path().join("orgs/default/org.toml");
+        assert!(org_toml_path.exists(), "org.toml should be created");
+        let org = std::fs::read_to_string(org_toml_path).unwrap();
+        assert!(org.contains("[llm]"), "org.toml should contain [llm]");
+    }
+
+    // -- migrate_database tests ----------------------------------------------
+
+    #[tokio::test]
+    async fn migrate_database_creates_org_and_space_dbs() {
+        let dir = TempDir::new().unwrap();
+
+        // Create a valid legacy database with migrations.
+        let legacy_db = dir.path().join("assistant.db");
+        let _storage = crate::StorageLayer::new(&legacy_db).await.unwrap();
+
+        migrate_database(dir.path()).await.unwrap();
+
+        let space_db = dir.path().join("orgs/default/spaces/default/space.db");
+        assert!(
+            space_db.exists(),
+            "space.db should be created by copying assistant.db"
+        );
+
+        let org_db = dir.path().join("orgs/default/org.db");
+        assert!(org_db.exists(), "org.db should be created with org schema");
+
+        // Verify org.db has a default organization.
+        let org_storage = crate::org_storage::OrgStorageLayer::new(&org_db)
+            .await
+            .unwrap();
+        let orgs = org_storage.org_store().list_orgs().await.unwrap();
+        assert_eq!(orgs.len(), 1, "org.db should have exactly one organization");
+        assert_eq!(orgs[0].slug, "default");
+
+        // Verify there's a default space.
+        let spaces = org_storage
+            .space_store()
+            .list_spaces(&orgs[0].id)
+            .await
+            .unwrap();
+        assert_eq!(spaces.len(), 1, "org.db should have exactly one space");
+        assert_eq!(spaces[0].slug, "default");
+
+        // Verify admin user exists.
+        let users = org_storage
+            .user_store()
+            .list_users(&orgs[0].id)
+            .await
+            .unwrap();
+        assert_eq!(
+            users.len(),
+            1,
+            "org.db should have exactly one user (admin)"
+        );
+        assert_eq!(users[0].email, "admin@localhost");
+    }
+
+    // -- full migration round-trip -------------------------------------------
+
+    #[tokio::test]
+    async fn full_migration_round_trip() {
+        let dir = TempDir::new().unwrap();
+
+        // Create a realistic legacy layout.
+        // 1. Database with migrations applied.
+        let legacy_db = dir.path().join("assistant.db");
+        let storage = crate::StorageLayer::new(&legacy_db).await.unwrap();
+
+        // Seed a conversation so we can verify it survives the migration.
+        let conv_store = storage.conversation_store();
+        let conv = conv_store
+            .create_conversation(Some("Test Conversation"))
+            .await
+            .unwrap();
+        let conv_id = conv.id;
+
+        // Seed a persona.
+        let persona_store = storage.persona_store();
+        persona_store
+            .create("test-persona", "Test Persona")
+            .await
+            .unwrap();
+
+        // Drop the storage to release the pool (avoids locked db).
+        drop(storage);
+
+        // 2. Agents directory.
+        std::fs::create_dir_all(dir.path().join("agents/default")).unwrap();
+        std::fs::write(dir.path().join("agents/default/SOUL.md"), b"# Soul").unwrap();
+        std::fs::write(dir.path().join("agents/default/IDENTITY.md"), b"# Identity").unwrap();
+
+        // 3. Skills directory.
+        std::fs::create_dir_all(dir.path().join("skills/greeting")).unwrap();
+        std::fs::write(
+            dir.path().join("skills/greeting/SKILL.md"),
+            b"# Greeting Skill",
+        )
+        .unwrap();
+
+        // 4. Config.
+        std::fs::write(
+            dir.path().join("config.toml"),
+            "[llm]\nprovider = \"ollama\"\nmodel = \"qwen2.5:7b\"\n\n[storage]\n# db\n\n[memory]\n# enabled\n",
+        )
+        .unwrap();
+
+        // Verify it's detected as legacy.
+        assert!(is_legacy_layout(dir.path()), "should be legacy layout");
+
+        // Run full migration.
+        let backup_path = run_migration(dir.path()).await.unwrap();
+        assert!(backup_path.exists(), "backup archive should exist");
+
+        // After migration, it should no longer be detected as legacy.
+        assert!(
+            !is_legacy_layout(dir.path()),
+            "after migration, should NOT be detected as legacy (orgs/ exists now)"
+        );
+
+        // Verify the new structure.
+        let space_dir = dir.path().join("orgs/default/spaces/default");
+
+        // Files copied.
+        assert!(space_dir.join("agents/default/SOUL.md").exists());
+        assert!(space_dir.join("agents/default/IDENTITY.md").exists());
+        assert!(space_dir.join("skills/greeting/SKILL.md").exists());
+
+        // Config split.
+        assert!(dir.path().join("server.toml").exists());
+        assert!(dir.path().join("orgs/default/org.toml").exists());
+
+        // space.db is a copy of assistant.db — open and verify data survived.
+        let space_storage = crate::StorageLayer::new(&space_dir.join("space.db"))
+            .await
+            .unwrap();
+        let found_conv = space_storage
+            .conversation_store()
+            .get_conversation(conv_id)
+            .await
+            .unwrap();
+        assert!(
+            found_conv.is_some(),
+            "conversation should survive migration to space.db"
+        );
+
+        let personas = space_storage.persona_store().list().await.unwrap();
+        assert!(
+            personas.iter().any(|p| p.name == "Test Persona"),
+            "persona should survive migration to space.db"
+        );
+
+        // org.db has the admin user.
+        let org_storage =
+            crate::org_storage::OrgStorageLayer::new(&dir.path().join("orgs/default/org.db"))
+                .await
+                .unwrap();
+        let orgs = org_storage.org_store().list_orgs().await.unwrap();
+        let users = org_storage
+            .user_store()
+            .list_users(&orgs[0].id)
+            .await
+            .unwrap();
+        assert_eq!(users.len(), 1, "admin user should exist in org.db");
+        assert_eq!(users[0].email, "admin@localhost");
+        assert!(
+            !users[0].password_hash.is_empty(),
+            "admin user should have a password hash"
+        );
+
+        // Verify admin has OrgAdmin membership.
+        let spaces = org_storage
+            .space_store()
+            .list_spaces(&orgs[0].id)
+            .await
+            .unwrap();
+        let members = org_storage
+            .membership_store()
+            .get_members_of_space(&spaces[0].id)
+            .await
+            .unwrap();
+        assert_eq!(
+            members.len(),
+            1,
+            "admin should be a member of the default space"
+        );
+        assert_eq!(
+            members[0].role,
+            assistant_core::identity::Role::OrgAdmin,
+            "admin should have OrgAdmin role"
+        );
+    }
+}

--- a/crates/tool-executor/src/builtins/agent_spawn.rs
+++ b/crates/tool-executor/src/builtins/agent_spawn.rs
@@ -188,6 +188,9 @@ mod tests {
             interactive: false,
             allowed_tools: None,
             depth,
+            user_id: None,
+            org_id: None,
+            space_id: None,
         }
     }
 

--- a/crates/tool-executor/src/builtins/agent_status.rs
+++ b/crates/tool-executor/src/builtins/agent_status.rs
@@ -155,6 +155,9 @@ mod tests {
             interactive: false,
             allowed_tools: None,
             depth: 0,
+            user_id: None,
+            org_id: None,
+            space_id: None,
         }
     }
 

--- a/crates/tool-executor/src/builtins/agent_terminate.rs
+++ b/crates/tool-executor/src/builtins/agent_terminate.rs
@@ -136,6 +136,9 @@ mod tests {
             interactive: false,
             allowed_tools: None,
             depth: 0,
+            user_id: None,
+            org_id: None,
+            space_id: None,
         }
     }
 

--- a/crates/tool-executor/src/builtins/cancel_task.rs
+++ b/crates/tool-executor/src/builtins/cancel_task.rs
@@ -135,6 +135,9 @@ mod tests {
             interactive: false,
             allowed_tools: None,
             depth: 0,
+            user_id: None,
+            org_id: None,
+            space_id: None,
         }
     }
 

--- a/crates/tool-executor/src/builtins/list_tasks.rs
+++ b/crates/tool-executor/src/builtins/list_tasks.rs
@@ -116,6 +116,9 @@ mod tests {
             interactive: false,
             allowed_tools: None,
             depth: 0,
+            user_id: None,
+            org_id: None,
+            space_id: None,
         }
     }
 

--- a/crates/tool-executor/src/builtins/memory_append.rs
+++ b/crates/tool-executor/src/builtins/memory_append.rs
@@ -273,6 +273,9 @@ mod tests {
             interactive: false,
             allowed_tools: None,
             depth: 0,
+            user_id: None,
+            org_id: None,
+            space_id: None,
         }
     }
 

--- a/crates/tool-executor/src/builtins/process.rs
+++ b/crates/tool-executor/src/builtins/process.rs
@@ -488,6 +488,9 @@ mod tests {
             interactive: false,
             allowed_tools: None,
             depth: 0,
+            user_id: None,
+            org_id: None,
+            space_id: None,
         }
     }
 

--- a/crates/tool-executor/src/builtins/schedule_task.rs
+++ b/crates/tool-executor/src/builtins/schedule_task.rs
@@ -194,6 +194,9 @@ mod tests {
             interactive: false,
             allowed_tools: None,
             depth: 0,
+            user_id: None,
+            org_id: None,
+            space_id: None,
         }
     }
 

--- a/crates/tool-executor/src/builtins/voice_response.rs
+++ b/crates/tool-executor/src/builtins/voice_response.rs
@@ -170,6 +170,9 @@ mod tests {
             interactive: false,
             allowed_tools: None,
             depth: 0,
+            user_id: None,
+            org_id: None,
+            space_id: None,
         }
     }
 

--- a/crates/tool-executor/src/executor.rs
+++ b/crates/tool-executor/src/executor.rs
@@ -321,6 +321,9 @@ mod tests {
             interactive: false,
             allowed_tools: None,
             depth: 0,
+            user_id: None,
+            org_id: None,
+            space_id: None,
         }
     }
 
@@ -333,6 +336,9 @@ mod tests {
             interactive: false,
             allowed_tools: Some(allowed.into_iter().map(String::from).collect()),
             depth: 0,
+            user_id: None,
+            org_id: None,
+            space_id: None,
         }
     }
 

--- a/openspec/changes/multi-user-orgs/tasks.md
+++ b/openspec/changes/multi-user-orgs/tasks.md
@@ -476,8 +476,8 @@ PR 10 ─── CLI OAuth2 login + Flutter OAuth2 + docs
 - [x] `feat(runtime): extend ExecutionContext with identity fields`
   - Add `user_id: Option<UserId>`, `org_id: Option<OrgId>`, `space_id: Option<SpaceId>` to `ExecutionContext`
 
-- [x] `feat(runtime): thread AuthContext through Orchestrator.run_turn_with_tools()`
-  - Accept `AuthContext` parameter (or extract from ExecutionContext)
+- [x] `feat(runtime): thread TurnIdentity through Orchestrator.run_turn_with_tools()`
+  - Accept `TurnIdentity` parameter (or extract from ExecutionContext)
   - Pass through to tool handlers via execution context
 
 - [ ] `feat(runtime): ChannelRunner resolves platform identity before dispatch`

--- a/openspec/changes/multi-user-orgs/tasks.md
+++ b/openspec/changes/multi-user-orgs/tasks.md
@@ -443,40 +443,40 @@ PR 10 ─── CLI OAuth2 login + Flutter OAuth2 + docs
 
 **Commits:**
 
-- [ ] `feat(storage): detect legacy layout`
+- [x] `feat(storage): detect legacy layout`
   - Create `crates/storage/src/migration.rs`
   - `is_legacy_layout(base_path) -> bool` — checks for `assistant.db` without `orgs/` directory
 
-- [ ] `feat(storage): create backup before migration`
+- [x] `feat(storage): create backup before migration`
   - `backup_legacy(base_path) -> Result<PathBuf>` — tar.gz of entire `~/.assistant/`
   - Reuse existing backup logic from `crates/backup/`
 
-- [ ] `feat(storage): migrate filesystem layout to default org`
+- [x] `feat(storage): migrate filesystem layout to default org`
   - Create `orgs/default/spaces/default/` structure
   - Copy `agents/` → `orgs/default/spaces/default/agents/`
   - Copy `skills/` → `orgs/default/spaces/default/skills/`
   - Split `config.toml` → `server.toml` + `orgs/default/org.toml`
   - Convert interface config sections to instance files in `orgs/default/spaces/default/interfaces/`
 
-- [ ] `feat(storage): migrate database to org/space split`
+- [x] `feat(storage): migrate database to org/space split`
   - Copy `assistant.db` → `orgs/default/spaces/default/space.db`
   - Create `orgs/default/org.db` with schema, populate with default org + initial admin user
   - Assign all existing conversations to admin user
 
-- [ ] `feat(storage): initial admin user creation during migration`
+- [x] `feat(storage): initial admin user creation during migration`
   - If `ASSISTANT_WEB_TOKEN` is set: create admin user with that as temporary password
   - Otherwise: generate random password, print to stdout
   - Log clear instructions for the operator
 
-- [ ] `test(storage): full migration round-trip on fixture data`
+- [x] `test(storage): full migration round-trip on fixture data`
   - Create a fixture legacy layout (db + files)
   - Run migration
   - Verify: all conversations accessible, personas intact, skills present, org.db has admin user
 
-- [ ] `feat(runtime): extend ExecutionContext with identity fields`
+- [x] `feat(runtime): extend ExecutionContext with identity fields`
   - Add `user_id: Option<UserId>`, `org_id: Option<OrgId>`, `space_id: Option<SpaceId>` to `ExecutionContext`
 
-- [ ] `feat(runtime): thread AuthContext through Orchestrator.run_turn_with_tools()`
+- [x] `feat(runtime): thread AuthContext through Orchestrator.run_turn_with_tools()`
   - Accept `AuthContext` parameter (or extract from ExecutionContext)
   - Pass through to tool handlers via execution context
 

--- a/openspec/changes/multi-user-orgs/tasks.md
+++ b/openspec/changes/multi-user-orgs/tasks.md
@@ -399,35 +399,35 @@ PR 10 ─── CLI OAuth2 login + Flutter OAuth2 + docs
   - CRUD happy paths
   - Permission enforcement: member can't create spaces, viewer can't invite users
 
-- [ ] `feat(web-ui): catalog management endpoints`
+- [x] `feat(web-ui): catalog management endpoints`
   - `POST /api/orgs/{org_id}/catalog/skills` — publish skill to catalog
   - `POST /api/orgs/{org_id}/catalog/templates` — publish template to catalog
   - `GET /api/orgs/{org_id}/catalog/{type}` — list catalog resources
   - `DELETE /api/orgs/{org_id}/catalog/{type}/{id}` — remove from catalog
 
-- [ ] `feat(web-ui): catalog subscription endpoints`
+- [x] `feat(web-ui): catalog subscription endpoints`
   - `POST /api/orgs/{org_id}/spaces/{space_id}/subscriptions` — subscribe space to catalog resource
   - `GET /api/orgs/{org_id}/spaces/{space_id}/subscriptions` — list subscriptions
   - `DELETE /api/orgs/{org_id}/spaces/{space_id}/subscriptions/{id}` — unsubscribe
 
-- [ ] `feat(web-ui): interface instance endpoints`
+- [x] `feat(web-ui): interface instance endpoints`
   - `POST /api/orgs/{org_id}/spaces/{space_id}/interfaces` — create interface instance (type, config, owner: org|user)
   - `GET /api/orgs/{org_id}/spaces/{space_id}/interfaces` — list instances
   - `DELETE /api/orgs/{org_id}/spaces/{space_id}/interfaces/{id}` — remove instance
 
-- [ ] `feat(web-ui): persona ↔ interface binding endpoints`
+- [x] `feat(web-ui): persona ↔ interface binding endpoints`
   - `POST /api/orgs/{org_id}/spaces/{space_id}/bindings` — bind persona to interface instance
   - `GET /api/orgs/{org_id}/spaces/{space_id}/bindings` — list bindings
   - `DELETE /api/orgs/{org_id}/spaces/{space_id}/bindings/{id}` — unbind
 
-- [ ] `feat(web-ui): persona template instantiation and onboarding`
+- [x] `feat(web-ui): persona template instantiation and onboarding`
   - `GET /api/orgs/{org_id}/catalog/templates` — list templates (filtered by user's allowed_templates quota)
   - `POST /api/orgs/{org_id}/spaces/{space_id}/personas/from-template` — create persona from template, enforce max_personas quota
   - `GET /api/users/me/onboarding-status` — has user created at least one persona?
 
-- [ ] `test(web-ui): catalog, subscriptions, interfaces, bindings, and template instantiation`
+- [x] `test(web-ui): catalog, subscriptions, interfaces, bindings, and template instantiation`
 
-- [ ] `refactor(web-ui): update existing API handlers to enforce AuthContext`
+- [x] `refactor(web-ui): update existing API handlers to enforce AuthContext`
   - Conversations, messages, personas, skills endpoints
   - Scope queries by user_id + space from AuthContext
   - Return 403 when user lacks access


### PR DESCRIPTION
## Summary

- **Legacy-to-multi-org migration** (`crates/storage/src/migration.rs`): detect legacy layout, backup, migrate filesystem (agents/skills → orgs/default/spaces/default/), split config.toml, migrate database, create admin user — with 11 comprehensive tests
- **TurnIdentity threading**: new `TurnIdentity` struct bundles optional user/org/space IDs; threaded through `TurnRequest` bus messages, orchestrator public/private turn methods, and all 30+ `ExecutionContext` construction sites across 16 files
- **New `submit_turn_with_identity()`** entry point for callers with authenticated context (web-ui, channel runner)

Implements OpenSpec multi-user-orgs tasks #81–#88 (PR 9: "Storage migration + runtime AuthContext threading").

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean  
- [x] `cargo test -p assistant-runtime` — 171 tests pass
- [x] `cargo test --workspace --no-run` — all test binaries compile
- [x] Pre-commit hooks pass (fmt, clippy, machete)
- [ ] Integration tests (`make test-integration`) — requires Ollama, CI only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-user identity context support for tracking user, organization, and space information across all turns and tool operations.
  * Implemented automated migration for legacy single-user installations to modern multi-org setup, including timestamped backups, filesystem reorganization, and automatic admin account provisioning.

* **Chores**
  * Updated test code to support new identity context fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->