### PR TITLE
refactor(storage): remove default persona API in favor of ensure_exists

### DIFF
--- a/crates/interface-cli/src/main.rs
+++ b/crates/interface-cli/src/main.rs
@@ -153,13 +153,10 @@ enum PersonaCommand {
     Create {
         /// Persona ID (letters, numbers, '-', '_').
         id: String,
-        /// Mark the created/existing Persona as default.
-        #[arg(long)]
-        default: bool,
     },
-    /// Set an existing Persona as default.
+    /// Switch to an existing Persona (creates it if needed).
     Use {
-        /// Persona ID to mark as default.
+        /// Persona ID to activate.
         id: String,
     },
     /// Set the skill access mode for a persona (all, whitelist, blacklist).
@@ -649,7 +646,7 @@ fn cmd_reset(db_path: &Path, config: &AssistantConfig, skip_confirm: bool) -> Re
 async fn cmd_persona(db_path: &Path, command: &PersonaCommand) -> Result<()> {
     let storage = StorageLayer::new(db_path).await?;
     let store = storage.persona_store();
-    store.ensure_default().await?;
+    store.ensure_exists("default").await?;
 
     match command {
         PersonaCommand::List => {
@@ -660,12 +657,10 @@ async fn cmd_persona(db_path: &Path, command: &PersonaCommand) -> Result<()> {
             }
             println!("Configured Personas:\n");
             for item in items {
-                let marker = if item.is_default { "*" } else { " " };
-                println!("{marker} {:20} {}", item.id, item.name);
+                println!("  {:20} {}", item.id, item.name);
             }
-            println!("\n* default");
         }
-        PersonaCommand::Create { id, default } => {
+        PersonaCommand::Create { id } => {
             if !validate_agent_id(id) {
                 anyhow::bail!(
                     "Invalid Persona ID '{}'. Use only letters, numbers, '-' and '_'.",
@@ -673,18 +668,12 @@ async fn cmd_persona(db_path: &Path, command: &PersonaCommand) -> Result<()> {
                 );
             }
             store.ensure_exists(id).await?;
-            if *default {
-                store.set_default(id).await?;
-            }
 
             let root = home_agent_root(id)?;
             let workspace = default_workspace_dir(id);
             tokio::fs::create_dir_all(&root).await?;
             tokio::fs::create_dir_all(&workspace).await?;
             println!("Persona '{}' is ready.", id);
-            if *default {
-                println!("Default Persona set to '{}'.", id);
-            }
         }
         PersonaCommand::Use { id } => {
             if !validate_agent_id(id) {
@@ -694,12 +683,14 @@ async fn cmd_persona(db_path: &Path, command: &PersonaCommand) -> Result<()> {
                 );
             }
             store.ensure_exists(id).await?;
-            store.set_default(id).await?;
             let root = home_agent_root(id)?;
             let workspace = default_workspace_dir(id);
             tokio::fs::create_dir_all(&root).await?;
             tokio::fs::create_dir_all(&workspace).await?;
-            println!("Default Persona set to '{}'.", id);
+            println!(
+                "Persona '{}' activated. Use --agent {} on next run.",
+                id, id
+            );
         }
         PersonaCommand::SkillMode { persona_id, mode } => {
             let access_store = PersonaSkillAccessStore::new(storage.pool.clone());
@@ -1170,7 +1161,7 @@ async fn main() -> Result<()> {
     let (mut config, config_logs) = load_config_messages(&config_path);
 
     let cli_persona_override = cli.persona.clone();
-    let mut selected_persona = cli_persona_override
+    let selected_persona = cli_persona_override
         .clone()
         .unwrap_or_else(|| config.agent.id.clone());
     if !validate_agent_id(&selected_persona) {
@@ -1278,23 +1269,6 @@ async fn main() -> Result<()> {
             .with_context(|| format!("Failed to open database at {}", db_path.display()))?,
     );
     let personas = storage.persona_store();
-    personas.ensure_default().await?;
-    if cli_persona_override.is_none() {
-        let default_id = personas.default_id().await?;
-        if default_id != selected_persona {
-            selected_persona = default_id;
-            apply_agent_context(&mut config, &selected_persona);
-            let agent_root = assistant_dir.join("agents").join(&selected_persona);
-            let workspace_dir = default_workspace_dir(&selected_persona);
-            set_runtime_agent_root(agent_root);
-            set_runtime_workspace_dir(workspace_dir.clone());
-            tokio::fs::create_dir_all(&workspace_dir)
-                .await
-                .with_context(|| {
-                    format!("Failed to create workspace at {}", workspace_dir.display())
-                })?;
-        }
-    }
     personas.ensure_exists(&selected_persona).await?;
 
     let _otel_guard = init_tracing(storage.pool.clone(), &config.observability).await?;

--- a/crates/runtime/src/orchestrator/tests.rs
+++ b/crates/runtime/src/orchestrator/tests.rs
@@ -2029,7 +2029,11 @@ async fn conversation_can_delegate_to_existing_agent_context() {
         .await;
 
     let (orch, storage) = build(&server.uri()).await;
-    storage.persona_store().ensure_default().await.unwrap();
+    storage
+        .persona_store()
+        .ensure_exists("default")
+        .await
+        .unwrap();
     storage
         .persona_store()
         .ensure_exists("marketing")

--- a/crates/runtime/src/scheduler.rs
+++ b/crates/runtime/src/scheduler.rs
@@ -896,7 +896,11 @@ mod tests {
         let (orch, storage) = build(&server.uri()).await;
 
         // Persona exists but has no home_channel set (default).
-        storage.persona_store().ensure_default().await.unwrap();
+        storage
+            .persona_store()
+            .ensure_exists("default")
+            .await
+            .unwrap();
 
         let conv_id = Uuid::new_v4();
         let tools = resolve_home_channel_tools(&storage, &orch, conv_id).await;
@@ -911,7 +915,11 @@ mod tests {
         let server = MockServer::start().await;
         let (orch, storage) = build(&server.uri()).await;
 
-        storage.persona_store().ensure_default().await.unwrap();
+        storage
+            .persona_store()
+            .ensure_exists("default")
+            .await
+            .unwrap();
         storage
             .persona_store()
             .set_home_channel("default", "slack", "#ops")

--- a/crates/storage/src/persona_skill_access.rs
+++ b/crates/storage/src/persona_skill_access.rs
@@ -138,7 +138,11 @@ mod tests {
     async fn test_set_and_get_mode() {
         let storage = StorageLayer::new_in_memory().await.unwrap();
         // Ensure default persona exists
-        storage.persona_store().ensure_default().await.unwrap();
+        storage
+            .persona_store()
+            .ensure_exists("default")
+            .await
+            .unwrap();
 
         let store = PersonaSkillAccessStore::new(storage.pool.clone());
         store.set_mode("default", MODE_BLACKLIST).await.unwrap();
@@ -149,7 +153,11 @@ mod tests {
     #[tokio::test]
     async fn test_invalid_mode_rejected() {
         let storage = StorageLayer::new_in_memory().await.unwrap();
-        storage.persona_store().ensure_default().await.unwrap();
+        storage
+            .persona_store()
+            .ensure_exists("default")
+            .await
+            .unwrap();
 
         let store = PersonaSkillAccessStore::new(storage.pool.clone());
         let result = store.set_mode("default", "invalid").await;
@@ -159,7 +167,11 @@ mod tests {
     #[tokio::test]
     async fn test_add_remove_skill() {
         let storage = StorageLayer::new_in_memory().await.unwrap();
-        storage.persona_store().ensure_default().await.unwrap();
+        storage
+            .persona_store()
+            .ensure_exists("default")
+            .await
+            .unwrap();
 
         let store = PersonaSkillAccessStore::new(storage.pool.clone());
         store.add_skill("default", "git-commit").await.unwrap();
@@ -176,7 +188,11 @@ mod tests {
     #[tokio::test]
     async fn test_add_skill_idempotent() {
         let storage = StorageLayer::new_in_memory().await.unwrap();
-        storage.persona_store().ensure_default().await.unwrap();
+        storage
+            .persona_store()
+            .ensure_exists("default")
+            .await
+            .unwrap();
 
         let store = PersonaSkillAccessStore::new(storage.pool.clone());
         store.add_skill("default", "git-commit").await.unwrap();

--- a/crates/storage/src/personas.rs
+++ b/crates/storage/src/personas.rs
@@ -41,30 +41,6 @@ impl PersonaStore {
         Self { pool }
     }
 
-    pub async fn ensure_default(&self) -> Result<PersonaRecord> {
-        sqlx::query(
-            "INSERT INTO personas (id, name, is_default) VALUES ('default', 'Default', 1) \
-             ON CONFLICT(id) DO NOTHING",
-        )
-        .execute(&self.pool)
-        .await?;
-
-        sqlx::query(
-            "UPDATE personas
-             SET is_default = CASE WHEN id = 'default' THEN 1 ELSE 0 END,
-                 updated_at = CURRENT_TIMESTAMP
-             WHERE NOT EXISTS (
-                 SELECT 1 FROM personas WHERE is_default = 1
-             )",
-        )
-        .execute(&self.pool)
-        .await?;
-
-        self.get("default")
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("default persona missing after ensure_default"))
-    }
-
     pub async fn ensure_exists(&self, id: &str) -> Result<PersonaRecord> {
         if let Some(existing) = self.get(id).await? {
             return Ok(existing);
@@ -93,52 +69,12 @@ impl PersonaStore {
         let rows = sqlx::query(
             "SELECT id, name, is_default, skill_access_mode, turn_timeout_secs, home_interface, home_channel, owner_user_id, created_at, updated_at
              FROM personas
-             ORDER BY is_default DESC, id ASC",
+             ORDER BY id ASC",
         )
         .fetch_all(&self.pool)
         .await?;
 
         rows.into_iter().map(row_to_record).collect()
-    }
-
-    pub async fn set_default(&self, id: &str) -> Result<()> {
-        let mut tx = self.pool.begin().await?;
-
-        let exists: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM personas WHERE id = ?1")
-            .bind(id)
-            .fetch_one(&mut *tx)
-            .await?;
-        if exists == 0 {
-            anyhow::bail!("persona '{}' does not exist", id);
-        }
-
-        sqlx::query("UPDATE personas SET is_default = 0, updated_at = CURRENT_TIMESTAMP")
-            .execute(&mut *tx)
-            .await?;
-        sqlx::query(
-            "UPDATE personas
-             SET is_default = 1, updated_at = CURRENT_TIMESTAMP
-             WHERE id = ?1",
-        )
-        .bind(id)
-        .execute(&mut *tx)
-        .await?;
-
-        tx.commit().await?;
-        Ok(())
-    }
-
-    pub async fn default_id(&self) -> Result<String> {
-        let id = sqlx::query_scalar::<_, String>(
-            "SELECT id
-             FROM personas
-             WHERE is_default = 1
-             LIMIT 1",
-        )
-        .fetch_optional(&self.pool)
-        .await?
-        .unwrap_or_else(|| "default".to_string());
-        Ok(id)
     }
 
     pub async fn get(&self, id: &str) -> Result<Option<PersonaRecord>> {
@@ -264,7 +200,7 @@ impl PersonaStore {
             "SELECT id, name, is_default, skill_access_mode, turn_timeout_secs, home_interface, home_channel, owner_user_id, created_at, updated_at
              FROM personas
              WHERE owner_user_id IS NULL OR owner_user_id = ?1
-             ORDER BY is_default DESC, id ASC",
+             ORDER BY id ASC",
         )
         .bind(user_id)
         .fetch_all(&self.pool)
@@ -330,6 +266,38 @@ mod tests {
     use crate::StorageLayer;
 
     #[tokio::test]
+    async fn ensure_exists_replaces_ensure_default() {
+        let storage = StorageLayer::new_in_memory().await.unwrap();
+        let store = super::PersonaStore::new(storage.pool.clone());
+
+        // ensure_exists("default") should work as the replacement for ensure_default()
+        let persona = store.ensure_exists("default").await.unwrap();
+        assert_eq!(persona.id, "default");
+        // Migration seeds "Default" — ensure_exists returns the existing record
+        assert_eq!(persona.name, "Default");
+    }
+
+    #[tokio::test]
+    async fn list_orders_by_id_not_is_default() {
+        let storage = StorageLayer::new_in_memory().await.unwrap();
+        let store = super::PersonaStore::new(storage.pool.clone());
+
+        // Create personas with IDs that sort alphabetically
+        store.create("zeta", "Zeta").await.unwrap();
+        store.create("alpha", "Alpha").await.unwrap();
+        store.create("beta", "Beta").await.unwrap();
+
+        let items = store.list().await.unwrap();
+        let ids: Vec<&str> = items.iter().map(|p| p.id.as_str()).collect();
+        // "default" is seeded by migration — should sort alphabetically with the rest
+        assert_eq!(
+            ids,
+            vec!["alpha", "beta", "default", "zeta"],
+            "list should order by id ASC without is_default priority"
+        );
+    }
+
+    #[tokio::test]
     async fn create_returns_error_on_duplicate_id() {
         let storage = StorageLayer::new_in_memory().await.unwrap();
         let store = super::PersonaStore::new(storage.pool.clone());
@@ -344,7 +312,7 @@ mod tests {
         let storage = StorageLayer::new_in_memory().await.unwrap();
         let store = super::PersonaStore::new(storage.pool.clone());
 
-        store.ensure_default().await.unwrap();
+        store.ensure_exists("default").await.unwrap();
         let persona = store.get("default").await.unwrap().unwrap();
         assert!(
             persona.turn_timeout_secs.is_none(),
@@ -402,7 +370,7 @@ mod tests {
         let storage = StorageLayer::new_in_memory().await.unwrap();
         let store = super::PersonaStore::new(storage.pool.clone());
 
-        store.ensure_default().await.unwrap();
+        store.ensure_exists("default").await.unwrap();
         let persona = store.get("default").await.unwrap().unwrap();
         assert!(
             persona.home_channel.is_none(),
@@ -468,7 +436,7 @@ mod tests {
         let storage = StorageLayer::new_in_memory().await.unwrap();
         let store = super::PersonaStore::new(storage.pool.clone());
 
-        store.ensure_default().await.unwrap();
+        store.ensure_exists("default").await.unwrap();
         store.create("notifier", "Notifier").await.unwrap();
         store
             .set_home_channel("notifier", "signal", "+12345678901")
@@ -490,7 +458,7 @@ mod tests {
         let storage = StorageLayer::new_in_memory().await.unwrap();
         let store = super::PersonaStore::new(storage.pool.clone());
 
-        store.ensure_default().await.unwrap();
+        store.ensure_exists("default").await.unwrap();
         store.create("slow", "Slow").await.unwrap();
         store.set_turn_timeout("slow", 21600).await.unwrap();
 

--- a/crates/web-ui/src/api/personas.rs
+++ b/crates/web-ui/src/api/personas.rs
@@ -108,7 +108,6 @@ pub struct PersonaSummary {
     pub id: String,
     pub name: String,
     pub description: String,
-    pub is_default: bool,
 }
 
 /// Full persona detail including file slot inventory.
@@ -116,7 +115,6 @@ pub struct PersonaSummary {
 pub struct PersonaDetail {
     pub id: String,
     pub name: String,
-    pub is_default: bool,
     pub skill_access_mode: String,
     pub turn_timeout_secs: Option<u64>,
     pub created_at: String,
@@ -230,7 +228,6 @@ pub async fn list_personas(
                     id: p.id,
                     name: p.name,
                     description: String::new(),
-                    is_default: p.is_default,
                 })
                 .collect();
             Json(summaries).into_response()
@@ -294,7 +291,6 @@ pub async fn create_persona(
             let detail = PersonaDetail {
                 id: p.id,
                 name: p.name,
-                is_default: p.is_default,
                 skill_access_mode: p.skill_access_mode,
                 turn_timeout_secs: p.turn_timeout_secs,
                 created_at: p.created_at.to_rfc3339(),
@@ -366,7 +362,6 @@ pub async fn set_active_persona(
         id: persona.id,
         name: persona.name,
         description: String::new(),
-        is_default: persona.is_default,
     })
     .into_response()
 }
@@ -418,7 +413,6 @@ pub async fn get_persona(
     let detail = PersonaDetail {
         id: persona.id,
         name: persona.name,
-        is_default: persona.is_default,
         skill_access_mode: persona.skill_access_mode,
         turn_timeout_secs: persona.turn_timeout_secs,
         created_at: persona.created_at.to_rfc3339(),
@@ -857,7 +851,11 @@ mod tests {
 
     async fn test_state() -> (PersonaApiState, Arc<StorageLayer>) {
         let storage = Arc::new(StorageLayer::new_in_memory().await.unwrap());
-        storage.persona_store().ensure_default().await.unwrap();
+        storage
+            .persona_store()
+            .ensure_exists("default")
+            .await
+            .unwrap();
         let state = PersonaApiState {
             pool: storage.pool.clone(),
             agent_id: Arc::new(RwLock::new("default".to_string())),

--- a/crates/web-ui/src/api/skills.rs
+++ b/crates/web-ui/src/api/skills.rs
@@ -422,7 +422,11 @@ mod tests {
 
     async fn test_state() -> (SkillsApiState, Arc<StorageLayer>) {
         let storage = Arc::new(StorageLayer::new_in_memory().await.unwrap());
-        storage.persona_store().ensure_default().await.unwrap();
+        storage
+            .persona_store()
+            .ensure_exists("default")
+            .await
+            .unwrap();
         let registry = Arc::new(SkillRegistry::new(storage.pool.clone()).await.unwrap());
         let state = SkillsApiState {
             pool: storage.pool.clone(),

--- a/crates/web-ui/src/main.rs
+++ b/crates/web-ui/src/main.rs
@@ -256,7 +256,7 @@ async fn run_with_args(args: Args) -> Result<()> {
     };
 
     let cli_agent_override = args.agent.clone();
-    let mut selected_agent = cli_agent_override
+    let selected_agent = cli_agent_override
         .clone()
         .unwrap_or_else(|| config.agent.id.clone());
     if !validate_agent_id(&selected_agent) {
@@ -277,23 +277,6 @@ async fn run_with_args(args: Args) -> Result<()> {
         .with_context(|| format!("Failed to create workspace at {}", workspace_dir.display()))?;
 
     let personas = storage.persona_store();
-    personas.ensure_default().await?;
-    if cli_agent_override.is_none() {
-        let default_id = personas.default_id().await?;
-        selected_agent = default_id;
-        apply_agent_context(&mut config, &selected_agent);
-        if let Some(home) = dirs::home_dir() {
-            let agent_root = home.join(".assistant").join("agents").join(&selected_agent);
-            set_runtime_agent_root(agent_root);
-        }
-        let workspace_dir = default_workspace_dir(&selected_agent);
-        set_runtime_workspace_dir(workspace_dir.clone());
-        tokio::fs::create_dir_all(&workspace_dir)
-            .await
-            .with_context(|| {
-                format!("Failed to create workspace at {}", workspace_dir.display())
-            })?;
-    }
     personas.ensure_exists(&selected_agent).await?;
 
     // -- Build the full orchestrator chain -----------------------------------

--- a/openspec/changes/multi-user-orgs/tasks.md
+++ b/openspec/changes/multi-user-orgs/tasks.md
@@ -271,8 +271,12 @@ PR 10 ─── CLI OAuth2 login + Flutter OAuth2 + docs
   - User-private persona visible only to owner
   - `list()` returns all personas regardless of owner
 
-- [ ] `refactor(storage): update callers of removed default persona API`
-  - Deferred to PR 9 — is_default not yet removed, existing callers unchanged
+- [x] `refactor(storage): update callers of removed default persona API`
+  - Removed `ensure_default()`, `set_default()`, `default_id()` from PersonaStore
+  - Replaced all callers with `ensure_exists("default")` and direct `"default"` fallback
+  - Removed `is_default` from API response types (`PersonaSummary`, `PersonaDetail`)
+  - Removed `--default` flag from CLI `persona create`, simplified `persona use`
+  - Updated ORDER BY in `list()` / `list_accessible()` to sort by `id ASC` only
 
 - [x] `feat(storage): add sender_user_id to messages`
   - Migration 040: `ALTER TABLE messages ADD COLUMN sender_user_id TEXT`


### PR DESCRIPTION
## Summary

- Remove `ensure_default()`, `set_default()`, and `default_id()` from `PersonaStore` — in multi-user mode there is no single "default persona", each user selects their active persona per session
- Replace all callers across CLI, web-ui, and runtime with `ensure_exists("default")` and direct `"default"` string fallback
- Remove `is_default` from `PersonaSummary` / `PersonaDetail` API response types
- Remove `--default` flag from CLI `persona create`, simplify `persona use`
- Update `list()` / `list_accessible()` ORDER BY to `id ASC` only (no `is_default DESC` priority)
- Keep `is_default` column in DB for backward compatibility (no migration needed)
- A2A `agent_store` `is_default` is a separate concern, unchanged

Part of multi-user-orgs change (task #49).

## Test plan

- [x] New test: `ensure_exists_replaces_ensure_default` — verifies `ensure_exists("default")` works as drop-in replacement
- [x] New test: `list_orders_by_id_not_is_default` — verifies list sorts alphabetically without is_default priority
- [x] All existing persona tests updated and passing (23 persona tests, 4 persona_skill_access tests)
- [x] Full workspace: `cargo test --workspace` — zero failures
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] Pre-commit hooks pass (fmt, clippy, machete)