### PR TITLE
fix(runtime): prevent context window overflow with provider-aware compaction

### DIFF
--- a/crates/core/src/llm/embedding.rs
+++ b/crates/core/src/llm/embedding.rs
@@ -128,6 +128,7 @@ mod tests {
                 streaming: false,
                 vision: false,
                 hosted_tools: Vec::new(),
+                context_window_tokens: None,
             }
         }
 
@@ -186,6 +187,7 @@ mod tests {
                 streaming: false,
                 vision: false,
                 hosted_tools: Vec::new(),
+                context_window_tokens: None,
             }
         }
 

--- a/crates/core/src/llm/provider.rs
+++ b/crates/core/src/llm/provider.rs
@@ -33,6 +33,12 @@ pub struct Capabilities {
     pub vision: bool,
     /// Hosted tools supplied directly by the provider (e.g. Anthropic web search).
     pub hosted_tools: Vec<HostedTool>,
+    /// The model's context window size in tokens, if known.
+    ///
+    /// When set, the orchestrator uses this to override the default compaction
+    /// `context_window_tokens` so that history compaction triggers at the right
+    /// threshold for the actual model being used.
+    pub context_window_tokens: Option<u64>,
 }
 
 /// Provider-managed tools that should suppress local equivalents.

--- a/crates/llm-provider/src/anthropic/mod.rs
+++ b/crates/llm-provider/src/anthropic/mod.rs
@@ -371,6 +371,7 @@ impl LlmProvider for AnthropicProvider {
                 }
                 hosted
             },
+            context_window_tokens: Some(200_000),
         }
     }
 

--- a/crates/llm-provider/src/moonshot/mod.rs
+++ b/crates/llm-provider/src/moonshot/mod.rs
@@ -270,6 +270,7 @@ impl LlmProvider for MoonshotProvider {
             streaming: true,
             vision: true,
             hosted_tools,
+            context_window_tokens: Some(262_144),
         }
     }
 

--- a/crates/llm-provider/src/ollama/client.rs
+++ b/crates/llm-provider/src/ollama/client.rs
@@ -427,6 +427,7 @@ impl LlmProvider for LlmClient {
             streaming: true,
             vision: false,
             hosted_tools: Vec::new(),
+            context_window_tokens: None, // varies by model
         }
     }
 

--- a/crates/llm-provider/src/ollama/mod.rs
+++ b/crates/llm-provider/src/ollama/mod.rs
@@ -104,6 +104,7 @@ impl LlmProvider for OllamaProvider {
             streaming: true,
             vision: false,
             hosted_tools: Vec::new(),
+            context_window_tokens: None, // varies by model
         }
     }
 

--- a/crates/llm-provider/src/openai/provider.rs
+++ b/crates/llm-provider/src/openai/provider.rs
@@ -376,6 +376,7 @@ impl LlmProvider for OpenAIProvider {
             streaming: true,
             vision: true,
             hosted_tools,
+            context_window_tokens: Some(128_000),
         }
     }
 

--- a/crates/llm-provider/src/openrouter/mod.rs
+++ b/crates/llm-provider/src/openrouter/mod.rs
@@ -100,6 +100,7 @@ impl LlmProvider for OpenRouterProvider {
             // handles multimodal content blocks regardless.
             vision: true,
             hosted_tools: vec![],
+            context_window_tokens: None, // varies by model
         }
     }
 

--- a/crates/runtime/src/compaction.rs
+++ b/crates/runtime/src/compaction.rs
@@ -54,6 +54,70 @@ pub fn estimate_tokens(history: &[ChatHistoryMessage]) -> u64 {
     (chars / 4) as u64
 }
 
+/// Estimate total input tokens including the system prompt and tool specs.
+///
+/// The basic `estimate_tokens` only counts history characters. The actual
+/// request also includes the system prompt and tool definitions, which can
+/// add tens of thousands of tokens. This function provides a more accurate
+/// pre-call estimate.
+pub fn estimate_total_tokens(
+    system_prompt: &str,
+    history: &[ChatHistoryMessage],
+    tool_specs: &[assistant_core::ToolSpec],
+) -> u64 {
+    let history_chars: usize = history.iter().map(message_estimated_chars).sum();
+    let system_chars = system_prompt.len();
+    let tool_chars: usize = tool_specs
+        .iter()
+        .map(|t| t.name.len() + t.description.len() + t.params_schema.to_string().len())
+        .sum();
+    ((history_chars + system_chars + tool_chars) / 4) as u64
+}
+
+/// Hard-truncate history by dropping the oldest messages when the estimated
+/// token count exceeds the hard limit (`context_window - reserve_floor`).
+///
+/// Unlike soft compaction (which summarises old turns via an LLM call), this
+/// is a synchronous, zero-cost safety net that prevents sending an
+/// over-limit request. It drops whole messages from the front of the
+/// history until the estimate fits.
+///
+/// Returns `true` if any messages were dropped.
+pub fn hard_truncate(
+    system_prompt: &str,
+    history: &mut Vec<ChatHistoryMessage>,
+    tool_specs: &[assistant_core::ToolSpec],
+    cfg: &CompactionConfig,
+) -> bool {
+    let hard_limit = cfg
+        .context_window_tokens
+        .saturating_sub(cfg.reserve_floor_tokens);
+
+    if hard_limit == 0 {
+        return false;
+    }
+
+    let initial_len = history.len();
+    while history.len() > 1 {
+        let estimated = estimate_total_tokens(system_prompt, history, tool_specs);
+        if estimated < hard_limit {
+            break;
+        }
+        // Drop the oldest message.
+        history.remove(0);
+    }
+
+    let dropped = history.len() < initial_len;
+    if dropped {
+        let n = initial_len - history.len();
+        warn!(
+            dropped_messages = n,
+            hard_limit, "Hard-truncated {n} oldest messages to fit within context window"
+        );
+    }
+    dropped
+}
+
 /// Estimate character count for a message, including binary payload sizes for
 /// image/document blocks that `message_text` would skip.
 fn message_estimated_chars(msg: &ChatHistoryMessage) -> usize {
@@ -520,5 +584,92 @@ mod tests {
                 .saturating_sub(default_cfg.reserve_floor_tokens)
                 .saturating_sub(default_cfg.soft_threshold_tokens),
         );
+    }
+
+    #[test]
+    fn estimate_total_tokens_includes_system_and_tools() {
+        let history = vec![ChatHistoryMessage::Text {
+            role: ChatRole::User,
+            content: "a".repeat(400),
+        }];
+        let system_prompt = "b".repeat(200);
+        let tools = vec![assistant_core::ToolSpec {
+            name: "test-tool".into(),
+            description: "A test tool".into(),
+            params_schema: serde_json::json!({"type": "object"}),
+            is_mutating: false,
+            requires_confirmation: false,
+        }];
+
+        let history_only = estimate_tokens(&history);
+        let total = estimate_total_tokens(&system_prompt, &history, &tools);
+
+        assert!(
+            total > history_only,
+            "total estimate ({total}) should be larger than history-only ({history_only})"
+        );
+    }
+
+    #[test]
+    fn hard_truncate_drops_messages_when_over_limit() {
+        // Context window = 1000 tokens, reserve = 200 → hard limit = 800 tokens.
+        // Each message is 400 chars = 100 estimated tokens.
+        let c = cfg(true, 1_000, 200, 100, 2);
+        let mut history: Vec<ChatHistoryMessage> = (0..10)
+            .map(|i| ChatHistoryMessage::Text {
+                role: if i % 2 == 0 {
+                    ChatRole::User
+                } else {
+                    ChatRole::Assistant
+                },
+                content: "x".repeat(400),
+            })
+            .collect();
+
+        // 10 messages × 100 tokens = 1000 tokens > 800 hard limit
+        let dropped = hard_truncate("", &mut history, &[], &c);
+        assert!(dropped, "should have dropped messages");
+        assert!(
+            history.len() < 10,
+            "should have fewer messages after truncation"
+        );
+
+        // The remaining history should fit within the hard limit.
+        let remaining_estimate = estimate_total_tokens("", &history, &[]);
+        assert!(
+            remaining_estimate < 800,
+            "remaining estimate ({remaining_estimate}) should be below hard limit (800)"
+        );
+    }
+
+    #[test]
+    fn hard_truncate_noop_when_under_limit() {
+        let c = cfg(true, 200_000, 20_000, 30_000, 10);
+        let mut history = vec![
+            ChatHistoryMessage::Text {
+                role: ChatRole::User,
+                content: "hello".into(),
+            },
+            ChatHistoryMessage::Text {
+                role: ChatRole::Assistant,
+                content: "hi there".into(),
+            },
+        ];
+        let original_len = history.len();
+        let dropped = hard_truncate("system prompt", &mut history, &[], &c);
+        assert!(!dropped, "should not have dropped any messages");
+        assert_eq!(history.len(), original_len);
+    }
+
+    #[test]
+    fn hard_truncate_preserves_at_least_one_message() {
+        // Even when a single message exceeds the limit, we keep at least 1.
+        let c = cfg(true, 100, 50, 10, 1);
+        let mut history = vec![ChatHistoryMessage::Text {
+            role: ChatRole::User,
+            content: "x".repeat(10_000),
+        }];
+        hard_truncate("", &mut history, &[], &c);
+        assert_eq!(history.len(), 1, "should keep at least one message");
     }
 }

--- a/crates/runtime/src/conversation_indexer.rs
+++ b/crates/runtime/src/conversation_indexer.rs
@@ -259,6 +259,7 @@ mod tests {
                 streaming: false,
                 vision: false,
                 hosted_tools: vec![],
+                context_window_tokens: None,
             }
         }
         async fn chat(

--- a/crates/runtime/src/orchestrator/mod.rs
+++ b/crates/runtime/src/orchestrator/mod.rs
@@ -234,6 +234,24 @@ impl Orchestrator {
     ) -> Self {
         let memory_loader = MemoryLoader::new(config);
         memory_loader.ensure_defaults();
+
+        // Use the provider's reported context window to configure compaction.
+        // If the provider reports a specific window, use the smaller of that
+        // and the user-configured value to avoid exceeding the model's limit.
+        let mut compaction_config = config.compaction.clone();
+        if let Some(provider_window) = llm.capabilities().context_window_tokens {
+            let effective = provider_window.min(compaction_config.context_window_tokens);
+            if effective != compaction_config.context_window_tokens {
+                info!(
+                    config_window = compaction_config.context_window_tokens,
+                    provider_window,
+                    effective,
+                    "Adjusting compaction context_window_tokens to match provider limit"
+                );
+            }
+            compaction_config.context_window_tokens = effective;
+        }
+
         Self {
             llm,
             storage,
@@ -250,7 +268,7 @@ impl Orchestrator {
             turn_cancellations: tokio::sync::RwLock::new(HashMap::new()),
             metrics: crate::MetricsRecorder::new(),
             agent_id: config.agent.id.clone(),
-            compaction_config: config.compaction.clone(),
+            compaction_config,
             submit_timeout_secs: 10_800,
             adapter_registry: crate::AdapterRegistry::new(),
             audio_store: None,
@@ -559,10 +577,11 @@ impl Orchestrator {
             debug!(iteration, "Extension-tools loop iteration");
 
             // Pre-call compaction: compact before sending to the LLM so we
-            // never exceed the context window on the call itself.  Use the
-            // token estimator as a fallback when we have no prior metadata.
+            // never exceed the context window on the call itself.  Uses the
+            // total estimator (history + system prompt + tool specs).
             {
-                let estimated = crate::compaction::estimate_tokens(&history);
+                let estimated =
+                    crate::compaction::estimate_total_tokens(&system_prompt, &history, &all_specs);
                 if crate::compaction::should_compact(estimated, &self.compaction_config) {
                     crate::compaction::maybe_compact(
                         &mut history,
@@ -573,6 +592,15 @@ impl Orchestrator {
                     .await;
                 }
             }
+
+            // Hard-truncate as a safety net: if the estimate still exceeds the
+            // hard limit after compaction, drop oldest messages.
+            crate::compaction::hard_truncate(
+                &system_prompt,
+                &mut history,
+                &all_specs,
+                &self.compaction_config,
+            );
 
             let ctx = ExecutionContext {
                 conversation_id,
@@ -937,9 +965,11 @@ impl Orchestrator {
             let iteration_span = info_span!("turn_iteration", iteration);
             debug!(parent: &iteration_span, iteration, "Tool-calling loop iteration");
 
-            // Pre-call compaction using the token estimator.
+            // Pre-call compaction using the total token estimator (includes
+            // system prompt and tool specs for a more accurate picture).
             {
-                let estimated = crate::compaction::estimate_tokens(&history);
+                let estimated =
+                    crate::compaction::estimate_total_tokens(&system_prompt, &history, &tool_specs);
                 if crate::compaction::should_compact(estimated, &self.compaction_config) {
                     crate::compaction::maybe_compact(
                         &mut history,
@@ -950,6 +980,16 @@ impl Orchestrator {
                     .await;
                 }
             }
+
+            // Hard-truncate as a safety net: if the estimate still exceeds the
+            // hard limit after compaction (e.g. a single huge tool result),
+            // drop oldest messages to avoid a 400 from the provider.
+            crate::compaction::hard_truncate(
+                &system_prompt,
+                &mut history,
+                &tool_specs,
+                &self.compaction_config,
+            );
 
             let ctx = ExecutionContext {
                 conversation_id,

--- a/crates/runtime/src/skill_improver.rs
+++ b/crates/runtime/src/skill_improver.rs
@@ -330,6 +330,7 @@ mod tests {
                 streaming: false,
                 vision: false,
                 hosted_tools: vec![],
+                context_window_tokens: None,
             }
         }
 

--- a/crates/runtime/src/skill_learner.rs
+++ b/crates/runtime/src/skill_learner.rs
@@ -345,6 +345,7 @@ mod tests {
                     streaming: false,
                     vision: false,
                     hosted_tools: vec![],
+                    context_window_tokens: None,
                 }
             }
             async fn chat(


### PR DESCRIPTION
## Summary

Fixes Moonshot API 400 errors (`requested: 315479 > limit: 262144`) in long Slack conversations by making compaction aware of each provider's actual context window.

- Add `context_window_tokens: Option<u64>` to `Capabilities` — each LLM provider now reports its real context window (Moonshot 262k, Anthropic 200k, OpenAI 128k, Ollama/OpenRouter unknown)
- Orchestrator uses `min(config, provider_reported)` so compaction triggers at the right threshold
- New `estimate_total_tokens` includes system prompt + tool specs in the pre-call estimate (previously only history was counted)
- New `hard_truncate` safety net drops oldest messages before the LLM call when the estimate exceeds the hard limit — prevents 400 errors even when the estimate is somewhat off

## Known limitation

Compaction currently **deletes original messages** from SQLite and replaces them with a summary. This is destructive — chat history in the web UI and Slack is lost after compaction. A follow-up PR will change persistence to preserve originals (virtual compaction / soft-delete). This PR focuses on preventing the immediate 400 error.

## Test plan

- [x] 14 compaction unit tests pass (including 4 new tests for `estimate_total_tokens`, `hard_truncate` edge cases)
- [x] `cargo clippy -D warnings` clean on affected crates
- [x] Pre-commit hooks pass (fmt, clippy, machete)
- [ ] Deploy to schorschvm and verify long Slack thread no longer errors