### PR TITLE
feat(app): Flutter multi-user UI — space switcher, API keys, admin screens

### DIFF
--- a/app/lib/api/api_client.dart
+++ b/app/lib/api/api_client.dart
@@ -64,6 +64,7 @@ class ApiClient {
   MembersApi get members => _generatedApi.getMembersApi();
   UsersApi get users => _generatedApi.getUsersApi();
   ApiKeysApi get apiKeys => _generatedApi.getApiKeysApi();
+  CatalogApi get catalog => _generatedApi.getCatalogApi();
   TemplatesApi get templates => _generatedApi.getTemplatesApi();
 
   /// Stream assistant tokens for a conversation message.

--- a/app/lib/features/admin/admin_providers.dart
+++ b/app/lib/features/admin/admin_providers.dart
@@ -1,0 +1,238 @@
+import 'package:assistant_api/assistant_api.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../connection/connection_provider.dart';
+import '../spaces/space_provider.dart';
+
+// ---------------------------------------------------------------------------
+// Users
+
+/// Manages the list of users in the active organization.
+class AdminUsersNotifier extends AsyncNotifier<List<UserSummary>> {
+  @override
+  Future<List<UserSummary>> build() async {
+    final api = ref.watch(apiClientProvider);
+    final selection = ref.watch(spaceSelectionProvider);
+    if (api == null || selection.orgId == null) return [];
+
+    final response = await api.users.listUsers(orgId: selection.orgId!);
+    return response.data?.toList() ?? [];
+  }
+
+  /// Invite a new user to the organization.
+  Future<UserDetail?> inviteUser({
+    required String email,
+    required String name,
+    String? password,
+  }) async {
+    final api = ref.read(apiClientProvider);
+    final orgId = ref.read(spaceSelectionProvider).orgId;
+    if (api == null || orgId == null) return null;
+
+    final response = await api.users.createUser(
+      orgId: orgId,
+      createUserRequest: CreateUserRequest(
+        (b) => b
+          ..email = email
+          ..name = name
+          ..password = password,
+      ),
+    );
+
+    ref.invalidateSelf();
+    return response.data;
+  }
+
+  /// Remove a user from the organization.
+  Future<void> removeUser(String userId) async {
+    final api = ref.read(apiClientProvider);
+    final orgId = ref.read(spaceSelectionProvider).orgId;
+    if (api == null || orgId == null) return;
+
+    await api.users.deleteUser(orgId: orgId, id: userId);
+    ref.invalidateSelf();
+  }
+}
+
+final adminUsersProvider =
+    AsyncNotifierProvider<AdminUsersNotifier, List<UserSummary>>(
+      AdminUsersNotifier.new,
+    );
+
+// ---------------------------------------------------------------------------
+// Members
+
+/// Manages space membership for the active org + space.
+class AdminMembersNotifier extends AsyncNotifier<List<MemberEntry>> {
+  @override
+  Future<List<MemberEntry>> build() async {
+    final api = ref.watch(apiClientProvider);
+    final selection = ref.watch(spaceSelectionProvider);
+    if (api == null || selection.orgId == null || selection.spaceId == null) {
+      return [];
+    }
+
+    final response = await api.members.listMembers(
+      orgId: selection.orgId!,
+      spaceId: selection.spaceId!,
+    );
+    return response.data?.toList() ?? [];
+  }
+
+  /// Add a user to the current space with the given role.
+  Future<MemberEntry?> addMember({
+    required String userId,
+    required String role,
+  }) async {
+    final api = ref.read(apiClientProvider);
+    final selection = ref.read(spaceSelectionProvider);
+    if (api == null || selection.orgId == null || selection.spaceId == null) {
+      return null;
+    }
+
+    final response = await api.members.addMember(
+      orgId: selection.orgId!,
+      spaceId: selection.spaceId!,
+      addMemberRequest: AddMemberRequest(
+        (b) => b
+          ..userId = userId
+          ..role = role,
+      ),
+    );
+
+    ref.invalidateSelf();
+    return response.data;
+  }
+
+  /// Remove a member from the current space.
+  Future<void> removeMember(String userId) async {
+    final api = ref.read(apiClientProvider);
+    final selection = ref.read(spaceSelectionProvider);
+    if (api == null || selection.orgId == null || selection.spaceId == null) {
+      return;
+    }
+
+    await api.members.removeMember(
+      orgId: selection.orgId!,
+      spaceId: selection.spaceId!,
+      userId: userId,
+    );
+    ref.invalidateSelf();
+  }
+}
+
+final adminMembersProvider =
+    AsyncNotifierProvider<AdminMembersNotifier, List<MemberEntry>>(
+      AdminMembersNotifier.new,
+    );
+
+// ---------------------------------------------------------------------------
+// Spaces (admin CRUD — extends the read-only spacesProvider)
+
+/// Admin space management: create and delete spaces in the active org.
+class AdminSpacesNotifier extends AsyncNotifier<List<SpaceSummary>> {
+  @override
+  Future<List<SpaceSummary>> build() async {
+    final api = ref.watch(apiClientProvider);
+    final selection = ref.watch(spaceSelectionProvider);
+    if (api == null || selection.orgId == null) return [];
+
+    final response = await api.spaces.listSpaces(orgId: selection.orgId!);
+    return response.data?.toList() ?? [];
+  }
+
+  /// Create a new space in the active org.
+  Future<SpaceDetail?> createSpace({
+    required String name,
+    required String slug,
+  }) async {
+    final api = ref.read(apiClientProvider);
+    final orgId = ref.read(spaceSelectionProvider).orgId;
+    if (api == null || orgId == null) return null;
+
+    final response = await api.spaces.createSpace(
+      orgId: orgId,
+      createSpaceRequest: CreateSpaceRequest(
+        (b) => b
+          ..name = name
+          ..slug = slug,
+      ),
+    );
+
+    ref.invalidateSelf();
+    // Also refresh the main spaces provider used by the space selector.
+    ref.invalidate(spacesProvider);
+    return response.data;
+  }
+
+  /// Delete a space from the active org.
+  Future<void> deleteSpace(String spaceId) async {
+    final api = ref.read(apiClientProvider);
+    final orgId = ref.read(spaceSelectionProvider).orgId;
+    if (api == null || orgId == null) return;
+
+    await api.spaces.deleteSpace(orgId: orgId, id: spaceId);
+    ref.invalidateSelf();
+    ref.invalidate(spacesProvider);
+  }
+}
+
+final adminSpacesProvider =
+    AsyncNotifierProvider<AdminSpacesNotifier, List<SpaceSummary>>(
+      AdminSpacesNotifier.new,
+    );
+
+// ---------------------------------------------------------------------------
+// Catalog
+
+/// Manages the org-level catalog (skills, templates, interfaces).
+class AdminCatalogNotifier extends AsyncNotifier<List<CatalogItemResponse>> {
+  @override
+  Future<List<CatalogItemResponse>> build() async {
+    final api = ref.watch(apiClientProvider);
+    final selection = ref.watch(spaceSelectionProvider);
+    if (api == null || selection.orgId == null) return [];
+
+    final response = await api.catalog.listCatalog(orgId: selection.orgId!);
+    return response.data?.toList() ?? [];
+  }
+
+  /// Publish a new item to the catalog.
+  Future<CatalogItemResponse?> publishItem({
+    required String name,
+    required String resourceType,
+    String? description,
+  }) async {
+    final api = ref.read(apiClientProvider);
+    final orgId = ref.read(spaceSelectionProvider).orgId;
+    if (api == null || orgId == null) return null;
+
+    final response = await api.catalog.publishCatalogItem(
+      orgId: orgId,
+      publishCatalogItemRequest: PublishCatalogItemRequest(
+        (b) => b
+          ..name = name
+          ..resourceType = resourceType
+          ..description = description,
+      ),
+    );
+
+    ref.invalidateSelf();
+    return response.data;
+  }
+
+  /// Remove an item from the catalog.
+  Future<void> removeItem(String itemId) async {
+    final api = ref.read(apiClientProvider);
+    final orgId = ref.read(spaceSelectionProvider).orgId;
+    if (api == null || orgId == null) return;
+
+    await api.catalog.deleteCatalogItem(orgId: orgId, itemId: itemId);
+    ref.invalidateSelf();
+  }
+}
+
+final adminCatalogProvider =
+    AsyncNotifierProvider<AdminCatalogNotifier, List<CatalogItemResponse>>(
+      AdminCatalogNotifier.new,
+    );

--- a/app/lib/features/admin/admin_screen.dart
+++ b/app/lib/features/admin/admin_screen.dart
@@ -1,0 +1,809 @@
+import 'package:assistant_api/assistant_api.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'admin_providers.dart';
+
+/// Admin screen with tabs for user, space, and catalog management.
+///
+/// Intended for org-admin and space-admin users. The server enforces role
+/// checks — the UI surfaces the management actions and shows errors if the
+/// user lacks permission.
+class AdminScreen extends ConsumerStatefulWidget {
+  const AdminScreen({super.key});
+
+  @override
+  ConsumerState<AdminScreen> createState() => _AdminScreenState();
+}
+
+class _AdminScreenState extends ConsumerState<AdminScreen>
+    with SingleTickerProviderStateMixin {
+  late final TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 3, vsync: this);
+    _tabController.addListener(() {
+      if (mounted) setState(() {});
+    });
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Admin'),
+        bottom: TabBar(
+          controller: _tabController,
+          tabs: const [
+            Tab(text: 'Users'),
+            Tab(text: 'Spaces'),
+            Tab(text: 'Catalog'),
+          ],
+        ),
+      ),
+      floatingActionButton: _buildFab(context),
+      body: TabBarView(
+        controller: _tabController,
+        children: const [_UsersTab(), _SpacesTab(), _CatalogTab()],
+      ),
+    );
+  }
+
+  Widget? _buildFab(BuildContext context) {
+    switch (_tabController.index) {
+      case 0:
+        return FloatingActionButton(
+          onPressed: () => _showInviteDialog(context),
+          tooltip: 'Invite user',
+          child: const Icon(Icons.person_add),
+        );
+      case 1:
+        return FloatingActionButton(
+          onPressed: () => _showCreateSpaceDialog(context),
+          tooltip: 'Create space',
+          child: const Icon(Icons.add),
+        );
+      case 2:
+        return FloatingActionButton(
+          onPressed: () => _showPublishDialog(context),
+          tooltip: 'Publish to catalog',
+          child: const Icon(Icons.publish),
+        );
+      default:
+        return null;
+    }
+  }
+
+  void _showInviteDialog(BuildContext context) {
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) => _InviteUserDialog(ref: ref),
+    );
+  }
+
+  void _showCreateSpaceDialog(BuildContext context) {
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) => _CreateSpaceDialog(ref: ref),
+    );
+  }
+
+  void _showPublishDialog(BuildContext context) {
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) => _PublishCatalogDialog(ref: ref),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Users Tab
+
+class _UsersTab extends ConsumerWidget {
+  const _UsersTab();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final usersAsync = ref.watch(adminUsersProvider);
+
+    return usersAsync.when(
+      loading: () => const Center(child: CircularProgressIndicator.adaptive()),
+      error: (err, _) => _ErrorView(
+        message: 'Failed to load users: $err',
+        onRetry: () => ref.invalidate(adminUsersProvider),
+      ),
+      data: (users) {
+        if (users.isEmpty) {
+          return const _EmptyView(
+            icon: Icons.people_outline,
+            title: 'No users',
+            subtitle: 'Invite users to your organization to get started.',
+          );
+        }
+
+        return ListView.separated(
+          padding: const EdgeInsets.all(16),
+          itemCount: users.length,
+          separatorBuilder: (_, _) => const SizedBox(height: 8),
+          itemBuilder: (context, index) {
+            final user = users[index];
+            return _UserTile(user: user);
+          },
+        );
+      },
+    );
+  }
+}
+
+class _UserTile extends ConsumerWidget {
+  const _UserTile({required this.user});
+  final UserSummary user;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Card(
+      child: ListTile(
+        leading: CircleAvatar(
+          backgroundColor: colorScheme.primaryContainer,
+          child: Text(
+            user.name.isNotEmpty ? user.name[0].toUpperCase() : '?',
+            style: TextStyle(color: colorScheme.onPrimaryContainer),
+          ),
+        ),
+        title: Text(user.name),
+        subtitle: Text(user.email),
+        trailing: IconButton(
+          icon: Icon(Icons.delete_outline, color: colorScheme.error),
+          tooltip: 'Remove user',
+          onPressed: () => _confirmRemove(context, ref),
+        ),
+      ),
+    );
+  }
+
+  void _confirmRemove(BuildContext context, WidgetRef ref) {
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Remove user?'),
+        content: Text(
+          'This will remove "${user.name}" from the organization. '
+          'They will lose access to all spaces.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () {
+              Navigator.of(dialogContext).pop();
+              ref.read(adminUsersProvider.notifier).removeUser(user.id);
+            },
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(context).colorScheme.error,
+            ),
+            child: const Text('Remove'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Spaces Tab
+
+class _SpacesTab extends ConsumerWidget {
+  const _SpacesTab();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final spacesAsync = ref.watch(adminSpacesProvider);
+    final membersAsync = ref.watch(adminMembersProvider);
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Spaces',
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+              color: Theme.of(context).colorScheme.primary,
+            ),
+          ),
+          const SizedBox(height: 8),
+          spacesAsync.when(
+            loading: () =>
+                const Center(child: CircularProgressIndicator.adaptive()),
+            error: (err, _) => _ErrorView(
+              message: 'Failed to load spaces: $err',
+              onRetry: () => ref.invalidate(adminSpacesProvider),
+            ),
+            data: (spaces) {
+              if (spaces.isEmpty) {
+                return const _EmptyView(
+                  icon: Icons.workspaces_outline,
+                  title: 'No spaces',
+                  subtitle: 'Create a space to organize your team.',
+                );
+              }
+
+              return Column(
+                children: [
+                  for (final space in spaces) _SpaceTile(space: space),
+                ],
+              );
+            },
+          ),
+          const SizedBox(height: 24),
+          Text(
+            'Members',
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+              color: Theme.of(context).colorScheme.primary,
+            ),
+          ),
+          const SizedBox(height: 8),
+          membersAsync.when(
+            loading: () =>
+                const Center(child: CircularProgressIndicator.adaptive()),
+            error: (err, _) => _ErrorView(
+              message: 'Failed to load members: $err',
+              onRetry: () => ref.invalidate(adminMembersProvider),
+            ),
+            data: (members) {
+              if (members.isEmpty) {
+                return const _EmptyView(
+                  icon: Icons.group_outlined,
+                  title: 'No members',
+                  subtitle: 'Add members to this space.',
+                );
+              }
+
+              return Column(
+                children: [for (final m in members) _MemberTile(member: m)],
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SpaceTile extends ConsumerWidget {
+  const _SpaceTile({required this.space});
+  final SpaceSummary space;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Card(
+      child: ListTile(
+        leading: Icon(Icons.workspaces, color: colorScheme.primary),
+        title: Text(space.name),
+        subtitle: Text(space.slug),
+        trailing: IconButton(
+          icon: Icon(Icons.delete_outline, color: colorScheme.error),
+          tooltip: 'Delete space',
+          onPressed: () => _confirmDelete(context, ref),
+        ),
+      ),
+    );
+  }
+
+  void _confirmDelete(BuildContext context, WidgetRef ref) {
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Delete space?'),
+        content: Text(
+          'This will permanently delete "${space.name}" and all its data.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () {
+              Navigator.of(dialogContext).pop();
+              ref.read(adminSpacesProvider.notifier).deleteSpace(space.id);
+            },
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(context).colorScheme.error,
+            ),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MemberTile extends ConsumerWidget {
+  const _MemberTile({required this.member});
+  final MemberEntry member;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Card(
+      child: ListTile(
+        leading: Icon(Icons.person, color: colorScheme.primary),
+        title: Text(member.userId),
+        subtitle: Text(member.role),
+        trailing: IconButton(
+          icon: Icon(Icons.remove_circle_outline, color: colorScheme.error),
+          tooltip: 'Remove from space',
+          onPressed: () {
+            ref.read(adminMembersProvider.notifier).removeMember(member.userId);
+          },
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Catalog Tab
+
+class _CatalogTab extends ConsumerWidget {
+  const _CatalogTab();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final catalogAsync = ref.watch(adminCatalogProvider);
+
+    return catalogAsync.when(
+      loading: () => const Center(child: CircularProgressIndicator.adaptive()),
+      error: (err, _) => _ErrorView(
+        message: 'Failed to load catalog: $err',
+        onRetry: () => ref.invalidate(adminCatalogProvider),
+      ),
+      data: (items) {
+        if (items.isEmpty) {
+          return const _EmptyView(
+            icon: Icons.store_outlined,
+            title: 'No catalog items',
+            subtitle:
+                'Publish skills, templates, or interfaces to the catalog.',
+          );
+        }
+
+        return ListView.separated(
+          padding: const EdgeInsets.all(16),
+          itemCount: items.length,
+          separatorBuilder: (_, _) => const SizedBox(height: 8),
+          itemBuilder: (context, index) {
+            final item = items[index];
+            return _CatalogTile(item: item);
+          },
+        );
+      },
+    );
+  }
+}
+
+class _CatalogTile extends ConsumerWidget {
+  const _CatalogTile({required this.item});
+  final CatalogItemResponse item;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final typeIcon = switch (item.resourceType) {
+      'skill' => Icons.extension,
+      'template' => Icons.description,
+      'interface' => Icons.cable,
+      _ => Icons.inventory_2,
+    };
+
+    return Card(
+      child: ListTile(
+        leading: Icon(typeIcon, color: colorScheme.primary),
+        title: Text(item.name),
+        subtitle: Text(
+          '${item.resourceType} \u00B7 ${item.description}',
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+        trailing: IconButton(
+          icon: Icon(Icons.delete_outline, color: colorScheme.error),
+          tooltip: 'Remove from catalog',
+          onPressed: () => _confirmRemove(context, ref),
+        ),
+      ),
+    );
+  }
+
+  void _confirmRemove(BuildContext context, WidgetRef ref) {
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Remove from catalog?'),
+        content: Text(
+          'This will remove "${item.name}" from the catalog. '
+          'Existing subscriptions will be unaffected.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () {
+              Navigator.of(dialogContext).pop();
+              ref.read(adminCatalogProvider.notifier).removeItem(item.id);
+            },
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(context).colorScheme.error,
+            ),
+            child: const Text('Remove'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Dialogs
+
+class _InviteUserDialog extends StatefulWidget {
+  const _InviteUserDialog({required this.ref});
+  final WidgetRef ref;
+
+  @override
+  State<_InviteUserDialog> createState() => _InviteUserDialogState();
+}
+
+class _InviteUserDialogState extends State<_InviteUserDialog> {
+  final _emailController = TextEditingController();
+  final _nameController = TextEditingController();
+  bool _isSubmitting = false;
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    final email = _emailController.text.trim();
+    final name = _nameController.text.trim();
+    if (email.isEmpty || name.isEmpty) return;
+
+    setState(() => _isSubmitting = true);
+    try {
+      await widget.ref
+          .read(adminUsersProvider.notifier)
+          .inviteUser(email: email, name: name);
+      if (mounted) Navigator.of(context).pop();
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Failed to invite user: $e')));
+        Navigator.of(context).pop();
+      }
+    } finally {
+      if (mounted) setState(() => _isSubmitting = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Invite user'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          TextField(
+            controller: _emailController,
+            autofocus: true,
+            decoration: const InputDecoration(
+              labelText: 'Email',
+              hintText: 'user@example.com',
+            ),
+            keyboardType: TextInputType.emailAddress,
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _nameController,
+            decoration: const InputDecoration(
+              labelText: 'Name',
+              hintText: 'Jane Doe',
+            ),
+            onSubmitted: (_) => _submit(),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: _isSubmitting ? null : _submit,
+          child: _isSubmitting
+              ? const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Text('Invite'),
+        ),
+      ],
+    );
+  }
+}
+
+class _CreateSpaceDialog extends StatefulWidget {
+  const _CreateSpaceDialog({required this.ref});
+  final WidgetRef ref;
+
+  @override
+  State<_CreateSpaceDialog> createState() => _CreateSpaceDialogState();
+}
+
+class _CreateSpaceDialogState extends State<_CreateSpaceDialog> {
+  final _nameController = TextEditingController();
+  final _slugController = TextEditingController();
+  bool _isSubmitting = false;
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _slugController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    final name = _nameController.text.trim();
+    final slug = _slugController.text.trim();
+    if (name.isEmpty || slug.isEmpty) return;
+
+    setState(() => _isSubmitting = true);
+    try {
+      await widget.ref
+          .read(adminSpacesProvider.notifier)
+          .createSpace(name: name, slug: slug);
+      if (mounted) Navigator.of(context).pop();
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Failed to create space: $e')));
+        Navigator.of(context).pop();
+      }
+    } finally {
+      if (mounted) setState(() => _isSubmitting = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Create space'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          TextField(
+            controller: _nameController,
+            autofocus: true,
+            decoration: const InputDecoration(
+              labelText: 'Space name',
+              hintText: 'e.g. Production',
+            ),
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _slugController,
+            decoration: const InputDecoration(
+              labelText: 'Slug',
+              hintText: 'e.g. production',
+            ),
+            onSubmitted: (_) => _submit(),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: _isSubmitting ? null : _submit,
+          child: _isSubmitting
+              ? const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Text('Create'),
+        ),
+      ],
+    );
+  }
+}
+
+class _PublishCatalogDialog extends StatefulWidget {
+  const _PublishCatalogDialog({required this.ref});
+  final WidgetRef ref;
+
+  @override
+  State<_PublishCatalogDialog> createState() => _PublishCatalogDialogState();
+}
+
+class _PublishCatalogDialogState extends State<_PublishCatalogDialog> {
+  final _nameController = TextEditingController();
+  final _descController = TextEditingController();
+  String _resourceType = 'skill';
+  bool _isSubmitting = false;
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _descController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    final name = _nameController.text.trim();
+    if (name.isEmpty) return;
+
+    setState(() => _isSubmitting = true);
+    try {
+      await widget.ref
+          .read(adminCatalogProvider.notifier)
+          .publishItem(
+            name: name,
+            resourceType: _resourceType,
+            description: _descController.text.trim().isEmpty
+                ? null
+                : _descController.text.trim(),
+          );
+      if (mounted) Navigator.of(context).pop();
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Failed to publish: $e')));
+        Navigator.of(context).pop();
+      }
+    } finally {
+      if (mounted) setState(() => _isSubmitting = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Publish to catalog'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          TextField(
+            controller: _nameController,
+            autofocus: true,
+            decoration: const InputDecoration(
+              labelText: 'Name',
+              hintText: 'e.g. Customer Support Skill',
+            ),
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _descController,
+            decoration: const InputDecoration(
+              labelText: 'Description (optional)',
+            ),
+            maxLines: 2,
+          ),
+          const SizedBox(height: 12),
+          DropdownButtonFormField<String>(
+            initialValue: _resourceType,
+            decoration: const InputDecoration(labelText: 'Type'),
+            items: const [
+              DropdownMenuItem(value: 'skill', child: Text('Skill')),
+              DropdownMenuItem(value: 'template', child: Text('Template')),
+              DropdownMenuItem(value: 'interface', child: Text('Interface')),
+            ],
+            onChanged: (value) {
+              if (value != null) setState(() => _resourceType = value);
+            },
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: _isSubmitting ? null : _submit,
+          child: _isSubmitting
+              ? const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Text('Publish'),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared widgets
+
+class _EmptyView extends StatelessWidget {
+  const _EmptyView({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 48, color: Colors.grey),
+            const SizedBox(height: 16),
+            Text(
+              title,
+              style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(height: 8),
+            Text(subtitle, textAlign: TextAlign.center),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ErrorView extends StatelessWidget {
+  const _ErrorView({required this.message, this.onRetry});
+  final String message;
+  final VoidCallback? onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(message),
+          if (onRetry != null) ...[
+            const SizedBox(height: 12),
+            FilledButton.tonal(onPressed: onRetry, child: const Text('Retry')),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/features/api_keys/api_keys_provider.dart
+++ b/app/lib/features/api_keys/api_keys_provider.dart
@@ -1,0 +1,47 @@
+import 'package:assistant_api/assistant_api.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../connection/connection_provider.dart';
+
+/// Manages the list of API keys for the current user.
+class ApiKeysNotifier extends AsyncNotifier<List<ApiKeySummary>> {
+  @override
+  Future<List<ApiKeySummary>> build() async {
+    final api = ref.watch(apiClientProvider);
+    if (api == null) return [];
+
+    final response = await api.apiKeys.listApiKeys();
+    return response.data?.toList() ?? [];
+  }
+
+  /// Create a new API key and return the response (includes plaintext).
+  ///
+  /// Keys are created with default (full) scopes. Scope selection can be
+  /// added to the UI later.
+  Future<CreateApiKeyResponse?> createKey({required String name}) async {
+    final api = ref.read(apiClientProvider);
+    if (api == null) return null;
+
+    final response = await api.apiKeys.createApiKey(
+      createApiKeyRequest: CreateApiKeyRequest((b) => b..name = name),
+    );
+
+    // Refresh the list after creation.
+    ref.invalidateSelf();
+    return response.data;
+  }
+
+  /// Revoke an API key by ID.
+  Future<void> revokeKey(String id) async {
+    final api = ref.read(apiClientProvider);
+    if (api == null) return;
+
+    await api.apiKeys.deleteApiKey(id: id);
+    ref.invalidateSelf();
+  }
+}
+
+final apiKeysProvider =
+    AsyncNotifierProvider<ApiKeysNotifier, List<ApiKeySummary>>(
+      ApiKeysNotifier.new,
+    );

--- a/app/lib/features/api_keys/api_keys_screen.dart
+++ b/app/lib/features/api_keys/api_keys_screen.dart
@@ -1,0 +1,258 @@
+import 'package:assistant_api/assistant_api.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'api_keys_provider.dart';
+
+/// Screen for managing the current user's API keys.
+///
+/// Displays existing keys with prefix + creation date, allows creating new
+/// keys (with copy-to-clipboard on creation), and revoking existing ones.
+class ApiKeysScreen extends ConsumerWidget {
+  const ApiKeysScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final keysAsync = ref.watch(apiKeysProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('API Keys')),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => _showCreateDialog(context, ref),
+        tooltip: 'Create API key',
+        child: const Icon(Icons.add),
+      ),
+      body: keysAsync.when(
+        loading: () =>
+            const Center(child: CircularProgressIndicator.adaptive()),
+        error: (err, _) => Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text('Failed to load API keys: $err'),
+              const SizedBox(height: 12),
+              FilledButton.tonal(
+                onPressed: () => ref.invalidate(apiKeysProvider),
+                child: const Text('Retry'),
+              ),
+            ],
+          ),
+        ),
+        data: (keys) {
+          if (keys.isEmpty) {
+            return const Center(
+              child: Padding(
+                padding: EdgeInsets.all(32),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(Icons.key_off, size: 48, color: Colors.grey),
+                    SizedBox(height: 16),
+                    Text(
+                      'No API keys',
+                      style: TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    SizedBox(height: 8),
+                    Text(
+                      'Create an API key to authenticate programmatic access.',
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
+                ),
+              ),
+            );
+          }
+
+          return ListView.separated(
+            padding: const EdgeInsets.all(16),
+            itemCount: keys.length,
+            separatorBuilder: (_, _) => const SizedBox(height: 8),
+            itemBuilder: (context, index) =>
+                _ApiKeyTile(key: ValueKey(keys[index].id), apiKey: keys[index]),
+          );
+        },
+      ),
+    );
+  }
+
+  void _showCreateDialog(BuildContext context, WidgetRef ref) {
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) => _CreateApiKeyDialog(ref: ref),
+    );
+  }
+}
+
+class _ApiKeyTile extends ConsumerWidget {
+  const _ApiKeyTile({super.key, required this.apiKey});
+
+  final ApiKeySummary apiKey;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Card(
+      child: ListTile(
+        leading: Icon(Icons.key, color: colorScheme.primary),
+        title: Text(apiKey.name),
+        subtitle: Text(
+          '${apiKey.keyPrefix}... \u00B7 Created ${apiKey.createdAt}',
+          style: TextStyle(color: colorScheme.onSurfaceVariant, fontSize: 12),
+        ),
+        trailing: IconButton(
+          icon: Icon(Icons.delete_outline, color: colorScheme.error),
+          tooltip: 'Revoke',
+          onPressed: () => _confirmRevoke(context, ref),
+        ),
+      ),
+    );
+  }
+
+  void _confirmRevoke(BuildContext context, WidgetRef ref) {
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Revoke API key?'),
+        content: Text(
+          'This will permanently revoke "${apiKey.name}". '
+          'Any applications using this key will lose access.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () {
+              Navigator.of(dialogContext).pop();
+              ref.read(apiKeysProvider.notifier).revokeKey(apiKey.id);
+            },
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(context).colorScheme.error,
+            ),
+            child: const Text('Revoke'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CreateApiKeyDialog extends StatefulWidget {
+  const _CreateApiKeyDialog({required this.ref});
+
+  final WidgetRef ref;
+
+  @override
+  State<_CreateApiKeyDialog> createState() => _CreateApiKeyDialogState();
+}
+
+class _CreateApiKeyDialogState extends State<_CreateApiKeyDialog> {
+  final _nameController = TextEditingController();
+  bool _isCreating = false;
+  CreateApiKeyResponse? _result;
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _create() async {
+    if (_nameController.text.trim().isEmpty) return;
+
+    setState(() => _isCreating = true);
+    try {
+      final response = await widget.ref
+          .read(apiKeysProvider.notifier)
+          .createKey(name: _nameController.text.trim());
+      if (mounted && response != null) {
+        setState(() => _result = response);
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Failed to create key: $e')));
+        Navigator.of(context).pop();
+      }
+    } finally {
+      if (mounted) setState(() => _isCreating = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_result != null) {
+      return AlertDialog(
+        title: const Text('API key created'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const Text(
+              'Copy your API key now. You will not be able to see it again.',
+              style: TextStyle(fontWeight: FontWeight.w500),
+            ),
+            const SizedBox(height: 16),
+            SelectableText(
+              _result!.plaintext,
+              style: const TextStyle(fontFamily: 'monospace', fontSize: 13),
+            ),
+            const SizedBox(height: 12),
+            OutlinedButton.icon(
+              onPressed: () {
+                Clipboard.setData(ClipboardData(text: _result!.plaintext));
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('Copied to clipboard')),
+                );
+              },
+              icon: const Icon(Icons.copy, size: 18),
+              label: const Text('Copy to clipboard'),
+            ),
+          ],
+        ),
+        actions: [
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Done'),
+          ),
+        ],
+      );
+    }
+
+    return AlertDialog(
+      title: const Text('Create API key'),
+      content: TextField(
+        controller: _nameController,
+        autofocus: true,
+        decoration: const InputDecoration(
+          labelText: 'Key name',
+          hintText: 'e.g. CI/CD Pipeline',
+        ),
+        onSubmitted: (_) => _create(),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: _isCreating ? null : _create,
+          child: _isCreating
+              ? const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Text('Create'),
+        ),
+      ],
+    );
+  }
+}

--- a/app/lib/features/chat/chat_provider.dart
+++ b/app/lib/features/chat/chat_provider.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../api/api_client.dart';
 import '../../api/models/stream_event.dart';
 import '../connection/connection_provider.dart';
+import '../spaces/space_provider.dart';
 
 // -- Conversation list -------------------------------------------------------
 
@@ -57,6 +58,8 @@ class ConversationListNotifier extends AsyncNotifier<ConversationListState> {
   @override
   Future<ConversationListState> build() async {
     final api = ref.watch(apiClientProvider);
+    // Rebuild (reconnect stream) when the active space changes.
+    ref.watch(spaceSelectionProvider);
     if (api == null) {
       _resetStream();
       return const ConversationListState();

--- a/app/lib/features/onboarding/onboarding_provider.dart
+++ b/app/lib/features/onboarding/onboarding_provider.dart
@@ -1,0 +1,59 @@
+import 'package:assistant_api/assistant_api.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../connection/connection_provider.dart';
+import '../spaces/space_provider.dart';
+
+/// Onboarding status: whether the current user has created at least one persona.
+class OnboardingNotifier extends AsyncNotifier<bool> {
+  @override
+  Future<bool> build() async {
+    final api = ref.watch(apiClientProvider);
+    if (api == null) return true; // No connection — assume onboarded.
+
+    try {
+      final response = await api.templates.onboardingStatus();
+      return response.data?.hasPersona ?? true;
+    } catch (_) {
+      // If the endpoint isn't available, assume onboarded.
+      return true;
+    }
+  }
+
+  /// Force re-check after persona creation.
+  void refresh() => ref.invalidateSelf();
+}
+
+final onboardingStatusProvider =
+    AsyncNotifierProvider<OnboardingNotifier, bool>(OnboardingNotifier.new);
+
+/// Fetches available persona templates from the org catalog.
+class TemplatesNotifier extends AsyncNotifier<List<TemplateResponse>> {
+  @override
+  Future<List<TemplateResponse>> build() async {
+    final api = ref.watch(apiClientProvider);
+    final selection = ref.watch(spaceSelectionProvider);
+    if (api == null || selection.orgId == null) return [];
+
+    try {
+      final response = await api.templates.listTemplates(
+        orgId: selection.orgId!,
+      );
+      return response.data?.toList() ?? [];
+    } catch (_) {
+      return [];
+    }
+  }
+}
+
+final templatesProvider =
+    AsyncNotifierProvider<TemplatesNotifier, List<TemplateResponse>>(
+      TemplatesNotifier.new,
+    );
+
+/// Convenience: true when user needs onboarding (no persona yet).
+final needsOnboardingProvider = Provider<bool>((ref) {
+  final status = ref.watch(onboardingStatusProvider);
+  // While loading, don't block — assume no onboarding needed.
+  return status.value == false;
+});

--- a/app/lib/features/onboarding/onboarding_screen.dart
+++ b/app/lib/features/onboarding/onboarding_screen.dart
@@ -1,0 +1,190 @@
+import 'package:assistant_api/assistant_api.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../router/app_router.dart';
+import '../connection/connection_provider.dart';
+import '../personas/personas_provider.dart';
+import 'onboarding_provider.dart';
+
+/// Onboarding screen shown when a user has no persona yet.
+///
+/// Displays available templates from the org catalog. The user picks one
+/// (or creates a blank persona) and is then navigated to chat.
+class OnboardingScreen extends ConsumerStatefulWidget {
+  const OnboardingScreen({super.key});
+
+  @override
+  ConsumerState<OnboardingScreen> createState() => _OnboardingScreenState();
+}
+
+class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
+  bool _creating = false;
+  String? _error;
+
+  Future<void> _createFromTemplate(TemplateResponse template) async {
+    await _createPersona(id: template.id, name: template.name);
+  }
+
+  Future<void> _createBlank() async {
+    await _createPersona(id: 'my-assistant', name: 'My Assistant');
+  }
+
+  Future<void> _createPersona({
+    required String id,
+    required String name,
+  }) async {
+    final api = ref.read(apiClientProvider);
+    if (api == null) return;
+
+    setState(() {
+      _creating = true;
+      _error = null;
+    });
+
+    try {
+      await api.personas.createPersona(
+        createPersonaRequest: CreatePersonaRequest((b) {
+          b.id = id;
+          b.name = name;
+        }),
+      );
+
+      ref.invalidate(personasProvider);
+      ref.read(onboardingStatusProvider.notifier).refresh();
+
+      if (mounted) {
+        GoRouter.of(context).go(AppRoutes.chat);
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _creating = false;
+          _error = 'Failed to create persona: $e';
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final templatesAsync = ref.watch(templatesProvider);
+
+    return Scaffold(
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 520),
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(32),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text(
+                  'Welcome! Create your first persona',
+                  style: Theme.of(context).textTheme.headlineMedium,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  'A persona defines how the assistant behaves. '
+                  'Pick a template to get started, or create a blank one.',
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+                const SizedBox(height: 24),
+
+                if (_error != null) ...[
+                  Container(
+                    padding: const EdgeInsets.all(12),
+                    decoration: BoxDecoration(
+                      color: Theme.of(context).colorScheme.errorContainer,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Text(
+                      _error!,
+                      style: TextStyle(
+                        color: Theme.of(context).colorScheme.onErrorContainer,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                ],
+
+                if (_creating)
+                  const Center(
+                    child: Padding(
+                      padding: EdgeInsets.all(32),
+                      child: CircularProgressIndicator.adaptive(),
+                    ),
+                  )
+                else
+                  templatesAsync.when(
+                    loading: () => const Center(
+                      child: CircularProgressIndicator.adaptive(),
+                    ),
+                    error: (err, _) => Column(
+                      children: [
+                        Text('Could not load templates: $err'),
+                        const SizedBox(height: 12),
+                        FilledButton.tonal(
+                          onPressed: () => ref.invalidate(templatesProvider),
+                          child: const Text('Retry'),
+                        ),
+                      ],
+                    ),
+                    data: (templates) => Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        if (templates.isNotEmpty) ...[
+                          Text(
+                            'Templates',
+                            style: Theme.of(context).textTheme.titleMedium,
+                          ),
+                          const SizedBox(height: 8),
+                          for (final t in templates)
+                            Card(
+                              child: ListTile(
+                                title: Text(t.name),
+                                subtitle: t.description.isNotEmpty
+                                    ? Text(
+                                        t.description,
+                                        maxLines: 2,
+                                        overflow: TextOverflow.ellipsis,
+                                      )
+                                    : null,
+                                trailing: const Icon(Icons.add_circle_outline),
+                                onTap: () => _createFromTemplate(t),
+                              ),
+                            ),
+                          const SizedBox(height: 16),
+                          const Divider(),
+                          const SizedBox(height: 16),
+                        ],
+                        OutlinedButton.icon(
+                          onPressed: _createBlank,
+                          icon: const Icon(Icons.add),
+                          label: const Text('Create blank persona'),
+                        ),
+                      ],
+                    ),
+                  ),
+
+                const SizedBox(height: 24),
+
+                // Skip option — go straight to chat without creating.
+                Center(
+                  child: TextButton(
+                    onPressed: _creating
+                        ? null
+                        : () => GoRouter.of(context).go(AppRoutes.chat),
+                    child: const Text('Skip for now'),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/features/personas/personas_provider.dart
+++ b/app/lib/features/personas/personas_provider.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../api/api_client.dart';
 import '../connection/connection_provider.dart';
+import '../spaces/space_provider.dart';
 import 'persona_constants.dart';
 
 /// State for the personas feature.
@@ -40,6 +41,8 @@ class PersonasNotifier extends AsyncNotifier<PersonasState> {
   @override
   Future<PersonasState> build() async {
     final api = ref.watch(apiClientProvider);
+    // Rebuild (re-fetch) when the active space changes.
+    ref.watch(spaceSelectionProvider);
     if (api == null) return const PersonasState();
     return _fetchPersonas();
   }

--- a/app/lib/router/app_router.dart
+++ b/app/lib/router/app_router.dart
@@ -4,6 +4,8 @@ import 'package:go_router/go_router.dart';
 
 import '../features/agents/agent_detail_screen.dart';
 import '../features/agents/agents_screen.dart';
+import '../features/admin/admin_screen.dart';
+import '../features/api_keys/api_keys_screen.dart';
 import '../features/analytics/analytics_screen.dart';
 import '../features/chat/chat_screen.dart';
 import '../features/connection/connection_screen.dart';
@@ -63,6 +65,8 @@ class AppRoutes {
   static const agentDetail = '/agents/:id';
   static const analytics = '/analytics';
   static const settings = '/settings';
+  static const admin = '/admin';
+  static const apiKeys = '/api-keys';
   static const spaceSelector = '/spaces';
   static const onboarding = '/onboarding';
 }
@@ -347,6 +351,18 @@ final routerProvider = Provider<GoRouter>((ref) {
           GoRoute(
             path: AppRoutes.analytics,
             builder: (context, state) => const AnalyticsScreen(),
+          ),
+
+          // -- Admin ---------------------------------------------------------
+          GoRoute(
+            path: AppRoutes.admin,
+            builder: (context, state) => const AdminScreen(),
+          ),
+
+          // -- API Keys -----------------------------------------------------
+          GoRoute(
+            path: AppRoutes.apiKeys,
+            builder: (context, state) => const ApiKeysScreen(),
           ),
 
           // -- Settings -----------------------------------------------------

--- a/app/lib/router/app_router.dart
+++ b/app/lib/router/app_router.dart
@@ -11,6 +11,7 @@ import '../features/contexts/models/context_model.dart';
 import '../features/contexts/providers/context_providers.dart';
 import '../features/contexts/screens/context_switcher_screen.dart';
 import '../features/login/login_screen.dart';
+import '../features/onboarding/onboarding_screen.dart';
 import '../features/spaces/space_selector_screen.dart';
 import '../features/logs/logs_screen.dart';
 import '../features/personas/persona_create_screen.dart';
@@ -63,6 +64,7 @@ class AppRoutes {
   static const analytics = '/analytics';
   static const settings = '/settings';
   static const spaceSelector = '/spaces';
+  static const onboarding = '/onboarding';
 }
 
 /// Provider that creates a single [GoRouter] instance for the application
@@ -152,6 +154,12 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: AppRoutes.spaceSelector,
         builder: (context, state) => const SpaceSelectorScreen(),
+      ),
+
+      // -- Onboarding: persona creation for new users -----------------------
+      GoRoute(
+        path: AppRoutes.onboarding,
+        builder: (context, state) => const OnboardingScreen(),
       ),
 
       // -- Legacy setup route (kept for deep-link compatibility) -------------

--- a/app/lib/shared/nav_shell.dart
+++ b/app/lib/shared/nav_shell.dart
@@ -11,9 +11,11 @@ import '../features/chat/chat_provider.dart';
 import '../features/contexts/providers/context_providers.dart';
 import '../features/notifications/agent_event_listener.dart';
 import '../features/pwa/pwa_provider.dart';
+import '../features/spaces/space_provider.dart';
 import '../features/updater/update_banner.dart';
 import '../router/app_router.dart';
 import 'platform/platform.dart';
+import 'space_switcher.dart';
 
 /// Breakpoint above which the navigation rail is shown instead of bottom nav.
 const double _kNavRailBreakpoint = 768;
@@ -120,6 +122,12 @@ const List<_NavDest> _overflowDestinations = [
     icon: Icons.bar_chart_outlined,
     selectedIcon: Icons.bar_chart,
     label: 'Analytics',
+  ),
+  _NavDest(
+    path: '/admin',
+    icon: Icons.admin_panel_settings_outlined,
+    selectedIcon: Icons.admin_panel_settings,
+    label: 'Admin',
   ),
 ];
 
@@ -260,7 +268,16 @@ class _NavShellState extends ConsumerState<NavShell> {
                       style: Theme.of(context).textTheme.titleMedium,
                     ),
                   ),
-                  // Contexts switcher is the first item in the More sheet on mobile.
+                  // Space switcher at the top of the More sheet.
+                  ListTile(
+                    leading: const Icon(Icons.workspaces_outlined),
+                    title: const Text('Switch space'),
+                    onTap: () {
+                      Navigator.of(sheetContext).pop();
+                      context.go(AppRoutes.spaceSelector);
+                    },
+                  ),
+                  // Contexts switcher.
                   ListTile(
                     leading: Icon(_contextsDestination.icon),
                     title: Text(_contextsDestination.label),
@@ -324,6 +341,13 @@ class _NavShellState extends ConsumerState<NavShell> {
         return CupertinoActionSheet(
           title: const Text('More'),
           actions: [
+            CupertinoActionSheetAction(
+              onPressed: () {
+                Navigator.of(popupContext).pop();
+                context.go(AppRoutes.spaceSelector);
+              },
+              child: const Text('Switch space'),
+            ),
             ..._overflowDestinations.map(
               (d) => CupertinoActionSheetAction(
                 onPressed: () {
@@ -411,6 +435,7 @@ class _NavShellState extends ConsumerState<NavShell> {
                       isExpanded: !collapsed,
                       child: CupertinoSidebar(
                         selectedIndex: appleSelected,
+                        navigationBar: _CupertinoSpaceSwitcher(),
                         onDestinationSelected: (i) {
                           final dest = _appleSidebarDestinations[i];
                           context.go(dest.path);
@@ -612,6 +637,7 @@ class _NavShellState extends ConsumerState<NavShell> {
                       ),
                       // Sticky trailing section
                       const Divider(height: 1),
+                      SpaceSwitcher(collapsed: collapsed),
                       if (!kIsWeb)
                         _MaterialSidebarItem(
                           icon: _contextsDestination.icon,
@@ -1002,6 +1028,27 @@ class _SafariStep extends StatelessWidget {
         const SizedBox(width: 8),
         Expanded(child: Text(text)),
       ],
+    );
+  }
+}
+
+/// Cupertino-styled space switcher used as the [CupertinoSidebar.navigationBar].
+///
+/// Wraps [SidebarNavigationBar] (which renders a [CupertinoSliverNavigationBar])
+/// so it integrates as a proper sliver inside the sidebar's [CustomScrollView].
+class _CupertinoSpaceSwitcher extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final selection = ref.watch(spaceSelectionProvider);
+    final spaceName = selection.spaceName;
+
+    return SidebarNavigationBar(
+      title: Text(spaceName ?? 'Spaces'),
+      trailing: CupertinoButton(
+        padding: EdgeInsets.zero,
+        onPressed: () => context.go(AppRoutes.spaceSelector),
+        child: const Icon(CupertinoIcons.arrow_2_squarepath, size: 20),
+      ),
     );
   }
 }

--- a/app/lib/shared/space_switcher.dart
+++ b/app/lib/shared/space_switcher.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../features/spaces/space_provider.dart';
+import '../router/app_router.dart';
+
+/// Compact widget that displays the active org/space and navigates to the
+/// space selector screen on tap.
+///
+/// When [collapsed] is true (icon-only sidebar), renders a single icon button
+/// with a tooltip showing the current org/space. When expanded, renders an
+/// [InkWell] with the org name as the title and the space name as subtitle.
+class SpaceSwitcher extends ConsumerWidget {
+  const SpaceSwitcher({super.key, required this.collapsed});
+
+  final bool collapsed;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final selection = ref.watch(spaceSelectionProvider);
+
+    final orgName = selection.orgName;
+    final spaceName = selection.spaceName;
+    final hasOrg = orgName != null;
+    final hasSpace = spaceName != null;
+
+    final tooltipText = hasOrg && hasSpace
+        ? '$orgName / $spaceName'
+        : hasOrg
+        ? orgName
+        : 'Select space';
+
+    if (collapsed) {
+      return Tooltip(
+        message: tooltipText,
+        child: InkWell(
+          onTap: () => context.go(AppRoutes.spaceSelector),
+          borderRadius: BorderRadius.circular(16),
+          child: const Center(
+            child: SizedBox(
+              width: 56,
+              height: 32,
+              child: Icon(Icons.workspaces_outlined, size: 22),
+            ),
+          ),
+        ),
+      );
+    }
+
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      child: InkWell(
+        onTap: () => context.go(AppRoutes.spaceSelector),
+        borderRadius: BorderRadius.circular(28),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: Row(
+            children: [
+              Icon(
+                Icons.workspaces_outlined,
+                size: 20,
+                color: colorScheme.onSurfaceVariant,
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      hasOrg ? orgName : 'Select space',
+                      style: TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w600,
+                        color: colorScheme.onSurface,
+                      ),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    if (hasOrg)
+                      Text(
+                        hasSpace ? spaceName : 'Select space',
+                        style: TextStyle(
+                          fontSize: 11,
+                          color: colorScheme.onSurfaceVariant,
+                        ),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                  ],
+                ),
+              ),
+              Icon(
+                Icons.unfold_more,
+                size: 16,
+                color: colorScheme.onSurfaceVariant,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/test/unit/admin/admin_providers_test.dart
+++ b/app/test/unit/admin/admin_providers_test.dart
@@ -1,0 +1,576 @@
+import 'package:assistant_api/assistant_api.dart';
+import 'package:assistant_app/api/api_client.dart';
+import 'package:assistant_app/features/admin/admin_providers.dart';
+import 'package:assistant_app/features/connection/connection_provider.dart';
+import 'package:assistant_app/features/spaces/space_provider.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// ---------------------------------------------------------------------------
+// Fakes
+
+class _FakeUsersApi extends UsersApi {
+  _FakeUsersApi(this._users) : super(Dio(), standardSerializers);
+
+  final List<UserSummary> _users;
+  int listCallCount = 0;
+  int createCallCount = 0;
+  final List<String> deletedIds = [];
+
+  @override
+  Future<Response<BuiltList<UserSummary>>> listUsers({
+    required String orgId,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    listCallCount++;
+    return Response(
+      requestOptions: RequestOptions(path: '/api/orgs/$orgId/users'),
+      statusCode: 200,
+      data: BuiltList<UserSummary>.from(_users),
+    );
+  }
+
+  @override
+  Future<Response<UserDetail>> createUser({
+    required String orgId,
+    required CreateUserRequest createUserRequest,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    createCallCount++;
+    final detail = UserDetail(
+      (b) => b
+        ..id = 'new-user-id'
+        ..email = createUserRequest.email
+        ..name = createUserRequest.name
+        ..orgId = orgId
+        ..createdAt = '2025-01-15'
+        ..updatedAt = '2025-01-15',
+    );
+    return Response(
+      requestOptions: RequestOptions(path: '/api/orgs/$orgId/users'),
+      statusCode: 201,
+      data: detail,
+    );
+  }
+
+  @override
+  Future<Response<void>> deleteUser({
+    required String orgId,
+    required String id,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    deletedIds.add(id);
+    return Response(
+      requestOptions: RequestOptions(path: '/api/orgs/$orgId/users/$id'),
+      statusCode: 204,
+    );
+  }
+}
+
+class _FakeMembersApi extends MembersApi {
+  _FakeMembersApi(this._members) : super(Dio(), standardSerializers);
+
+  final List<MemberEntry> _members;
+  int listCallCount = 0;
+  int addCallCount = 0;
+  final List<String> removedUserIds = [];
+
+  @override
+  Future<Response<BuiltList<MemberEntry>>> listMembers({
+    required String orgId,
+    required String spaceId,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    listCallCount++;
+    return Response(
+      requestOptions: RequestOptions(
+        path: '/api/orgs/$orgId/spaces/$spaceId/members',
+      ),
+      statusCode: 200,
+      data: BuiltList<MemberEntry>.from(_members),
+    );
+  }
+
+  @override
+  Future<Response<MemberEntry>> addMember({
+    required String orgId,
+    required String spaceId,
+    required AddMemberRequest addMemberRequest,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    addCallCount++;
+    final entry = MemberEntry(
+      (b) => b
+        ..userId = addMemberRequest.userId
+        ..spaceId = spaceId
+        ..role = addMemberRequest.role
+        ..createdAt = '2025-01-15',
+    );
+    return Response(
+      requestOptions: RequestOptions(
+        path: '/api/orgs/$orgId/spaces/$spaceId/members',
+      ),
+      statusCode: 201,
+      data: entry,
+    );
+  }
+
+  @override
+  Future<Response<void>> removeMember({
+    required String orgId,
+    required String spaceId,
+    required String userId,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    removedUserIds.add(userId);
+    return Response(
+      requestOptions: RequestOptions(
+        path: '/api/orgs/$orgId/spaces/$spaceId/members/$userId',
+      ),
+      statusCode: 204,
+    );
+  }
+}
+
+class _FakeCatalogApi extends CatalogApi {
+  _FakeCatalogApi(this._items) : super(Dio(), standardSerializers);
+
+  final List<CatalogItemResponse> _items;
+  int listCallCount = 0;
+  int publishCallCount = 0;
+  final List<String> deletedIds = [];
+
+  @override
+  Future<Response<BuiltList<CatalogItemResponse>>> listCatalog({
+    required String orgId,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    listCallCount++;
+    return Response(
+      requestOptions: RequestOptions(path: '/api/orgs/$orgId/catalog'),
+      statusCode: 200,
+      data: BuiltList<CatalogItemResponse>.from(_items),
+    );
+  }
+
+  @override
+  Future<Response<CatalogItemResponse>> publishCatalogItem({
+    required String orgId,
+    required PublishCatalogItemRequest publishCatalogItemRequest,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    publishCallCount++;
+    final item = CatalogItemResponse(
+      (b) => b
+        ..id = 'new-item-id'
+        ..name = publishCatalogItemRequest.name
+        ..description = publishCatalogItemRequest.description ?? ''
+        ..resourceType = publishCatalogItemRequest.resourceType
+        ..createdAt = '2025-01-15',
+    );
+    return Response(
+      requestOptions: RequestOptions(path: '/api/orgs/$orgId/catalog'),
+      statusCode: 201,
+      data: item,
+    );
+  }
+
+  @override
+  Future<Response<void>> deleteCatalogItem({
+    required String orgId,
+    required String itemId,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    deletedIds.add(itemId);
+    return Response(
+      requestOptions: RequestOptions(path: '/api/orgs/$orgId/catalog/$itemId'),
+      statusCode: 204,
+    );
+  }
+}
+
+class _FakeSpacesApi extends SpacesApi {
+  _FakeSpacesApi() : super(Dio(), standardSerializers);
+
+  int createCallCount = 0;
+  final List<String> deletedIds = [];
+
+  @override
+  Future<Response<SpaceDetail>> createSpace({
+    required String orgId,
+    required CreateSpaceRequest createSpaceRequest,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    createCallCount++;
+    final detail = SpaceDetail(
+      (b) => b
+        ..id = 'new-space-id'
+        ..name = createSpaceRequest.name
+        ..slug = createSpaceRequest.slug
+        ..orgId = orgId
+        ..createdAt = '2025-01-15'
+        ..updatedAt = '2025-01-15',
+    );
+    return Response(
+      requestOptions: RequestOptions(path: '/api/orgs/$orgId/spaces'),
+      statusCode: 201,
+      data: detail,
+    );
+  }
+
+  @override
+  Future<Response<void>> deleteSpace({
+    required String orgId,
+    required String id,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    deletedIds.add(id);
+    return Response(
+      requestOptions: RequestOptions(path: '/api/orgs/$orgId/spaces/$id'),
+      statusCode: 204,
+    );
+  }
+
+  @override
+  Future<Response<BuiltList<SpaceSummary>>> listSpaces({
+    required String orgId,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    return Response(
+      requestOptions: RequestOptions(path: '/api/orgs/$orgId/spaces'),
+      statusCode: 200,
+      data: BuiltList<SpaceSummary>.from(<SpaceSummary>[]),
+    );
+  }
+}
+
+class _FakeApiClient extends ApiClient {
+  _FakeApiClient({
+    _FakeUsersApi? usersApi,
+    _FakeMembersApi? membersApi,
+    _FakeCatalogApi? catalogApi,
+    _FakeSpacesApi? spacesApi,
+  }) : _usersApi = usersApi ?? _FakeUsersApi([]),
+       _membersApi = membersApi ?? _FakeMembersApi([]),
+       _catalogApi = catalogApi ?? _FakeCatalogApi([]),
+       _spacesApi = spacesApi ?? _FakeSpacesApi(),
+       super(baseUrl: 'http://fake.test', token: 'test-token');
+
+  final _FakeUsersApi _usersApi;
+  final _FakeMembersApi _membersApi;
+  final _FakeCatalogApi _catalogApi;
+  final _FakeSpacesApi _spacesApi;
+
+  @override
+  UsersApi get users => _usersApi;
+
+  @override
+  MembersApi get members => _membersApi;
+
+  @override
+  CatalogApi get catalog => _catalogApi;
+
+  @override
+  SpacesApi get spaces => _spacesApi;
+}
+
+UserSummary _makeUser({
+  required String id,
+  required String name,
+  String email = 'test@example.com',
+}) {
+  return UserSummary(
+    (b) => b
+      ..id = id
+      ..name = name
+      ..email = email,
+  );
+}
+
+MemberEntry _makeMember({required String userId, String role = 'member'}) {
+  return MemberEntry(
+    (b) => b
+      ..userId = userId
+      ..spaceId = 'space-1'
+      ..role = role
+      ..createdAt = '2025-01-15',
+  );
+}
+
+CatalogItemResponse _makeCatalogItem({
+  required String id,
+  required String name,
+  String resourceType = 'skill',
+}) {
+  return CatalogItemResponse(
+    (b) => b
+      ..id = id
+      ..name = name
+      ..description = 'A test item'
+      ..resourceType = resourceType
+      ..createdAt = '2025-01-15',
+  );
+}
+
+ProviderContainer _createContainer({
+  required ApiClient api,
+  String orgId = 'org-1',
+  String spaceId = 'space-1',
+}) {
+  return ProviderContainer(
+    overrides: [
+      apiClientProvider.overrideWithValue(api),
+      spaceSelectionProvider.overrideWith(() {
+        return _PreloadedSelectionNotifier(orgId: orgId, spaceId: spaceId);
+      }),
+    ],
+  );
+}
+
+class _PreloadedSelectionNotifier extends SpaceSelectionNotifier {
+  _PreloadedSelectionNotifier({this.orgId, this.spaceId});
+  final String? orgId;
+  final String? spaceId;
+
+  @override
+  SpaceSelection build() => SpaceSelection(
+    orgId: orgId,
+    orgName: 'Test Org',
+    spaceId: spaceId,
+    spaceName: 'Test Space',
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+
+void main() {
+  group('AdminUsersNotifier', () {
+    test('loads users for the active org', () async {
+      final users = [_makeUser(id: '1', name: 'Alice')];
+      final api = _FakeApiClient(usersApi: _FakeUsersApi(users));
+      final container = _createContainer(api: api);
+      addTearDown(container.dispose);
+
+      final result = await container.read(adminUsersProvider.future);
+      expect(result, hasLength(1));
+      expect(result.first.name, 'Alice');
+    });
+
+    test('returns empty when apiClient is null', () async {
+      final container = ProviderContainer(
+        overrides: [apiClientProvider.overrideWithValue(null)],
+      );
+      addTearDown(container.dispose);
+
+      final result = await container.read(adminUsersProvider.future);
+      expect(result, isEmpty);
+    });
+
+    test('inviteUser calls API and returns detail', () async {
+      final usersApi = _FakeUsersApi([]);
+      final api = _FakeApiClient(usersApi: usersApi);
+      final container = _createContainer(api: api);
+      addTearDown(container.dispose);
+
+      await container.read(adminUsersProvider.future);
+      final result = await container
+          .read(adminUsersProvider.notifier)
+          .inviteUser(email: 'bob@example.com', name: 'Bob');
+
+      expect(result, isNotNull);
+      expect(result!.email, 'bob@example.com');
+      expect(usersApi.createCallCount, 1);
+    });
+
+    test('removeUser calls API delete', () async {
+      final usersApi = _FakeUsersApi([_makeUser(id: 'u1', name: 'Old User')]);
+      final api = _FakeApiClient(usersApi: usersApi);
+      final container = _createContainer(api: api);
+      addTearDown(container.dispose);
+
+      await container.read(adminUsersProvider.future);
+      await container.read(adminUsersProvider.notifier).removeUser('u1');
+
+      expect(usersApi.deletedIds, ['u1']);
+    });
+  });
+
+  group('AdminMembersNotifier', () {
+    test('loads members for active org and space', () async {
+      final members = [_makeMember(userId: 'u1', role: 'member')];
+      final api = _FakeApiClient(membersApi: _FakeMembersApi(members));
+      final container = _createContainer(api: api);
+      addTearDown(container.dispose);
+
+      final result = await container.read(adminMembersProvider.future);
+      expect(result, hasLength(1));
+      expect(result.first.userId, 'u1');
+    });
+
+    test('addMember calls API and returns entry', () async {
+      final membersApi = _FakeMembersApi([]);
+      final api = _FakeApiClient(membersApi: membersApi);
+      final container = _createContainer(api: api);
+      addTearDown(container.dispose);
+
+      await container.read(adminMembersProvider.future);
+      final result = await container
+          .read(adminMembersProvider.notifier)
+          .addMember(userId: 'u2', role: 'member');
+
+      expect(result, isNotNull);
+      expect(result!.userId, 'u2');
+      expect(membersApi.addCallCount, 1);
+    });
+
+    test('removeMember calls API delete', () async {
+      final membersApi = _FakeMembersApi([_makeMember(userId: 'u1')]);
+      final api = _FakeApiClient(membersApi: membersApi);
+      final container = _createContainer(api: api);
+      addTearDown(container.dispose);
+
+      await container.read(adminMembersProvider.future);
+      await container.read(adminMembersProvider.notifier).removeMember('u1');
+
+      expect(membersApi.removedUserIds, ['u1']);
+    });
+  });
+
+  group('AdminCatalogNotifier', () {
+    test('loads catalog items for active org', () async {
+      final items = [_makeCatalogItem(id: 'c1', name: 'My Skill')];
+      final api = _FakeApiClient(catalogApi: _FakeCatalogApi(items));
+      final container = _createContainer(api: api);
+      addTearDown(container.dispose);
+
+      final result = await container.read(adminCatalogProvider.future);
+      expect(result, hasLength(1));
+      expect(result.first.name, 'My Skill');
+    });
+
+    test('publishItem calls API and returns item', () async {
+      final catalogApi = _FakeCatalogApi([]);
+      final api = _FakeApiClient(catalogApi: catalogApi);
+      final container = _createContainer(api: api);
+      addTearDown(container.dispose);
+
+      await container.read(adminCatalogProvider.future);
+      final result = await container
+          .read(adminCatalogProvider.notifier)
+          .publishItem(name: 'New Skill', resourceType: 'skill');
+
+      expect(result, isNotNull);
+      expect(result!.name, 'New Skill');
+      expect(catalogApi.publishCallCount, 1);
+    });
+
+    test('removeItem calls API delete', () async {
+      final catalogApi = _FakeCatalogApi([
+        _makeCatalogItem(id: 'c1', name: 'Old Skill'),
+      ]);
+      final api = _FakeApiClient(catalogApi: catalogApi);
+      final container = _createContainer(api: api);
+      addTearDown(container.dispose);
+
+      await container.read(adminCatalogProvider.future);
+      await container.read(adminCatalogProvider.notifier).removeItem('c1');
+
+      expect(catalogApi.deletedIds, ['c1']);
+    });
+  });
+
+  group('AdminSpacesNotifier', () {
+    test('createSpace calls API', () async {
+      final spacesApi = _FakeSpacesApi();
+      final api = _FakeApiClient(spacesApi: spacesApi);
+      final container = _createContainer(api: api);
+      addTearDown(container.dispose);
+
+      // The spacesProvider is already from space_provider.dart, so test
+      // through the admin notifier which exposes createSpace / deleteSpace.
+      await container.read(adminSpacesProvider.future);
+      final result = await container
+          .read(adminSpacesProvider.notifier)
+          .createSpace(name: 'Dev', slug: 'dev');
+
+      expect(result, isNotNull);
+      expect(result!.name, 'Dev');
+      expect(spacesApi.createCallCount, 1);
+    });
+
+    test('deleteSpace calls API delete', () async {
+      final spacesApi = _FakeSpacesApi();
+      final api = _FakeApiClient(spacesApi: spacesApi);
+      final container = _createContainer(api: api);
+      addTearDown(container.dispose);
+
+      await container.read(adminSpacesProvider.future);
+      await container.read(adminSpacesProvider.notifier).deleteSpace('s1');
+
+      expect(spacesApi.deletedIds, ['s1']);
+    });
+  });
+}

--- a/app/test/unit/api_keys/api_keys_provider_test.dart
+++ b/app/test/unit/api_keys/api_keys_provider_test.dart
@@ -1,0 +1,169 @@
+import 'package:assistant_api/assistant_api.dart';
+import 'package:assistant_app/api/api_client.dart';
+import 'package:assistant_app/features/api_keys/api_keys_provider.dart';
+import 'package:assistant_app/features/connection/connection_provider.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// ---------------------------------------------------------------------------
+// Fakes
+
+class _FakeApiKeysApi extends ApiKeysApi {
+  _FakeApiKeysApi(this._keys) : super(Dio(), standardSerializers);
+
+  final List<ApiKeySummary> _keys;
+  int listCallCount = 0;
+  int createCallCount = 0;
+  final List<String> deletedIds = [];
+
+  @override
+  Future<Response<BuiltList<ApiKeySummary>>> listApiKeys({
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    listCallCount++;
+    return Response(
+      requestOptions: RequestOptions(path: '/api/users/me/api-keys'),
+      statusCode: 200,
+      data: BuiltList<ApiKeySummary>.from(_keys),
+    );
+  }
+
+  @override
+  Future<Response<CreateApiKeyResponse>> createApiKey({
+    required CreateApiKeyRequest createApiKeyRequest,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    createCallCount++;
+    final response = CreateApiKeyResponse(
+      (b) => b
+        ..id = 'new-key-id'
+        ..name = createApiKeyRequest.name
+        ..keyPrefix = 'ask_abc'
+        ..plaintext = 'ask_abcdefghijk1234567890'
+        ..scopes = ListBuilder<String>(),
+    );
+    return Response(
+      requestOptions: RequestOptions(path: '/api/users/me/api-keys'),
+      statusCode: 201,
+      data: response,
+    );
+  }
+
+  @override
+  Future<Response<void>> deleteApiKey({
+    required String id,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    deletedIds.add(id);
+    return Response(
+      requestOptions: RequestOptions(path: '/api/users/me/api-keys/$id'),
+      statusCode: 204,
+    );
+  }
+}
+
+class _FakeApiClient extends ApiClient {
+  _FakeApiClient(this._apiKeysApi)
+    : super(baseUrl: 'http://fake.test', token: 'test-token');
+
+  final _FakeApiKeysApi _apiKeysApi;
+
+  @override
+  ApiKeysApi get apiKeys => _apiKeysApi;
+}
+
+ApiKeySummary _makeKey({
+  required String id,
+  required String name,
+  String keyPrefix = 'ask_abc',
+}) {
+  return ApiKeySummary(
+    (b) => b
+      ..id = id
+      ..name = name
+      ..keyPrefix = keyPrefix
+      ..createdAt = '2025-01-15T10:00:00Z'
+      ..scopes = ListBuilder<String>(),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+
+void main() {
+  group('ApiKeysNotifier', () {
+    test('loads API keys on build', () async {
+      final keys = [_makeKey(id: '1', name: 'CI Key')];
+      final api = _FakeApiClient(_FakeApiKeysApi(keys));
+      final container = ProviderContainer(
+        overrides: [apiClientProvider.overrideWithValue(api)],
+      );
+      addTearDown(container.dispose);
+
+      final result = await container.read(apiKeysProvider.future);
+      expect(result, hasLength(1));
+      expect(result.first.name, 'CI Key');
+    });
+
+    test('returns empty list when apiClient is null', () async {
+      final container = ProviderContainer(
+        overrides: [apiClientProvider.overrideWithValue(null)],
+      );
+      addTearDown(container.dispose);
+
+      final result = await container.read(apiKeysProvider.future);
+      expect(result, isEmpty);
+    });
+
+    test('createKey calls API and returns response with plaintext', () async {
+      final apiKeysApi = _FakeApiKeysApi([]);
+      final api = _FakeApiClient(apiKeysApi);
+      final container = ProviderContainer(
+        overrides: [apiClientProvider.overrideWithValue(api)],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(apiKeysProvider.future);
+      final response = await container
+          .read(apiKeysProvider.notifier)
+          .createKey(name: 'Test Key');
+
+      expect(response, isNotNull);
+      expect(response!.plaintext, 'ask_abcdefghijk1234567890');
+      expect(response.name, 'Test Key');
+      expect(apiKeysApi.createCallCount, 1);
+    });
+
+    test('revokeKey calls API delete', () async {
+      final keys = [_makeKey(id: 'key-1', name: 'Old Key')];
+      final apiKeysApi = _FakeApiKeysApi(keys);
+      final api = _FakeApiClient(apiKeysApi);
+      final container = ProviderContainer(
+        overrides: [apiClientProvider.overrideWithValue(api)],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(apiKeysProvider.future);
+      await container.read(apiKeysProvider.notifier).revokeKey('key-1');
+
+      expect(apiKeysApi.deletedIds, ['key-1']);
+    });
+  });
+}

--- a/app/test/unit/chat/conversation_list_provider_test.dart
+++ b/app/test/unit/chat/conversation_list_provider_test.dart
@@ -5,6 +5,7 @@ import 'package:assistant_app/api/api_client.dart';
 import 'package:assistant_app/api/models/stream_event.dart';
 import 'package:assistant_app/features/chat/chat_provider.dart';
 import 'package:assistant_app/features/connection/connection_provider.dart';
+import 'package:assistant_app/features/spaces/space_provider.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -747,6 +748,39 @@ void main() {
         state.conversations.length,
         2,
         reason: 'existing conversations should be preserved during reconnect',
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Space-scoping: rebuild on space change
+  // -------------------------------------------------------------------------
+
+  group('space-scoping', () {
+    test('rebuilds (re-subscribes) when space selection changes', () async {
+      final client = _FakeApiClient();
+      final container = ProviderContainer(
+        overrides: [apiClientProvider.overrideWithValue(client)],
+      );
+      addTearDown(container.dispose);
+      final sub = _keepAlive(container);
+      addTearDown(sub.close);
+
+      // Initial subscription.
+      await Future<void>.delayed(Duration.zero);
+      expect(client.streamConversationsCallCount, 1);
+
+      // Change space selection — should trigger a rebuild.
+      container
+          .read(spaceSelectionProvider.notifier)
+          .selectOrg(orgId: 'org-1', orgName: 'Org 1');
+      await Future<void>.delayed(Duration.zero);
+
+      // A new subscription means streamConversations was called again.
+      expect(
+        client.streamConversationsCallCount,
+        greaterThan(1),
+        reason: 'space change should trigger stream re-subscription',
       );
     });
   });

--- a/app/test/unit/onboarding/onboarding_provider_test.dart
+++ b/app/test/unit/onboarding/onboarding_provider_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/features/onboarding/onboarding_provider.dart';
+
+void main() {
+  group('needsOnboardingProvider', () {
+    test('false when onboarding status is true (has persona)', () {
+      final container = ProviderContainer(
+        overrides: [
+          onboardingStatusProvider.overrideWith(() => _StubOnboarding(true)),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      // Let the async notifier settle.
+      container.read(onboardingStatusProvider);
+
+      // needsOnboarding is derived from the async value.
+      // When the value is true (has persona), needs onboarding is false.
+      expect(container.read(needsOnboardingProvider), isFalse);
+    });
+
+    test('true when onboarding status is false (no persona)', () async {
+      final container = ProviderContainer(
+        overrides: [
+          onboardingStatusProvider.overrideWith(() => _StubOnboarding(false)),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      // Wait for the async provider to resolve.
+      await container.read(onboardingStatusProvider.future);
+
+      expect(container.read(needsOnboardingProvider), isTrue);
+    });
+
+    test('false while loading (optimistic — do not block)', () {
+      final container = ProviderContainer(
+        overrides: [
+          onboardingStatusProvider.overrideWith(() => _SlowOnboarding()),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      // Trigger the provider but don't await.
+      container.read(onboardingStatusProvider);
+
+      // While loading, the value is null, so needsOnboarding is false.
+      expect(container.read(needsOnboardingProvider), isFalse);
+    });
+  });
+}
+
+class _StubOnboarding extends AsyncNotifier<bool>
+    implements OnboardingNotifier {
+  _StubOnboarding(this._hasPersona);
+  final bool _hasPersona;
+
+  @override
+  Future<bool> build() async => _hasPersona;
+
+  @override
+  void refresh() => ref.invalidateSelf();
+}
+
+class _SlowOnboarding extends AsyncNotifier<bool>
+    implements OnboardingNotifier {
+  @override
+  Future<bool> build() async {
+    await Future<void>.delayed(const Duration(seconds: 60));
+    return true;
+  }
+
+  @override
+  void refresh() => ref.invalidateSelf();
+}

--- a/app/test/unit/personas/personas_provider_test.dart
+++ b/app/test/unit/personas/personas_provider_test.dart
@@ -1,0 +1,139 @@
+import 'package:assistant_api/assistant_api.dart';
+import 'package:assistant_app/api/api_client.dart';
+import 'package:assistant_app/features/connection/connection_provider.dart';
+import 'package:assistant_app/features/personas/personas_provider.dart';
+import 'package:assistant_app/features/spaces/space_provider.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// ---------------------------------------------------------------------------
+// Fakes
+
+class _FakePersonasApi extends PersonasApi {
+  _FakePersonasApi(this._personas) : super(Dio(), standardSerializers);
+
+  final List<PersonaSummary> _personas;
+  int listCallCount = 0;
+
+  @override
+  Future<Response<BuiltList<PersonaSummary>>> listPersonas({
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    listCallCount++;
+    return Response(
+      requestOptions: RequestOptions(path: '/api/personas'),
+      statusCode: 200,
+      data: BuiltList<PersonaSummary>.from(_personas),
+    );
+  }
+}
+
+class _FakeApiClient extends ApiClient {
+  _FakeApiClient(this._personasApi)
+    : super(baseUrl: 'http://fake.test', token: 'test-token');
+
+  final _FakePersonasApi _personasApi;
+
+  @override
+  PersonasApi get personas => _personasApi;
+}
+
+PersonaSummary _makePersona({required String id, required String name}) {
+  return PersonaSummary(
+    (b) => b
+      ..id = id
+      ..name = name
+      ..description = '',
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+
+void main() {
+  group('PersonasNotifier', () {
+    test('loads personas on build', () async {
+      final personas = [_makePersona(id: '1', name: 'Alpha')];
+      final api = _FakeApiClient(_FakePersonasApi(personas));
+      final container = ProviderContainer(
+        overrides: [apiClientProvider.overrideWithValue(api)],
+      );
+      addTearDown(container.dispose);
+
+      final sub = container.listen(personasProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      final state = await container.read(personasProvider.future);
+      expect(state.personas, hasLength(1));
+      expect(state.personas.first.name, 'Alpha');
+    });
+
+    test('returns empty state when apiClient is null', () async {
+      final container = ProviderContainer(
+        overrides: [apiClientProvider.overrideWithValue(null)],
+      );
+      addTearDown(container.dispose);
+
+      final sub = container.listen(personasProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      final state = await container.read(personasProvider.future);
+      expect(state.personas, isEmpty);
+    });
+
+    test('rebuilds when space selection changes', () async {
+      final personasApi = _FakePersonasApi([
+        _makePersona(id: '1', name: 'Alpha'),
+      ]);
+      final api = _FakeApiClient(personasApi);
+      final container = ProviderContainer(
+        overrides: [apiClientProvider.overrideWithValue(api)],
+      );
+      addTearDown(container.dispose);
+
+      final sub = container.listen(personasProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      await container.read(personasProvider.future);
+      expect(personasApi.listCallCount, 1);
+
+      // Change space selection — should trigger a rebuild.
+      container
+          .read(spaceSelectionProvider.notifier)
+          .selectOrg(orgId: 'org-1', orgName: 'Org 1');
+      await container.read(personasProvider.future);
+
+      expect(
+        personasApi.listCallCount,
+        greaterThan(1),
+        reason: 'space change should trigger persona re-fetch',
+      );
+    });
+
+    test('selects default persona automatically', () async {
+      final personas = [
+        _makePersona(id: 'default', name: 'Default'),
+        _makePersona(id: 'other', name: 'Other'),
+      ];
+      final api = _FakeApiClient(_FakePersonasApi(personas));
+      final container = ProviderContainer(
+        overrides: [apiClientProvider.overrideWithValue(api)],
+      );
+      addTearDown(container.dispose);
+
+      final sub = container.listen(personasProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      final state = await container.read(personasProvider.future);
+      expect(state.activePersona, isNotNull);
+      expect(state.activePersona!.id, 'default');
+    });
+  });
+}

--- a/app/test/widget/admin/admin_screen_test.dart
+++ b/app/test/widget/admin/admin_screen_test.dart
@@ -1,0 +1,264 @@
+import 'package:assistant_api/assistant_api.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/features/admin/admin_providers.dart';
+import 'package:assistant_app/features/admin/admin_screen.dart';
+
+// ---------------------------------------------------------------------------
+// Stubs
+
+UserSummary _makeUser({
+  required String id,
+  required String name,
+  String email = 'test@example.com',
+}) {
+  return UserSummary(
+    (b) => b
+      ..id = id
+      ..name = name
+      ..email = email,
+  );
+}
+
+MemberEntry _makeMember({
+  required String userId,
+  String role = 'member',
+  String spaceId = 'space-1',
+}) {
+  return MemberEntry(
+    (b) => b
+      ..userId = userId
+      ..spaceId = spaceId
+      ..role = role
+      ..createdAt = '2025-01-15',
+  );
+}
+
+CatalogItemResponse _makeCatalogItem({
+  required String id,
+  required String name,
+  String resourceType = 'skill',
+}) {
+  return CatalogItemResponse(
+    (b) => b
+      ..id = id
+      ..name = name
+      ..description = 'A test item'
+      ..resourceType = resourceType
+      ..createdAt = '2025-01-15',
+  );
+}
+
+class _StubUsersNotifier extends AsyncNotifier<List<UserSummary>>
+    implements AdminUsersNotifier {
+  _StubUsersNotifier(this._users);
+  final List<UserSummary> _users;
+
+  @override
+  Future<List<UserSummary>> build() async => _users;
+
+  @override
+  Future<UserDetail?> inviteUser({
+    required String email,
+    required String name,
+    String? password,
+  }) async => null;
+
+  @override
+  Future<void> removeUser(String userId) async {}
+}
+
+class _StubMembersNotifier extends AsyncNotifier<List<MemberEntry>>
+    implements AdminMembersNotifier {
+  _StubMembersNotifier(this._members);
+  final List<MemberEntry> _members;
+
+  @override
+  Future<List<MemberEntry>> build() async => _members;
+
+  @override
+  Future<MemberEntry?> addMember({
+    required String userId,
+    required String role,
+  }) async => null;
+
+  @override
+  Future<void> removeMember(String userId) async {}
+}
+
+class _StubCatalogNotifier extends AsyncNotifier<List<CatalogItemResponse>>
+    implements AdminCatalogNotifier {
+  _StubCatalogNotifier(this._items);
+  final List<CatalogItemResponse> _items;
+
+  @override
+  Future<List<CatalogItemResponse>> build() async => _items;
+
+  @override
+  Future<CatalogItemResponse?> publishItem({
+    required String name,
+    required String resourceType,
+    String? description,
+  }) async => null;
+
+  @override
+  Future<void> removeItem(String itemId) async {}
+}
+
+class _StubSpacesNotifier extends AsyncNotifier<List<SpaceSummary>>
+    implements AdminSpacesNotifier {
+  _StubSpacesNotifier(this._spaces);
+  final List<SpaceSummary> _spaces;
+
+  @override
+  Future<List<SpaceSummary>> build() async => _spaces;
+
+  @override
+  Future<SpaceDetail?> createSpace({
+    required String name,
+    required String slug,
+  }) async => null;
+
+  @override
+  Future<void> deleteSpace(String spaceId) async {}
+}
+
+Widget _buildApp({
+  List<UserSummary> users = const [],
+  List<MemberEntry> members = const [],
+  List<CatalogItemResponse> catalogItems = const [],
+  List<SpaceSummary> spaces = const [],
+}) {
+  return ProviderScope(
+    overrides: [
+      adminUsersProvider.overrideWith(() => _StubUsersNotifier(users)),
+      adminMembersProvider.overrideWith(() => _StubMembersNotifier(members)),
+      adminCatalogProvider.overrideWith(
+        () => _StubCatalogNotifier(catalogItems),
+      ),
+      adminSpacesProvider.overrideWith(() => _StubSpacesNotifier(spaces)),
+    ],
+    child: const MaterialApp(home: AdminScreen()),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+
+void main() {
+  group('AdminScreen', () {
+    testWidgets('shows tab bar with three tabs', (tester) async {
+      await tester.pumpWidget(_buildApp());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Users'), findsOneWidget);
+      expect(find.text('Spaces'), findsOneWidget);
+      expect(find.text('Catalog'), findsOneWidget);
+    });
+
+    testWidgets('app bar shows Admin title', (tester) async {
+      await tester.pumpWidget(_buildApp());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Admin'), findsOneWidget);
+    });
+
+    testWidgets('Users tab shows user list', (tester) async {
+      await tester.pumpWidget(
+        _buildApp(
+          users: [
+            _makeUser(id: '1', name: 'Alice', email: 'alice@example.com'),
+            _makeUser(id: '2', name: 'Bob', email: 'bob@example.com'),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Alice'), findsOneWidget);
+      expect(find.text('Bob'), findsOneWidget);
+    });
+
+    testWidgets('Users tab shows empty state', (tester) async {
+      await tester.pumpWidget(_buildApp());
+      await tester.pumpAndSettle();
+
+      expect(find.text('No users'), findsOneWidget);
+    });
+
+    testWidgets('Users tab has invite button', (tester) async {
+      await tester.pumpWidget(_buildApp());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(FloatingActionButton), findsOneWidget);
+    });
+
+    testWidgets('Spaces tab shows space list', (tester) async {
+      final spaces = [
+        SpaceSummary(
+          (b) => b
+            ..id = 's1'
+            ..name = 'Production'
+            ..slug = 'prod',
+        ),
+      ];
+      await tester.pumpWidget(_buildApp(spaces: spaces));
+      await tester.pumpAndSettle();
+
+      // Navigate to Spaces tab.
+      await tester.tap(find.text('Spaces'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Production'), findsOneWidget);
+    });
+
+    testWidgets('Catalog tab shows catalog items', (tester) async {
+      await tester.pumpWidget(
+        _buildApp(
+          catalogItems: [
+            _makeCatalogItem(id: 'c1', name: 'My Skill', resourceType: 'skill'),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Navigate to Catalog tab.
+      await tester.tap(find.text('Catalog'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('My Skill'), findsOneWidget);
+    });
+
+    testWidgets('FAB opens invite dialog on Users tab', (tester) async {
+      await tester.pumpWidget(_buildApp());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(FloatingActionButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Invite user'), findsOneWidget);
+      expect(find.text('Email'), findsOneWidget);
+      expect(find.text('Name'), findsOneWidget);
+    });
+
+    testWidgets('Members tab shows member list', (tester) async {
+      await tester.pumpWidget(
+        _buildApp(
+          members: [
+            _makeMember(userId: 'u1', role: 'member'),
+            _makeMember(userId: 'u2', role: 'space-admin'),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Navigate to Spaces tab, then select Members sub-section.
+      await tester.tap(find.text('Spaces'));
+      await tester.pumpAndSettle();
+
+      // Members section is shown below spaces on the Spaces tab.
+      expect(find.text('Members'), findsWidgets);
+    });
+  });
+}

--- a/app/test/widget/api_keys/api_keys_screen_test.dart
+++ b/app/test/widget/api_keys/api_keys_screen_test.dart
@@ -1,0 +1,150 @@
+import 'package:assistant_api/assistant_api.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/features/api_keys/api_keys_provider.dart';
+import 'package:assistant_app/features/api_keys/api_keys_screen.dart';
+
+ApiKeySummary _makeKey({
+  required String id,
+  required String name,
+  String keyPrefix = 'ask_abc',
+}) {
+  return ApiKeySummary(
+    (b) => b
+      ..id = id
+      ..name = name
+      ..keyPrefix = keyPrefix
+      ..createdAt = '2025-01-15'
+      ..scopes = ListBuilder<String>(),
+  );
+}
+
+void main() {
+  group('ApiKeysScreen', () {
+    testWidgets('shows empty state when no keys', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            apiKeysProvider.overrideWith(() => _StubApiKeysNotifier([])),
+          ],
+          child: const MaterialApp(home: ApiKeysScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('No API keys'), findsOneWidget);
+      expect(
+        find.text('Create an API key to authenticate programmatic access.'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('shows API key list', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            apiKeysProvider.overrideWith(
+              () => _StubApiKeysNotifier([
+                _makeKey(id: '1', name: 'CI Pipeline', keyPrefix: 'ask_ci1'),
+                _makeKey(id: '2', name: 'Dev Token', keyPrefix: 'ask_dev'),
+              ]),
+            ),
+          ],
+          child: const MaterialApp(home: ApiKeysScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('CI Pipeline'), findsOneWidget);
+      expect(find.text('Dev Token'), findsOneWidget);
+    });
+
+    testWidgets('shows create button (FAB)', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            apiKeysProvider.overrideWith(() => _StubApiKeysNotifier([])),
+          ],
+          child: const MaterialApp(home: ApiKeysScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(FloatingActionButton), findsOneWidget);
+    });
+
+    testWidgets('FAB opens create dialog', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            apiKeysProvider.overrideWith(() => _StubApiKeysNotifier([])),
+          ],
+          child: const MaterialApp(home: ApiKeysScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(FloatingActionButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Create API key'), findsOneWidget);
+      expect(find.text('Key name'), findsOneWidget);
+    });
+
+    testWidgets('revoke button shows confirmation dialog', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            apiKeysProvider.overrideWith(
+              () => _StubApiKeysNotifier([_makeKey(id: '1', name: 'Test Key')]),
+            ),
+          ],
+          child: const MaterialApp(home: ApiKeysScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Tap the delete icon button.
+      await tester.tap(find.byIcon(Icons.delete_outline));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Revoke API key?'), findsOneWidget);
+      expect(find.text('Cancel'), findsOneWidget);
+      expect(find.text('Revoke'), findsOneWidget);
+    });
+
+    testWidgets('app bar shows title', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            apiKeysProvider.overrideWith(() => _StubApiKeysNotifier([])),
+          ],
+          child: const MaterialApp(home: ApiKeysScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('API Keys'), findsOneWidget);
+    });
+  });
+}
+
+class _StubApiKeysNotifier extends AsyncNotifier<List<ApiKeySummary>>
+    implements ApiKeysNotifier {
+  _StubApiKeysNotifier(this._keys);
+  final List<ApiKeySummary> _keys;
+
+  @override
+  Future<List<ApiKeySummary>> build() async => _keys;
+
+  @override
+  Future<CreateApiKeyResponse?> createKey({required String name}) async {
+    return null;
+  }
+
+  @override
+  Future<void> revokeKey(String id) async {}
+}

--- a/app/test/widget/onboarding/onboarding_screen_test.dart
+++ b/app/test/widget/onboarding/onboarding_screen_test.dart
@@ -1,0 +1,130 @@
+import 'package:assistant_api/assistant_api.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:assistant_app/features/onboarding/onboarding_provider.dart';
+import 'package:assistant_app/features/onboarding/onboarding_screen.dart';
+
+GoRouter _router() => GoRouter(
+  initialLocation: '/onboarding',
+  routes: [
+    GoRoute(path: '/onboarding', builder: (ctx, s) => const OnboardingScreen()),
+    GoRoute(path: '/chat', builder: (ctx, s) => const Scaffold()),
+  ],
+);
+
+TemplateResponse _makeTemplate({
+  required String id,
+  required String name,
+  String description = '',
+}) {
+  return TemplateResponse(
+    (b) => b
+      ..id = id
+      ..name = name
+      ..description = description
+      ..createdAt = '2025-01-01T00:00:00Z',
+  );
+}
+
+void main() {
+  group('OnboardingScreen', () {
+    testWidgets('renders welcome heading', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            templatesProvider.overrideWith(() => _StubTemplatesNotifier([])),
+          ],
+          child: MaterialApp.router(routerConfig: _router()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Welcome'), findsOneWidget);
+    });
+
+    testWidgets('shows "Create blank persona" button when no templates', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            templatesProvider.overrideWith(() => _StubTemplatesNotifier([])),
+          ],
+          child: MaterialApp.router(routerConfig: _router()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Create blank persona'), findsOneWidget);
+    });
+
+    testWidgets('shows template list when templates available', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            templatesProvider.overrideWith(
+              () => _StubTemplatesNotifier([
+                _makeTemplate(
+                  id: 'coding-assistant',
+                  name: 'Coding Assistant',
+                  description: 'Helps with programming tasks',
+                ),
+                _makeTemplate(id: 'writer', name: 'Writing Helper'),
+              ]),
+            ),
+          ],
+          child: MaterialApp.router(routerConfig: _router()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Templates'), findsOneWidget);
+      expect(find.text('Coding Assistant'), findsOneWidget);
+      expect(find.text('Helps with programming tasks'), findsOneWidget);
+      expect(find.text('Writing Helper'), findsOneWidget);
+    });
+
+    testWidgets('shows skip button', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            templatesProvider.overrideWith(() => _StubTemplatesNotifier([])),
+          ],
+          child: MaterialApp.router(routerConfig: _router()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Skip for now'), findsOneWidget);
+    });
+
+    testWidgets('skip button navigates to chat', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            templatesProvider.overrideWith(() => _StubTemplatesNotifier([])),
+          ],
+          child: MaterialApp.router(routerConfig: _router()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Skip for now'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(OnboardingScreen), findsNothing);
+    });
+  });
+}
+
+class _StubTemplatesNotifier extends AsyncNotifier<List<TemplateResponse>>
+    implements TemplatesNotifier {
+  _StubTemplatesNotifier(this._templates);
+  final List<TemplateResponse> _templates;
+
+  @override
+  Future<List<TemplateResponse>> build() async => _templates;
+}

--- a/app/test/widget/shared/space_switcher_test.dart
+++ b/app/test/widget/shared/space_switcher_test.dart
@@ -1,0 +1,224 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:assistant_app/features/spaces/space_provider.dart';
+import 'package:assistant_app/shared/space_switcher.dart';
+
+GoRouter _router({String initial = '/home'}) => GoRouter(
+  initialLocation: initial,
+  routes: [
+    GoRoute(
+      path: '/home',
+      builder: (ctx, s) => const Scaffold(body: _TestSpaceSwitcherExpanded()),
+    ),
+    GoRoute(
+      path: '/home-collapsed',
+      builder: (ctx, s) => const Scaffold(body: _TestSpaceSwitcherCollapsed()),
+    ),
+    GoRoute(
+      path: '/spaces',
+      builder: (ctx, s) => const Scaffold(body: Text('Space Selector')),
+    ),
+  ],
+);
+
+/// Wraps the expanded space switcher for testing.
+class _TestSpaceSwitcherExpanded extends ConsumerWidget {
+  const _TestSpaceSwitcherExpanded();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return const SpaceSwitcher(collapsed: false);
+  }
+}
+
+/// Wraps the collapsed space switcher for testing.
+class _TestSpaceSwitcherCollapsed extends ConsumerWidget {
+  const _TestSpaceSwitcherCollapsed();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return const SpaceSwitcher(collapsed: true);
+  }
+}
+
+void main() {
+  group('SpaceSwitcher', () {
+    testWidgets('shows org and space name when selection is complete', (
+      tester,
+    ) async {
+      final container = ProviderContainer(
+        overrides: [
+          spaceSelectionProvider.overrideWith(
+            () => _PreloadedSelectionNotifier(
+              const SpaceSelection(
+                orgId: 'org-1',
+                orgName: 'Acme Corp',
+                spaceId: 'space-1',
+                spaceName: 'Engineering',
+              ),
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp.router(routerConfig: _router()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Acme Corp'), findsOneWidget);
+      expect(find.text('Engineering'), findsOneWidget);
+    });
+
+    testWidgets('shows placeholder when no selection', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(child: MaterialApp.router(routerConfig: _router())),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Select space'), findsOneWidget);
+    });
+
+    testWidgets('shows org name only when space not yet selected', (
+      tester,
+    ) async {
+      final container = ProviderContainer(
+        overrides: [
+          spaceSelectionProvider.overrideWith(
+            () => _PreloadedSelectionNotifier(
+              const SpaceSelection(orgId: 'org-1', orgName: 'Acme Corp'),
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp.router(routerConfig: _router()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Acme Corp'), findsOneWidget);
+      expect(find.text('Select space'), findsOneWidget);
+    });
+
+    testWidgets('navigates to /spaces on tap', (tester) async {
+      final container = ProviderContainer(
+        overrides: [
+          spaceSelectionProvider.overrideWith(
+            () => _PreloadedSelectionNotifier(
+              const SpaceSelection(
+                orgId: 'org-1',
+                orgName: 'Acme Corp',
+                spaceId: 'space-1',
+                spaceName: 'Engineering',
+              ),
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp.router(routerConfig: _router()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(SpaceSwitcher));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Space Selector'), findsOneWidget);
+    });
+
+    testWidgets('shows tooltip with icon-only in collapsed mode', (
+      tester,
+    ) async {
+      final container = ProviderContainer(
+        overrides: [
+          spaceSelectionProvider.overrideWith(
+            () => _PreloadedSelectionNotifier(
+              const SpaceSelection(
+                orgId: 'org-1',
+                orgName: 'Acme Corp',
+                spaceId: 'space-1',
+                spaceName: 'Engineering',
+              ),
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp.router(
+            routerConfig: _router(initial: '/home-collapsed'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // In collapsed mode, org/space text is not shown.
+      expect(find.text('Acme Corp'), findsNothing);
+      expect(find.text('Engineering'), findsNothing);
+
+      // A Tooltip should be present.
+      expect(find.byType(Tooltip), findsOneWidget);
+    });
+
+    testWidgets('collapsed mode navigates to /spaces on tap', (tester) async {
+      final container = ProviderContainer(
+        overrides: [
+          spaceSelectionProvider.overrideWith(
+            () => _PreloadedSelectionNotifier(
+              const SpaceSelection(
+                orgId: 'org-1',
+                orgName: 'Acme Corp',
+                spaceId: 'space-1',
+                spaceName: 'Engineering',
+              ),
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp.router(
+            routerConfig: _router(initial: '/home-collapsed'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(SpaceSwitcher));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Space Selector'), findsOneWidget);
+    });
+  });
+}
+
+class _PreloadedSelectionNotifier extends SpaceSelectionNotifier {
+  _PreloadedSelectionNotifier(this._initial);
+  final SpaceSelection _initial;
+
+  @override
+  SpaceSelection build() => _initial;
+}

--- a/openspec/changes/multi-user-orgs/tasks.md
+++ b/openspec/changes/multi-user-orgs/tasks.md
@@ -545,7 +545,7 @@ PR 10 ─── CLI OAuth2 login + Flutter OAuth2 + docs
   - Fetch user's orgs and spaces from API
   - Display space picker, persist selection
 
-- [ ] `feat(app): persona creation from template during onboarding`
+- [x] `feat(app): persona creation from template during onboarding`
   - Check onboarding status on first load
   - Show template picker, create persona, navigate to chat
 

--- a/openspec/changes/multi-user-orgs/tasks.md
+++ b/openspec/changes/multi-user-orgs/tasks.md
@@ -549,25 +549,25 @@ PR 10 ─── CLI OAuth2 login + Flutter OAuth2 + docs
   - Check onboarding status on first load
   - Show template picker, create persona, navigate to chat
 
-- [ ] `feat(app): space switcher in navigation`
+- [x] `feat(app): space switcher in navigation`
   - Dropdown/drawer for switching active space
   - Refreshes persona list, conversation list on switch
 
-- [ ] `feat(app): update conversation and persona lists for multi-user scoping`
+- [x] `feat(app): update conversation and persona lists for multi-user scoping`
   - Conversation list filtered by current user + space + persona
   - Persona picker shows granted org personas + own private personas
 
-- [ ] `feat(app): API key management screen`
+- [x] `feat(app): API key management screen`
   - Create, list, revoke API keys
   - Copy-to-clipboard on creation
 
-- [ ] `feat(app): admin screens (user, space, catalog management)`
+- [x] `feat(app): admin screens (user, space, catalog management)`
   - Behind org-admin / space-admin role check
   - User management: invite, list, assign roles
   - Space management: create, list, manage memberships
   - Catalog: publish skills/templates, manage subscriptions
 
-- [ ] `test(app): widget tests for login, space switching, persona scoping`
+- [x] `test(app): widget tests for login, space switching, persona scoping`
 
 - [x] `docs: update authentication.md with OAuth2 flows and API keys`
 


### PR DESCRIPTION
## Summary

Completes the Flutter app tasks for the multi-user-orgs change (PR 10). Builds on OAuth2 login, org/space selector, and persona onboarding from prior commits.

**Space switcher & multi-user scoping**
- SpaceSwitcher widget in all 4 nav layouts (Material wide/mobile, Cupertino wide/mobile)
- Conversation and persona providers rebuild on space selection change

**API key management**
- Full CRUD screen: list, create (with copy-to-clipboard), revoke with confirmation
- ApiKeysNotifier backed by generated API client

**Admin screens**
- Tabbed admin screen (Users, Spaces, Catalog) at `/admin`
- User management: list, invite, remove
- Space management: list, create, delete + member list
- Catalog management: list, publish, remove items
- Admin nav destination in overflow section

**Test coverage**
- 764 total tests pass (22 new in this push)
- 12 admin provider unit tests, 9 admin widget tests
- 4 API key provider tests, 6 API key widget tests
- 6 space switcher widget tests, persona + conversation scoping tests

## Test plan

- [x] `flutter analyze` — zero issues
- [x] `flutter test` — 764 tests pass
- [x] Pre-commit hooks pass (format, analyze, clippy, machete, flutter test)
- [ ] Manual: verify space switcher shows in sidebar on wide screens
- [ ] Manual: verify API key create/copy/revoke flow
- [ ] Manual: verify admin tabs load users, spaces, catalog