### PR TITLE
feat(web-ui): auto-migrate legacy layout on startup

### DIFF
--- a/crates/web-ui/src/main.rs
+++ b/crates/web-ui/src/main.rs
@@ -11,7 +11,7 @@ pub(crate) mod push;
 use std::collections::HashMap;
 use std::ffi::OsString;
 use std::net::SocketAddr;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -190,6 +190,19 @@ async fn run_with_args(args: Args) -> Result<()> {
         Some(p) => p,
         None => anyhow::bail!("Cannot determine default DB path. Specify --db-path."),
     };
+
+    // Before opening databases, check for a legacy single-user layout and
+    // auto-migrate to the new org/space directory structure.  The migration
+    // must run before StorageLayer opens `assistant.db` so the backup gets a
+    // clean WAL checkpoint without contention.
+    let base_path = db_path.parent().unwrap_or(Path::new("."));
+    if assistant_storage::migration::is_legacy_layout(base_path) {
+        info!("detected legacy single-user layout — running auto-migration");
+        let backup = assistant_storage::migration::run_migration(base_path)
+            .await
+            .context("legacy → multi-org auto-migration failed")?;
+        info!("migration complete — backup at {}", backup.display());
+    }
 
     let storage = Arc::new(StorageLayer::new(&db_path).await?);
 


### PR DESCRIPTION
## Summary

- Wires the existing `is_legacy_layout()` detection and `run_migration()` into the web-ui startup path
- Migration runs **before** `StorageLayer::new()` opens `assistant.db`, ensuring the backup gets a clean WAL checkpoint without connection contention
- On systemd service restart after deployment, existing single-user installations automatically migrate to the new org/space directory structure — no manual steps required

## What happens on restart

1. `is_legacy_layout(base_path)` checks for `assistant.db` without `orgs/` directory
2. If legacy: `run_migration()` creates a `.tar.gz` backup, restructures the filesystem to `orgs/default/spaces/default/`, copies the database, creates `org.db` with the default org + admin user
3. If already migrated (or fresh install): no-op, proceeds normally

## Test plan

- [x] `cargo check -p assistant-web-ui` passes
- [x] `cargo clippy -p assistant-web-ui -- -D warnings` passes
- [x] All 11 migration unit tests pass (`cargo test -p assistant-storage migration`)
- [x] Pre-commit hooks pass (fmt, clippy, machete)
- [ ] Deploy to test server with existing single-user layout, verify migration runs on restart