### PR TITLE
feat(app): OAuth2 login flow with PKCE and dual-mode auth

### DIFF
--- a/app/lib/features/auth/auth_provider.dart
+++ b/app/lib/features/auth/auth_provider.dart
@@ -1,0 +1,173 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../contexts/models/context_model.dart';
+import '../contexts/providers/context_providers.dart';
+import 'oauth_service.dart';
+import 'pkce.dart';
+
+/// State of an in-progress OAuth2 login flow.
+sealed class OAuthLoginState {
+  const OAuthLoginState();
+}
+
+class OAuthLoginIdle extends OAuthLoginState {
+  const OAuthLoginIdle();
+}
+
+class OAuthLoginLoading extends OAuthLoginState {
+  const OAuthLoginLoading({this.message = 'Connecting...'});
+  final String message;
+}
+
+class OAuthLoginSuccess extends OAuthLoginState {
+  const OAuthLoginSuccess(this.context);
+  final AssistantContext context;
+}
+
+class OAuthLoginError extends OAuthLoginState {
+  const OAuthLoginError(this.message);
+  final String message;
+}
+
+/// Manages the OAuth2 login flow for the Flutter app.
+///
+/// Orchestrates: server detection → client registration → login →
+/// token storage → context activation.
+class OAuthLoginNotifier extends Notifier<OAuthLoginState> {
+  @override
+  OAuthLoginState build() => const OAuthLoginIdle();
+
+  /// Performs a full OAuth2 login:
+  /// 1. Check server supports OAuth2
+  /// 2. Register a dynamic client
+  /// 3. Post credentials (email + password) to get an auth code
+  /// 4. Exchange code for tokens
+  /// 5. Save credentials and activate context
+  Future<void> login({
+    required String serverUrl,
+    required String email,
+    required String password,
+  }) async {
+    state = const OAuthLoginLoading(message: 'Checking server...');
+
+    try {
+      final service = OAuthService(serverUrl: serverUrl);
+
+      // 1. Verify server supports OAuth2.
+      final hasOAuth = await service.supportsOAuth();
+      if (!hasOAuth) {
+        state = const OAuthLoginError(
+          'This server does not support OAuth2 authentication. '
+          'Use the legacy token login instead.',
+        );
+        return;
+      }
+
+      // 2. Register a dynamic client.
+      state = const OAuthLoginLoading(message: 'Registering client...');
+      final redirectUri = _redirectUri(serverUrl);
+      final clientId = await service.registerClient(
+        clientName: 'Assistant Flutter App',
+        redirectUris: [redirectUri],
+      );
+
+      // 3. Generate PKCE and login.
+      state = const OAuthLoginLoading(message: 'Authenticating...');
+      final pkce = PkceChallenge.generate();
+      final creds = await service.login(
+        email: email,
+        password: password,
+        clientId: clientId,
+        redirectUri: redirectUri,
+        pkce: pkce,
+      );
+
+      // 4. Create and save context.
+      state = const OAuthLoginLoading(message: 'Saving credentials...');
+      final serverHost = Uri.parse(serverUrl).host;
+      final newCtx = AssistantContext.create(
+        name: serverHost,
+        serverUrl: serverUrl,
+        oauthCredentials: creds,
+        authMode: AuthMode.oauth2,
+      );
+
+      final saved = await ref
+          .read(contextsProvider.notifier)
+          .upsertContextByUrl(newCtx);
+      await ref.read(activeContextProvider.notifier).activate(saved);
+
+      state = OAuthLoginSuccess(saved);
+    } on OAuthException catch (e) {
+      state = OAuthLoginError(e.message);
+    } catch (e) {
+      state = OAuthLoginError('Login failed: $e');
+    }
+  }
+
+  /// Performs a legacy token login (for servers without OAuth2).
+  Future<void> legacyLogin({required String serverUrl, String? token}) async {
+    state = const OAuthLoginLoading(message: 'Connecting...');
+
+    try {
+      final serverHost = Uri.parse(serverUrl).host;
+      final newCtx = AssistantContext.create(
+        name: serverHost,
+        serverUrl: serverUrl,
+        authToken: token,
+        authMode: AuthMode.legacyToken,
+      );
+
+      final saved = await ref
+          .read(contextsProvider.notifier)
+          .upsertContextByUrl(newCtx);
+      await ref.read(activeContextProvider.notifier).activate(saved);
+
+      state = OAuthLoginSuccess(saved);
+    } catch (e) {
+      state = OAuthLoginError('Connection failed: $e');
+    }
+  }
+
+  /// The redirect URI for OAuth2 flows.
+  ///
+  /// On web, this is the same origin with `/oauth/callback`.
+  /// On macOS, this uses a loopback address (the server accepts this).
+  String _redirectUri(String serverUrl) {
+    final uri = Uri.parse(serverUrl);
+    return uri.replace(path: '/oauth/callback').toString();
+  }
+}
+
+final oauthLoginProvider =
+    NotifierProvider<OAuthLoginNotifier, OAuthLoginState>(
+      OAuthLoginNotifier.new,
+    );
+
+/// Refreshes OAuth2 tokens for the active context if needed.
+///
+/// Returns the (possibly updated) context. If refresh fails, returns the
+/// original context unchanged (callers should handle 401 errors).
+Future<AssistantContext> refreshIfNeeded(
+  WidgetRef ref,
+  AssistantContext context,
+) async {
+  if (!context.needsTokenRefresh) return context;
+
+  final creds = context.oauthCredentials!;
+  final service = OAuthService(serverUrl: context.serverUrl);
+
+  try {
+    final newCreds = await service.refresh(
+      refreshToken: creds.refreshToken,
+      clientId: creds.clientId,
+    );
+
+    final updated = context.copyWith(oauthCredentials: newCreds);
+    await ref.read(contextsProvider.notifier).saveContext(updated);
+    return updated;
+  } catch (_) {
+    // Refresh failed — caller will get a 401 and can redirect to login.
+    return context;
+  }
+}

--- a/app/lib/features/auth/oauth_credentials.dart
+++ b/app/lib/features/auth/oauth_credentials.dart
@@ -1,0 +1,86 @@
+import 'dart:convert';
+
+/// OAuth2 credentials associated with an [AssistantContext].
+///
+/// Stored separately in secure storage. The [accessToken] is the JWT used
+/// for API requests; the [refreshToken] enables silent renewal.
+class OAuthCredentials {
+  const OAuthCredentials({
+    required this.accessToken,
+    required this.refreshToken,
+    required this.expiresAt,
+    required this.clientId,
+  });
+
+  final String accessToken;
+  final String refreshToken;
+
+  /// UTC instant when [accessToken] expires.
+  final DateTime expiresAt;
+
+  /// The OAuth2 client ID used to obtain these tokens.
+  final String clientId;
+
+  /// Returns `true` when the access token has expired or will expire within
+  /// the given [buffer] (default 60 seconds).
+  bool isExpired({Duration buffer = const Duration(seconds: 60)}) {
+    return DateTime.now().toUtc().isAfter(expiresAt.subtract(buffer));
+  }
+
+  /// The token to use in `Authorization: Bearer` headers.
+  /// Returns the access token regardless of expiry — callers should check
+  /// [isExpired] and refresh first.
+  String get bearerToken => accessToken;
+
+  Map<String, dynamic> toJson() => {
+    'accessToken': accessToken,
+    'refreshToken': refreshToken,
+    'expiresAt': expiresAt.toIso8601String(),
+    'clientId': clientId,
+  };
+
+  factory OAuthCredentials.fromJson(Map<String, dynamic> json) {
+    return OAuthCredentials(
+      accessToken: json['accessToken'] as String,
+      refreshToken: json['refreshToken'] as String,
+      expiresAt: DateTime.parse(json['expiresAt'] as String),
+      clientId: json['clientId'] as String,
+    );
+  }
+
+  String toJsonString() => jsonEncode(toJson());
+
+  factory OAuthCredentials.fromJsonString(String source) =>
+      OAuthCredentials.fromJson(jsonDecode(source) as Map<String, dynamic>);
+
+  OAuthCredentials copyWith({
+    String? accessToken,
+    String? refreshToken,
+    DateTime? expiresAt,
+    String? clientId,
+  }) {
+    return OAuthCredentials(
+      accessToken: accessToken ?? this.accessToken,
+      refreshToken: refreshToken ?? this.refreshToken,
+      expiresAt: expiresAt ?? this.expiresAt,
+      clientId: clientId ?? this.clientId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is OAuthCredentials &&
+          accessToken == other.accessToken &&
+          refreshToken == other.refreshToken &&
+          expiresAt == other.expiresAt &&
+          clientId == other.clientId;
+
+  @override
+  int get hashCode =>
+      Object.hash(accessToken, refreshToken, expiresAt, clientId);
+
+  @override
+  String toString() =>
+      'OAuthCredentials(clientId: $clientId, expiresAt: $expiresAt)';
+}

--- a/app/lib/features/auth/oauth_service.dart
+++ b/app/lib/features/auth/oauth_service.dart
@@ -1,0 +1,236 @@
+import 'package:dio/dio.dart';
+
+import 'oauth_credentials.dart';
+import 'pkce.dart';
+
+/// Handles the OAuth2 Authorization Code + PKCE flow against the assistant
+/// server's OAuth2 endpoints.
+///
+/// This service is stateless — it takes a server URL and performs HTTP calls
+/// via [Dio]. Token storage is handled by the caller ([ContextRepository]).
+class OAuthService {
+  OAuthService({required this.serverUrl, Dio? dio})
+    : _dio = dio ?? Dio(BaseOptions(baseUrl: serverUrl));
+
+  final String serverUrl;
+  final Dio _dio;
+
+  // -- Dynamic Client Registration (RFC 7591) --------------------------------
+
+  /// Registers a new OAuth2 client via dynamic client registration.
+  ///
+  /// Returns the assigned [clientId]. The client is registered as a public
+  /// client (no secret) with `authorization_code` grant type.
+  Future<String> registerClient({
+    required String clientName,
+    required List<String> redirectUris,
+  }) async {
+    final response = await _dio.post<Map<String, dynamic>>(
+      '/oauth/register',
+      data: {
+        'client_name': clientName,
+        'redirect_uris': redirectUris,
+        'grant_types': ['authorization_code', 'refresh_token'],
+        'response_types': ['code'],
+        'token_endpoint_auth_method': 'none',
+      },
+      options: Options(contentType: 'application/json'),
+    );
+
+    final data = response.data!;
+    return data['client_id'] as String;
+  }
+
+  // -- Authorization Code + PKCE flow ----------------------------------------
+
+  /// Builds the authorization URL for the browser redirect.
+  ///
+  /// The caller should open this URL in a browser. After the user
+  /// authenticates, the server redirects to [redirectUri] with `?code=...`.
+  Uri buildAuthorizationUrl({
+    required String clientId,
+    required String redirectUri,
+    required PkceChallenge pkce,
+    String? state,
+    String? scope,
+  }) {
+    final params = <String, String>{
+      'response_type': 'code',
+      'client_id': clientId,
+      'redirect_uri': redirectUri,
+      'code_challenge': pkce.challenge,
+      'code_challenge_method': 'S256',
+    };
+    if (state != null) params['state'] = state;
+    if (scope != null) params['scope'] = scope;
+
+    return Uri.parse(
+      serverUrl,
+    ).replace(path: '/oauth/authorize', queryParameters: params);
+  }
+
+  /// Exchanges an authorization code for tokens.
+  ///
+  /// The [code] comes from the redirect URI query parameter after the user
+  /// approves. The [pkceVerifier] must match the challenge sent in the
+  /// authorization request.
+  Future<OAuthCredentials> exchangeCode({
+    required String code,
+    required String clientId,
+    required String redirectUri,
+    required String pkceVerifier,
+  }) async {
+    final response = await _dio.post<Map<String, dynamic>>(
+      '/oauth/token',
+      data: {
+        'grant_type': 'authorization_code',
+        'code': code,
+        'client_id': clientId,
+        'redirect_uri': redirectUri,
+        'code_verifier': pkceVerifier,
+      },
+      options: Options(contentType: 'application/x-www-form-urlencoded'),
+    );
+
+    return _parseTokenResponse(response.data!, clientId);
+  }
+
+  // -- Direct login (email + password → auth code → tokens) ------------------
+
+  /// Performs a direct login by posting credentials to the authorization
+  /// endpoint and then exchanging the resulting auth code for tokens.
+  ///
+  /// This is a convenience for web/macOS where we can show an in-app login
+  /// form rather than redirecting to a browser.
+  Future<OAuthCredentials> login({
+    required String email,
+    required String password,
+    required String clientId,
+    required String redirectUri,
+    required PkceChallenge pkce,
+  }) async {
+    // POST credentials to get an auth code via redirect.
+    final authResponse = await _dio.post<dynamic>(
+      '/oauth/authorize',
+      data: {
+        'client_id': clientId,
+        'redirect_uri': redirectUri,
+        'code_challenge': pkce.challenge,
+        'email': email,
+        'password': password,
+      },
+      options: Options(
+        contentType: 'application/x-www-form-urlencoded',
+        followRedirects: false,
+        validateStatus: (status) =>
+            status != null && (status >= 200 && status < 400),
+      ),
+    );
+
+    // Extract the auth code from the redirect Location header.
+    final location = authResponse.headers.value('location');
+    if (location == null) {
+      throw OAuthException('No redirect location in authorization response');
+    }
+
+    final locationUri = Uri.parse(location);
+    final code = locationUri.queryParameters['code'];
+    if (code == null) {
+      final error = locationUri.queryParameters['error'] ?? 'unknown_error';
+      final desc = locationUri.queryParameters['error_description'] ?? '';
+      throw OAuthException('Authorization failed: $error $desc');
+    }
+
+    // Exchange the auth code for tokens.
+    return exchangeCode(
+      code: code,
+      clientId: clientId,
+      redirectUri: redirectUri,
+      pkceVerifier: pkce.verifier,
+    );
+  }
+
+  // -- Token refresh ---------------------------------------------------------
+
+  /// Refreshes an expired access token using the stored refresh token.
+  ///
+  /// Returns new credentials with a fresh access token and potentially a
+  /// rotated refresh token.
+  Future<OAuthCredentials> refresh({
+    required String refreshToken,
+    required String clientId,
+  }) async {
+    final response = await _dio.post<Map<String, dynamic>>(
+      '/oauth/token',
+      data: {
+        'grant_type': 'refresh_token',
+        'refresh_token': refreshToken,
+        'client_id': clientId,
+      },
+      options: Options(contentType: 'application/x-www-form-urlencoded'),
+    );
+
+    return _parseTokenResponse(response.data!, clientId);
+  }
+
+  // -- Token revocation ------------------------------------------------------
+
+  /// Revokes a refresh token, invalidating the session.
+  Future<void> revoke({required String token, String? clientId}) async {
+    await _dio.post<void>(
+      '/oauth/revoke',
+      data: {
+        'token': token,
+        'client_id': ?clientId,
+        'token_type_hint': 'refresh_token',
+      },
+      options: Options(contentType: 'application/x-www-form-urlencoded'),
+    );
+  }
+
+  // -- Server metadata -------------------------------------------------------
+
+  /// Checks whether the server supports OAuth2 by fetching the well-known
+  /// metadata endpoint. Returns `true` if the endpoint responds successfully.
+  Future<bool> supportsOAuth() async {
+    try {
+      final response = await _dio.get<dynamic>(
+        '/.well-known/oauth-authorization-server',
+      );
+      return response.statusCode == 200;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  // -- Helpers ---------------------------------------------------------------
+
+  OAuthCredentials _parseTokenResponse(
+    Map<String, dynamic> data,
+    String clientId,
+  ) {
+    final accessToken = data['access_token'] as String;
+    final refreshToken = data['refresh_token'] as String?;
+    final expiresIn = data['expires_in'] as int;
+
+    if (refreshToken == null) {
+      throw OAuthException('Server did not return a refresh token');
+    }
+
+    return OAuthCredentials(
+      accessToken: accessToken,
+      refreshToken: refreshToken,
+      expiresAt: DateTime.now().toUtc().add(Duration(seconds: expiresIn)),
+      clientId: clientId,
+    );
+  }
+}
+
+/// Exception thrown when an OAuth2 operation fails.
+class OAuthException implements Exception {
+  const OAuthException(this.message);
+  final String message;
+
+  @override
+  String toString() => 'OAuthException: $message';
+}

--- a/app/lib/features/auth/pkce.dart
+++ b/app/lib/features/auth/pkce.dart
@@ -1,0 +1,50 @@
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:crypto/crypto.dart';
+
+/// PKCE (RFC 7636) helper for OAuth2 Authorization Code flow.
+///
+/// Generates a cryptographically random code verifier and derives the
+/// S256 code challenge from it.
+class PkceChallenge {
+  PkceChallenge._({required this.verifier, required this.challenge});
+
+  /// The code verifier — a high-entropy random string sent in the token
+  /// exchange request.
+  final String verifier;
+
+  /// The S256 code challenge — `BASE64URL(SHA256(verifier))`, sent in the
+  /// authorization request.
+  final String challenge;
+
+  /// Generates a new PKCE challenge pair.
+  ///
+  /// The [length] parameter controls the number of random bytes (default 32,
+  /// which produces a 43-character base64url verifier).
+  factory PkceChallenge.generate({int length = 32}) {
+    final verifier = _generateVerifier(length);
+    final challenge = _deriveChallenge(verifier);
+    return PkceChallenge._(verifier: verifier, challenge: challenge);
+  }
+
+  /// Derives the S256 challenge from a given [verifier].
+  ///
+  /// Useful for testing or when you need to recompute the challenge.
+  static String deriveChallenge(String verifier) => _deriveChallenge(verifier);
+
+  static String _generateVerifier(int length) {
+    final random = Random.secure();
+    final bytes = List<int>.generate(length, (_) => random.nextInt(256));
+    return base64UrlEncode(bytes).replaceAll('=', '');
+  }
+
+  static String _deriveChallenge(String verifier) {
+    final digest = sha256.convert(utf8.encode(verifier));
+    return base64UrlEncode(digest.bytes).replaceAll('=', '');
+  }
+
+  @override
+  String toString() =>
+      'PkceChallenge(verifier: ${verifier.substring(0, 8)}...)';
+}

--- a/app/lib/features/connection/connection_provider.dart
+++ b/app/lib/features/connection/connection_provider.dart
@@ -25,7 +25,7 @@ class ServerProfileNotifier extends AsyncNotifier<ServerConnectionState> {
     if (activeContext == null) return const ServerConnectionState();
     final profile = ServerProfile(
       baseUrl: activeContext.serverUrl,
-      token: activeContext.authToken ?? '',
+      token: activeContext.effectiveToken ?? '',
       label: activeContext.name,
     );
     return ServerConnectionState(profile: profile);

--- a/app/lib/features/contexts/data/context_repository.dart
+++ b/app/lib/features/contexts/data/context_repository.dart
@@ -7,9 +7,12 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../models/context_model.dart';
 import 'shared_credentials_channel.dart';
 
+import '../../auth/oauth_credentials.dart';
+
 const _kContextsKey = 'assistant_contexts';
 const _kActiveContextIdKey = 'assistant_active_context_id';
 const _kTokenPrefix = 'assistant_context_token_';
+const _kOAuthPrefix = 'assistant_context_oauth_';
 
 /// Well-known Keychain keys for native Siri/Shortcuts integration.
 /// Swift App Intent code reads these directly from the Keychain.
@@ -106,8 +109,20 @@ class ContextRepository {
     final result = <AssistantContext>[];
     for (final ctx in contexts) {
       try {
+        var restored = ctx;
         final token = await _secureStorage.read(key: '$_kTokenPrefix${ctx.id}');
-        result.add(token != null ? ctx.copyWith(authToken: token) : ctx);
+        if (token != null) {
+          restored = restored.copyWith(authToken: token);
+        }
+        final oauthJson = await _secureStorage.read(
+          key: '$_kOAuthPrefix${ctx.id}',
+        );
+        if (oauthJson != null) {
+          restored = restored.copyWith(
+            oauthCredentials: OAuthCredentials.fromJsonString(oauthJson),
+          );
+        }
+        result.add(restored);
       } catch (_) {
         result.add(ctx);
       }
@@ -137,6 +152,16 @@ class ContextRepository {
       await _secureStorage.delete(key: '$_kTokenPrefix${context.id}');
     }
 
+    // Persist OAuth credentials.
+    if (context.oauthCredentials != null) {
+      await _secureStorage.write(
+        key: '$_kOAuthPrefix${context.id}',
+        value: context.oauthCredentials!.toJsonString(),
+      );
+    } else {
+      await _secureStorage.delete(key: '$_kOAuthPrefix${context.id}');
+    }
+
     // Keep Siri credentials in sync if this is the active context.
     if (context.id == getActiveContextId()) {
       await syncSiriCredentials();
@@ -156,10 +181,12 @@ class ContextRepository {
     final idx = existing.indexWhere((c) => c.serverUrl == context.serverUrl);
     final AssistantContext toSave;
     if (idx >= 0) {
-      // Preserve ID and createdAt; update name and (below) token.
+      // Preserve ID and createdAt; update name, auth mode, and (below) tokens.
       toSave = existing[idx].copyWith(
         name: context.name,
         authToken: context.authToken,
+        oauthCredentials: context.oauthCredentials,
+        authMode: context.authMode,
       );
       existing[idx] = toSave;
     } else {
@@ -177,6 +204,16 @@ class ContextRepository {
       await _secureStorage.delete(key: '$_kTokenPrefix${toSave.id}');
     }
 
+    // Persist OAuth credentials.
+    if (toSave.oauthCredentials != null) {
+      await _secureStorage.write(
+        key: '$_kOAuthPrefix${toSave.id}',
+        value: toSave.oauthCredentials!.toJsonString(),
+      );
+    } else {
+      await _secureStorage.delete(key: '$_kOAuthPrefix${toSave.id}');
+    }
+
     if (toSave.id == getActiveContextId()) {
       await syncSiriCredentials();
     }
@@ -192,6 +229,7 @@ class ContextRepository {
     existing.removeWhere((c) => c.id == id);
     await _persistMetadata(existing);
     await _secureStorage.delete(key: '$_kTokenPrefix$id');
+    await _secureStorage.delete(key: '$_kOAuthPrefix$id');
 
     if (getActiveContextId() == id) {
       await setActiveContextId(null);

--- a/app/lib/features/contexts/models/context_model.dart
+++ b/app/lib/features/contexts/models/context_model.dart
@@ -2,16 +2,30 @@ import 'dart:convert';
 
 import 'package:uuid/uuid.dart';
 
+import '../../auth/oauth_credentials.dart';
+
+/// Authentication mode for a context.
+enum AuthMode {
+  /// Legacy single-token auth (shared token, no refresh).
+  legacyToken,
+
+  /// Full OAuth2 with access + refresh tokens.
+  oauth2,
+}
+
 /// A named server connection profile (context).
 ///
-/// Stores everything except [authToken] in plaintext. The token is held
-/// out-of-band in [FlutterSecureStorage] by [ContextRepository].
+/// Stores everything except secrets in plaintext. The [authToken] and
+/// [oauthCredentials] are held out-of-band in secure storage by
+/// [ContextRepository].
 class AssistantContext {
   const AssistantContext({
     required this.id,
     required this.name,
     required this.serverUrl,
     this.authToken,
+    this.oauthCredentials,
+    this.authMode = AuthMode.legacyToken,
     required this.createdAt,
   });
 
@@ -23,23 +37,49 @@ class AssistantContext {
   /// Base URL of the assistant server, e.g. `http://localhost:8080`.
   final String serverUrl;
 
-  /// Bearer token.  `null` means the server requires no auth.
+  /// Legacy bearer token.  `null` means the server requires no auth.
   /// Never serialised to JSON — stored separately in secure storage.
   final String? authToken;
 
+  /// OAuth2 credentials (access + refresh tokens).
+  /// Never serialised to JSON — stored separately in secure storage.
+  final OAuthCredentials? oauthCredentials;
+
+  /// Which auth mode this context uses.
+  final AuthMode authMode;
+
   final DateTime createdAt;
+
+  /// The bearer token to use for API requests — picks the right one based
+  /// on [authMode].
+  String? get effectiveToken {
+    if (authMode == AuthMode.oauth2 && oauthCredentials != null) {
+      return oauthCredentials!.bearerToken;
+    }
+    return authToken;
+  }
+
+  /// Whether the OAuth2 access token needs refreshing.
+  bool get needsTokenRefresh =>
+      authMode == AuthMode.oauth2 &&
+      oauthCredentials != null &&
+      oauthCredentials!.isExpired();
 
   /// Creates a new context with a freshly generated UUID and current timestamp.
   factory AssistantContext.create({
     required String name,
     required String serverUrl,
     String? authToken,
+    OAuthCredentials? oauthCredentials,
+    AuthMode authMode = AuthMode.legacyToken,
   }) {
     return AssistantContext(
       id: const Uuid().v4(),
       name: name,
       serverUrl: serverUrl,
       authToken: authToken,
+      oauthCredentials: oauthCredentials,
+      authMode: authMode,
       createdAt: DateTime.now().toUtc(),
     );
   }
@@ -50,6 +90,9 @@ class AssistantContext {
     String? serverUrl,
     String? authToken,
     bool clearAuthToken = false,
+    OAuthCredentials? oauthCredentials,
+    bool clearOAuthCredentials = false,
+    AuthMode? authMode,
     DateTime? createdAt,
   }) {
     return AssistantContext(
@@ -57,26 +100,38 @@ class AssistantContext {
       name: name ?? this.name,
       serverUrl: serverUrl ?? this.serverUrl,
       authToken: clearAuthToken ? null : (authToken ?? this.authToken),
+      oauthCredentials: clearOAuthCredentials
+          ? null
+          : (oauthCredentials ?? this.oauthCredentials),
+      authMode: authMode ?? this.authMode,
       createdAt: createdAt ?? this.createdAt,
     );
   }
 
-  /// Serialises metadata only — [authToken] is intentionally excluded.
+  /// Serialises metadata only — secrets ([authToken], [oauthCredentials])
+  /// are intentionally excluded.
   Map<String, dynamic> toJson() => {
     'id': id,
     'name': name,
     'serverUrl': serverUrl,
+    'authMode': authMode.name,
     'createdAt': createdAt.toIso8601String(),
   };
 
-  /// Deserialises from [toJson].  [authToken] is NOT restored here.
+  /// Deserialises from [toJson].  Secrets are NOT restored here.
   factory AssistantContext.fromJson(Map<String, dynamic> json) {
     return AssistantContext(
       id: json['id'] as String,
       name: json['name'] as String,
       serverUrl: json['serverUrl'] as String,
+      authMode: _parseAuthMode(json['authMode'] as String?),
       createdAt: DateTime.parse(json['createdAt'] as String),
     );
+  }
+
+  static AuthMode _parseAuthMode(String? value) {
+    if (value == AuthMode.oauth2.name) return AuthMode.oauth2;
+    return AuthMode.legacyToken;
   }
 
   /// Convenience: encode to a JSON string.

--- a/app/lib/features/login/login_screen.dart
+++ b/app/lib/features/login/login_screen.dart
@@ -2,15 +2,18 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../contexts/models/context_model.dart';
-import '../contexts/providers/context_providers.dart';
 import '../../router/app_router.dart';
+import '../../shared/platform/platform.dart';
+import '../auth/auth_provider.dart';
 
-/// Web-only login screen.
+/// Login mode shown in the UI.
+enum _LoginMode { oauth2, legacyToken }
+
+/// Adaptive login screen supporting both OAuth2 (email + password) and
+/// legacy token authentication.
 ///
-/// Displays the server URL (derived from [Uri.base.origin]) as read-only text
-/// and prompts the user for an optional auth token.  On submit it upserts a
-/// local context and activates it, then navigates to [AppRoutes.chat].
+/// On web, the server URL is derived from the page origin. On native
+/// platforms, the user enters the server URL manually.
 class LoginScreen extends ConsumerStatefulWidget {
   const LoginScreen({super.key});
 
@@ -20,55 +23,82 @@ class LoginScreen extends ConsumerStatefulWidget {
 
 class _LoginScreenState extends ConsumerState<LoginScreen> {
   final _formKey = GlobalKey<FormState>();
+  final _serverCtrl = TextEditingController();
+  final _emailCtrl = TextEditingController();
+  final _passwordCtrl = TextEditingController();
   final _tokenCtrl = TextEditingController();
+  bool _passwordVisible = false;
   bool _tokenVisible = false;
-  bool _saving = false;
+  _LoginMode _mode = _LoginMode.oauth2;
 
-  // Derive server URL from the page origin at runtime.
-  // Uri.base is always available on all platforms; on web it equals
-  // window.location.href, so Uri.base.origin is window.location.origin.
   String get _serverUrl {
-    final base = Uri.base;
-    return '${base.scheme}://${base.host}${base.hasPort && base.port != 80 && base.port != 443 ? ':${base.port}' : ''}';
+    if (isMaterial && _isWebContext) {
+      // On web, derive from page origin.
+      final base = Uri.base;
+      return '${base.scheme}://${base.host}'
+          '${base.hasPort && base.port != 80 && base.port != 443 ? ':${base.port}' : ''}';
+    }
+    return _serverCtrl.text.trim();
   }
 
-  String get _serverHost => Uri.base.host;
+  bool get _isWebContext {
+    try {
+      // Uri.base.host is empty in test environments.
+      return Uri.base.host.isNotEmpty;
+    } catch (_) {
+      return false;
+    }
+  }
 
   @override
   void dispose() {
+    _serverCtrl.dispose();
+    _emailCtrl.dispose();
+    _passwordCtrl.dispose();
     _tokenCtrl.dispose();
     super.dispose();
   }
 
   Future<void> _submit() async {
     if (!_formKey.currentState!.validate()) return;
-    setState(() => _saving = true);
-    try {
-      final token = _tokenCtrl.text.trim();
-      final newCtx = AssistantContext.create(
-        name: _serverHost,
+
+    final loginNotifier = ref.read(oauthLoginProvider.notifier);
+
+    if (_mode == _LoginMode.oauth2) {
+      await loginNotifier.login(
         serverUrl: _serverUrl,
-        authToken: token.isEmpty ? null : token,
+        email: _emailCtrl.text.trim(),
+        password: _passwordCtrl.text,
       );
-      final saved = await ref
-          .read(contextsProvider.notifier)
-          .upsertContextByUrl(newCtx);
-      await ref.read(activeContextProvider.notifier).activate(saved);
-      if (mounted) {
-        GoRouter.of(context).go(AppRoutes.chat);
-      }
-    } finally {
-      if (mounted) setState(() => _saving = false);
+    } else {
+      final token = _tokenCtrl.text.trim();
+      await loginNotifier.legacyLogin(
+        serverUrl: _serverUrl,
+        token: token.isEmpty ? null : token,
+      );
     }
   }
 
   @override
-  Widget build(BuildContext buildContext) {
+  Widget build(BuildContext context) {
+    final loginState = ref.watch(oauthLoginProvider);
+    final isLoading = loginState is OAuthLoginLoading;
+    final loadingMessage = loginState is OAuthLoginLoading
+        ? loginState.message
+        : null;
+
+    // Navigate on success.
+    ref.listen<OAuthLoginState>(oauthLoginProvider, (prev, next) {
+      if (next is OAuthLoginSuccess && mounted) {
+        GoRouter.of(this.context).go(AppRoutes.chat);
+      }
+    });
+
     return Scaffold(
       body: Center(
         child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 400),
-          child: Padding(
+          constraints: const BoxConstraints(maxWidth: 420),
+          child: SingleChildScrollView(
             padding: const EdgeInsets.all(32),
             child: Form(
               key: _formKey,
@@ -78,61 +108,186 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                 children: [
                   Text(
                     'Sign in',
-                    style: Theme.of(buildContext).textTheme.headlineMedium,
+                    style: Theme.of(context).textTheme.headlineMedium,
                   ),
                   const SizedBox(height: 8),
                   Text(
-                    'Enter your API token to connect to this server.',
-                    style: Theme.of(buildContext).textTheme.bodyMedium,
+                    _mode == _LoginMode.oauth2
+                        ? 'Sign in with your email and password.'
+                        : 'Enter an API token to connect.',
+                    style: Theme.of(context).textTheme.bodyMedium,
                   ),
                   const SizedBox(height: 24),
-                  // Read-only server URL.
-                  InputDecorator(
-                    decoration: const InputDecoration(
-                      labelText: 'Server',
-                      border: OutlineInputBorder(),
+
+                  // Server URL — read-only on web, editable on native.
+                  if (_isWebContext)
+                    InputDecorator(
+                      decoration: const InputDecoration(
+                        labelText: 'Server',
+                        border: OutlineInputBorder(),
+                      ),
+                      child: Text(
+                        _serverUrl,
+                        style: Theme.of(context).textTheme.bodyMedium,
+                      ),
+                    )
+                  else
+                    TextFormField(
+                      controller: _serverCtrl,
+                      decoration: const InputDecoration(
+                        labelText: 'Server URL',
+                        hintText: 'http://localhost:8080',
+                        border: OutlineInputBorder(),
+                      ),
+                      keyboardType: TextInputType.url,
+                      textInputAction: TextInputAction.next,
+                      validator: (v) {
+                        if (v == null || v.trim().isEmpty) {
+                          return 'Server URL is required';
+                        }
+                        final uri = Uri.tryParse(v.trim());
+                        if (uri == null || !uri.hasScheme) {
+                          return 'Enter a valid URL (e.g. http://localhost:8080)';
+                        }
+                        return null;
+                      },
                     ),
-                    child: Text(
-                      _serverUrl,
-                      style: Theme.of(buildContext).textTheme.bodyMedium,
-                    ),
-                  ),
                   const SizedBox(height: 16),
-                  // Token input.
-                  TextFormField(
-                    controller: _tokenCtrl,
-                    decoration: InputDecoration(
-                      labelText: 'Token (optional)',
-                      border: const OutlineInputBorder(),
-                      suffixIcon: IconButton(
-                        icon: Icon(
-                          _tokenVisible
-                              ? Icons.visibility_off
-                              : Icons.visibility,
+
+                  // Auth mode fields.
+                  if (_mode == _LoginMode.oauth2) ...[
+                    TextFormField(
+                      controller: _emailCtrl,
+                      decoration: const InputDecoration(
+                        labelText: 'Email',
+                        border: OutlineInputBorder(),
+                      ),
+                      keyboardType: TextInputType.emailAddress,
+                      textInputAction: TextInputAction.next,
+                      autofillHints: const [AutofillHints.email],
+                      validator: (v) {
+                        if (v == null || v.trim().isEmpty) {
+                          return 'Email is required';
+                        }
+                        return null;
+                      },
+                    ),
+                    const SizedBox(height: 16),
+                    TextFormField(
+                      controller: _passwordCtrl,
+                      decoration: InputDecoration(
+                        labelText: 'Password',
+                        border: const OutlineInputBorder(),
+                        suffixIcon: IconButton(
+                          icon: Icon(
+                            _passwordVisible
+                                ? Icons.visibility_off
+                                : Icons.visibility,
+                          ),
+                          onPressed: () => setState(
+                            () => _passwordVisible = !_passwordVisible,
+                          ),
                         ),
-                        onPressed: () =>
-                            setState(() => _tokenVisible = !_tokenVisible),
+                      ),
+                      obscureText: !_passwordVisible,
+                      textInputAction: TextInputAction.done,
+                      autofillHints: const [AutofillHints.password],
+                      validator: (v) {
+                        if (v == null || v.isEmpty) {
+                          return 'Password is required';
+                        }
+                        return null;
+                      },
+                      onFieldSubmitted: (_) => isLoading ? null : _submit(),
+                    ),
+                  ] else ...[
+                    TextFormField(
+                      controller: _tokenCtrl,
+                      decoration: InputDecoration(
+                        labelText: 'Token (optional)',
+                        border: const OutlineInputBorder(),
+                        suffixIcon: IconButton(
+                          icon: Icon(
+                            _tokenVisible
+                                ? Icons.visibility_off
+                                : Icons.visibility,
+                          ),
+                          onPressed: () =>
+                              setState(() => _tokenVisible = !_tokenVisible),
+                        ),
+                      ),
+                      obscureText: !_tokenVisible,
+                      textInputAction: TextInputAction.done,
+                      onFieldSubmitted: (_) => isLoading ? null : _submit(),
+                    ),
+                  ],
+
+                  // Error message.
+                  if (loginState is OAuthLoginError) ...[
+                    const SizedBox(height: 16),
+                    Container(
+                      padding: const EdgeInsets.all(12),
+                      decoration: BoxDecoration(
+                        color: Theme.of(context).colorScheme.errorContainer,
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Text(
+                        loginState.message,
+                        style: TextStyle(
+                          color: Theme.of(context).colorScheme.onErrorContainer,
+                        ),
                       ),
                     ),
-                    obscureText: !_tokenVisible,
-                    textInputAction: TextInputAction.done,
-                    onFieldSubmitted: (_) => _saving ? null : _submit(),
-                  ),
+                  ],
+
                   const SizedBox(height: 24),
+
+                  // Submit button.
                   FilledButton(
-                    onPressed: _saving ? null : _submit,
-                    child: _saving
-                        ? SizedBox(
-                            width: 18,
-                            height: 18,
-                            child: CircularProgressIndicator.adaptive(
-                              strokeWidth: 2,
-                              valueColor: AlwaysStoppedAnimation<Color>(
-                                Theme.of(buildContext).colorScheme.onPrimary,
+                    onPressed: isLoading ? null : _submit,
+                    child: isLoading
+                        ? Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              SizedBox(
+                                width: 18,
+                                height: 18,
+                                child: CircularProgressIndicator.adaptive(
+                                  strokeWidth: 2,
+                                  valueColor: AlwaysStoppedAnimation<Color>(
+                                    Theme.of(context).colorScheme.onPrimary,
+                                  ),
+                                ),
                               ),
-                            ),
+                              if (loadingMessage != null) ...[
+                                const SizedBox(width: 12),
+                                Text(loadingMessage),
+                              ],
+                            ],
                           )
-                        : const Text('Connect'),
+                        : Text(
+                            _mode == _LoginMode.oauth2 ? 'Sign in' : 'Connect',
+                          ),
+                  ),
+
+                  const SizedBox(height: 16),
+
+                  // Mode switcher.
+                  Center(
+                    child: TextButton(
+                      onPressed: isLoading
+                          ? null
+                          : () => setState(() {
+                              _mode = _mode == _LoginMode.oauth2
+                                  ? _LoginMode.legacyToken
+                                  : _LoginMode.oauth2;
+                            }),
+                      child: Text(
+                        _mode == _LoginMode.oauth2
+                            ? 'Use token authentication instead'
+                            : 'Sign in with email and password',
+                      ),
+                    ),
                   ),
                 ],
               ),

--- a/app/test/unit/auth/auth_provider_test.dart
+++ b/app/test/unit/auth/auth_provider_test.dart
@@ -1,0 +1,220 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:assistant_app/features/auth/auth_provider.dart';
+import 'package:assistant_app/features/contexts/data/context_repository.dart';
+import 'package:assistant_app/features/contexts/models/context_model.dart';
+import 'package:assistant_app/features/contexts/providers/context_providers.dart';
+
+class _FakeSecureStorage implements SecureKeyValueStorage {
+  final Map<String, String> _data = {};
+  @override
+  Future<String?> read({required String key}) async => _data[key];
+  @override
+  Future<void> write({required String key, required String value}) async =>
+      _data[key] = value;
+  @override
+  Future<void> delete({required String key}) async => _data.remove(key);
+}
+
+Future<ContextRepository> _makeRepo() async {
+  SharedPreferences.setMockInitialValues({});
+  final p = await SharedPreferences.getInstance();
+  return ContextRepository(prefs: p, secureStorage: _FakeSecureStorage());
+}
+
+ProviderContainer _makeContainer(ContextRepository repo) {
+  return ProviderContainer(
+    overrides: [contextRepositoryProvider.overrideWithValue(repo)],
+  );
+}
+
+void main() {
+  group('OAuthLoginState', () {
+    test('OAuthLoginIdle is an OAuthLoginState', () {
+      const state = OAuthLoginIdle();
+      expect(state, isA<OAuthLoginState>());
+    });
+
+    test('OAuthLoginLoading has default message', () {
+      const state = OAuthLoginLoading();
+      expect(state.message, 'Connecting...');
+    });
+
+    test('OAuthLoginLoading accepts custom message', () {
+      const state = OAuthLoginLoading(message: 'Checking server...');
+      expect(state.message, 'Checking server...');
+    });
+
+    test('OAuthLoginSuccess carries context', () {
+      final ctx = AssistantContext.create(
+        name: 'test',
+        serverUrl: 'http://localhost',
+      );
+      final state = OAuthLoginSuccess(ctx);
+      expect(state.context.name, 'test');
+    });
+
+    test('OAuthLoginError carries message', () {
+      const state = OAuthLoginError('bad credentials');
+      expect(state.message, 'bad credentials');
+    });
+  });
+
+  group('OAuthLoginNotifier', () {
+    test('initial state is OAuthLoginIdle', () async {
+      final repo = await _makeRepo();
+      final container = _makeContainer(repo);
+      addTearDown(container.dispose);
+
+      final state = container.read(oauthLoginProvider);
+      expect(state, isA<OAuthLoginIdle>());
+    });
+
+    group('legacyLogin', () {
+      test('creates context and transitions to Success', () async {
+        final repo = await _makeRepo();
+        final container = _makeContainer(repo);
+        addTearDown(container.dispose);
+
+        final notifier = container.read(oauthLoginProvider.notifier);
+        await notifier.legacyLogin(serverUrl: 'http://localhost:8080');
+
+        final state = container.read(oauthLoginProvider);
+        expect(state, isA<OAuthLoginSuccess>());
+        final success = state as OAuthLoginSuccess;
+        expect(success.context.serverUrl, 'http://localhost:8080');
+        expect(success.context.authMode, AuthMode.legacyToken);
+      });
+
+      test('persists token when provided', () async {
+        final repo = await _makeRepo();
+        final container = _makeContainer(repo);
+        addTearDown(container.dispose);
+
+        final notifier = container.read(oauthLoginProvider.notifier);
+        await notifier.legacyLogin(
+          serverUrl: 'http://localhost:8080',
+          token: 'my-secret',
+        );
+
+        final contexts = await repo.loadContexts();
+        expect(contexts, hasLength(1));
+        expect(contexts.single.authToken, 'my-secret');
+      });
+
+      test('creates context without token when none provided', () async {
+        final repo = await _makeRepo();
+        final container = _makeContainer(repo);
+        addTearDown(container.dispose);
+
+        final notifier = container.read(oauthLoginProvider.notifier);
+        await notifier.legacyLogin(serverUrl: 'http://localhost:8080');
+
+        final contexts = await repo.loadContexts();
+        expect(contexts, hasLength(1));
+        expect(contexts.single.authToken, isNull);
+      });
+
+      test('uses server host as context name', () async {
+        final repo = await _makeRepo();
+        final container = _makeContainer(repo);
+        addTearDown(container.dispose);
+
+        final notifier = container.read(oauthLoginProvider.notifier);
+        await notifier.legacyLogin(
+          serverUrl: 'http://my-server.example.com:9090',
+        );
+
+        final state = container.read(oauthLoginProvider) as OAuthLoginSuccess;
+        expect(state.context.name, 'my-server.example.com');
+      });
+
+      test('activates context as the active context', () async {
+        final repo = await _makeRepo();
+        final container = _makeContainer(repo);
+        addTearDown(container.dispose);
+
+        final notifier = container.read(oauthLoginProvider.notifier);
+        await notifier.legacyLogin(serverUrl: 'http://localhost:8080');
+
+        final activeId = repo.getActiveContextId();
+        expect(activeId, isNotNull);
+
+        final state = container.read(oauthLoginProvider) as OAuthLoginSuccess;
+        expect(activeId, state.context.id);
+      });
+
+      test('upserts existing context with same URL', () async {
+        final repo = await _makeRepo();
+        final container = _makeContainer(repo);
+        addTearDown(container.dispose);
+
+        final notifier = container.read(oauthLoginProvider.notifier);
+
+        // First login.
+        await notifier.legacyLogin(
+          serverUrl: 'http://localhost:8080',
+          token: 'v1',
+        );
+        final firstId =
+            (container.read(oauthLoginProvider) as OAuthLoginSuccess)
+                .context
+                .id;
+
+        // Second login to same URL.
+        await notifier.legacyLogin(
+          serverUrl: 'http://localhost:8080',
+          token: 'v2',
+        );
+        final secondId =
+            (container.read(oauthLoginProvider) as OAuthLoginSuccess)
+                .context
+                .id;
+
+        // Same context was updated (same ID), not duplicated.
+        expect(firstId, secondId);
+        final contexts = await repo.loadContexts();
+        expect(contexts, hasLength(1));
+        expect(contexts.single.authToken, 'v2');
+      });
+
+      test('different URLs create separate contexts', () async {
+        final repo = await _makeRepo();
+        final container = _makeContainer(repo);
+        addTearDown(container.dispose);
+
+        final notifier = container.read(oauthLoginProvider.notifier);
+
+        await notifier.legacyLogin(serverUrl: 'http://server-a:8080');
+        await notifier.legacyLogin(serverUrl: 'http://server-b:9090');
+
+        final contexts = await repo.loadContexts();
+        expect(contexts, hasLength(2));
+      });
+    });
+
+    group('state transitions', () {
+      test('legacyLogin emits Loading then Success', () async {
+        final repo = await _makeRepo();
+        final container = _makeContainer(repo);
+        addTearDown(container.dispose);
+
+        final states = <OAuthLoginState>[];
+        container.listen(oauthLoginProvider, (prev, next) {
+          states.add(next);
+        });
+
+        final notifier = container.read(oauthLoginProvider.notifier);
+        await notifier.legacyLogin(serverUrl: 'http://localhost:8080');
+
+        // Should have gone through Loading → Success.
+        expect(states.length, greaterThanOrEqualTo(2));
+        expect(states.first, isA<OAuthLoginLoading>());
+        expect((states.first as OAuthLoginLoading).message, 'Connecting...');
+        expect(states.last, isA<OAuthLoginSuccess>());
+      });
+    });
+  });
+}

--- a/app/test/unit/auth/oauth_credentials_test.dart
+++ b/app/test/unit/auth/oauth_credentials_test.dart
@@ -1,0 +1,192 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/features/auth/oauth_credentials.dart';
+
+void main() {
+  OAuthCredentials makeCreds({
+    String accessToken = 'access_123',
+    String refreshToken = 'refresh_456',
+    DateTime? expiresAt,
+    String clientId = 'client_abc',
+  }) {
+    return OAuthCredentials(
+      accessToken: accessToken,
+      refreshToken: refreshToken,
+      expiresAt: expiresAt ?? DateTime.utc(2026, 6, 1, 12, 0, 0),
+      clientId: clientId,
+    );
+  }
+
+  group('OAuthCredentials', () {
+    group('isExpired', () {
+      test('returns false when token has not expired', () {
+        final creds = makeCreds(
+          expiresAt: DateTime.now().toUtc().add(const Duration(hours: 1)),
+        );
+        expect(creds.isExpired(), isFalse);
+      });
+
+      test('returns true when token has expired', () {
+        final creds = makeCreds(
+          expiresAt: DateTime.now().toUtc().subtract(
+            const Duration(minutes: 5),
+          ),
+        );
+        expect(creds.isExpired(), isTrue);
+      });
+
+      test('returns true when token expires within default buffer (60s)', () {
+        final creds = makeCreds(
+          expiresAt: DateTime.now().toUtc().add(const Duration(seconds: 30)),
+        );
+        expect(creds.isExpired(), isTrue);
+      });
+
+      test('respects custom buffer', () {
+        final creds = makeCreds(
+          expiresAt: DateTime.now().toUtc().add(const Duration(seconds: 30)),
+        );
+        // With a 10-second buffer, 30 seconds of remaining life is sufficient.
+        expect(creds.isExpired(buffer: const Duration(seconds: 10)), isFalse);
+      });
+
+      test('returns true at exact expiry time', () {
+        final creds = makeCreds(expiresAt: DateTime.now().toUtc());
+        expect(creds.isExpired(buffer: Duration.zero), isTrue);
+      });
+    });
+
+    group('bearerToken', () {
+      test('returns the access token', () {
+        final creds = makeCreds(accessToken: 'jwt_token_here');
+        expect(creds.bearerToken, 'jwt_token_here');
+      });
+    });
+
+    group('JSON serialization', () {
+      test('round-trips through toJson/fromJson', () {
+        final original = makeCreds();
+        final json = original.toJson();
+        final restored = OAuthCredentials.fromJson(json);
+
+        expect(restored.accessToken, original.accessToken);
+        expect(restored.refreshToken, original.refreshToken);
+        expect(restored.expiresAt, original.expiresAt);
+        expect(restored.clientId, original.clientId);
+      });
+
+      test('round-trips through toJsonString/fromJsonString', () {
+        final original = makeCreds();
+        final jsonStr = original.toJsonString();
+        final restored = OAuthCredentials.fromJsonString(jsonStr);
+
+        expect(restored, original);
+      });
+
+      test('toJson produces expected keys', () {
+        final creds = makeCreds();
+        final json = creds.toJson();
+
+        expect(json, containsPair('accessToken', 'access_123'));
+        expect(json, containsPair('refreshToken', 'refresh_456'));
+        expect(json, containsPair('clientId', 'client_abc'));
+        expect(json, contains('expiresAt'));
+      });
+
+      test('toJsonString produces valid JSON', () {
+        final creds = makeCreds();
+        final jsonStr = creds.toJsonString();
+        final decoded = jsonDecode(jsonStr) as Map<String, dynamic>;
+
+        expect(decoded, isA<Map<String, dynamic>>());
+        expect(decoded['accessToken'], 'access_123');
+      });
+    });
+
+    group('copyWith', () {
+      test('copies all fields when none specified', () {
+        final original = makeCreds();
+        final copy = original.copyWith();
+
+        expect(copy, original);
+      });
+
+      test('replaces accessToken', () {
+        final original = makeCreds();
+        final copy = original.copyWith(accessToken: 'new_token');
+
+        expect(copy.accessToken, 'new_token');
+        expect(copy.refreshToken, original.refreshToken);
+        expect(copy.clientId, original.clientId);
+      });
+
+      test('replaces refreshToken', () {
+        final original = makeCreds();
+        final copy = original.copyWith(refreshToken: 'new_refresh');
+
+        expect(copy.refreshToken, 'new_refresh');
+        expect(copy.accessToken, original.accessToken);
+      });
+
+      test('replaces expiresAt', () {
+        final original = makeCreds();
+        final newExpiry = DateTime.utc(2027, 1, 1);
+        final copy = original.copyWith(expiresAt: newExpiry);
+
+        expect(copy.expiresAt, newExpiry);
+      });
+
+      test('replaces clientId', () {
+        final original = makeCreds();
+        final copy = original.copyWith(clientId: 'other_client');
+
+        expect(copy.clientId, 'other_client');
+      });
+    });
+
+    group('equality', () {
+      test('equal when all fields match', () {
+        final a = makeCreds();
+        final b = makeCreds();
+
+        expect(a, b);
+        expect(a.hashCode, b.hashCode);
+      });
+
+      test('not equal when accessToken differs', () {
+        final a = makeCreds(accessToken: 'a');
+        final b = makeCreds(accessToken: 'b');
+
+        expect(a, isNot(b));
+      });
+
+      test('not equal when refreshToken differs', () {
+        final a = makeCreds(refreshToken: 'a');
+        final b = makeCreds(refreshToken: 'b');
+
+        expect(a, isNot(b));
+      });
+
+      test('not equal when clientId differs', () {
+        final a = makeCreds(clientId: 'a');
+        final b = makeCreds(clientId: 'b');
+
+        expect(a, isNot(b));
+      });
+    });
+
+    group('toString', () {
+      test('does not expose tokens', () {
+        final creds = makeCreds();
+        final str = creds.toString();
+
+        expect(str, contains('clientId'));
+        expect(str, contains('expiresAt'));
+        expect(str, isNot(contains('access_123')));
+        expect(str, isNot(contains('refresh_456')));
+      });
+    });
+  });
+}

--- a/app/test/unit/auth/oauth_service_test.dart
+++ b/app/test/unit/auth/oauth_service_test.dart
@@ -1,0 +1,425 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/features/auth/oauth_service.dart';
+import 'package:assistant_app/features/auth/pkce.dart';
+
+/// A Dio interceptor that captures requests and returns canned responses.
+class MockInterceptor extends Interceptor {
+  final List<RequestOptions> requests = [];
+  final Map<String, MockResponse> _responses = {};
+
+  void when(String path, {required MockResponse respond}) {
+    _responses[path] = respond;
+  }
+
+  @override
+  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
+    requests.add(options);
+    final key = options.path;
+    final mock = _responses[key];
+    if (mock != null) {
+      if (mock.error != null) {
+        handler.reject(
+          DioException(
+            requestOptions: options,
+            response: Response(
+              requestOptions: options,
+              statusCode: mock.statusCode,
+              data: mock.data,
+            ),
+            type: DioExceptionType.badResponse,
+          ),
+        );
+      } else {
+        handler.resolve(
+          Response(
+            requestOptions: options,
+            statusCode: mock.statusCode,
+            data: mock.data,
+            headers: mock.headers != null
+                ? Headers.fromMap(mock.headers!.map((k, v) => MapEntry(k, [v])))
+                : Headers(),
+          ),
+        );
+      }
+    } else {
+      handler.reject(
+        DioException(
+          requestOptions: options,
+          type: DioExceptionType.connectionError,
+          error: 'No mock configured for $key',
+        ),
+      );
+    }
+  }
+}
+
+class MockResponse {
+  const MockResponse({
+    this.statusCode = 200,
+    this.data,
+    this.headers,
+    this.error,
+  });
+
+  final int statusCode;
+  final dynamic data;
+  final Map<String, String>? headers;
+  final String? error;
+}
+
+void main() {
+  late Dio dio;
+  late MockInterceptor mock;
+  late OAuthService service;
+
+  setUp(() {
+    dio = Dio(BaseOptions(baseUrl: 'http://localhost:8080'));
+    mock = MockInterceptor();
+    dio.interceptors.add(mock);
+    service = OAuthService(serverUrl: 'http://localhost:8080', dio: dio);
+  });
+
+  group('OAuthService', () {
+    group('registerClient', () {
+      test('posts registration and returns client_id', () async {
+        mock.when(
+          '/oauth/register',
+          respond: const MockResponse(
+            statusCode: 200,
+            data: {
+              'client_id': 'new_client_123',
+              'client_name': 'Test App',
+              'grant_types': ['authorization_code', 'refresh_token'],
+              'redirect_uris': ['http://localhost:4040/callback'],
+              'token_endpoint_auth_method': 'none',
+            },
+          ),
+        );
+
+        final clientId = await service.registerClient(
+          clientName: 'Test App',
+          redirectUris: ['http://localhost:4040/callback'],
+        );
+
+        expect(clientId, 'new_client_123');
+        expect(mock.requests, hasLength(1));
+        expect(mock.requests.first.path, '/oauth/register');
+        expect(mock.requests.first.method, 'POST');
+      });
+
+      test('throws on server error', () async {
+        mock.when(
+          '/oauth/register',
+          respond: const MockResponse(
+            statusCode: 400,
+            data: {'error': 'invalid_request'},
+            error: 'bad request',
+          ),
+        );
+
+        expect(
+          () => service.registerClient(
+            clientName: 'Bad',
+            redirectUris: ['http://localhost/cb'],
+          ),
+          throwsA(isA<DioException>()),
+        );
+      });
+    });
+
+    group('buildAuthorizationUrl', () {
+      test('constructs correct URL with all parameters', () {
+        final pkce = PkceChallenge.generate();
+        final url = service.buildAuthorizationUrl(
+          clientId: 'client_1',
+          redirectUri: 'http://localhost:4040/callback',
+          pkce: pkce,
+          state: 'random_state',
+          scope: 'personas:read conversations:write',
+        );
+
+        expect(url.scheme, 'http');
+        expect(url.host, 'localhost');
+        expect(url.port, 8080);
+        expect(url.path, '/oauth/authorize');
+        expect(url.queryParameters['response_type'], 'code');
+        expect(url.queryParameters['client_id'], 'client_1');
+        expect(
+          url.queryParameters['redirect_uri'],
+          'http://localhost:4040/callback',
+        );
+        expect(url.queryParameters['code_challenge'], pkce.challenge);
+        expect(url.queryParameters['code_challenge_method'], 'S256');
+        expect(url.queryParameters['state'], 'random_state');
+        expect(
+          url.queryParameters['scope'],
+          'personas:read conversations:write',
+        );
+      });
+
+      test('omits optional parameters when null', () {
+        final pkce = PkceChallenge.generate();
+        final url = service.buildAuthorizationUrl(
+          clientId: 'client_1',
+          redirectUri: 'http://localhost/cb',
+          pkce: pkce,
+        );
+
+        expect(url.queryParameters, isNot(contains('state')));
+        expect(url.queryParameters, isNot(contains('scope')));
+      });
+    });
+
+    group('exchangeCode', () {
+      test('exchanges auth code for credentials', () async {
+        mock.when(
+          '/oauth/token',
+          respond: const MockResponse(
+            statusCode: 200,
+            data: {
+              'access_token': 'jwt_access_token',
+              'refresh_token': 'rt_refresh_token',
+              'token_type': 'Bearer',
+              'expires_in': 3600,
+            },
+          ),
+        );
+
+        final creds = await service.exchangeCode(
+          code: 'auth_code_123',
+          clientId: 'client_1',
+          redirectUri: 'http://localhost/cb',
+          pkceVerifier: 'verifier_abc',
+        );
+
+        expect(creds.accessToken, 'jwt_access_token');
+        expect(creds.refreshToken, 'rt_refresh_token');
+        expect(creds.clientId, 'client_1');
+        expect(creds.expiresAt.isAfter(DateTime.now().toUtc()), isTrue);
+
+        final req = mock.requests.first;
+        expect(req.path, '/oauth/token');
+        expect(req.data, containsPair('grant_type', 'authorization_code'));
+        expect(req.data, containsPair('code', 'auth_code_123'));
+        expect(req.data, containsPair('code_verifier', 'verifier_abc'));
+      });
+
+      test('throws OAuthException when no refresh token returned', () async {
+        mock.when(
+          '/oauth/token',
+          respond: const MockResponse(
+            statusCode: 200,
+            data: {
+              'access_token': 'jwt',
+              'token_type': 'Bearer',
+              'expires_in': 3600,
+            },
+          ),
+        );
+
+        expect(
+          () => service.exchangeCode(
+            code: 'code',
+            clientId: 'c',
+            redirectUri: 'http://localhost/cb',
+            pkceVerifier: 'v',
+          ),
+          throwsA(isA<OAuthException>()),
+        );
+      });
+    });
+
+    group('login', () {
+      test('posts credentials and exchanges code for tokens', () async {
+        // Step 1: POST /oauth/authorize returns redirect with code
+        mock.when(
+          '/oauth/authorize',
+          respond: const MockResponse(
+            statusCode: 302,
+            data: null,
+            headers: {'location': 'http://localhost/cb?code=code_xyz&state=s'},
+          ),
+        );
+
+        // Step 2: POST /oauth/token returns tokens
+        mock.when(
+          '/oauth/token',
+          respond: const MockResponse(
+            statusCode: 200,
+            data: {
+              'access_token': 'at_login',
+              'refresh_token': 'rt_login',
+              'token_type': 'Bearer',
+              'expires_in': 3600,
+            },
+          ),
+        );
+
+        final pkce = PkceChallenge.generate();
+        final creds = await service.login(
+          email: 'alice@example.com',
+          password: 'secret',
+          clientId: 'client_1',
+          redirectUri: 'http://localhost/cb',
+          pkce: pkce,
+        );
+
+        expect(creds.accessToken, 'at_login');
+        expect(creds.refreshToken, 'rt_login');
+        expect(creds.clientId, 'client_1');
+
+        // Verify auth request included credentials
+        final authReq = mock.requests.firstWhere(
+          (r) => r.path == '/oauth/authorize',
+        );
+        expect(authReq.data, containsPair('email', 'alice@example.com'));
+        expect(authReq.data, containsPair('password', 'secret'));
+        expect(authReq.data, containsPair('code_challenge', pkce.challenge));
+
+        // Verify token request used correct code
+        final tokenReq = mock.requests.firstWhere(
+          (r) => r.path == '/oauth/token',
+        );
+        expect(tokenReq.data, containsPair('code', 'code_xyz'));
+        expect(tokenReq.data, containsPair('code_verifier', pkce.verifier));
+      });
+
+      test('throws OAuthException when redirect has no code', () async {
+        mock.when(
+          '/oauth/authorize',
+          respond: const MockResponse(
+            statusCode: 302,
+            headers: {
+              'location':
+                  'http://localhost/cb?error=access_denied&error_description=Bad+creds',
+            },
+          ),
+        );
+
+        final pkce = PkceChallenge.generate();
+        expect(
+          () => service.login(
+            email: 'bad@example.com',
+            password: 'wrong',
+            clientId: 'c',
+            redirectUri: 'http://localhost/cb',
+            pkce: pkce,
+          ),
+          throwsA(
+            isA<OAuthException>().having(
+              (e) => e.message,
+              'message',
+              contains('access_denied'),
+            ),
+          ),
+        );
+      });
+
+      test('throws OAuthException when no Location header', () async {
+        mock.when(
+          '/oauth/authorize',
+          respond: const MockResponse(statusCode: 200, data: 'OK'),
+        );
+
+        final pkce = PkceChallenge.generate();
+        expect(
+          () => service.login(
+            email: 'a@b.com',
+            password: 'p',
+            clientId: 'c',
+            redirectUri: 'http://localhost/cb',
+            pkce: pkce,
+          ),
+          throwsA(isA<OAuthException>()),
+        );
+      });
+    });
+
+    group('refresh', () {
+      test('exchanges refresh token for new credentials', () async {
+        mock.when(
+          '/oauth/token',
+          respond: const MockResponse(
+            statusCode: 200,
+            data: {
+              'access_token': 'at_refreshed',
+              'refresh_token': 'rt_rotated',
+              'token_type': 'Bearer',
+              'expires_in': 3600,
+            },
+          ),
+        );
+
+        final creds = await service.refresh(
+          refreshToken: 'rt_old',
+          clientId: 'client_1',
+        );
+
+        expect(creds.accessToken, 'at_refreshed');
+        expect(creds.refreshToken, 'rt_rotated');
+
+        final req = mock.requests.first;
+        expect(req.data, containsPair('grant_type', 'refresh_token'));
+        expect(req.data, containsPair('refresh_token', 'rt_old'));
+      });
+
+      test('throws DioException on 401 (revoked token)', () async {
+        mock.when(
+          '/oauth/token',
+          respond: const MockResponse(
+            statusCode: 401,
+            data: {'error': 'invalid_grant'},
+            error: 'unauthorized',
+          ),
+        );
+
+        expect(
+          () => service.refresh(refreshToken: 'bad', clientId: 'c'),
+          throwsA(isA<DioException>()),
+        );
+      });
+    });
+
+    group('revoke', () {
+      test('posts revocation request', () async {
+        mock.when(
+          '/oauth/revoke',
+          respond: const MockResponse(statusCode: 200),
+        );
+
+        await service.revoke(token: 'rt_to_revoke', clientId: 'client_1');
+
+        expect(mock.requests, hasLength(1));
+        final req = mock.requests.first;
+        expect(req.path, '/oauth/revoke');
+        expect(req.data, containsPair('token', 'rt_to_revoke'));
+        expect(req.data, containsPair('token_type_hint', 'refresh_token'));
+      });
+    });
+
+    group('supportsOAuth', () {
+      test('returns true when metadata endpoint responds 200', () async {
+        mock.when(
+          '/.well-known/oauth-authorization-server',
+          respond: const MockResponse(
+            statusCode: 200,
+            data: {'issuer': 'http://localhost:8080'},
+          ),
+        );
+
+        expect(await service.supportsOAuth(), isTrue);
+      });
+
+      test('returns false when metadata endpoint fails', () async {
+        mock.when(
+          '/.well-known/oauth-authorization-server',
+          respond: const MockResponse(statusCode: 404, error: 'not found'),
+        );
+
+        expect(await service.supportsOAuth(), isFalse);
+      });
+    });
+  });
+}

--- a/app/test/unit/auth/pkce_test.dart
+++ b/app/test/unit/auth/pkce_test.dart
@@ -1,0 +1,110 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/features/auth/pkce.dart';
+
+void main() {
+  group('PkceChallenge', () {
+    group('generate', () {
+      test('produces a non-empty verifier', () {
+        final pkce = PkceChallenge.generate();
+        expect(pkce.verifier, isNotEmpty);
+      });
+
+      test('produces a non-empty challenge', () {
+        final pkce = PkceChallenge.generate();
+        expect(pkce.challenge, isNotEmpty);
+      });
+
+      test('verifier is base64url-encoded without padding', () {
+        final pkce = PkceChallenge.generate();
+        expect(pkce.verifier, isNot(contains('=')));
+        // base64url alphabet: A-Z, a-z, 0-9, -, _
+        expect(pkce.verifier, matches(RegExp(r'^[A-Za-z0-9_-]+$')));
+      });
+
+      test('challenge is base64url-encoded without padding', () {
+        final pkce = PkceChallenge.generate();
+        expect(pkce.challenge, isNot(contains('=')));
+        expect(pkce.challenge, matches(RegExp(r'^[A-Za-z0-9_-]+$')));
+      });
+
+      test(
+        'default verifier has expected length (~43 chars from 32 bytes)',
+        () {
+          final pkce = PkceChallenge.generate();
+          // 32 bytes → ceil(32*4/3) = 43 base64 chars (no padding)
+          expect(pkce.verifier.length, 43);
+        },
+      );
+
+      test('challenge is always 43 chars (SHA-256 → 32 bytes → base64url)', () {
+        final pkce = PkceChallenge.generate();
+        expect(pkce.challenge.length, 43);
+      });
+
+      test('custom length produces different verifier length', () {
+        final pkce = PkceChallenge.generate(length: 64);
+        // 64 bytes → ceil(64*4/3) = 86 base64 chars (no padding)
+        expect(pkce.verifier.length, 86);
+        // challenge is still 43 (always SHA-256 output)
+        expect(pkce.challenge.length, 43);
+      });
+
+      test('generates unique verifiers on each call', () {
+        final a = PkceChallenge.generate();
+        final b = PkceChallenge.generate();
+        expect(a.verifier, isNot(a.challenge));
+        expect(a.verifier, isNot(b.verifier));
+      });
+
+      test('generates unique challenges on each call', () {
+        final a = PkceChallenge.generate();
+        final b = PkceChallenge.generate();
+        expect(a.challenge, isNot(b.challenge));
+      });
+    });
+
+    group('S256 correctness', () {
+      test('challenge equals BASE64URL(SHA256(verifier))', () {
+        final pkce = PkceChallenge.generate();
+
+        // Manually compute expected challenge.
+        final digest = sha256.convert(utf8.encode(pkce.verifier));
+        final expected = base64UrlEncode(digest.bytes).replaceAll('=', '');
+
+        expect(pkce.challenge, expected);
+      });
+
+      test('deriveChallenge matches generated challenge', () {
+        final pkce = PkceChallenge.generate();
+        final derived = PkceChallenge.deriveChallenge(pkce.verifier);
+        expect(derived, pkce.challenge);
+      });
+
+      test('known test vector', () {
+        // RFC 7636 Appendix B test vector:
+        // verifier: dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk
+        // expected challenge: E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM
+        const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+        const expected = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+
+        final challenge = PkceChallenge.deriveChallenge(verifier);
+        expect(challenge, expected);
+      });
+    });
+
+    group('toString', () {
+      test('includes truncated verifier', () {
+        final pkce = PkceChallenge.generate();
+        final str = pkce.toString();
+        expect(str, contains('PkceChallenge'));
+        expect(str, contains('...'));
+        // Should not contain full verifier
+        expect(str, isNot(contains(pkce.verifier)));
+      });
+    });
+  });
+}

--- a/app/test/unit/contexts/context_model_test.dart
+++ b/app/test/unit/contexts/context_model_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:assistant_app/features/auth/oauth_credentials.dart';
 import 'package:assistant_app/features/contexts/models/context_model.dart';
 
 void main() {
@@ -116,6 +117,212 @@ void main() {
       final after = DateTime.now().toUtc().add(const Duration(seconds: 1));
       expect(ctx.createdAt.isAfter(before), isTrue);
       expect(ctx.createdAt.isBefore(after), isTrue);
+    });
+
+    // -- AuthMode ---------------------------------------------------------------
+
+    test('default authMode is legacyToken', () {
+      final ctx = makeCtx();
+      expect(ctx.authMode, AuthMode.legacyToken);
+    });
+
+    test('create() accepts authMode parameter', () {
+      final ctx = AssistantContext.create(
+        name: 'Test',
+        serverUrl: 'http://localhost',
+        authMode: AuthMode.oauth2,
+      );
+      expect(ctx.authMode, AuthMode.oauth2);
+    });
+
+    test('toJson includes authMode', () {
+      final ctx = AssistantContext.create(
+        name: 'Test',
+        serverUrl: 'http://localhost',
+        authMode: AuthMode.oauth2,
+      );
+      expect(ctx.toJson()['authMode'], 'oauth2');
+    });
+
+    test('fromJson restores authMode', () {
+      final ctx = AssistantContext.create(
+        name: 'Test',
+        serverUrl: 'http://localhost',
+        authMode: AuthMode.oauth2,
+      );
+      final restored = AssistantContext.fromJson(ctx.toJson());
+      expect(restored.authMode, AuthMode.oauth2);
+    });
+
+    test('fromJson defaults to legacyToken when authMode is missing', () {
+      final json = {
+        'id': 'old-ctx',
+        'name': 'Old',
+        'serverUrl': 'http://old.example.com',
+        'createdAt': DateTime.now().toUtc().toIso8601String(),
+      };
+      final restored = AssistantContext.fromJson(json);
+      expect(restored.authMode, AuthMode.legacyToken);
+    });
+
+    test('toJson omits oauthCredentials', () {
+      final creds = OAuthCredentials(
+        accessToken: 'at',
+        refreshToken: 'rt',
+        expiresAt: DateTime.now().toUtc(),
+        clientId: 'cid',
+      );
+      final ctx = AssistantContext.create(
+        name: 'Test',
+        serverUrl: 'http://localhost',
+        oauthCredentials: creds,
+        authMode: AuthMode.oauth2,
+      );
+      final json = ctx.toJson();
+      expect(json.containsKey('oauthCredentials'), isFalse);
+    });
+
+    // -- effectiveToken ---------------------------------------------------------
+
+    test('effectiveToken returns authToken for legacyToken mode', () {
+      final ctx = makeCtx(authToken: 'legacy-tok');
+      expect(ctx.effectiveToken, 'legacy-tok');
+    });
+
+    test('effectiveToken returns null when legacyToken has no token', () {
+      final ctx = makeCtx();
+      expect(ctx.effectiveToken, isNull);
+    });
+
+    test('effectiveToken returns accessToken for oauth2 mode', () {
+      final creds = OAuthCredentials(
+        accessToken: 'oauth-access',
+        refreshToken: 'rt',
+        expiresAt: DateTime.now().toUtc().add(const Duration(hours: 1)),
+        clientId: 'cid',
+      );
+      final ctx = AssistantContext(
+        id: 'test',
+        name: 'Test',
+        serverUrl: 'http://localhost',
+        oauthCredentials: creds,
+        authMode: AuthMode.oauth2,
+        createdAt: DateTime.now().toUtc(),
+      );
+      expect(ctx.effectiveToken, 'oauth-access');
+    });
+
+    test('effectiveToken falls back to authToken when oauth2 has no creds', () {
+      final ctx = AssistantContext(
+        id: 'test',
+        name: 'Test',
+        serverUrl: 'http://localhost',
+        authToken: 'fallback',
+        authMode: AuthMode.oauth2,
+        createdAt: DateTime.now().toUtc(),
+      );
+      expect(ctx.effectiveToken, 'fallback');
+    });
+
+    // -- needsTokenRefresh ------------------------------------------------------
+
+    test('needsTokenRefresh is false for legacyToken mode', () {
+      final ctx = makeCtx(authToken: 'tok');
+      expect(ctx.needsTokenRefresh, isFalse);
+    });
+
+    test('needsTokenRefresh is false when oauth2 creds are not expired', () {
+      final creds = OAuthCredentials(
+        accessToken: 'at',
+        refreshToken: 'rt',
+        expiresAt: DateTime.now().toUtc().add(const Duration(hours: 1)),
+        clientId: 'cid',
+      );
+      final ctx = AssistantContext(
+        id: 'test',
+        name: 'Test',
+        serverUrl: 'http://localhost',
+        oauthCredentials: creds,
+        authMode: AuthMode.oauth2,
+        createdAt: DateTime.now().toUtc(),
+      );
+      expect(ctx.needsTokenRefresh, isFalse);
+    });
+
+    test('needsTokenRefresh is true when oauth2 creds are expired', () {
+      final creds = OAuthCredentials(
+        accessToken: 'at',
+        refreshToken: 'rt',
+        expiresAt: DateTime.now().toUtc().subtract(const Duration(hours: 1)),
+        clientId: 'cid',
+      );
+      final ctx = AssistantContext(
+        id: 'test',
+        name: 'Test',
+        serverUrl: 'http://localhost',
+        oauthCredentials: creds,
+        authMode: AuthMode.oauth2,
+        createdAt: DateTime.now().toUtc(),
+      );
+      expect(ctx.needsTokenRefresh, isTrue);
+    });
+
+    test('needsTokenRefresh is false when oauth2 has no creds', () {
+      final ctx = AssistantContext(
+        id: 'test',
+        name: 'Test',
+        serverUrl: 'http://localhost',
+        authMode: AuthMode.oauth2,
+        createdAt: DateTime.now().toUtc(),
+      );
+      expect(ctx.needsTokenRefresh, isFalse);
+    });
+
+    // -- copyWith with OAuth fields -------------------------------------------
+
+    test('copyWith preserves oauthCredentials', () {
+      final creds = OAuthCredentials(
+        accessToken: 'at',
+        refreshToken: 'rt',
+        expiresAt: DateTime.now().toUtc(),
+        clientId: 'cid',
+      );
+      final ctx = AssistantContext(
+        id: 'test',
+        name: 'Test',
+        serverUrl: 'http://localhost',
+        oauthCredentials: creds,
+        authMode: AuthMode.oauth2,
+        createdAt: DateTime.now().toUtc(),
+      );
+      final copy = ctx.copyWith(name: 'Updated');
+      expect(copy.oauthCredentials, creds);
+      expect(copy.authMode, AuthMode.oauth2);
+    });
+
+    test('copyWith with clearOAuthCredentials removes creds', () {
+      final creds = OAuthCredentials(
+        accessToken: 'at',
+        refreshToken: 'rt',
+        expiresAt: DateTime.now().toUtc(),
+        clientId: 'cid',
+      );
+      final ctx = AssistantContext(
+        id: 'test',
+        name: 'Test',
+        serverUrl: 'http://localhost',
+        oauthCredentials: creds,
+        authMode: AuthMode.oauth2,
+        createdAt: DateTime.now().toUtc(),
+      );
+      final cleared = ctx.copyWith(clearOAuthCredentials: true);
+      expect(cleared.oauthCredentials, isNull);
+    });
+
+    test('copyWith can change authMode', () {
+      final ctx = makeCtx();
+      final updated = ctx.copyWith(authMode: AuthMode.oauth2);
+      expect(updated.authMode, AuthMode.oauth2);
     });
   });
 }

--- a/app/test/widget/login/login_screen_test.dart
+++ b/app/test/widget/login/login_screen_test.dart
@@ -40,101 +40,226 @@ Widget _buildSubject(ContextRepository repo) {
   );
 }
 
+/// Switches the login screen to legacy token mode by tapping the mode toggle.
+Future<void> _switchToLegacyMode(WidgetTester tester) async {
+  await tester.tap(find.text('Use token authentication instead'));
+  await tester.pumpAndSettle();
+}
+
+/// Enters a valid server URL so form validation passes in test (non-web).
+Future<void> _enterServerUrl(
+  WidgetTester tester, [
+  String url = 'http://localhost:8080',
+]) async {
+  await tester.enterText(find.widgetWithText(TextFormField, 'Server URL'), url);
+}
+
 void main() {
   group('LoginScreen', () {
-    testWidgets('renders server URL as read-only text', (tester) async {
-      final repo = await _makeRepo();
-      await tester.pumpWidget(_buildSubject(repo));
-      await tester.pumpAndSettle();
+    group('OAuth2 mode (default)', () {
+      testWidgets('renders Sign in heading', (tester) async {
+        final repo = await _makeRepo();
+        await tester.pumpWidget(_buildSubject(repo));
+        await tester.pumpAndSettle();
 
-      // The InputDecorator shows a 'Server' label.
-      expect(find.text('Server'), findsOneWidget);
+        expect(find.text('Sign in'), findsWidgets);
+      });
+
+      testWidgets('renders email and password fields', (tester) async {
+        final repo = await _makeRepo();
+        await tester.pumpWidget(_buildSubject(repo));
+        await tester.pumpAndSettle();
+
+        expect(find.widgetWithText(TextFormField, 'Email'), findsOneWidget);
+        expect(find.widgetWithText(TextFormField, 'Password'), findsOneWidget);
+      });
+
+      testWidgets('renders Sign in button', (tester) async {
+        final repo = await _makeRepo();
+        await tester.pumpWidget(_buildSubject(repo));
+        await tester.pumpAndSettle();
+
+        expect(find.widgetWithText(FilledButton, 'Sign in'), findsOneWidget);
+      });
+
+      testWidgets('shows mode switcher to legacy token', (tester) async {
+        final repo = await _makeRepo();
+        await tester.pumpWidget(_buildSubject(repo));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Use token authentication instead'), findsOneWidget);
+      });
+
+      testWidgets('validates empty email', (tester) async {
+        final repo = await _makeRepo();
+        await tester.pumpWidget(_buildSubject(repo));
+        await tester.pumpAndSettle();
+
+        // Leave email empty, enter password.
+        await tester.enterText(
+          find.widgetWithText(TextFormField, 'Password'),
+          'secret',
+        );
+        await tester.tap(find.widgetWithText(FilledButton, 'Sign in'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Email is required'), findsOneWidget);
+      });
+
+      testWidgets('validates empty password', (tester) async {
+        final repo = await _makeRepo();
+        await tester.pumpWidget(_buildSubject(repo));
+        await tester.pumpAndSettle();
+
+        // Enter email, leave password empty.
+        await tester.enterText(
+          find.widgetWithText(TextFormField, 'Email'),
+          'alice@example.com',
+        );
+        await tester.tap(find.widgetWithText(FilledButton, 'Sign in'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Password is required'), findsOneWidget);
+      });
     });
 
-    testWidgets('renders token input field', (tester) async {
-      final repo = await _makeRepo();
-      await tester.pumpWidget(_buildSubject(repo));
-      await tester.pumpAndSettle();
+    group('legacy token mode', () {
+      testWidgets('renders token input after switching mode', (tester) async {
+        final repo = await _makeRepo();
+        await tester.pumpWidget(_buildSubject(repo));
+        await tester.pumpAndSettle();
+        await _switchToLegacyMode(tester);
 
-      expect(
-        find.widgetWithText(TextFormField, 'Token (optional)'),
-        findsOneWidget,
-      );
+        expect(
+          find.widgetWithText(TextFormField, 'Token (optional)'),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('renders Connect button', (tester) async {
+        final repo = await _makeRepo();
+        await tester.pumpWidget(_buildSubject(repo));
+        await tester.pumpAndSettle();
+        await _switchToLegacyMode(tester);
+
+        expect(find.widgetWithText(FilledButton, 'Connect'), findsOneWidget);
+      });
+
+      testWidgets('shows mode switcher back to OAuth2', (tester) async {
+        final repo = await _makeRepo();
+        await tester.pumpWidget(_buildSubject(repo));
+        await tester.pumpAndSettle();
+        await _switchToLegacyMode(tester);
+
+        expect(find.text('Sign in with email and password'), findsOneWidget);
+      });
+
+      testWidgets('submitting with empty token creates context and navigates', (
+        tester,
+      ) async {
+        final repo = await _makeRepo();
+        await tester.pumpWidget(_buildSubject(repo));
+        await tester.pumpAndSettle();
+        await _enterServerUrl(tester);
+        await _switchToLegacyMode(tester);
+
+        await tester.tap(find.widgetWithText(FilledButton, 'Connect'));
+        await tester.pumpAndSettle();
+
+        // Should navigate to /chat after successful login.
+        expect(find.byType(Scaffold), findsOneWidget);
+
+        // A context should have been created.
+        final contexts = await repo.loadContexts();
+        expect(contexts, hasLength(1));
+      });
+
+      testWidgets('submitting with a token persists the token', (tester) async {
+        final repo = await _makeRepo();
+        await tester.pumpWidget(_buildSubject(repo));
+        await tester.pumpAndSettle();
+        await _enterServerUrl(tester);
+        await _switchToLegacyMode(tester);
+
+        await tester.enterText(
+          find.widgetWithText(TextFormField, 'Token (optional)'),
+          'my-secret-token',
+        );
+        await tester.tap(find.widgetWithText(FilledButton, 'Connect'));
+        await tester.pumpAndSettle();
+
+        final contexts = await repo.loadContexts();
+        expect(contexts.single.authToken, 'my-secret-token');
+      });
+
+      testWidgets('submitting twice for same URL updates existing context', (
+        tester,
+      ) async {
+        final repo = await _makeRepo();
+
+        // First login.
+        await tester.pumpWidget(_buildSubject(repo));
+        await tester.pumpAndSettle();
+        await _enterServerUrl(tester);
+        await _switchToLegacyMode(tester);
+        await tester.enterText(
+          find.widgetWithText(TextFormField, 'Token (optional)'),
+          'token-v1',
+        );
+        await tester.tap(find.widgetWithText(FilledButton, 'Connect'));
+        await tester.pumpAndSettle();
+
+        expect((await repo.loadContexts()).length, 1);
+
+        // Navigate back to /login manually via router and submit again.
+        await tester.pumpWidget(_buildSubject(repo));
+        await tester.pumpAndSettle();
+        await _enterServerUrl(tester);
+        await _switchToLegacyMode(tester);
+        await tester.enterText(
+          find.widgetWithText(TextFormField, 'Token (optional)'),
+          'token-v2',
+        );
+        await tester.tap(find.widgetWithText(FilledButton, 'Connect'));
+        await tester.pumpAndSettle();
+
+        // Still only 1 context — it was updated, not duplicated.
+        final contexts = await repo.loadContexts();
+        expect(contexts.length, 1);
+        expect(contexts.single.authToken, 'token-v2');
+      });
     });
 
-    testWidgets('renders Connect button', (tester) async {
-      final repo = await _makeRepo();
-      await tester.pumpWidget(_buildSubject(repo));
-      await tester.pumpAndSettle();
+    group('mode switching', () {
+      testWidgets('toggles between OAuth2 and legacy modes', (tester) async {
+        final repo = await _makeRepo();
+        await tester.pumpWidget(_buildSubject(repo));
+        await tester.pumpAndSettle();
 
-      expect(find.widgetWithText(FilledButton, 'Connect'), findsOneWidget);
-    });
+        // Starts in OAuth2 mode.
+        expect(find.widgetWithText(TextFormField, 'Email'), findsOneWidget);
+        expect(
+          find.widgetWithText(TextFormField, 'Token (optional)'),
+          findsNothing,
+        );
 
-    testWidgets('submitting with empty token creates context and navigates', (
-      tester,
-    ) async {
-      final repo = await _makeRepo();
-      await tester.pumpWidget(_buildSubject(repo));
-      await tester.pumpAndSettle();
+        // Switch to legacy.
+        await _switchToLegacyMode(tester);
+        expect(find.widgetWithText(TextFormField, 'Email'), findsNothing);
+        expect(
+          find.widgetWithText(TextFormField, 'Token (optional)'),
+          findsOneWidget,
+        );
 
-      await tester.tap(find.widgetWithText(FilledButton, 'Connect'));
-      await tester.pumpAndSettle();
-
-      // Should navigate to /chat after successful login.
-      expect(find.byType(Scaffold), findsOneWidget);
-
-      // A context should have been created.
-      final contexts = await repo.loadContexts();
-      expect(contexts, hasLength(1));
-    });
-
-    testWidgets('submitting with a token persists the token', (tester) async {
-      final repo = await _makeRepo();
-      await tester.pumpWidget(_buildSubject(repo));
-      await tester.pumpAndSettle();
-
-      await tester.enterText(
-        find.widgetWithText(TextFormField, 'Token (optional)'),
-        'my-secret-token',
-      );
-      await tester.tap(find.widgetWithText(FilledButton, 'Connect'));
-      await tester.pumpAndSettle();
-
-      final contexts = await repo.loadContexts();
-      expect(contexts.single.authToken, 'my-secret-token');
-    });
-
-    testWidgets('submitting twice for same URL updates existing context', (
-      tester,
-    ) async {
-      final repo = await _makeRepo();
-
-      // First login.
-      await tester.pumpWidget(_buildSubject(repo));
-      await tester.pumpAndSettle();
-      await tester.enterText(
-        find.widgetWithText(TextFormField, 'Token (optional)'),
-        'token-v1',
-      );
-      await tester.tap(find.widgetWithText(FilledButton, 'Connect'));
-      await tester.pumpAndSettle();
-
-      expect((await repo.loadContexts()).length, 1);
-
-      // Navigate back to /login manually via router and submit again.
-      await tester.pumpWidget(_buildSubject(repo));
-      await tester.pumpAndSettle();
-      await tester.enterText(
-        find.widgetWithText(TextFormField, 'Token (optional)'),
-        'token-v2',
-      );
-      await tester.tap(find.widgetWithText(FilledButton, 'Connect'));
-      await tester.pumpAndSettle();
-
-      // Still only 1 context — it was updated, not duplicated.
-      final contexts = await repo.loadContexts();
-      expect(contexts.length, 1);
-      expect(contexts.single.authToken, 'token-v2');
+        // Switch back to OAuth2.
+        await tester.tap(find.text('Sign in with email and password'));
+        await tester.pumpAndSettle();
+        expect(find.widgetWithText(TextFormField, 'Email'), findsOneWidget);
+        expect(
+          find.widgetWithText(TextFormField, 'Token (optional)'),
+          findsNothing,
+        );
+      });
     });
   });
 }


### PR DESCRIPTION
## Summary

- Add OAuth2 Authorization Code + PKCE support to the Flutter app alongside legacy token authentication
- Login screen defaults to email/password (OAuth2) mode with a toggle to switch to legacy token mode
- New auth library: `OAuthCredentials` model, PKCE challenge generation (RFC 7636), `OAuthService` HTTP client for dynamic client registration/login/refresh/revoke, and `OAuthLoginNotifier` Riverpod provider with sealed state hierarchy
- Extended `AssistantContext` with `AuthMode` enum, `effectiveToken` getter, `needsTokenRefresh`, and secure storage for OAuth credentials
- 75 new tests (696 total, all passing)

## Test plan

- [x] All 696 Flutter tests pass (`flutter test`)
- [x] `flutter analyze` passes with zero issues
- [x] Pre-commit hooks pass (format, lint, analyze)
- [ ] Manual test: legacy token login still works on web
- [ ] Manual test: OAuth2 login flow against server with OAuth2 support
- [ ] Manual test: mode switching between OAuth2 and legacy token