### PR TITLE
chore: regenerate OpenAPI spec and Flutter client

### DIFF
--- a/app/lib/features/personas/persona_constants.dart
+++ b/app/lib/features/personas/persona_constants.dart
@@ -1,0 +1,2 @@
+/// The well-known persona ID that the server always ensures exists.
+const kDefaultPersonaId = 'default';

--- a/app/lib/features/personas/persona_detail_screen.dart
+++ b/app/lib/features/personas/persona_detail_screen.dart
@@ -83,7 +83,7 @@ class _PersonaDetailBody extends StatelessWidget {
                         style: Theme.of(context).textTheme.headlineSmall,
                       ),
                     ),
-                    if (detail.isDefault)
+                    if (detail.id == 'default')
                       Container(
                         padding: const EdgeInsets.symmetric(
                           horizontal: 8,

--- a/app/lib/features/personas/persona_detail_screen.dart
+++ b/app/lib/features/personas/persona_detail_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import 'package:assistant_api/assistant_api.dart';
 
+import 'persona_constants.dart';
 import 'persona_detail_provider.dart';
 
 /// Screen that shows the full detail of a single persona.
@@ -83,7 +84,7 @@ class _PersonaDetailBody extends StatelessWidget {
                         style: Theme.of(context).textTheme.headlineSmall,
                       ),
                     ),
-                    if (detail.id == 'default')
+                    if (detail.id == kDefaultPersonaId)
                       Container(
                         padding: const EdgeInsets.symmetric(
                           horizontal: 8,

--- a/app/lib/features/personas/personas_provider.dart
+++ b/app/lib/features/personas/personas_provider.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../api/api_client.dart';
 import '../connection/connection_provider.dart';
+import 'persona_constants.dart';
 
 /// State for the personas feature.
 class PersonasState {
@@ -53,7 +54,7 @@ class PersonasNotifier extends AsyncNotifier<PersonasState> {
       final response = await api.personas.listPersonas();
       final personas = response.data!.toList();
       final defaultPersona =
-          personas.where((p) => p.id == 'default').firstOrNull ??
+          personas.where((p) => p.id == kDefaultPersonaId).firstOrNull ??
           personas.firstOrNull;
       return PersonasState(personas: personas, activePersona: defaultPersona);
     } catch (e) {

--- a/app/lib/features/personas/personas_provider.dart
+++ b/app/lib/features/personas/personas_provider.dart
@@ -53,7 +53,7 @@ class PersonasNotifier extends AsyncNotifier<PersonasState> {
       final response = await api.personas.listPersonas();
       final personas = response.data!.toList();
       final defaultPersona =
-          personas.where((p) => p.isDefault).firstOrNull ??
+          personas.where((p) => p.id == 'default').firstOrNull ??
           personas.firstOrNull;
       return PersonasState(personas: personas, activePersona: defaultPersona);
     } catch (e) {

--- a/app/lib/features/personas/personas_screen.dart
+++ b/app/lib/features/personas/personas_screen.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import 'package:assistant_api/assistant_api.dart';
 
 import '../../shared/platform/platform.dart';
+import 'persona_constants.dart';
 import 'personas_provider.dart';
 
 /// Screen that lists all personas.
@@ -187,15 +188,16 @@ class _PersonaRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final isDefault = persona.id == kDefaultPersonaId;
     return ListTile(
       leading: CircleAvatar(
-        backgroundColor: persona.id == 'default'
+        backgroundColor: isDefault
             ? Theme.of(context).colorScheme.primaryContainer
             : Theme.of(context).colorScheme.surfaceContainerHighest,
         child: Text(
           persona.name.isNotEmpty ? persona.name[0].toUpperCase() : '?',
           style: TextStyle(
-            color: persona.id == 'default'
+            color: isDefault
                 ? Theme.of(context).colorScheme.onPrimaryContainer
                 : Theme.of(context).colorScheme.onSurface,
             fontWeight: FontWeight.w600,
@@ -213,7 +215,7 @@ class _PersonaRow extends StatelessWidget {
           color: Theme.of(context).colorScheme.onSurfaceVariant,
         ),
       ),
-      trailing: persona.id == 'default'
+      trailing: isDefault
           ? Container(
               padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
               decoration: BoxDecoration(

--- a/app/lib/features/personas/personas_screen.dart
+++ b/app/lib/features/personas/personas_screen.dart
@@ -189,13 +189,13 @@ class _PersonaRow extends StatelessWidget {
   Widget build(BuildContext context) {
     return ListTile(
       leading: CircleAvatar(
-        backgroundColor: persona.isDefault
+        backgroundColor: persona.id == 'default'
             ? Theme.of(context).colorScheme.primaryContainer
             : Theme.of(context).colorScheme.surfaceContainerHighest,
         child: Text(
           persona.name.isNotEmpty ? persona.name[0].toUpperCase() : '?',
           style: TextStyle(
-            color: persona.isDefault
+            color: persona.id == 'default'
                 ? Theme.of(context).colorScheme.onPrimaryContainer
                 : Theme.of(context).colorScheme.onSurface,
             fontWeight: FontWeight.w600,
@@ -213,7 +213,7 @@ class _PersonaRow extends StatelessWidget {
           color: Theme.of(context).colorScheme.onSurfaceVariant,
         ),
       ),
-      trailing: persona.isDefault
+      trailing: persona.id == 'default'
           ? Container(
               padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
               decoration: BoxDecoration(

--- a/app/packages/assistant_api/.openapi-generator/FILES
+++ b/app/packages/assistant_api/.openapi-generator/FILES
@@ -172,6 +172,7 @@ doc/WorkflowRunSummary.md
 doc/WorkflowSummary.md
 doc/WorkflowUpsertRequest.md
 doc/WorkflowWebhookSecrets.md
+doc/WorkflowWebhookTriggerAccepted.md
 doc/WorkflowsApi.md
 doc/WritePersonaFileRequest.md
 lib/assistant_api.dart
@@ -356,6 +357,8 @@ lib/src/model/workflow_run_summary.dart
 lib/src/model/workflow_summary.dart
 lib/src/model/workflow_upsert_request.dart
 lib/src/model/workflow_webhook_secrets.dart
+lib/src/model/workflow_webhook_trigger_accepted.dart
 lib/src/model/write_persona_file_request.dart
 lib/src/serializers.dart
 pubspec.yaml
+test/workflow_webhook_trigger_accepted_test.dart

--- a/app/packages/assistant_api/.openapi-generator/FILES
+++ b/app/packages/assistant_api/.openapi-generator/FILES
@@ -361,4 +361,3 @@ lib/src/model/workflow_webhook_trigger_accepted.dart
 lib/src/model/write_persona_file_request.dart
 lib/src/serializers.dart
 pubspec.yaml
-test/workflow_webhook_trigger_accepted_test.dart

--- a/app/packages/assistant_api/README.md
+++ b/app/packages/assistant_api/README.md
@@ -190,6 +190,7 @@ Class | Method | HTTP request | Description
 [*WorkflowsApi*](doc/WorkflowsApi.md) | [**getWorkflowWebhookSecrets**](doc/WorkflowsApi.md#getworkflowwebhooksecrets) | **GET** /api/workflows/{id}/webhook-secrets | &#x60;GET /api/workflows/{id}/webhook-secrets&#x60; — reveal webhook URL and token.
 [*WorkflowsApi*](doc/WorkflowsApi.md) | [**listWorkflowRuns**](doc/WorkflowsApi.md#listworkflowruns) | **GET** /api/workflows/{id}/runs | &#x60;GET /api/workflows/{id}/runs&#x60; — list recent runs (up to 50).
 [*WorkflowsApi*](doc/WorkflowsApi.md) | [**listWorkflows**](doc/WorkflowsApi.md#listworkflows) | **GET** /api/workflows | &#x60;GET /api/workflows&#x60; — list all workflows.
+[*WorkflowsApi*](doc/WorkflowsApi.md) | [**publicWebhookTrigger**](doc/WorkflowsApi.md#publicwebhooktrigger) | **POST** /workflow-hooks/{id}/{token} | Public webhook trigger endpoint — no auth required.
 [*WorkflowsApi*](doc/WorkflowsApi.md) | [**testRunWorkflow**](doc/WorkflowsApi.md#testrunworkflow) | **POST** /api/workflows/{id}/test-run | &#x60;POST /api/workflows/{id}/test-run&#x60; — queue a manual test run.
 [*WorkflowsApi*](doc/WorkflowsApi.md) | [**updateWorkflow**](doc/WorkflowsApi.md#updateworkflow) | **PUT** /api/workflows/{id} | &#x60;PUT /api/workflows/{id}&#x60; — update a workflow.
 
@@ -341,6 +342,7 @@ Class | Method | HTTP request | Description
  - [WorkflowSummary](doc/WorkflowSummary.md)
  - [WorkflowUpsertRequest](doc/WorkflowUpsertRequest.md)
  - [WorkflowWebhookSecrets](doc/WorkflowWebhookSecrets.md)
+ - [WorkflowWebhookTriggerAccepted](doc/WorkflowWebhookTriggerAccepted.md)
  - [WritePersonaFileRequest](doc/WritePersonaFileRequest.md)
 
 

--- a/app/packages/assistant_api/doc/PersonaDetail.md
+++ b/app/packages/assistant_api/doc/PersonaDetail.md
@@ -11,7 +11,6 @@ Name | Type | Description | Notes
 **createdAt** | **String** |  | 
 **files** | [**BuiltList&lt;PersonaFileSlot&gt;**](PersonaFileSlot.md) |  | 
 **id** | **String** |  | 
-**isDefault** | **bool** |  | 
 **name** | **String** |  | 
 **skillAccessMode** | **String** |  | 
 **turnTimeoutSecs** | **int** |  | [optional] 

--- a/app/packages/assistant_api/doc/PublishCatalogItemRequest.md
+++ b/app/packages/assistant_api/doc/PublishCatalogItemRequest.md
@@ -10,7 +10,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **description** | **String** |  | [optional] 
 **name** | **String** |  | 
-**resourceType** | **String** | `\"skill\"`, `\"template\"`, or `\"interface\"`. | 
+**resourceType** | **String** | Resource type: `\"skill\"`, `\"template\"`, or `\"interface\"`. | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/app/packages/assistant_api/doc/WorkflowWebhookTriggerAccepted.md
+++ b/app/packages/assistant_api/doc/WorkflowWebhookTriggerAccepted.md
@@ -1,4 +1,4 @@
-# assistant_api.model.PersonaSummary
+# assistant_api.model.WorkflowWebhookTriggerAccepted
 
 ## Load the model package
 ```dart
@@ -8,9 +8,9 @@ import 'package:assistant_api/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**description** | **String** |  | 
-**id** | **String** |  | 
-**name** | **String** |  | 
+**runId** | **String** |  | 
+**status** | **String** |  | 
+**workflowId** | **String** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/app/packages/assistant_api/doc/WorkflowsApi.md
+++ b/app/packages/assistant_api/doc/WorkflowsApi.md
@@ -18,6 +18,7 @@ Method | HTTP request | Description
 [**getWorkflowWebhookSecrets**](WorkflowsApi.md#getworkflowwebhooksecrets) | **GET** /api/workflows/{id}/webhook-secrets | &#x60;GET /api/workflows/{id}/webhook-secrets&#x60; — reveal webhook URL and token.
 [**listWorkflowRuns**](WorkflowsApi.md#listworkflowruns) | **GET** /api/workflows/{id}/runs | &#x60;GET /api/workflows/{id}/runs&#x60; — list recent runs (up to 50).
 [**listWorkflows**](WorkflowsApi.md#listworkflows) | **GET** /api/workflows | &#x60;GET /api/workflows&#x60; — list all workflows.
+[**publicWebhookTrigger**](WorkflowsApi.md#publicwebhooktrigger) | **POST** /workflow-hooks/{id}/{token} | Public webhook trigger endpoint — no auth required.
 [**testRunWorkflow**](WorkflowsApi.md#testrunworkflow) | **POST** /api/workflows/{id}/test-run | &#x60;POST /api/workflows/{id}/test-run&#x60; — queue a manual test run.
 [**updateWorkflow**](WorkflowsApi.md#updateworkflow) | **PUT** /api/workflows/{id} | &#x60;PUT /api/workflows/{id}&#x60; — update a workflow.
 
@@ -384,6 +385,53 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
  - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **publicWebhookTrigger**
+> WorkflowWebhookTriggerAccepted publicWebhookTrigger(id, token, body)
+
+Public webhook trigger endpoint — no auth required.
+
+Receives an inbound HTTP POST from an external system and queues a workflow run with trigger type `Webhook`.  The `token` path parameter is the per-workflow HMAC secret that acts as authentication.
+
+### Example
+```dart
+import 'package:assistant_api/api.dart';
+
+final api = AssistantApi().getWorkflowsApi();
+final String id = id_example; // String | Workflow ID
+final String token = token_example; // String | Webhook HMAC token
+final JsonObject body = ; // JsonObject | 
+
+try {
+    final response = api.publicWebhookTrigger(id, token, body);
+    print(response);
+} on DioException catch (e) {
+    print('Exception when calling WorkflowsApi->publicWebhookTrigger: $e\n');
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **id** | **String**| Workflow ID | 
+ **token** | **String**| Webhook HMAC token | 
+ **body** | **JsonObject**|  | 
+
+### Return type
+
+[**WorkflowWebhookTriggerAccepted**](WorkflowWebhookTriggerAccepted.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
  - **Accept**: application/json
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)

--- a/app/packages/assistant_api/lib/assistant_api.dart
+++ b/app/packages/assistant_api/lib/assistant_api.dart
@@ -183,4 +183,5 @@ export 'package:assistant_api/src/model/workflow_run_summary.dart';
 export 'package:assistant_api/src/model/workflow_summary.dart';
 export 'package:assistant_api/src/model/workflow_upsert_request.dart';
 export 'package:assistant_api/src/model/workflow_webhook_secrets.dart';
+export 'package:assistant_api/src/model/workflow_webhook_trigger_accepted.dart';
 export 'package:assistant_api/src/model/write_persona_file_request.dart';

--- a/app/packages/assistant_api/lib/src/api/workflows_api.dart
+++ b/app/packages/assistant_api/lib/src/api/workflows_api.dart
@@ -16,7 +16,9 @@ import 'package:assistant_api/src/model/workflow_run_summary.dart';
 import 'package:assistant_api/src/model/workflow_summary.dart';
 import 'package:assistant_api/src/model/workflow_upsert_request.dart';
 import 'package:assistant_api/src/model/workflow_webhook_secrets.dart';
+import 'package:assistant_api/src/model/workflow_webhook_trigger_accepted.dart';
 import 'package:built_collection/built_collection.dart';
+import 'package:built_value/json_object.dart';
 
 class WorkflowsApi {
   final Dio _dio;
@@ -771,6 +773,112 @@ class WorkflowsApi {
     }
 
     return Response<BuiltList<WorkflowSummary>>(
+      data: _responseData,
+      headers: _response.headers,
+      isRedirect: _response.isRedirect,
+      requestOptions: _response.requestOptions,
+      redirects: _response.redirects,
+      statusCode: _response.statusCode,
+      statusMessage: _response.statusMessage,
+      extra: _response.extra,
+    );
+  }
+
+  /// Public webhook trigger endpoint — no auth required.
+  /// Receives an inbound HTTP POST from an external system and queues a workflow run with trigger type &#x60;Webhook&#x60;.  The &#x60;token&#x60; path parameter is the per-workflow HMAC secret that acts as authentication.
+  ///
+  /// Parameters:
+  /// * [id] - Workflow ID
+  /// * [token] - Webhook HMAC token
+  /// * [body]
+  /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
+  /// * [headers] - Can be used to add additional headers to the request
+  /// * [extras] - Can be used to add flags to the request
+  /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
+  /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
+  /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
+  ///
+  /// Returns a [Future] containing a [Response] with a [WorkflowWebhookTriggerAccepted] as data
+  /// Throws [DioException] if API call or serialization fails
+  Future<Response<WorkflowWebhookTriggerAccepted>> publicWebhookTrigger({
+    required String id,
+    required String token,
+    JsonObject? body,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    final _path = r'/workflow-hooks/{id}/{token}'
+        .replaceAll(
+            '{' r'id' '}',
+            encodeQueryParameter(_serializers, id, const FullType(String))
+                .toString())
+        .replaceAll(
+            '{' r'token' '}',
+            encodeQueryParameter(_serializers, token, const FullType(String))
+                .toString());
+    final _options = Options(
+      method: r'POST',
+      headers: <String, dynamic>{
+        ...?headers,
+      },
+      extra: <String, dynamic>{
+        'secure': <Map<String, String>>[],
+        ...?extra,
+      },
+      contentType: 'application/json',
+      validateStatus: validateStatus,
+    );
+
+    dynamic _bodyData;
+
+    try {
+      _bodyData = body;
+    } catch (error, stackTrace) {
+      throw DioException(
+        requestOptions: _options.compose(
+          _dio.options,
+          _path,
+        ),
+        type: DioExceptionType.unknown,
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+
+    final _response = await _dio.request<Object>(
+      _path,
+      data: _bodyData,
+      options: _options,
+      cancelToken: cancelToken,
+      onSendProgress: onSendProgress,
+      onReceiveProgress: onReceiveProgress,
+    );
+
+    WorkflowWebhookTriggerAccepted? _responseData;
+
+    try {
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null
+          ? null
+          : _serializers.deserialize(
+              rawResponse,
+              specifiedType: const FullType(WorkflowWebhookTriggerAccepted),
+            ) as WorkflowWebhookTriggerAccepted;
+    } catch (error, stackTrace) {
+      throw DioException(
+        requestOptions: _response.requestOptions,
+        response: _response,
+        type: DioExceptionType.unknown,
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+
+    return Response<WorkflowWebhookTriggerAccepted>(
       data: _responseData,
       headers: _response.headers,
       isRedirect: _response.isRedirect,

--- a/app/packages/assistant_api/lib/src/model/persona_detail.dart
+++ b/app/packages/assistant_api/lib/src/model/persona_detail.dart
@@ -16,7 +16,6 @@ part 'persona_detail.g.dart';
 /// * [createdAt]
 /// * [files]
 /// * [id]
-/// * [isDefault]
 /// * [name]
 /// * [skillAccessMode]
 /// * [turnTimeoutSecs]
@@ -32,9 +31,6 @@ abstract class PersonaDetail
 
   @BuiltValueField(wireName: r'id')
   String get id;
-
-  @BuiltValueField(wireName: r'is_default')
-  bool get isDefault;
 
   @BuiltValueField(wireName: r'name')
   String get name;
@@ -87,11 +83,6 @@ class _$PersonaDetailSerializer implements PrimitiveSerializer<PersonaDetail> {
     yield serializers.serialize(
       object.id,
       specifiedType: const FullType(String),
-    );
-    yield r'is_default';
-    yield serializers.serialize(
-      object.isDefault,
-      specifiedType: const FullType(bool),
     );
     yield r'name';
     yield serializers.serialize(
@@ -161,13 +152,6 @@ class _$PersonaDetailSerializer implements PrimitiveSerializer<PersonaDetail> {
             specifiedType: const FullType(String),
           ) as String;
           result.id = valueDes;
-          break;
-        case r'is_default':
-          final valueDes = serializers.deserialize(
-            value,
-            specifiedType: const FullType(bool),
-          ) as bool;
-          result.isDefault = valueDes;
           break;
         case r'name':
           final valueDes = serializers.deserialize(

--- a/app/packages/assistant_api/lib/src/model/persona_detail.g.dart
+++ b/app/packages/assistant_api/lib/src/model/persona_detail.g.dart
@@ -14,8 +14,6 @@ class _$PersonaDetail extends PersonaDetail {
   @override
   final String id;
   @override
-  final bool isDefault;
-  @override
   final String name;
   @override
   final String skillAccessMode;
@@ -31,7 +29,6 @@ class _$PersonaDetail extends PersonaDetail {
       {required this.createdAt,
       required this.files,
       required this.id,
-      required this.isDefault,
       required this.name,
       required this.skillAccessMode,
       this.turnTimeoutSecs,
@@ -51,7 +48,6 @@ class _$PersonaDetail extends PersonaDetail {
         createdAt == other.createdAt &&
         files == other.files &&
         id == other.id &&
-        isDefault == other.isDefault &&
         name == other.name &&
         skillAccessMode == other.skillAccessMode &&
         turnTimeoutSecs == other.turnTimeoutSecs &&
@@ -64,7 +60,6 @@ class _$PersonaDetail extends PersonaDetail {
     _$hash = $jc(_$hash, createdAt.hashCode);
     _$hash = $jc(_$hash, files.hashCode);
     _$hash = $jc(_$hash, id.hashCode);
-    _$hash = $jc(_$hash, isDefault.hashCode);
     _$hash = $jc(_$hash, name.hashCode);
     _$hash = $jc(_$hash, skillAccessMode.hashCode);
     _$hash = $jc(_$hash, turnTimeoutSecs.hashCode);
@@ -79,7 +74,6 @@ class _$PersonaDetail extends PersonaDetail {
           ..add('createdAt', createdAt)
           ..add('files', files)
           ..add('id', id)
-          ..add('isDefault', isDefault)
           ..add('name', name)
           ..add('skillAccessMode', skillAccessMode)
           ..add('turnTimeoutSecs', turnTimeoutSecs)
@@ -104,10 +98,6 @@ class PersonaDetailBuilder
   String? _id;
   String? get id => _$this._id;
   set id(String? id) => _$this._id = id;
-
-  bool? _isDefault;
-  bool? get isDefault => _$this._isDefault;
-  set isDefault(bool? isDefault) => _$this._isDefault = isDefault;
 
   String? _name;
   String? get name => _$this._name;
@@ -137,7 +127,6 @@ class PersonaDetailBuilder
       _createdAt = $v.createdAt;
       _files = $v.files.toBuilder();
       _id = $v.id;
-      _isDefault = $v.isDefault;
       _name = $v.name;
       _skillAccessMode = $v.skillAccessMode;
       _turnTimeoutSecs = $v.turnTimeoutSecs;
@@ -170,8 +159,6 @@ class PersonaDetailBuilder
             files: files.build(),
             id: BuiltValueNullFieldError.checkNotNull(
                 id, r'PersonaDetail', 'id'),
-            isDefault: BuiltValueNullFieldError.checkNotNull(
-                isDefault, r'PersonaDetail', 'isDefault'),
             name: BuiltValueNullFieldError.checkNotNull(
                 name, r'PersonaDetail', 'name'),
             skillAccessMode: BuiltValueNullFieldError.checkNotNull(

--- a/app/packages/assistant_api/lib/src/model/persona_summary.g.dart
+++ b/app/packages/assistant_api/lib/src/model/persona_summary.g.dart
@@ -12,18 +12,13 @@ class _$PersonaSummary extends PersonaSummary {
   @override
   final String id;
   @override
-  final bool isDefault;
-  @override
   final String name;
 
   factory _$PersonaSummary([void Function(PersonaSummaryBuilder)? updates]) =>
       (PersonaSummaryBuilder()..update(updates))._build();
 
   _$PersonaSummary._(
-      {required this.description,
-      required this.id,
-      required this.isDefault,
-      required this.name})
+      {required this.description, required this.id, required this.name})
       : super._();
   @override
   PersonaSummary rebuild(void Function(PersonaSummaryBuilder) updates) =>
@@ -38,7 +33,6 @@ class _$PersonaSummary extends PersonaSummary {
     return other is PersonaSummary &&
         description == other.description &&
         id == other.id &&
-        isDefault == other.isDefault &&
         name == other.name;
   }
 
@@ -47,7 +41,6 @@ class _$PersonaSummary extends PersonaSummary {
     var _$hash = 0;
     _$hash = $jc(_$hash, description.hashCode);
     _$hash = $jc(_$hash, id.hashCode);
-    _$hash = $jc(_$hash, isDefault.hashCode);
     _$hash = $jc(_$hash, name.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
@@ -58,7 +51,6 @@ class _$PersonaSummary extends PersonaSummary {
     return (newBuiltValueToStringHelper(r'PersonaSummary')
           ..add('description', description)
           ..add('id', id)
-          ..add('isDefault', isDefault)
           ..add('name', name))
         .toString();
   }
@@ -76,10 +68,6 @@ class PersonaSummaryBuilder
   String? get id => _$this._id;
   set id(String? id) => _$this._id = id;
 
-  bool? _isDefault;
-  bool? get isDefault => _$this._isDefault;
-  set isDefault(bool? isDefault) => _$this._isDefault = isDefault;
-
   String? _name;
   String? get name => _$this._name;
   set name(String? name) => _$this._name = name;
@@ -93,7 +81,6 @@ class PersonaSummaryBuilder
     if ($v != null) {
       _description = $v.description;
       _id = $v.id;
-      _isDefault = $v.isDefault;
       _name = $v.name;
       _$v = null;
     }
@@ -120,8 +107,6 @@ class PersonaSummaryBuilder
               description, r'PersonaSummary', 'description'),
           id: BuiltValueNullFieldError.checkNotNull(
               id, r'PersonaSummary', 'id'),
-          isDefault: BuiltValueNullFieldError.checkNotNull(
-              isDefault, r'PersonaSummary', 'isDefault'),
           name: BuiltValueNullFieldError.checkNotNull(
               name, r'PersonaSummary', 'name'),
         );

--- a/app/packages/assistant_api/lib/src/model/publish_catalog_item_request.dart
+++ b/app/packages/assistant_api/lib/src/model/publish_catalog_item_request.dart
@@ -13,7 +13,7 @@ part 'publish_catalog_item_request.g.dart';
 /// Properties:
 /// * [description]
 /// * [name]
-/// * [resourceType] - `\"skill\"`, `\"template\"`, or `\"interface\"`.
+/// * [resourceType] - Resource type: `\"skill\"`, `\"template\"`, or `\"interface\"`.
 @BuiltValue()
 abstract class PublishCatalogItemRequest
     implements
@@ -24,7 +24,7 @@ abstract class PublishCatalogItemRequest
   @BuiltValueField(wireName: r'name')
   String get name;
 
-  /// `\"skill\"`, `\"template\"`, or `\"interface\"`.
+  /// Resource type: `\"skill\"`, `\"template\"`, or `\"interface\"`.
   @BuiltValueField(wireName: r'resource_type')
   String get resourceType;
 

--- a/app/packages/assistant_api/lib/src/model/workflow_webhook_trigger_accepted.dart
+++ b/app/packages/assistant_api/lib/src/model/workflow_webhook_trigger_accepted.dart
@@ -6,65 +6,71 @@
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 
-part 'persona_summary.g.dart';
+part 'workflow_webhook_trigger_accepted.g.dart';
 
-/// A persona summary returned by the API.
+/// Accepted response for a public webhook trigger.
 ///
 /// Properties:
-/// * [description]
-/// * [id]
-/// * [name]
+/// * [runId]
+/// * [status]
+/// * [workflowId]
 @BuiltValue()
-abstract class PersonaSummary
-    implements Built<PersonaSummary, PersonaSummaryBuilder> {
-  @BuiltValueField(wireName: r'description')
-  String get description;
+abstract class WorkflowWebhookTriggerAccepted
+    implements
+        Built<WorkflowWebhookTriggerAccepted,
+            WorkflowWebhookTriggerAcceptedBuilder> {
+  @BuiltValueField(wireName: r'run_id')
+  String get runId;
 
-  @BuiltValueField(wireName: r'id')
-  String get id;
+  @BuiltValueField(wireName: r'status')
+  String get status;
 
-  @BuiltValueField(wireName: r'name')
-  String get name;
+  @BuiltValueField(wireName: r'workflow_id')
+  String get workflowId;
 
-  PersonaSummary._();
+  WorkflowWebhookTriggerAccepted._();
 
-  factory PersonaSummary([void updates(PersonaSummaryBuilder b)]) =
-      _$PersonaSummary;
+  factory WorkflowWebhookTriggerAccepted(
+          [void updates(WorkflowWebhookTriggerAcceptedBuilder b)]) =
+      _$WorkflowWebhookTriggerAccepted;
 
   @BuiltValueHook(initializeBuilder: true)
-  static void _defaults(PersonaSummaryBuilder b) => b;
+  static void _defaults(WorkflowWebhookTriggerAcceptedBuilder b) => b;
 
   @BuiltValueSerializer(custom: true)
-  static Serializer<PersonaSummary> get serializer =>
-      _$PersonaSummarySerializer();
+  static Serializer<WorkflowWebhookTriggerAccepted> get serializer =>
+      _$WorkflowWebhookTriggerAcceptedSerializer();
 }
 
-class _$PersonaSummarySerializer
-    implements PrimitiveSerializer<PersonaSummary> {
+class _$WorkflowWebhookTriggerAcceptedSerializer
+    implements PrimitiveSerializer<WorkflowWebhookTriggerAccepted> {
   @override
-  final Iterable<Type> types = const [PersonaSummary, _$PersonaSummary];
+  final Iterable<Type> types = const [
+    WorkflowWebhookTriggerAccepted,
+    _$WorkflowWebhookTriggerAccepted
+  ];
 
   @override
-  final String wireName = r'PersonaSummary';
+  final String wireName = r'WorkflowWebhookTriggerAccepted';
 
   Iterable<Object?> _serializeProperties(
     Serializers serializers,
-    PersonaSummary object, {
+    WorkflowWebhookTriggerAccepted object, {
     FullType specifiedType = FullType.unspecified,
   }) sync* {
-    yield r'description';
+    yield r'run_id';
     yield serializers.serialize(
-      object.description,
+      object.runId,
       specifiedType: const FullType(String),
     );
-    yield r'id';
+    yield r'status';
     yield serializers.serialize(
-      object.id,
+      object.status,
       specifiedType: const FullType(String),
     );
-    yield r'name';
+    yield r'workflow_id';
     yield serializers.serialize(
-      object.name,
+      object.workflowId,
       specifiedType: const FullType(String),
     );
   }
@@ -72,7 +78,7 @@ class _$PersonaSummarySerializer
   @override
   Object serialize(
     Serializers serializers,
-    PersonaSummary object, {
+    WorkflowWebhookTriggerAccepted object, {
     FullType specifiedType = FullType.unspecified,
   }) {
     return _serializeProperties(serializers, object,
@@ -85,33 +91,33 @@ class _$PersonaSummarySerializer
     Object serialized, {
     FullType specifiedType = FullType.unspecified,
     required List<Object?> serializedList,
-    required PersonaSummaryBuilder result,
+    required WorkflowWebhookTriggerAcceptedBuilder result,
     required List<Object?> unhandled,
   }) {
     for (var i = 0; i < serializedList.length; i += 2) {
       final key = serializedList[i] as String;
       final value = serializedList[i + 1];
       switch (key) {
-        case r'description':
+        case r'run_id':
           final valueDes = serializers.deserialize(
             value,
             specifiedType: const FullType(String),
           ) as String;
-          result.description = valueDes;
+          result.runId = valueDes;
           break;
-        case r'id':
+        case r'status':
           final valueDes = serializers.deserialize(
             value,
             specifiedType: const FullType(String),
           ) as String;
-          result.id = valueDes;
+          result.status = valueDes;
           break;
-        case r'name':
+        case r'workflow_id':
           final valueDes = serializers.deserialize(
             value,
             specifiedType: const FullType(String),
           ) as String;
-          result.name = valueDes;
+          result.workflowId = valueDes;
           break;
         default:
           unhandled.add(key);
@@ -122,12 +128,12 @@ class _$PersonaSummarySerializer
   }
 
   @override
-  PersonaSummary deserialize(
+  WorkflowWebhookTriggerAccepted deserialize(
     Serializers serializers,
     Object serialized, {
     FullType specifiedType = FullType.unspecified,
   }) {
-    final result = PersonaSummaryBuilder();
+    final result = WorkflowWebhookTriggerAcceptedBuilder();
     final serializedList = (serialized as Iterable<Object?>).toList();
     final unhandled = <Object?>[];
     _deserializeProperties(

--- a/app/packages/assistant_api/lib/src/model/workflow_webhook_trigger_accepted.g.dart
+++ b/app/packages/assistant_api/lib/src/model/workflow_webhook_trigger_accepted.g.dart
@@ -1,0 +1,123 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'workflow_webhook_trigger_accepted.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$WorkflowWebhookTriggerAccepted extends WorkflowWebhookTriggerAccepted {
+  @override
+  final String runId;
+  @override
+  final String status;
+  @override
+  final String workflowId;
+
+  factory _$WorkflowWebhookTriggerAccepted(
+          [void Function(WorkflowWebhookTriggerAcceptedBuilder)? updates]) =>
+      (WorkflowWebhookTriggerAcceptedBuilder()..update(updates))._build();
+
+  _$WorkflowWebhookTriggerAccepted._(
+      {required this.runId, required this.status, required this.workflowId})
+      : super._();
+  @override
+  WorkflowWebhookTriggerAccepted rebuild(
+          void Function(WorkflowWebhookTriggerAcceptedBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  WorkflowWebhookTriggerAcceptedBuilder toBuilder() =>
+      WorkflowWebhookTriggerAcceptedBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is WorkflowWebhookTriggerAccepted &&
+        runId == other.runId &&
+        status == other.status &&
+        workflowId == other.workflowId;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, runId.hashCode);
+    _$hash = $jc(_$hash, status.hashCode);
+    _$hash = $jc(_$hash, workflowId.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'WorkflowWebhookTriggerAccepted')
+          ..add('runId', runId)
+          ..add('status', status)
+          ..add('workflowId', workflowId))
+        .toString();
+  }
+}
+
+class WorkflowWebhookTriggerAcceptedBuilder
+    implements
+        Builder<WorkflowWebhookTriggerAccepted,
+            WorkflowWebhookTriggerAcceptedBuilder> {
+  _$WorkflowWebhookTriggerAccepted? _$v;
+
+  String? _runId;
+  String? get runId => _$this._runId;
+  set runId(String? runId) => _$this._runId = runId;
+
+  String? _status;
+  String? get status => _$this._status;
+  set status(String? status) => _$this._status = status;
+
+  String? _workflowId;
+  String? get workflowId => _$this._workflowId;
+  set workflowId(String? workflowId) => _$this._workflowId = workflowId;
+
+  WorkflowWebhookTriggerAcceptedBuilder() {
+    WorkflowWebhookTriggerAccepted._defaults(this);
+  }
+
+  WorkflowWebhookTriggerAcceptedBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _runId = $v.runId;
+      _status = $v.status;
+      _workflowId = $v.workflowId;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(WorkflowWebhookTriggerAccepted other) {
+    _$v = other as _$WorkflowWebhookTriggerAccepted;
+  }
+
+  @override
+  void update(void Function(WorkflowWebhookTriggerAcceptedBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  WorkflowWebhookTriggerAccepted build() => _build();
+
+  _$WorkflowWebhookTriggerAccepted _build() {
+    final _$result = _$v ??
+        _$WorkflowWebhookTriggerAccepted._(
+          runId: BuiltValueNullFieldError.checkNotNull(
+              runId, r'WorkflowWebhookTriggerAccepted', 'runId'),
+          status: BuiltValueNullFieldError.checkNotNull(
+              status, r'WorkflowWebhookTriggerAccepted', 'status'),
+          workflowId: BuiltValueNullFieldError.checkNotNull(
+              workflowId, r'WorkflowWebhookTriggerAccepted', 'workflowId'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/app/packages/assistant_api/lib/src/serializers.dart
+++ b/app/packages/assistant_api/lib/src/serializers.dart
@@ -159,6 +159,7 @@ import 'package:assistant_api/src/model/workflow_run_summary.dart';
 import 'package:assistant_api/src/model/workflow_summary.dart';
 import 'package:assistant_api/src/model/workflow_upsert_request.dart';
 import 'package:assistant_api/src/model/workflow_webhook_secrets.dart';
+import 'package:assistant_api/src/model/workflow_webhook_trigger_accepted.dart';
 import 'package:assistant_api/src/model/write_persona_file_request.dart';
 
 part 'serializers.g.dart';
@@ -309,6 +310,7 @@ part 'serializers.g.dart';
   WorkflowSummary,
   WorkflowUpsertRequest,
   WorkflowWebhookSecrets,
+  WorkflowWebhookTriggerAccepted,
   WritePersonaFileRequest,
 ])
 Serializers serializers = (_$serializers.toBuilder()

--- a/app/packages/assistant_api/lib/src/serializers.g.dart
+++ b/app/packages/assistant_api/lib/src/serializers.g.dart
@@ -152,6 +152,7 @@ Serializers _$serializers = (Serializers().toBuilder()
       ..add(WorkflowSummary.serializer)
       ..add(WorkflowUpsertRequest.serializer)
       ..add(WorkflowWebhookSecrets.serializer)
+      ..add(WorkflowWebhookTriggerAccepted.serializer)
       ..add(WritePersonaFileRequest.serializer)
       ..addBuilderFactory(
           const FullType(BuiltList, const [const FullType(AgentExtension)]),

--- a/app/packages/assistant_api/test/workflow_webhook_trigger_accepted_test.dart
+++ b/app/packages/assistant_api/test/workflow_webhook_trigger_accepted_test.dart
@@ -1,0 +1,25 @@
+import 'package:test/test.dart';
+import 'package:assistant_api/assistant_api.dart';
+
+// tests for WorkflowWebhookTriggerAccepted
+void main() {
+  final instance = WorkflowWebhookTriggerAcceptedBuilder();
+  // TODO add properties to the builder and call build()
+
+  group(WorkflowWebhookTriggerAccepted, () {
+    // String runId
+    test('to test the property `runId`', () async {
+      // TODO
+    });
+
+    // String status
+    test('to test the property `status`', () async {
+      // TODO
+    });
+
+    // String workflowId
+    test('to test the property `workflowId`', () async {
+      // TODO
+    });
+  });
+}

--- a/app/test/widget/features/personas/personas_screen_test.dart
+++ b/app/test/widget/features/personas/personas_screen_test.dart
@@ -117,10 +117,9 @@ void main() {
 PersonaSummary _persona(String id, String name, {bool isDefault = false}) =>
     PersonaSummary(
       (b) => b
-        ..id = id
+        ..id = isDefault ? 'default' : id
         ..name = name
-        ..description = 'Test persona $name'
-        ..isDefault = isDefault,
+        ..description = 'Test persona $name',
     );
 
 // ---------------------------------------------------------------------------

--- a/app/test/widget/features/personas/personas_screen_test.dart
+++ b/app/test/widget/features/personas/personas_screen_test.dart
@@ -63,7 +63,7 @@ void main() {
 
     testWidgets('shows Default badge for default persona', (tester) async {
       final state = PersonasState(
-        personas: [_persona('p1', 'Default Persona', isDefault: true)],
+        personas: [_persona('default', 'Default Persona')],
       );
       await tester.pumpWidget(buildUnderTest(state: state));
       await tester.pump();
@@ -114,13 +114,12 @@ void main() {
 // ---------------------------------------------------------------------------
 // Fixtures
 
-PersonaSummary _persona(String id, String name, {bool isDefault = false}) =>
-    PersonaSummary(
-      (b) => b
-        ..id = isDefault ? 'default' : id
-        ..name = name
-        ..description = 'Test persona $name',
-    );
+PersonaSummary _persona(String id, String name) => PersonaSummary(
+  (b) => b
+    ..id = id
+    ..name = name
+    ..description = 'Test persona $name',
+);
 
 // ---------------------------------------------------------------------------
 // Fake notifier

--- a/app/test/widget/features/skills/skills_screen_test.dart
+++ b/app/test/widget/features/skills/skills_screen_test.dart
@@ -86,10 +86,9 @@ void main() {
     testWidgets('shows active persona name in app bar title', (tester) async {
       final persona = PersonaSummary(
         (b) => b
-          ..id = 'p1'
+          ..id = 'default'
           ..name = 'Ada'
-          ..description = ''
-          ..isDefault = true,
+          ..description = '',
       );
       final personasState = PersonasState(
         personas: [persona],

--- a/crates/web-ui/src/api/workflows.rs
+++ b/crates/web-ui/src/api/workflows.rs
@@ -609,7 +609,7 @@ async fn set_active(
 // -- Public webhook trigger --------------------------------------------------
 
 /// Accepted response for a public webhook trigger.
-#[derive(Serialize)]
+#[derive(Serialize, utoipa::ToSchema)]
 pub struct WorkflowWebhookTriggerAccepted {
     workflow_id: String,
     run_id: String,
@@ -621,6 +621,21 @@ pub struct WorkflowWebhookTriggerAccepted {
 /// Receives an inbound HTTP POST from an external system and queues a workflow
 /// run with trigger type `Webhook`.  The `token` path parameter is the
 /// per-workflow HMAC secret that acts as authentication.
+#[utoipa::path(
+    post,
+    path = "/workflow-hooks/{id}/{token}",
+    tag = "workflows",
+    security(()),
+    params(
+        ("id" = String, Path, description = "Workflow ID"),
+        ("token" = String, Path, description = "Webhook HMAC token"),
+    ),
+    request_body(content = serde_json::Value, content_type = "application/json"),
+    responses(
+        (status = 202, description = "Webhook accepted, run queued", body = WorkflowWebhookTriggerAccepted),
+        (status = 404, description = "Workflow webhook not found"),
+    )
+)]
 pub async fn public_webhook_trigger(
     State(state): State<WorkflowsApiState>,
     Path((id, token)): Path<(String, String)>,

--- a/crates/web-ui/src/api/workflows.rs
+++ b/crates/web-ui/src/api/workflows.rs
@@ -609,7 +609,7 @@ async fn set_active(
 // -- Public webhook trigger --------------------------------------------------
 
 /// Accepted response for a public webhook trigger.
-#[derive(Serialize, utoipa::ToSchema)]
+#[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct WorkflowWebhookTriggerAccepted {
     workflow_id: String,
     run_id: String,
@@ -633,6 +633,7 @@ pub struct WorkflowWebhookTriggerAccepted {
     request_body(content = serde_json::Value, content_type = "application/json"),
     responses(
         (status = 202, description = "Webhook accepted, run queued", body = WorkflowWebhookTriggerAccepted),
+        (status = 400, description = "Invalid UUID"),
         (status = 404, description = "Workflow webhook not found"),
     )
 )]

--- a/crates/web-ui/src/openapi.rs
+++ b/crates/web-ui/src/openapi.rs
@@ -81,6 +81,7 @@ use crate::api::{
     workflows::{
         WorkflowDetail, WorkflowRunDetail, WorkflowRunPreview, WorkflowRunStep, WorkflowRunSummary,
         WorkflowSummary, WorkflowUpsertRequest, WorkflowWebhookSecrets,
+        WorkflowWebhookTriggerAccepted,
     },
 };
 
@@ -237,6 +238,7 @@ pub struct ApiErrorResponse {
         crate::api::workflows::get_workflow_webhook_secrets,
         crate::api::workflows::list_workflow_runs,
         crate::api::workflows::get_workflow_run,
+        crate::api::workflows::public_webhook_trigger,
         handlers::get_agent_card_well_known,
         handlers::get_extended_agent_card,
         handlers::send_message,
@@ -417,6 +419,7 @@ pub struct ApiErrorResponse {
             WorkflowRunDetail,
             WorkflowRunPreview,
             WorkflowWebhookSecrets,
+            WorkflowWebhookTriggerAccepted,
             // Command API types
             CommandDefResponse,
             CommandArgResponse,

--- a/openapi.json
+++ b/openapi.json
@@ -6350,6 +6350,9 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid UUID"
+          },
           "404": {
             "description": "Workflow webhook not found"
           }

--- a/openapi.json
+++ b/openapi.json
@@ -6302,6 +6302,62 @@
           }
         ]
       }
+    },
+    "/workflow-hooks/{id}/{token}": {
+      "post": {
+        "tags": [
+          "workflows"
+        ],
+        "summary": "Public webhook trigger endpoint — no auth required.",
+        "description": "Receives an inbound HTTP POST from an external system and queues a workflow\nrun with trigger type `Webhook`.  The `token` path parameter is the\nper-workflow HMAC secret that acts as authentication.",
+        "operationId": "public_webhook_trigger",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Workflow ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "token",
+            "in": "path",
+            "description": "Webhook HMAC token",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Webhook accepted, run queued",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowWebhookTriggerAccepted"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workflow webhook not found"
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
     }
   },
   "components": {
@@ -8485,7 +8541,6 @@
         "required": [
           "id",
           "name",
-          "is_default",
           "skill_access_mode",
           "created_at",
           "updated_at",
@@ -8503,9 +8558,6 @@
           },
           "id": {
             "type": "string"
-          },
-          "is_default": {
-            "type": "boolean"
           },
           "name": {
             "type": "string"
@@ -8606,8 +8658,7 @@
         "required": [
           "id",
           "name",
-          "description",
-          "is_default"
+          "description"
         ],
         "properties": {
           "description": {
@@ -8615,9 +8666,6 @@
           },
           "id": {
             "type": "string"
-          },
-          "is_default": {
-            "type": "boolean"
           },
           "name": {
             "type": "string"
@@ -8639,7 +8687,8 @@
           },
           "resource_type": {
             "type": "string",
-            "description": "`\"skill\"`, `\"template\"`, or `\"interface\"`."
+            "description": "Resource type: `\"skill\"`, `\"template\"`, or `\"interface\"`.",
+            "example": "skill"
           }
         }
       },
@@ -10508,6 +10557,26 @@
             "type": "string"
           },
           "webhook_url": {
+            "type": "string"
+          }
+        }
+      },
+      "WorkflowWebhookTriggerAccepted": {
+        "type": "object",
+        "description": "Accepted response for a public webhook trigger.",
+        "required": [
+          "workflow_id",
+          "run_id",
+          "status"
+        ],
+        "properties": {
+          "run_id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "workflow_id": {
             "type": "string"
           }
         }


### PR DESCRIPTION
## Summary

- Document the only undocumented endpoint: `POST /workflow-hooks/{id}/{token}` (utoipa annotation + openapi.rs registration)
- Regenerate `openapi.json` — now 88 paths / 126 endpoints (was 87/125)
- Regenerate dart-dio Flutter client + build_runner `.g.dart` files
- Fix Flutter app + tests: replace `isDefault` getter with `id == 'default'` check after `PersonaSummary.isDefault` was removed from the API in #638

## Test plan
- [x] `make lint` — zero clippy warnings
- [x] `dart_pre_commit` — 0 analyze issues
- [x] 611 Flutter tests pass
- [x] `openapi.json` contains `/workflow-hooks/{id}/{token}` path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public workflow webhook trigger endpoint (POST /workflow-hooks/{id}/{token}) and its accepted response model.

* **Refactor**
  * Persona default detection now relies on a canonical default identifier rather than per-persona flag.

* **Documentation**
  * Updated API docs and schemas to reflect persona model changes and the new workflow webhook response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->