### PR TITLE
feat(app): theme-aware Mermaid diagrams from ColorScheme

### DIFF
--- a/app/lib/features/chat/chat_screen.dart
+++ b/app/lib/features/chat/chat_screen.dart
@@ -35,6 +35,7 @@ import 'commands_provider.dart';
 import 'conversation_list.dart';
 import 'image_utils.dart';
 import 'streaming_timeline_entry.dart';
+import 'theme_aware_mermaid.dart';
 import 'voice_recorder_button.dart';
 
 /// Main chat screen.
@@ -761,7 +762,12 @@ class _MessageBubble extends StatelessWidget {
                             ..registerBlock(MermaidPlugin())
                             ..registerBlock(const SvgPlugin()),
                           builderRegistry: BuilderRegistry()
-                            ..register('mermaid', const MermaidBuilder())
+                            ..register(
+                              'mermaid',
+                              ThemeAwareMermaidBuilder(
+                                style: mermaidStyleFromColorScheme(colorScheme),
+                              ),
+                            )
                             ..register('svg', const SvgBuilder()),
                         )
                       else if (message.content.isNotEmpty)
@@ -786,7 +792,12 @@ class _MessageBubble extends StatelessWidget {
                             ..registerBlock(MermaidPlugin())
                             ..registerBlock(const SvgPlugin()),
                           builderRegistry: BuilderRegistry()
-                            ..register('mermaid', const MermaidBuilder())
+                            ..register(
+                              'mermaid',
+                              ThemeAwareMermaidBuilder(
+                                style: mermaidStyleFromColorScheme(colorScheme),
+                              ),
+                            )
                             ..register('svg', const SvgBuilder()),
                         ),
                       // Attachment thumbnails (assistant-produced images).

--- a/app/lib/features/chat/theme_aware_mermaid.dart
+++ b/app/lib/features/chat/theme_aware_mermaid.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_smooth_markdown/flutter_smooth_markdown.dart';
+
+/// Derives a [MermaidStyle] from a Flutter [ColorScheme] so that Mermaid
+/// diagrams use the same tinted surfaces, accent colors, and contrast
+/// ratios as the rest of the app — instead of the library's hardcoded
+/// light/dark palettes.
+MermaidStyle mermaidStyleFromColorScheme(ColorScheme cs) {
+  final isDark = cs.brightness == Brightness.dark;
+
+  return MermaidStyle(
+    backgroundColor: cs.surfaceContainerHighest.toARGB32(),
+    defaultNodeStyle: NodeStyle(
+      fillColor: cs.primaryContainer.toARGB32(),
+      strokeColor: cs.primary.toARGB32(),
+      textColor: cs.onPrimaryContainer.toARGB32(),
+    ),
+    defaultEdgeStyle: EdgeStyle(
+      strokeColor: cs.outline.toARGB32(),
+      labelColor: cs.onSurfaceVariant.toARGB32(),
+      labelBackgroundColor: cs.surfaceContainerHighest.toARGB32(),
+    ),
+    themeMode: isDark ? MermaidThemeMode.dark : MermaidThemeMode.light,
+  );
+}
+
+/// A [MarkdownWidgetBuilder] that renders Mermaid diagrams using a
+/// [MermaidStyle] derived from the app's [ColorScheme], so diagrams
+/// blend with the surrounding UI instead of using hardcoded palettes.
+class ThemeAwareMermaidBuilder extends MarkdownWidgetBuilder {
+  const ThemeAwareMermaidBuilder({required this.style});
+
+  final MermaidStyle style;
+
+  @override
+  bool canBuild(MarkdownNode node) => node is MermaidDiagramNode;
+
+  @override
+  Widget build(
+    MarkdownNode node,
+    MarkdownStyleSheet styleSheet,
+    MarkdownRenderContext context,
+  ) {
+    if (node is! MermaidDiagramNode) return const SizedBox.shrink();
+
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 16),
+      decoration: BoxDecoration(
+        color: Color(style.backgroundColor),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: MermaidDiagram(code: node.code, style: style),
+    );
+  }
+}

--- a/app/test/unit/chat/theme_aware_mermaid_test.dart
+++ b/app/test/unit/chat/theme_aware_mermaid_test.dart
@@ -1,0 +1,213 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_smooth_markdown/flutter_smooth_markdown.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/features/chat/theme_aware_mermaid.dart';
+
+void main() {
+  group('mermaidStyleFromColorScheme', () {
+    test('uses dark themeMode for dark ColorScheme', () {
+      final cs = ColorScheme.fromSeed(
+        seedColor: const Color(0xFF1A73E8),
+        brightness: Brightness.dark,
+      );
+
+      final style = mermaidStyleFromColorScheme(cs);
+
+      expect(style.themeMode, MermaidThemeMode.dark);
+    });
+
+    test('uses light themeMode for light ColorScheme', () {
+      final cs = ColorScheme.fromSeed(
+        seedColor: const Color(0xFF1A73E8),
+        brightness: Brightness.light,
+      );
+
+      final style = mermaidStyleFromColorScheme(cs);
+
+      expect(style.themeMode, MermaidThemeMode.light);
+    });
+
+    test('maps background to surfaceContainerHighest', () {
+      final cs = ColorScheme.fromSeed(
+        seedColor: const Color(0xFF1A73E8),
+        brightness: Brightness.dark,
+      );
+
+      final style = mermaidStyleFromColorScheme(cs);
+
+      expect(
+        style.backgroundColor,
+        cs.surfaceContainerHighest.toARGB32(),
+        reason: 'Diagram background should match the bubble background',
+      );
+    });
+
+    test('maps node fill to primaryContainer', () {
+      final cs = ColorScheme.fromSeed(
+        seedColor: const Color(0xFF1A73E8),
+        brightness: Brightness.dark,
+      );
+
+      final style = mermaidStyleFromColorScheme(cs);
+
+      expect(style.defaultNodeStyle.fillColor, cs.primaryContainer.toARGB32());
+    });
+
+    test('maps node stroke to primary', () {
+      final cs = ColorScheme.fromSeed(
+        seedColor: const Color(0xFF1A73E8),
+        brightness: Brightness.dark,
+      );
+
+      final style = mermaidStyleFromColorScheme(cs);
+
+      expect(style.defaultNodeStyle.strokeColor, cs.primary.toARGB32());
+    });
+
+    test('maps node text to onPrimaryContainer', () {
+      final cs = ColorScheme.fromSeed(
+        seedColor: const Color(0xFF1A73E8),
+        brightness: Brightness.dark,
+      );
+
+      final style = mermaidStyleFromColorScheme(cs);
+
+      expect(
+        style.defaultNodeStyle.textColor,
+        cs.onPrimaryContainer.toARGB32(),
+      );
+    });
+
+    test('maps edge stroke to outline', () {
+      final cs = ColorScheme.fromSeed(
+        seedColor: const Color(0xFF1A73E8),
+        brightness: Brightness.dark,
+      );
+
+      final style = mermaidStyleFromColorScheme(cs);
+
+      expect(style.defaultEdgeStyle.strokeColor, cs.outline.toARGB32());
+    });
+
+    test('maps edge label color to onSurfaceVariant', () {
+      final cs = ColorScheme.fromSeed(
+        seedColor: const Color(0xFF1A73E8),
+        brightness: Brightness.dark,
+      );
+
+      final style = mermaidStyleFromColorScheme(cs);
+
+      expect(style.defaultEdgeStyle.labelColor, cs.onSurfaceVariant.toARGB32());
+    });
+
+    test('maps edge label background to surfaceContainerHighest', () {
+      final cs = ColorScheme.fromSeed(
+        seedColor: const Color(0xFF1A73E8),
+        brightness: Brightness.dark,
+      );
+
+      final style = mermaidStyleFromColorScheme(cs);
+
+      expect(
+        style.defaultEdgeStyle.labelBackgroundColor,
+        cs.surfaceContainerHighest.toARGB32(),
+      );
+    });
+
+    test('produces different styles for light vs dark', () {
+      final light = mermaidStyleFromColorScheme(
+        ColorScheme.fromSeed(
+          seedColor: const Color(0xFF1A73E8),
+          brightness: Brightness.light,
+        ),
+      );
+      final dark = mermaidStyleFromColorScheme(
+        ColorScheme.fromSeed(
+          seedColor: const Color(0xFF1A73E8),
+          brightness: Brightness.dark,
+        ),
+      );
+
+      expect(
+        light.backgroundColor,
+        isNot(dark.backgroundColor),
+        reason: 'Light and dark should have distinct backgrounds',
+      );
+      expect(
+        light.defaultNodeStyle.fillColor,
+        isNot(dark.defaultNodeStyle.fillColor),
+        reason: 'Light and dark should have distinct node fills',
+      );
+    });
+  });
+
+  group('ThemeAwareMermaidBuilder', () {
+    test('canBuild returns true for MermaidDiagramNode', () {
+      final style = mermaidStyleFromColorScheme(
+        ColorScheme.fromSeed(seedColor: const Color(0xFF1A73E8)),
+      );
+      final builder = ThemeAwareMermaidBuilder(style: style);
+
+      expect(
+        builder.canBuild(const MermaidDiagramNode(code: 'graph TD\nA-->B')),
+        isTrue,
+      );
+    });
+
+    test('canBuild returns false for non-Mermaid nodes', () {
+      final style = mermaidStyleFromColorScheme(
+        ColorScheme.fromSeed(seedColor: const Color(0xFF1A73E8)),
+      );
+      final builder = ThemeAwareMermaidBuilder(style: style);
+
+      // Use a generic MarkdownNode subtype that isn't MermaidDiagramNode.
+      expect(builder.canBuild(const _FakeNode()), isFalse);
+    });
+
+    testWidgets('build produces a MermaidDiagram with the given style', (
+      tester,
+    ) async {
+      final cs = ColorScheme.fromSeed(
+        seedColor: const Color(0xFF1A73E8),
+        brightness: Brightness.dark,
+      );
+      final style = mermaidStyleFromColorScheme(cs);
+      final builder = ThemeAwareMermaidBuilder(style: style);
+      const node = MermaidDiagramNode(code: 'graph TD\n  A-->B');
+
+      final widget = builder.build(
+        node,
+        MarkdownStyleSheet.dark(),
+        const MarkdownRenderContext(),
+      );
+
+      // Pump the widget inside a constrained box so LayoutBuilder resolves.
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(colorScheme: cs),
+          home: Scaffold(
+            body: SizedBox(width: 600, height: 400, child: widget),
+          ),
+        ),
+      );
+
+      // The tree should contain a MermaidDiagram somewhere.
+      expect(find.byType(MermaidDiagram), findsOneWidget);
+    });
+  });
+}
+
+/// Minimal fake node for testing canBuild rejects non-Mermaid nodes.
+class _FakeNode extends MarkdownNode {
+  const _FakeNode();
+
+  @override
+  String get type => 'fake';
+
+  @override
+  Map<String, dynamic> toJson() => {'type': type};
+
+  @override
+  MarkdownNode copyWith() => this;
+}


### PR DESCRIPTION
## Summary

- Mermaid diagrams in dark mode used hardcoded neutral grey palettes (`#1E1E1E` background, `#2D2D2D` nodes) that clashed with the app's Material 3 tinted dark surfaces, creating a visible "hole" inside chat bubbles.
- Adds `mermaidStyleFromColorScheme()` that derives `MermaidStyle` from the live `ColorScheme` — background matches `surfaceContainerHighest` (the bubble), nodes use `primaryContainer`/`primary`, edges use `outline`.
- Replaces `const MermaidBuilder()` with `ThemeAwareMermaidBuilder` in both `StreamMarkdown` and `SmoothMarkdown` renderers.

## Test plan

- [x] 13 new unit/widget tests covering all color mappings, light/dark divergence, builder `canBuild` behavior, and widget tree output
- [x] Full suite passes (611 tests, 0 failures)
- [ ] Visual check: open a conversation with a Mermaid diagram in dark mode — diagram should blend with the bubble background instead of showing a neutral grey rectangle