### PR TITLE
fix(app): handle Dio redirect exceptions in OAuth2 login

### DIFF
--- a/app/lib/features/auth/oauth_service.dart
+++ b/app/lib/features/auth/oauth_service.dart
@@ -109,26 +109,43 @@ class OAuthService {
     required String redirectUri,
     required PkceChallenge pkce,
   }) async {
-    // POST credentials to get an auth code via redirect.
-    final authResponse = await _dio.post<dynamic>(
-      '/oauth/authorize',
-      data: {
-        'client_id': clientId,
-        'redirect_uri': redirectUri,
-        'code_challenge': pkce.challenge,
-        'email': email,
-        'password': password,
-      },
-      options: Options(
-        contentType: 'application/x-www-form-urlencoded',
-        followRedirects: false,
-        validateStatus: (status) =>
-            status != null && (status >= 200 && status < 400),
-      ),
-    );
+    // POST credentials to get an auth code via redirect (302/303).
+    //
+    // Dio on some platforms (notably iOS) does not reliably honour
+    // `followRedirects: false` — the underlying HttpClient may follow
+    // the redirect or throw a DioException with the redirect status.
+    // We handle both paths: a successful response with a Location header,
+    // and a DioException whose response carries the Location header.
+    String? location;
 
-    // Extract the auth code from the redirect Location header.
-    final location = authResponse.headers.value('location');
+    try {
+      final authResponse = await _dio.post<dynamic>(
+        '/oauth/authorize',
+        data: {
+          'client_id': clientId,
+          'redirect_uri': redirectUri,
+          'code_challenge': pkce.challenge,
+          'email': email,
+          'password': password,
+        },
+        options: Options(
+          contentType: 'application/x-www-form-urlencoded',
+          followRedirects: false,
+          validateStatus: (status) =>
+              status != null && (status >= 200 && status < 400),
+        ),
+      );
+      location = authResponse.headers.value('location');
+    } on DioException catch (e) {
+      // Dio threw on the redirect status — extract Location from the
+      // error response if available.
+      final status = e.response?.statusCode;
+      if (status != null && status >= 300 && status < 400) {
+        location = e.response?.headers.value('location');
+      }
+      if (location == null) rethrow;
+    }
+
     if (location == null) {
       throw OAuthException('No redirect location in authorization response');
     }


### PR DESCRIPTION
## Summary

- Dio on iOS does not reliably honour `followRedirects: false` — the underlying `HttpClient` throws a `DioException` with the redirect status code (302/303/307) instead of returning the response
- The `login()` method now catches redirect-status `DioException`s and extracts the `Location` header from the error response to complete the auth code exchange
- This fixes the "DioException [bad response]: status code 302/307" error seen on the iOS app login screen

## Test plan

- [x] `flutter analyze --fatal-infos` clean
- [x] All 764 Flutter tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth login reliability on platforms where redirect handling may not work as expected. The authentication flow now correctly processes authorization redirects in edge cases by extracting location information from alternative response sources, ensuring more consistent login functionality across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->