### PR TITLE
docs: multi-user authentication, setup guide, and ADR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,7 @@ Multiple crates under `crates/`, one root crate. Edition 2021, resolver 2.
 | Crate (package name)            | Path                                   | Purpose                                                                |
 | ------------------------------- | -------------------------------------- | ---------------------------------------------------------------------- |
 | `assistant-core`                | `crates/core`                          | Shared types, LLM traits (LlmProvider, EmbeddingProvider), ToolHandler |
+| `assistant-auth`                | `crates/auth`                          | OAuth2 server, JWT, API keys, OIDC federation, Axum auth middleware    |
 | `assistant-llm-provider`        | `crates/llm-provider`                  | All LlmProvider implementations (Ollama, Anthropic, OpenAI, Moonshot)  |
 | `assistant-skills`              | `crates/skills`                        | Skill parsing, validation, embedded builtins                           |
 | `assistant-storage`             | `crates/storage`                       | SQLite (sqlx), SkillRegistry, TraceStore, SqliteMessageBus             |
@@ -146,6 +147,8 @@ interface-cli -> runtime -> core
                     |-> bus-nats -> core  (optional, feature = "nats")
                     |-> tool-executor -> core, storage
                     '-> mcp-server, interfaces -> core, runtime, storage, transcription
+web-ui -> auth -> core, storage
+            '-> jwt, oauth2, oidc, api_keys, middleware
 ```
 
 ## Architecture Decisions

--- a/docs/adr/adr-0007-multi-user-orgs.md
+++ b/docs/adr/adr-0007-multi-user-orgs.md
@@ -1,0 +1,158 @@
+# ADR-0007: Multi-User Organizations, Spaces, and Identity
+
+**Status**: Accepted
+**Date**: 2026-04-25
+
+## Context
+
+The assistant was originally a single-user system: one database, one
+persona namespace, one shared auth token. As adoption grew, several
+requirements emerged:
+
+1. **Team use** — multiple people need separate conversations, personas,
+   and audit trails on a shared server.
+2. **Access control** — not all users should have the same permissions.
+   Some need admin access; others are read-only viewers.
+3. **Workgroup isolation** — teams within an organization need separate
+   contexts (personas, conversations, skills) without cross-contamination.
+4. **Machine access** — CI/CD pipelines and integrations need scoped,
+   long-lived credentials that don't require interactive login.
+5. **Federation** — enterprises want to use their existing IdP (Keycloak,
+   Auth0, etc.) rather than managing a separate password database.
+
+## Decision
+
+### Identity model: Org → Space → User
+
+Adopt a three-level hierarchy:
+
+- **Organization** — top-level tenant. One per deployment (for now).
+- **Space** — isolated workgroup within an org. Scopes personas,
+  conversations, and skill access.
+- **User** — authenticated individual. Has a role per space.
+
+This was chosen over flat RBAC because spaces provide a natural
+isolation boundary that maps to real-world team structure. The model
+is similar to Slack (workspace → channels → users) and GitHub
+(org → repo → collaborators).
+
+### Separate database for org data
+
+Org/user/space data lives in `org.db`, separate from `assistant.db`.
+
+Rationale:
+
+- **Backward compatibility** — existing single-user deployments keep
+  working with no migration. The server auto-detects whether `org.db`
+  exists.
+- **Independent evolution** — org schema (users, OAuth clients, API keys)
+  changes at a different cadence than conversation/persona schema.
+- **Operational isolation** — org data can be backed up, replicated, or
+  migrated independently from runtime data.
+
+Trade-off: two SQLite databases means two connection pools and no
+cross-database joins. In practice this hasn't been a problem because
+org queries (user lookup, role check) are fast and cacheable.
+
+### AuthContext threading
+
+Every authenticated request produces an `AuthContext` that flows through
+the entire call stack:
+
+```
+HTTP request
+  → Auth middleware (JWT/API key/legacy token)
+    → AuthContext { user_id, org_id, space_roles, scopes }
+      → Handler (permission check via can())
+        → Storage (filters by user/space)
+```
+
+This was chosen over per-handler auth checks because:
+
+- It's impossible to forget an auth check — the context is always present.
+- Storage layers can enforce row-level filtering without trusting callers.
+- The same AuthContext works for both JWT sessions and API keys.
+
+### OAuth2 for authentication
+
+Full OAuth2 stack with:
+
+- **Authorization Code + PKCE** — for browser apps (Flutter)
+- **Device Code** (RFC 8628) — for CLI and headless devices
+- **Dynamic Client Registration** (RFC 7591) — clients self-register
+- **Refresh Tokens** — silent renewal without re-authentication
+- **Token Revocation** (RFC 7009) — clean logout
+
+Rationale: OAuth2 is the industry standard for delegated auth. Using
+standard grants means the CLI and Flutter app use well-understood flows.
+The device code flow is particularly important for CLI UX — the user
+authorizes in a browser, not by pasting tokens into a terminal.
+
+Alternative considered: simple API key-only auth. Rejected because it
+doesn't support browser-based apps cleanly and doesn't allow token
+expiry/rotation.
+
+### HS256 JWTs for access tokens
+
+Access tokens are HS256 JWTs signed with a server-generated secret.
+
+Rationale:
+
+- **Self-contained** — the middleware can validate tokens without a
+  database lookup on every request.
+- **HS256 over RS256** — simpler key management for single-server
+  deployments. RS256 would be needed for multi-server token validation
+  but adds complexity we don't need yet.
+- **1-hour TTL** — short enough to limit damage from token theft,
+  long enough that refresh is infrequent.
+
+### API keys with prefix identification
+
+API keys use the format `ask_live_<43 base64url chars>`. Only the
+SHA-256 hash is stored.
+
+Design decisions:
+
+- **Prefix `ask_live_`** — allows the middleware to identify API keys
+  vs JWTs without attempting validation. Also makes keys recognizable
+  in logs and config files.
+- **Hash-only storage** — a compromised database doesn't leak usable
+  keys.
+- **Per-key scopes and resource restrictions** — keys can be limited to
+  specific resources and actions, following the principle of least
+  privilege.
+
+### Role hierarchy
+
+Four roles: `OrgAdmin > SpaceAdmin > Member > Viewer`.
+
+Kept simple intentionally. Custom roles and fine-grained permission
+matrices add complexity that isn't warranted at this stage. The
+`Scope` system (resource + action + optional resource IDs) provides
+fine-grained control for API keys without complicating the role model.
+
+## Consequences
+
+### Positive
+
+- Multi-user deployments are possible with proper isolation.
+- Backward compatible — single-user mode works unchanged.
+- Standard OAuth2 flows work with any OAuth2-capable client.
+- API keys enable secure machine access with least-privilege scoping.
+- The identity model is extensible (add roles, resources, actions)
+  without schema changes.
+
+### Negative
+
+- Two databases add operational complexity (backup, monitoring).
+- HS256 JWTs require the signing key to be available on every server
+  in a future multi-server deployment (would need migration to RS256).
+- The org model is currently single-org. Multi-org support would require
+  schema changes and routing logic.
+
+### Risks
+
+- **Key management** — the JWT signing key (`jwt_key.json`) is critical.
+  Loss means all active sessions are invalidated. It should be backed up.
+- **Token in URL** — the workflow webhook endpoint carries an HMAC token
+  in the URL path. Access logs must be configured to redact this.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,106 +1,231 @@
 # Authentication
 
-The web UI requires a single shared token for all access. There is no
-multi-user support yet — the token acts as a password that gates both
-the browser UI and API endpoints.
+The assistant web UI supports two authentication modes: a **legacy
+single-token** mode for quick local setups, and a full **OAuth2 / API key**
+system for multi-user deployments. The server auto-detects which mode to
+use based on configuration.
 
-## Configuration
+## Quick start (single-token mode)
 
-Set the token via CLI flag or environment variable:
+Set a shared token via CLI flag or environment variable:
 
 ```sh
-# Environment variable
-ASSISTANT_WEB_TOKEN=my-secret-token cargo run -p assistant-cli -- webui serve
-
-# CLI flag
-cargo run -p assistant-cli -- webui serve --auth-token my-secret-token
+ASSISTANT_WEB_TOKEN=my-secret-token assistant webui serve
+# or
+assistant webui serve --auth-token my-secret-token
 ```
 
-The server **refuses to start** if no token is configured. Whitespace
-is trimmed automatically.
+All users share the same token. This is the simplest setup and is
+appropriate for single-user local development.
 
-## Browser flow
+### Browser flow
 
-1. Unauthenticated requests to any protected page redirect to `/login`.
+1. Unauthenticated requests redirect to `/login`.
 2. Enter the token on the login page.
 3. On success, the server sets an `assistant_session` cookie and
    redirects to the dashboard.
-4. The cookie is `HttpOnly`, `SameSite=Strict`, and valid for 7 days.
-5. When the server binds to a non-loopback address, the `Secure`
-   attribute is added so the cookie is only sent over HTTPS.
-   Pass `--no-secure-cookie` to disable this if plain HTTP is acceptable.
-6. Sign out via the sidebar button (`POST /logout`), which clears the
-   cookie.
+4. Sign out via `POST /logout`, which clears the cookie.
 
-### Session cookie details
-
-The cookie value is an HMAC-SHA256 digest derived from the auth token —
-it never contains the raw token. Verification is constant-time.
-
-```
-cookie = hex(HMAC-SHA256(key=auth_token, msg="assistant-web-session-v1"))
-```
-
-Since the session value is deterministic, restarting the server with the
-same token preserves existing sessions.
-
-## API / A2A flow
-
-Machine callers authenticate with a Bearer token in the `Authorization`
-header:
+### API flow
 
 ```sh
-curl -H "Authorization: Bearer my-secret-token" http://localhost:8080/tasks
+curl -H "Authorization: Bearer my-secret-token" http://localhost:8080/api/personas
 ```
 
-Unauthenticated API requests receive `401 Unauthorized` with a
-`WWW-Authenticate: Bearer` header.
+## Multi-user mode (OAuth2 + API keys)
 
-## Route protection
+When an `org.db` database exists and users are registered, the server
+runs in multi-user mode with full OAuth2 support.
 
-| Route                     | Auth required            |
-| ------------------------- | ------------------------ |
-| `/login` (GET, POST)      | No                       |
-| `/logout` (POST)          | No                       |
-| `/.well-known/agent.json` | No (public per A2A spec) |
-| Everything else           | Yes                      |
+### OAuth2 endpoints
 
-The `/.well-known/agent.json` endpoint is intentionally public so that
-A2A callers can discover the authentication requirements before making
-authenticated requests.
+| Method | Path                                      | Description                                                |
+| ------ | ----------------------------------------- | ---------------------------------------------------------- |
+| POST   | `/oauth/register`                         | Dynamic client registration (RFC 7591)                     |
+| GET    | `/oauth/authorize`                        | Authorization endpoint (renders login or redirects to IdP) |
+| POST   | `/oauth/authorize`                        | Submit credentials, issue authorization code               |
+| GET    | `/oauth/callback`                         | OIDC IdP callback                                          |
+| POST   | `/oauth/token`                            | Token exchange (auth code, refresh, device code)           |
+| POST   | `/oauth/device`                           | Initiate device authorization (RFC 8628)                   |
+| GET    | `/oauth/device/verify`                    | User-facing code entry page                                |
+| POST   | `/oauth/device/verify`                    | Submit device code + credentials                           |
+| POST   | `/oauth/revoke`                           | Token revocation (RFC 7009)                                |
+| GET    | `/.well-known/oauth-authorization-server` | Server metadata (RFC 8414)                                 |
 
-## Auto-hardening
+### Grant types
 
-At startup, the web UI injects a `bearer_token` security scheme into the
-Persona A2A Profile card. This means the public discovery card at
-`/.well-known/agent.json` advertises:
+| Grant type                                     | Use case                               |
+| ---------------------------------------------- | -------------------------------------- |
+| `authorization_code`                           | Browser-based apps (Flutter web/macOS) |
+| `urn:ietf:params:oauth:grant-type:device_code` | CLI and headless devices               |
+| `refresh_token`                                | Silent token renewal                   |
+
+### Token format
+
+Access tokens are **HS256 JWTs** signed by the server. Claims include:
 
 ```json
 {
-  "securitySchemes": {
-    "bearer_token": {
-      "httpAuthSecurityScheme": {
-        "scheme": "Bearer",
-        "description": "Bearer token authentication. Pass the token via Authorization: Bearer <token>."
-      }
-    }
-  },
-  "securityRequirements": [{ "bearer_token": [] }]
+  "sub": "user_abc123",
+  "org_id": "org_1",
+  "email": "alice@example.com",
+  "spaces": { "eng": "member", "ops": "admin" },
+  "scope": "personas:read conversations:write",
+  "exp": 1719878400
 }
 ```
 
-A2A clients can use this to know they need to present a Bearer token
-before calling any protected endpoint.
+Default TTL is **1 hour**. Refresh tokens are opaque base64url strings
+stored server-side with a configurable TTL (default 30 days).
+
+### CLI authentication
+
+The CLI uses the **device code flow** (RFC 8628):
+
+```sh
+# Log in — opens browser for authorization
+assistant login http://localhost:8080
+
+# Check status
+assistant status
+
+# Log out — revokes tokens and removes credentials
+assistant logout
+```
+
+Credentials are stored in `~/.assistant/credentials.json` (mode `0600`).
+The CLI automatically refreshes expired access tokens using the stored
+refresh token.
+
+#### Non-interactive authentication
+
+For CI/CD and scripts, use an API key instead of the device code flow:
+
+```sh
+# Via flag
+assistant --api-key ask_live_... --server http://localhost:8080 api-keys list
+
+# Via environment variables
+export ASSISTANT_API_KEY=ask_live_...
+export ASSISTANT_SERVER=http://localhost:8080
+assistant api-keys list
+```
+
+## API keys
+
+API keys provide scoped, long-lived authentication for machine callers.
+
+### Key format
+
+Keys use the prefix `ask_live_` followed by 43 base64url characters:
+
+```
+ask_live_Ab3xY9kLm2nPq4rStUvWx5yZ...
+```
+
+Only the SHA-256 hash is stored server-side. The plaintext is shown
+**once** at creation time and cannot be recovered.
+
+### Managing keys
+
+Via CLI (requires login):
+
+```sh
+# Create a key
+assistant api-keys create --name "CI deploy" --scopes "conversations:read,skills:execute"
+
+# List keys (shows prefix, name, scopes — not the secret)
+assistant api-keys list
+
+# Revoke a key
+assistant api-keys revoke key_abc123
+```
+
+Via API:
+
+```sh
+# Create
+curl -X POST http://localhost:8080/api/users/me/api-keys \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "CI", "scopes": ["conversations:read"]}'
+
+# List
+curl http://localhost:8080/api/users/me/api-keys \
+  -H "Authorization: Bearer $TOKEN"
+
+# Revoke
+curl -X DELETE http://localhost:8080/api/users/me/api-keys/key_abc123 \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### Scopes
+
+Scopes follow the `resource:action` format:
+
+| Resource        | Actions                              |
+| --------------- | ------------------------------------ |
+| `personas`      | `read`, `write`, `delete`            |
+| `conversations` | `read`, `write`, `delete`            |
+| `messages`      | `read`, `write`                      |
+| `skills`        | `read`, `write`, `delete`, `execute` |
+| `interfaces`    | `read`, `write`, `manage`            |
+| `bindings`      | `read`, `write`                      |
+| `users`         | `read`, `write`, `manage`            |
+| `org`           | `read`, `manage`                     |
+| `api_keys`      | `read`, `write`                      |
+| `spaces`        | `read`, `write`, `manage`            |
+
+API keys can optionally restrict scopes to specific resource IDs
+(e.g., only a specific persona or space).
+
+## Auth middleware resolution order
+
+On every request, the auth middleware resolves identity in this order:
+
+1. Extract `Authorization: Bearer <token>` header.
+2. Try **JWT validation** — if valid, extract `AuthContext` from claims.
+3. If the token starts with `ask_live_`, try **API key resolution** —
+   look up the hash, build `AuthContext` from the key's stored metadata.
+4. If a legacy `--auth-token` is configured and the token matches,
+   return the legacy context (backward compatibility).
+5. Return `401 Unauthorized` if all checks fail.
+
+Org admins bypass all scope checks. Other users are gated by their
+space roles and the scopes attached to their token or API key.
+
+## Session cookie details
+
+On successful token exchange (auth code or refresh), the server sets:
+
+```
+assistant_session=<JWT>; HttpOnly; SameSite=Lax; Path=/; Max-Age=3600
+```
+
+- `HttpOnly` prevents JavaScript access.
+- `SameSite=Lax` prevents CSRF via cross-origin POST.
+- `Secure` is added when binding to a non-loopback address (override
+  with `--no-secure-cookie` for plain HTTP behind a VPN).
 
 ## Security notes
 
-- The token is compared using constant-time equality to prevent timing
-  attacks.
-- The session cookie uses HMAC-SHA256 derivation — the raw token is
-  never stored in the cookie.
-- `SameSite=Strict` prevents CSRF via cross-origin requests.
-- `HttpOnly` prevents JavaScript access to the cookie.
-- `Secure` is added automatically when binding to a non-loopback address
-  (override with `--no-secure-cookie` for plain HTTP behind a VPN).
-- A warning is logged when binding to a non-loopback address to flag
-  unintentional network exposure.
+- JWT signing key is auto-generated on first run and persisted in
+  `~/.assistant/jwt_key.json`. Back it up for session continuity
+  across restarts.
+- API key plaintext is shown once at creation — store it securely.
+- Password hashing uses Argon2id.
+- Token comparison uses constant-time equality.
+- The device code flow uses short-lived codes (15 min) with
+  rate-limited polling (5s interval).
+
+## Route protection
+
+| Route                                     | Auth required              |
+| ----------------------------------------- | -------------------------- |
+| `/login` (GET, POST)                      | No                         |
+| `/logout` (POST)                          | No                         |
+| `/oauth/*`                                | No (OAuth2 flow endpoints) |
+| `/workflow-hooks/{id}/{token}`            | No (HMAC token in URL)     |
+| `/.well-known/agent.json`                 | No (A2A discovery)         |
+| `/.well-known/oauth-authorization-server` | No (RFC 8414)              |
+| Everything else                           | Yes                        |

--- a/docs/multi-user.md
+++ b/docs/multi-user.md
@@ -1,0 +1,201 @@
+# Multi-User Setup
+
+This guide covers the organization, space, and user model that enables
+multi-user deployments of the assistant.
+
+## Data model
+
+```
+Organization (org)
+├── Users
+│   ├── alice (OrgAdmin)
+│   └── bob (Member)
+├── Spaces
+│   ├── engineering
+│   │   ├── Members: alice (SpaceAdmin), bob (Member)
+│   │   ├── Personas: code-reviewer, qa-bot
+│   │   └── Conversations (scoped to space + persona + user)
+│   └── marketing
+│       ├── Members: alice (Viewer)
+│       ├── Personas: content-writer
+│       └── Conversations
+└── Catalog
+    ├── Published skills
+    ├── Published templates
+    └── Interface bindings
+```
+
+### Organizations
+
+An organization is the top-level tenant. Each deployment typically has
+one organization. All users, spaces, and resources belong to an org.
+
+### Users
+
+Users authenticate via OAuth2 (browser or device code flow) or API keys.
+Each user has:
+
+- **User ID** — unique identifier (e.g. `user_abc123`)
+- **Email** — used for login and display
+- **Password hash** — Argon2id (for password-based auth)
+- **Org membership** — which org they belong to
+
+### Spaces
+
+Spaces are isolated workgroups within an organization. They scope:
+
+- **Personas** — each persona lives in a space
+- **Conversations** — scoped to space + persona + user
+- **Skills** — access controlled per space via the catalog
+
+Spaces enable teams to have separate contexts without cross-contamination.
+
+### Roles
+
+Roles form a hierarchy (highest to lowest):
+
+| Role         | Level | Capabilities                                                                         |
+| ------------ | ----- | ------------------------------------------------------------------------------------ |
+| `OrgAdmin`   | 3     | Full access to all spaces, user management, org settings. Bypasses all scope checks. |
+| `SpaceAdmin` | 2     | Manage space memberships, personas, and settings within their space.                 |
+| `Member`     | 1     | Use personas, create conversations, execute skills within their space.               |
+| `Viewer`     | 0     | Read-only access to conversations and personas in their space.                       |
+
+A user can have different roles in different spaces. For example, Alice
+might be `SpaceAdmin` in engineering but `Viewer` in marketing.
+
+### Scopes and permissions
+
+Every authenticated request carries an `AuthContext` with:
+
+- The user's identity (`user_id`, `org_id`, `email`)
+- A map of `space_id → role` for all spaces the user belongs to
+- A list of `scopes` (for API keys: restricted; for sessions: full)
+
+Permission checks use `AuthContext::can(space, resource, action)`:
+
+1. Org admins → always allowed
+2. Check the user's role in the target space
+3. Check whether the token's scopes include the required `resource:action`
+4. If the scope has `resource_ids` restrictions, verify the target ID is in the list
+
+## Storage
+
+Multi-user data lives in a **separate database** (`org.db`) from the
+main assistant data (`assistant.db`). This separation allows:
+
+- Clean upgrades — org schema evolves independently
+- Backup isolation — org data can be backed up separately
+- Single-user mode — works without `org.db` at all
+
+### Database tables (org.db)
+
+| Table                   | Purpose                                       |
+| ----------------------- | --------------------------------------------- |
+| `organizations`         | Org metadata                                  |
+| `users`                 | User accounts (id, email, password hash, org) |
+| `spaces`                | Workgroup definitions                         |
+| `space_memberships`     | User ↔ space ↔ role mappings                  |
+| `api_keys`              | Hashed API keys with scopes and restrictions  |
+| `oauth_clients`         | Registered OAuth2 clients                     |
+| `auth_codes`            | Short-lived authorization codes               |
+| `refresh_tokens`        | Long-lived refresh tokens                     |
+| `device_codes`          | Pending device authorization requests         |
+| `catalog_items`         | Published skills, templates, interfaces       |
+| `catalog_subscriptions` | Space subscriptions to catalog items          |
+| `interface_configs`     | Per-space interface configurations            |
+| `interface_bindings`    | Interface ↔ persona bindings                  |
+
+## Setup guide
+
+### 1. Start the web UI
+
+```sh
+assistant webui serve
+```
+
+On first run with no `org.db`, the server creates the database and runs
+migrations automatically.
+
+### 2. Create the first user
+
+The first user to register becomes the org admin. Use the web UI
+registration flow or create a user via the API:
+
+```sh
+curl -X POST http://localhost:8080/api/orgs/default/users \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "alice@example.com",
+    "password": "secure-password",
+    "display_name": "Alice"
+  }'
+```
+
+### 3. Create spaces
+
+```sh
+curl -X POST http://localhost:8080/api/orgs/default/spaces \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Engineering", "description": "Dev team workspace"}'
+```
+
+### 4. Add members to spaces
+
+```sh
+curl -X POST http://localhost:8080/api/orgs/default/spaces/eng/members \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"user_id": "user_bob", "role": "member"}'
+```
+
+### 5. CLI login
+
+Users can authenticate the CLI with the device code flow:
+
+```sh
+assistant login http://localhost:8080
+```
+
+This opens a browser for authorization. After approval, the CLI stores
+credentials in `~/.assistant/credentials.json` and can manage personas,
+conversations, and API keys.
+
+### 6. Create API keys for automation
+
+```sh
+assistant api-keys create --name "CI pipeline" --scopes "skills:execute,conversations:write"
+```
+
+Use the key in CI/CD:
+
+```sh
+export ASSISTANT_API_KEY=ask_live_...
+export ASSISTANT_SERVER=http://your-server:8080
+```
+
+## Backward compatibility
+
+The multi-user system is fully backward compatible:
+
+- **No org.db** → single-user mode with legacy token auth
+- **Legacy `--auth-token`** → still works, returns a default AuthContext
+- **Existing `assistant.db`** → untouched, personas and conversations
+  continue to work
+- The `is_default` column on personas is preserved in the database for
+  backward compatibility but is no longer exposed in the API
+
+## OIDC federation (optional)
+
+The server can delegate authentication to an external OIDC provider
+(e.g., Keycloak, Auth0, Google Workspace):
+
+1. Configure the OIDC provider in the server settings
+2. `GET /oauth/authorize` redirects to the IdP login page
+3. `GET /oauth/callback` receives the authorization code from the IdP
+4. The server exchanges it for an ID token, creates or updates the local
+   user, and issues its own JWT + refresh token
+
+This enables SSO without managing passwords locally.

--- a/openspec/changes/multi-user-orgs/tasks.md
+++ b/openspec/changes/multi-user-orgs/tasks.md
@@ -569,12 +569,12 @@ PR 10 ─── CLI OAuth2 login + Flutter OAuth2 + docs
 
 - [ ] `test(app): widget tests for login, space switching, persona scoping`
 
-- [ ] `docs: update authentication.md with OAuth2 flows and API keys`
+- [x] `docs: update authentication.md with OAuth2 flows and API keys`
 
-- [ ] `docs: add multi-user.md — org/space/user model, roles, setup guide`
+- [x] `docs: add multi-user.md — org/space/user model, roles, setup guide`
 
-- [ ] `docs: add ADR for multi-user-orgs architectural decision`
+- [x] `docs: add ADR for multi-user-orgs architectural decision`
 
-- [ ] `docs: update CLAUDE.md workspace structure with assistant-auth crate`
+- [x] `docs: update CLAUDE.md workspace structure with assistant-auth crate`
 
 - [ ] `chore: final OpenAPI spec update with all new endpoints`


### PR DESCRIPTION
## Summary

- Rewrites `docs/authentication.md` with comprehensive OAuth2 flows (auth code + PKCE, device code, refresh), API key management, CLI auth, session cookies, middleware resolution order, and security notes
- Adds `docs/multi-user.md` covering the org/space/user data model, role hierarchy, scopes and permissions, storage layout (separate `org.db`), 6-step setup guide, backward compatibility, and OIDC federation
- Adds `docs/adr/adr-0007-multi-user-orgs.md` documenting architectural decisions: identity model, separate database rationale, AuthContext threading, OAuth2 grant selection, HS256 JWT, API key design, and role hierarchy
- Adds `assistant-auth` crate to the workspace structure table in `AGENTS.md`

## Test plan

- [ ] Documentation renders correctly on GitHub
- [ ] All code examples in docs are consistent with actual API endpoints
- [ ] ADR accurately reflects implemented architecture