### PR TITLE
fix(auth): harden OAuth2 + resolve /oauth/callback route collision

### DIFF
--- a/app/lib/features/auth/auth_provider.dart
+++ b/app/lib/features/auth/auth_provider.dart
@@ -131,11 +131,12 @@ class OAuthLoginNotifier extends Notifier<OAuthLoginState> {
 
   /// The redirect URI for OAuth2 flows.
   ///
-  /// On web, this is the same origin with `/oauth/callback`.
-  /// On macOS, this uses a loopback address (the server accepts this).
+  /// Uses `/oauth/complete` — a dedicated endpoint that returns the auth
+  /// code as JSON.  This avoids colliding with `/oauth/callback` which is
+  /// reserved for OIDC IdP callbacks (and expects a `state` parameter).
   String _redirectUri(String serverUrl) {
     final uri = Uri.parse(serverUrl);
-    return uri.replace(path: '/oauth/callback').toString();
+    return uri.replace(path: '/oauth/complete').toString();
   }
 }
 

--- a/app/lib/features/auth/oauth_service.dart
+++ b/app/lib/features/auth/oauth_service.dart
@@ -111,12 +111,14 @@ class OAuthService {
   }) async {
     // POST credentials to get an auth code via redirect (302/303).
     //
-    // Dio on some platforms (notably iOS) does not reliably honour
-    // `followRedirects: false` — the underlying HttpClient may follow
-    // the redirect or throw a DioException with the redirect status.
-    // We handle both paths: a successful response with a Location header,
-    // and a DioException whose response carries the Location header.
-    String? location;
+    // The server redirects to /oauth/complete?code=... which returns JSON.
+    // We handle three platform-dependent behaviours:
+    //
+    // 1. Dio honours `followRedirects: false` → 303 with Location header.
+    // 2. Dio throws DioException on the 303 → extract Location from error.
+    // 3. Dio follows the redirect (web/iOS) → response body is JSON from
+    //    /oauth/complete containing `{"code": "..."}`.
+    String? code;
 
     try {
       final authResponse = await _dio.post<dynamic>(
@@ -135,40 +137,31 @@ class OAuthService {
               status != null && (status >= 200 && status < 400),
         ),
       );
-      location = authResponse.headers.value('location');
+
+      // Path 1: Redirect captured — extract code from Location header.
+      final location = authResponse.headers.value('location');
+      if (location != null) {
+        code = _extractCodeFromLocation(location, redirectUri);
+      }
+
+      // Path 3: Redirect was followed — extract code from response body.
+      if (code == null && authResponse.data is Map) {
+        code = (authResponse.data as Map)['code'] as String?;
+      }
     } on DioException catch (e) {
-      // Dio threw on the redirect status — extract Location from the
-      // error response if available.
+      // Path 2: Dio threw on the redirect status.
       final status = e.response?.statusCode;
       if (status != null && status >= 300 && status < 400) {
-        location = e.response?.headers.value('location');
+        final location = e.response?.headers.value('location');
+        if (location != null) {
+          code = _extractCodeFromLocation(location, redirectUri);
+        }
       }
-      if (location == null) rethrow;
+      if (code == null) rethrow;
     }
 
-    if (location == null) {
-      throw OAuthException('No redirect location in authorization response');
-    }
-
-    // Validate that the redirect target matches the registered redirect_uri.
-    // A reverse proxy or MITM could inject a different Location header
-    // to steal the authorization code.
-    final locationUri = Uri.parse(location);
-    final expectedUri = Uri.parse(redirectUri);
-    if (locationUri.scheme != expectedUri.scheme ||
-        locationUri.host != expectedUri.host ||
-        locationUri.port != expectedUri.port ||
-        locationUri.path != expectedUri.path) {
-      throw OAuthException(
-        'Redirect location does not match registered redirect_uri',
-      );
-    }
-
-    final code = locationUri.queryParameters['code'];
     if (code == null) {
-      final error = locationUri.queryParameters['error'] ?? 'unknown_error';
-      final desc = locationUri.queryParameters['error_description'] ?? '';
-      throw OAuthException('Authorization failed: $error $desc');
+      throw OAuthException('No authorization code in server response');
     }
 
     // Exchange the auth code for tokens.
@@ -234,6 +227,31 @@ class OAuthService {
   }
 
   // -- Helpers ---------------------------------------------------------------
+
+  /// Extracts the authorization code from a Location header value.
+  ///
+  /// Validates that the redirect target matches the registered [redirectUri]
+  /// to prevent code theft via injected Location headers.
+  String? _extractCodeFromLocation(String location, String redirectUri) {
+    final locationUri = Uri.parse(location);
+    final expectedUri = Uri.parse(redirectUri);
+    if (locationUri.scheme != expectedUri.scheme ||
+        locationUri.host != expectedUri.host ||
+        locationUri.port != expectedUri.port ||
+        locationUri.path != expectedUri.path) {
+      throw OAuthException(
+        'Redirect location does not match registered redirect_uri',
+      );
+    }
+
+    final code = locationUri.queryParameters['code'];
+    if (code == null) {
+      final error = locationUri.queryParameters['error'] ?? 'unknown_error';
+      final desc = locationUri.queryParameters['error_description'] ?? '';
+      throw OAuthException('Authorization failed: $error $desc');
+    }
+    return code;
+  }
 
   OAuthCredentials _parseTokenResponse(
     Map<String, dynamic> data,

--- a/app/lib/features/auth/oauth_service.dart
+++ b/app/lib/features/auth/oauth_service.dart
@@ -150,7 +150,20 @@ class OAuthService {
       throw OAuthException('No redirect location in authorization response');
     }
 
+    // Validate that the redirect target matches the registered redirect_uri.
+    // A reverse proxy or MITM could inject a different Location header
+    // to steal the authorization code.
     final locationUri = Uri.parse(location);
+    final expectedUri = Uri.parse(redirectUri);
+    if (locationUri.scheme != expectedUri.scheme ||
+        locationUri.host != expectedUri.host ||
+        locationUri.port != expectedUri.port ||
+        locationUri.path != expectedUri.path) {
+      throw OAuthException(
+        'Redirect location does not match registered redirect_uri',
+      );
+    }
+
     final code = locationUri.queryParameters['code'];
     if (code == null) {
       final error = locationUri.queryParameters['error'] ?? 'unknown_error';

--- a/app/test/unit/auth/oauth_service_test.dart
+++ b/app/test/unit/auth/oauth_service_test.dart
@@ -317,7 +317,7 @@ void main() {
         );
       });
 
-      test('throws OAuthException when no Location header', () async {
+      test('throws OAuthException when response has no code', () async {
         mock.when(
           '/oauth/authorize',
           respond: const MockResponse(statusCode: 200, data: 'OK'),
@@ -335,6 +335,52 @@ void main() {
           throwsA(isA<OAuthException>()),
         );
       });
+
+      test(
+        'extracts code from JSON body when redirect is followed (web)',
+        () async {
+          // Simulate Dio following the 303 redirect to /oauth/complete
+          // which returns JSON {"code": "..."}.
+          mock.when(
+            '/oauth/authorize',
+            respond: const MockResponse(
+              statusCode: 200,
+              data: {'code': 'code_from_body'},
+            ),
+          );
+
+          mock.when(
+            '/oauth/token',
+            respond: const MockResponse(
+              statusCode: 200,
+              data: {
+                'access_token': 'at_web',
+                'refresh_token': 'rt_web',
+                'token_type': 'Bearer',
+                'expires_in': 3600,
+              },
+            ),
+          );
+
+          final pkce = PkceChallenge.generate();
+          final creds = await service.login(
+            email: 'alice@example.com',
+            password: 'secret',
+            clientId: 'client_1',
+            redirectUri: 'http://localhost/cb',
+            pkce: pkce,
+          );
+
+          expect(creds.accessToken, 'at_web');
+          expect(creds.refreshToken, 'rt_web');
+
+          // Verify the code from the body was used in the token exchange.
+          final tokenReq = mock.requests.firstWhere(
+            (r) => r.path == '/oauth/token',
+          );
+          expect(tokenReq.data, containsPair('code', 'code_from_body'));
+        },
+      );
     });
 
     group('refresh', () {

--- a/crates/auth/src/oauth2/server.rs
+++ b/crates/auth/src/oauth2/server.rs
@@ -221,7 +221,7 @@ impl OAuth2Server {
             bail!("authorization code expired");
         }
 
-        // Validate PKCE.
+        // Validate PKCE — mandatory per OAuth 2.1 §4.1.3.
         match (&auth_code.pkce_challenge, pkce_verifier) {
             (Some(challenge), Some(verifier)) => {
                 if !pkce::verify(verifier, challenge) {
@@ -229,8 +229,8 @@ impl OAuth2Server {
                 }
             }
             (Some(_), None) => bail!("PKCE verifier required but not provided"),
-            (None, Some(_)) => { /* verifier provided but no challenge stored — ignore */ }
-            (None, None) => {}
+            (None, Some(_)) => bail!("PKCE verifier provided but no challenge was stored"),
+            (None, None) => bail!("PKCE code_challenge is required"),
         }
 
         // Generate tokens.
@@ -369,6 +369,13 @@ mod tests {
         )
     }
 
+    /// Generate a PKCE pair for tests that don't specifically test PKCE behaviour.
+    fn test_pkce() -> (String, String) {
+        let verifier = pkce::generate_verifier();
+        let challenge = pkce::challenge_from_verifier(&verifier);
+        (verifier, challenge)
+    }
+
     #[tokio::test]
     async fn auth_code_exchange_with_pkce() {
         let server = make_server();
@@ -398,21 +405,28 @@ mod tests {
     #[tokio::test]
     async fn auth_code_is_single_use() {
         let server = make_server();
+        let (verifier, challenge) = test_pkce();
 
         let code = server
-            .generate_auth_code("usr_alice", "webui", "http://localhost/cb", None, vec![])
+            .generate_auth_code(
+                "usr_alice",
+                "webui",
+                "http://localhost/cb",
+                Some(&challenge),
+                vec![],
+            )
             .await
             .unwrap();
 
         // First exchange succeeds.
         server
-            .exchange_auth_code(&code, "webui", "http://localhost/cb", None)
+            .exchange_auth_code(&code, "webui", "http://localhost/cb", Some(&verifier))
             .await
             .unwrap();
 
         // Second exchange fails.
         let err = server
-            .exchange_auth_code(&code, "webui", "http://localhost/cb", None)
+            .exchange_auth_code(&code, "webui", "http://localhost/cb", Some(&verifier))
             .await;
         assert!(err.is_err(), "auth code should be single-use");
     }
@@ -467,14 +481,26 @@ mod tests {
     #[tokio::test]
     async fn wrong_client_id_is_rejected() {
         let server = make_server();
+        let (verifier, challenge) = test_pkce();
 
         let code = server
-            .generate_auth_code("usr_alice", "webui", "http://localhost/cb", None, vec![])
+            .generate_auth_code(
+                "usr_alice",
+                "webui",
+                "http://localhost/cb",
+                Some(&challenge),
+                vec![],
+            )
             .await
             .unwrap();
 
         let err = server
-            .exchange_auth_code(&code, "wrong_client", "http://localhost/cb", None)
+            .exchange_auth_code(
+                &code,
+                "wrong_client",
+                "http://localhost/cb",
+                Some(&verifier),
+            )
             .await;
         assert!(err.is_err(), "wrong client_id should be rejected");
     }
@@ -482,14 +508,21 @@ mod tests {
     #[tokio::test]
     async fn wrong_redirect_uri_is_rejected() {
         let server = make_server();
+        let (verifier, challenge) = test_pkce();
 
         let code = server
-            .generate_auth_code("usr_alice", "webui", "http://localhost/cb", None, vec![])
+            .generate_auth_code(
+                "usr_alice",
+                "webui",
+                "http://localhost/cb",
+                Some(&challenge),
+                vec![],
+            )
             .await
             .unwrap();
 
         let err = server
-            .exchange_auth_code(&code, "webui", "http://evil.com/cb", None)
+            .exchange_auth_code(&code, "webui", "http://evil.com/cb", Some(&verifier))
             .await;
         assert!(err.is_err(), "wrong redirect_uri should be rejected");
     }
@@ -497,14 +530,21 @@ mod tests {
     #[tokio::test]
     async fn refresh_token_rotation() {
         let server = make_server();
+        let (verifier, challenge) = test_pkce();
 
         let code = server
-            .generate_auth_code("usr_alice", "webui", "http://localhost/cb", None, vec![])
+            .generate_auth_code(
+                "usr_alice",
+                "webui",
+                "http://localhost/cb",
+                Some(&challenge),
+                vec![],
+            )
             .await
             .unwrap();
 
         let pair1 = server
-            .exchange_auth_code(&code, "webui", "http://localhost/cb", None)
+            .exchange_auth_code(&code, "webui", "http://localhost/cb", Some(&verifier))
             .await
             .unwrap();
 
@@ -523,14 +563,21 @@ mod tests {
     #[tokio::test]
     async fn refresh_replay_revokes_all() {
         let server = make_server();
+        let (verifier, challenge) = test_pkce();
 
         let code = server
-            .generate_auth_code("usr_alice", "webui", "http://localhost/cb", None, vec![])
+            .generate_auth_code(
+                "usr_alice",
+                "webui",
+                "http://localhost/cb",
+                Some(&challenge),
+                vec![],
+            )
             .await
             .unwrap();
 
         let pair1 = server
-            .exchange_auth_code(&code, "webui", "http://localhost/cb", None)
+            .exchange_auth_code(&code, "webui", "http://localhost/cb", Some(&verifier))
             .await
             .unwrap();
 
@@ -549,6 +596,55 @@ mod tests {
     #[tokio::test]
     async fn expired_code_is_rejected() {
         let server = make_server().with_code_ttl(Duration::seconds(-10));
+        let (_verifier, challenge) = test_pkce();
+
+        let code = server
+            .generate_auth_code(
+                "usr_alice",
+                "webui",
+                "http://localhost/cb",
+                Some(&challenge),
+                vec![],
+            )
+            .await
+            .unwrap();
+
+        // Exchange will fail on expiry before PKCE is checked, but we still
+        // supply the challenge to satisfy the mandatory-PKCE invariant.
+        let err = server
+            .exchange_auth_code(&code, "webui", "http://localhost/cb", Some(&_verifier))
+            .await;
+        assert!(err.is_err(), "expired code should be rejected");
+    }
+
+    #[tokio::test]
+    async fn expired_refresh_token_is_rejected() {
+        let server = make_server().with_refresh_ttl(Duration::seconds(-10));
+        let (verifier, challenge) = test_pkce();
+
+        let code = server
+            .generate_auth_code(
+                "usr_alice",
+                "webui",
+                "http://localhost/cb",
+                Some(&challenge),
+                vec![],
+            )
+            .await
+            .unwrap();
+
+        let pair = server
+            .exchange_auth_code(&code, "webui", "http://localhost/cb", Some(&verifier))
+            .await
+            .unwrap();
+
+        let err = server.refresh(&pair.refresh_token, "webui").await;
+        assert!(err.is_err(), "expired refresh token should be rejected");
+    }
+
+    #[tokio::test]
+    async fn exchange_without_pkce_is_rejected() {
+        let server = make_server();
 
         let code = server
             .generate_auth_code("usr_alice", "webui", "http://localhost/cb", None, vec![])
@@ -558,25 +654,7 @@ mod tests {
         let err = server
             .exchange_auth_code(&code, "webui", "http://localhost/cb", None)
             .await;
-        assert!(err.is_err(), "expired code should be rejected");
-    }
-
-    #[tokio::test]
-    async fn expired_refresh_token_is_rejected() {
-        let server = make_server().with_refresh_ttl(Duration::seconds(-10));
-
-        let code = server
-            .generate_auth_code("usr_alice", "webui", "http://localhost/cb", None, vec![])
-            .await
-            .unwrap();
-
-        let pair = server
-            .exchange_auth_code(&code, "webui", "http://localhost/cb", None)
-            .await
-            .unwrap();
-
-        let err = server.refresh(&pair.refresh_token, "webui").await;
-        assert!(err.is_err(), "expired refresh token should be rejected");
+        assert!(err.is_err(), "exchange without PKCE should be rejected");
     }
 
     #[tokio::test]

--- a/crates/web-ui/src/oauth/authorize.rs
+++ b/crates/web-ui/src/oauth/authorize.rs
@@ -63,10 +63,20 @@ pub async fn authorize_get(
 
     let raw_client_id = params.client_id.as_deref().unwrap_or("");
     let raw_redirect_uri = params.redirect_uri.as_deref().unwrap_or("");
+    let raw_code_challenge = params.code_challenge.as_deref().unwrap_or("");
 
     // Validate client_id and redirect_uri against registered clients.
     if let Err(resp) = validate_client(&state, raw_client_id, raw_redirect_uri).await {
         return resp;
+    }
+
+    // PKCE is mandatory (OAuth 2.1).
+    if raw_code_challenge.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Html("error: code_challenge is required (PKCE)".to_string()),
+        )
+            .into_response();
     }
 
     // -- OIDC mode: redirect to external IdP instead of rendering login form --
@@ -204,6 +214,16 @@ pub async fn authorize_post(
         }
     }
 
+    // PKCE is mandatory per OAuth 2.1 §4.1.1 — reject requests without a
+    // code_challenge to prevent authorization code interception attacks.
+    if form.code_challenge.as_deref().unwrap_or("").is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Html("error: code_challenge is required (PKCE)".to_string()),
+        )
+            .into_response();
+    }
+
     // Generate authorization code.
     let scopes: Vec<String> = form
         .scope
@@ -279,7 +299,17 @@ async fn validate_client(
         }
     };
 
-    if !redirect_uri.is_empty() && !client.redirect_uris.contains(&redirect_uri.to_string()) {
+    // redirect_uri MUST be present and MUST exactly match one of the
+    // registered URIs (RFC 6749 §3.1.2.3).  Allowing an empty redirect_uri
+    // would let an attacker skip validation entirely.
+    if redirect_uri.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Html("error: redirect_uri is required".to_string()),
+        )
+            .into_response());
+    }
+    if !client.redirect_uris.contains(&redirect_uri.to_string()) {
         return Err((
             StatusCode::BAD_REQUEST,
             Html("error: redirect_uri not registered for this client".to_string()),

--- a/crates/web-ui/src/oauth/complete.rs
+++ b/crates/web-ui/src/oauth/complete.rs
@@ -1,0 +1,188 @@
+//! GET /oauth/complete — authorization completion endpoint.
+//!
+//! This endpoint serves as the redirect target for password-mode OAuth2
+//! authorization flows.  After the user authenticates via POST /oauth/authorize,
+//! the server redirects here with `?code=...`.
+//!
+//! **Why not `/oauth/callback`?**  That route is reserved for OIDC IdP callbacks
+//! (which carry a `state` parameter referencing a pending OIDC session).  Using
+//! the same path for password-mode redirects causes the OIDC handler to reject
+//! the request because no `state` is present.
+//!
+//! This handler returns the authorization code as JSON so that programmatic
+//! clients (e.g. Dio on Flutter web, where `followRedirects: false` may not be
+//! honoured) can extract it from the response body.
+
+use axum::extract::Query;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Json};
+use serde::{Deserialize, Serialize};
+
+/// Query parameters for GET /oauth/complete.
+#[derive(Deserialize, utoipa::IntoParams)]
+pub struct CompleteQuery {
+    /// Authorization code from the authorize endpoint.
+    pub code: Option<String>,
+    /// Client-supplied state (forwarded from the authorize request).
+    pub state: Option<String>,
+    /// Error code (if authorization failed).
+    pub error: Option<String>,
+    /// Human-readable error description.
+    pub error_description: Option<String>,
+}
+
+/// JSON response from the completion endpoint.
+#[derive(Serialize, utoipa::ToSchema)]
+pub struct CompleteResponse {
+    /// The authorization code.
+    pub code: String,
+    /// The client state, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<String>,
+}
+
+/// GET /oauth/complete — return the authorization code as JSON.
+#[utoipa::path(
+    get,
+    path = "/oauth/complete",
+    tag = "oauth",
+    security(()),
+    params(CompleteQuery),
+    responses(
+        (status = 200, description = "Authorization code", body = CompleteResponse),
+        (status = 400, description = "Missing or error parameters"),
+    )
+)]
+pub async fn complete(Query(params): Query<CompleteQuery>) -> impl IntoResponse {
+    // Surface authorization errors.
+    if let Some(err) = params.error {
+        let desc = params.error_description.unwrap_or_default();
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": err,
+                "error_description": desc,
+            })),
+        )
+            .into_response();
+    }
+
+    let code = match params.code {
+        Some(c) if !c.is_empty() => c,
+        _ => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": "invalid_request",
+                    "error_description": "missing 'code' parameter",
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    Json(CompleteResponse {
+        code,
+        state: params.state,
+    })
+    .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::routing::get;
+    use tower::ServiceExt;
+
+    use super::*;
+
+    fn build_app() -> Router {
+        Router::new().route("/oauth/complete", get(complete))
+    }
+
+    #[tokio::test]
+    async fn complete_returns_code_as_json() {
+        let app = build_app();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/oauth/complete?code=auth_code_123&state=my_state")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["code"], "auth_code_123");
+        assert_eq!(json["state"], "my_state");
+    }
+
+    #[tokio::test]
+    async fn complete_omits_state_when_absent() {
+        let app = build_app();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/oauth/complete?code=auth_code_456")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["code"], "auth_code_456");
+        assert!(json.get("state").is_none());
+    }
+
+    #[tokio::test]
+    async fn complete_rejects_missing_code() {
+        let app = build_app();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/oauth/complete?state=abc")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn complete_surfaces_error() {
+        let app = build_app();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/oauth/complete?error=access_denied&error_description=user+cancelled")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"], "access_denied");
+    }
+}

--- a/crates/web-ui/src/oauth/mod.rs
+++ b/crates/web-ui/src/oauth/mod.rs
@@ -158,6 +158,13 @@ mod tests {
     use assistant_core::identity::OrgId;
     use assistant_core::store::{OrgStore, Organization, User, UserStore};
 
+    /// Generate a PKCE pair for tests that don't specifically test PKCE behaviour.
+    fn test_pkce() -> (String, String) {
+        let verifier = assistant_auth::oauth2::pkce::generate_verifier();
+        let challenge = assistant_auth::oauth2::pkce::challenge_from_verifier(&verifier);
+        (verifier, challenge)
+    }
+
     /// Build a test `OAuthState` backed by in-memory stores.
     async fn test_state() -> OAuthState {
         let org_storage = Arc::new(OrgStorageLayer::new_in_memory().await.unwrap());
@@ -284,6 +291,7 @@ mod tests {
     #[tokio::test]
     async fn authorize_get_renders_form() {
         let state = test_state().await;
+        let (_verifier, challenge) = test_pkce();
 
         // Register a client first so authorize_get can validate it.
         let app = build_app(state.clone());
@@ -313,7 +321,7 @@ mod tests {
         let resp = app
             .oneshot(
                 Request::builder()
-                    .uri(&format!("/oauth/authorize?response_type=code&client_id={client_id}&redirect_uri=http://localhost/cb"))
+                    .uri(&format!("/oauth/authorize?response_type=code&client_id={client_id}&redirect_uri=http://localhost/cb&code_challenge={challenge}&code_challenge_method=S256"))
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -425,10 +433,11 @@ mod tests {
         let client_id = client["client_id"].as_str().unwrap();
 
         // GET /oauth/authorize should redirect to the IdP, not render a form.
+        let (_verifier, challenge) = test_pkce();
         let app = build_app(state);
         let resp = app.oneshot(
             Request::builder()
-                .uri(&format!("/oauth/authorize?response_type=code&client_id={client_id}&redirect_uri=http://localhost/cb&state=mystate"))
+                .uri(&format!("/oauth/authorize?response_type=code&client_id={client_id}&redirect_uri=http://localhost/cb&state=mystate&code_challenge={challenge}&code_challenge_method=S256"))
                 .body(Body::empty())
                 .unwrap(),
         ).await.unwrap();
@@ -551,6 +560,7 @@ mod tests {
     #[tokio::test]
     async fn full_auth_code_flow() {
         let state = test_state().await;
+        let (verifier, challenge) = test_pkce();
 
         // Step 1: Register a client.
         let app = build_app(state.clone());
@@ -576,10 +586,10 @@ mod tests {
         let client: serde_json::Value = serde_json::from_slice(&body).unwrap();
         let client_id = client["client_id"].as_str().unwrap();
 
-        // Step 2: POST /oauth/authorize with credentials.
+        // Step 2: POST /oauth/authorize with credentials + PKCE challenge.
         let app = build_app(state.clone());
         let form = format!(
-            "email=alice%40example.com&password=secret123&client_id={client_id}&redirect_uri=http%3A%2F%2Flocalhost%2Fcb"
+            "email=alice%40example.com&password=secret123&client_id={client_id}&redirect_uri=http%3A%2F%2Flocalhost%2Fcb&code_challenge={challenge}"
         );
         let resp = app
             .oneshot(
@@ -613,10 +623,10 @@ mod tests {
             .next()
             .unwrap();
 
-        // Step 3: Exchange code for tokens.
+        // Step 3: Exchange code for tokens (with PKCE verifier).
         let app = build_app(state.clone());
         let token_form = format!(
-            "grant_type=authorization_code&code={code}&client_id={client_id}&redirect_uri=http%3A%2F%2Flocalhost%2Fcb"
+            "grant_type=authorization_code&code={code}&client_id={client_id}&redirect_uri=http%3A%2F%2Flocalhost%2Fcb&code_verifier={verifier}"
         );
         let resp = app
             .oneshot(
@@ -653,6 +663,7 @@ mod tests {
     #[tokio::test]
     async fn auth_code_exchange_sets_session_cookie() {
         let state = test_state().await;
+        let (verifier, challenge) = test_pkce();
 
         // Register a client.
         let app = build_app(state.clone());
@@ -678,10 +689,10 @@ mod tests {
         let client: serde_json::Value = serde_json::from_slice(&body).unwrap();
         let client_id = client["client_id"].as_str().unwrap();
 
-        // Authorize (get auth code).
+        // Authorize (get auth code with PKCE challenge).
         let app = build_app(state.clone());
         let form = format!(
-            "email=alice%40example.com&password=secret123&client_id={client_id}&redirect_uri=http%3A%2F%2Flocalhost%2Fcb"
+            "email=alice%40example.com&password=secret123&client_id={client_id}&redirect_uri=http%3A%2F%2Flocalhost%2Fcb&code_challenge={challenge}"
         );
         let resp = app
             .oneshot(
@@ -703,10 +714,10 @@ mod tests {
             .next()
             .unwrap();
 
-        // Exchange code for tokens.
+        // Exchange code for tokens (with PKCE verifier).
         let app = build_app(state.clone());
         let token_form = format!(
-            "grant_type=authorization_code&code={code}&client_id={client_id}&redirect_uri=http%3A%2F%2Flocalhost%2Fcb"
+            "grant_type=authorization_code&code={code}&client_id={client_id}&redirect_uri=http%3A%2F%2Flocalhost%2Fcb&code_verifier={verifier}"
         );
         let resp = app
             .oneshot(
@@ -754,6 +765,7 @@ mod tests {
     #[tokio::test]
     async fn refresh_token_exchange_sets_session_cookie() {
         let state = test_state().await;
+        let (verifier, challenge) = test_pkce();
 
         // Register client + get auth code + exchange for tokens (setup).
         let app = build_app(state.clone());
@@ -781,7 +793,7 @@ mod tests {
 
         let app = build_app(state.clone());
         let form = format!(
-            "email=alice%40example.com&password=secret123&client_id={client_id}&redirect_uri=http%3A%2F%2Flocalhost%2Fcb"
+            "email=alice%40example.com&password=secret123&client_id={client_id}&redirect_uri=http%3A%2F%2Flocalhost%2Fcb&code_challenge={challenge}"
         );
         let resp = app
             .oneshot(
@@ -805,7 +817,7 @@ mod tests {
 
         let app = build_app(state.clone());
         let token_form = format!(
-            "grant_type=authorization_code&code={code}&client_id={client_id}&redirect_uri=http%3A%2F%2Flocalhost%2Fcb"
+            "grant_type=authorization_code&code={code}&client_id={client_id}&redirect_uri=http%3A%2F%2Flocalhost%2Fcb&code_verifier={verifier}"
         );
         let resp = app
             .oneshot(

--- a/crates/web-ui/src/oauth/mod.rs
+++ b/crates/web-ui/src/oauth/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod authorize;
 pub mod callback;
+pub mod complete;
 pub mod device;
 pub mod oidc_bridge;
 pub mod oidc_sessions;
@@ -60,6 +61,8 @@ pub fn oauth_router() -> Router<OAuthState> {
         .route("/oauth/authorize", post(authorize::authorize_post))
         // OIDC IdP callback (receives code from external IdP).
         .route("/oauth/callback", get(callback::callback))
+        // Password-mode redirect completion (returns code as JSON).
+        .route("/oauth/complete", get(complete::complete))
         // Token endpoint.
         .route("/oauth/token", post(token::token))
         // Dynamic client registration.

--- a/crates/web-ui/src/oauth/token.rs
+++ b/crates/web-ui/src/oauth/token.rs
@@ -87,8 +87,32 @@ async fn handle_auth_code(state: OAuthState, req: TokenRequest) -> axum::respons
                 .into_response();
         }
     };
-    let client_id = req.client_id.unwrap_or_default();
-    let redirect_uri = req.redirect_uri.unwrap_or_default();
+    let client_id = match req.client_id {
+        Some(c) if !c.is_empty() => c,
+        _ => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(OAuthError {
+                    error: "invalid_request",
+                    error_description: "missing client_id parameter".into(),
+                }),
+            )
+                .into_response();
+        }
+    };
+    let redirect_uri = match req.redirect_uri {
+        Some(r) if !r.is_empty() => r,
+        _ => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(OAuthError {
+                    error: "invalid_request",
+                    error_description: "missing redirect_uri parameter".into(),
+                }),
+            )
+                .into_response();
+        }
+    };
 
     match state
         .oauth2_server


### PR DESCRIPTION
## Summary
- **Close open redirect via empty redirect_uri**: The `validate_client()` function skipped redirect_uri validation when the parameter was empty, allowing authorization codes to be sent to unvalidated destinations. Now rejects empty redirect_uri with 400.
- **Enforce mandatory PKCE (OAuth 2.1)**: `code_challenge` is now required on both GET and POST `/oauth/authorize`. Token exchange rejects `(None, None)` PKCE state instead of silently allowing it.
- **Require client_id and redirect_uri in token endpoint**: No longer defaults to empty string via `unwrap_or_default()` — returns 400 if missing.
- **Flutter: validate redirect Location header**: Before extracting the authorization code from the server's redirect, the client now verifies that the Location header's origin (scheme, host, port, path) matches the registered `redirect_uri`. This prevents proxy or MITM redirect injection.
- **Fix "missing state parameter from IdP" error**: The Flutter app registered `/oauth/callback` as its redirect_uri, which collided with the OIDC IdP callback handler. Added a dedicated `/oauth/complete` endpoint that returns the auth code as JSON, and changed the Flutter redirect_uri to use it. Also handles the case where Dio on web follows the 303 redirect (extracting the code from the JSON response body).

## Test plan
- [x] `cargo test -p assistant-auth` — 99 passed (4 tests updated to supply PKCE, 1 new test for PKCE rejection)
- [x] `cargo test -p assistant-web-ui oauth` — 24 passed (5 tests updated with code_challenge + code_verifier, 4 new complete.rs tests)
- [x] `flutter test` — 765 passed (1 new test for followed-redirect code extraction)
- [x] Full pre-commit suite — clippy, fmt, machete, dart analyze all clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new `/oauth/complete` endpoint to complete OAuth authorization flows with authorization code returned as JSON.

* **Bug Fixes**
  * Enhanced OAuth authorization and token exchange with stricter redirect URI validation and parameter checking.
  * Enforced PKCE (Proof Key for Code Exchange) support in OAuth2 flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->