### PR TITLE
refactor(web-ui): use OrgPoolFactory for org.db resolution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,10 +26,12 @@ The Rust build embeds the Flutter web app via `rust-embed`. `cargo build -p assi
 
 All runtime data lives under `~/.assistant/`:
 
-- `assistant.db` — SQLite database (WAL mode)
+- `assistant.db` — SQLite database (WAL mode), space-level data
+- `org.db` — org-level database (users, spaces, auth state, API keys)
 - `config.toml` — copied from `config.toml` at repo root on first run
 - `skills/<name>/SKILL.md` — user-created skills
 - `agents/<id>/` — per-persona agent workspace
+- `orgs/{slug}/spaces/{space}/space.db` — per-space databases (multi-org layout)
 
 ## OpenAPI Spec
 

--- a/crates/storage/src/migration.rs
+++ b/crates/storage/src/migration.rs
@@ -292,8 +292,8 @@ pub async fn migrate_database(base_path: &Path) -> Result<()> {
         }
     }
 
-    // Create org.db at the installation root (next to assistant.db) so the
-    // web-ui startup path finds it at `db_path.with_file_name("org.db")`.
+    // Create org.db at the installation root (next to assistant.db), matching
+    // the path resolved by `OrgPoolFactory::org_db_path()`.
     let org_db_path = base_path.join("org.db");
     let org_storage = crate::org_storage::OrgStorageLayer::new(&org_db_path)
         .await

--- a/crates/web-ui/src/main.rs
+++ b/crates/web-ui/src/main.rs
@@ -207,9 +207,10 @@ async fn run_with_args(args: Args) -> Result<()> {
     let storage = Arc::new(StorageLayer::new(&db_path).await?);
 
     // -- Org-level storage (users, spaces, auth state) --------------------------
-    let org_db_path = db_path.with_file_name("org.db");
+    let pool_factory = assistant_storage::OrgPoolFactory::new(base_path);
     let org_storage = Arc::new(
-        assistant_storage::OrgStorageLayer::new(&org_db_path)
+        pool_factory
+            .org_storage()
             .await
             .context("Failed to open org.db")?,
     );

--- a/openspec/changes/multi-user-orgs/tasks.md
+++ b/openspec/changes/multi-user-orgs/tasks.md
@@ -234,7 +234,7 @@ PR 10 ─── CLI OAuth2 login + Flutter OAuth2 + docs
 
 - [x] `feat(storage): SQLite auth state stores and org pool factory`
   - `SqliteClientStore`, `SqliteAuthCodeStore`, `SqliteRefreshTokenStore`, `SqliteDeviceCodeStore`
-  - `OrgPoolFactory` resolves `~/.assistant/orgs/{slug}/org.db` paths
+  - `OrgPoolFactory` resolves `~/.assistant/org.db` and `~/.assistant/orgs/{slug}/spaces/{space}/space.db` paths
   - 14 tests
 
 ---


### PR DESCRIPTION
## Summary
- Replace direct `OrgStorageLayer::new()` + hardcoded path in web-ui startup with `OrgPoolFactory`, making the factory the single source of truth for org.db location
- Update migration comment to reference `OrgPoolFactory::org_db_path()` instead of the old hardcoded path pattern

## Test plan
- [x] `cargo check -p assistant-web-ui` passes
- [x] `cargo clippy -p assistant-web-ui -p assistant-storage -- -D warnings` clean
- [x] `cargo test -p assistant-storage pool_factory` — all 3 tests pass
- [x] Pre-commit hooks pass