### PR TITLE
fix(oauth): OpenAPI annotation fixes and client registration hardening

### DIFF
--- a/app/packages/assistant_api/.openapi-generator/FILES
+++ b/app/packages/assistant_api/.openapi-generator/FILES
@@ -363,4 +363,3 @@ lib/src/model/workflow_webhook_trigger_accepted.dart
 lib/src/model/write_persona_file_request.dart
 lib/src/serializers.dart
 pubspec.yaml
-test/complete_response_test.dart

--- a/app/packages/assistant_api/doc/OauthApi.md
+++ b/app/packages/assistant_api/doc/OauthApi.md
@@ -70,7 +70,7 @@ No authorization required
 ### HTTP request headers
 
  - **Content-Type**: Not defined
- - **Accept**: Not defined
+ - **Accept**: text/html
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
@@ -298,7 +298,7 @@ No authorization required
 ### HTTP request headers
 
  - **Content-Type**: Not defined
- - **Accept**: Not defined
+ - **Accept**: text/html
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
@@ -342,7 +342,7 @@ No authorization required
 ### HTTP request headers
 
  - **Content-Type**: application/x-www-form-urlencoded
- - **Accept**: Not defined
+ - **Accept**: text/html
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -56,8 +56,8 @@ flutter_launcher_icons:
   web:
     generate: true
     image_path: macos/Runner/Assets.xcassets/AppIcon.appiconset/app_icon_1024.png
-    background_color: '#080C1A'
-    theme_color: '#080C1A'
+    background_color: "#080C1A"
+    theme_color: "#080C1A"
 flutter:
   uses-material-design: true
   assets:

--- a/crates/auth/src/oauth2/clients.rs
+++ b/crates/auth/src/oauth2/clients.rs
@@ -70,6 +70,9 @@ const ALLOWED_GRANT_TYPES: &[&str] = &[
 /// Allowed response types for validation.
 const ALLOWED_RESPONSE_TYPES: &[&str] = &["code"];
 
+/// Allowed token endpoint auth methods.
+const ALLOWED_AUTH_METHODS: &[&str] = &["none", "client_secret_post", "client_secret_basic"];
+
 impl ClientRegistrar {
     /// Create a new client registrar.
     pub fn new(store: Arc<dyn ClientStore>) -> Self {
@@ -113,10 +116,26 @@ impl ClientRegistrar {
             }
         }
 
-        // Determine auth method.
+        // Validate auth method.
         let auth_method = req.token_endpoint_auth_method.as_deref().unwrap_or("none");
+        if !ALLOWED_AUTH_METHODS.contains(&auth_method) {
+            bail!("unsupported token_endpoint_auth_method: {auth_method}");
+        }
         let is_confidential =
             auth_method == "client_secret_post" || auth_method == "client_secret_basic";
+
+        // Cross-validate: authorization_code grant requires "code" response type (RFC 7591 §2).
+        if req.grant_types.contains(&"authorization_code".to_string()) {
+            let has_code = req
+                .response_types
+                .as_ref()
+                .is_some_and(|rts| rts.contains(&"code".to_string()));
+            if !has_code {
+                bail!(
+                    "grant_types includes 'authorization_code' but response_types does not include 'code'"
+                );
+            }
+        }
 
         // Generate client_id.
         let client_id = format!("cid_{}", uuid::Uuid::new_v4().as_simple());
@@ -320,6 +339,42 @@ mod tests {
         let mut req = valid_registration();
         req.response_types = Some(vec!["token".into()]);
         assert!(reg.register(req).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn unsupported_auth_method_is_rejected() {
+        let reg = make_registrar();
+        let mut req = valid_registration();
+        req.token_endpoint_auth_method = Some("private_key_jwt".into());
+        let err = reg.register(req).await.unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("unsupported token_endpoint_auth_method"),
+            "should reject unsupported auth method, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn auth_code_grant_requires_code_response_type() {
+        let reg = make_registrar();
+        let mut req = valid_registration();
+        req.grant_types = vec!["authorization_code".into()];
+        req.response_types = None; // Missing response_types
+        let err = reg.register(req).await.unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("response_types does not include 'code'"),
+            "should require code response type, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn auth_code_grant_with_code_response_type_succeeds() {
+        let reg = make_registrar();
+        let mut req = valid_registration();
+        req.grant_types = vec!["authorization_code".into(), "refresh_token".into()];
+        req.response_types = Some(vec!["code".into()]);
+        assert!(reg.register(req).await.is_ok());
     }
 
     #[tokio::test]

--- a/crates/auth/src/providers.rs
+++ b/crates/auth/src/providers.rs
@@ -696,7 +696,7 @@ mod tests {
                 client_name: "Test App".into(),
                 redirect_uris: vec!["http://localhost:4040/callback".into()],
                 grant_types: vec!["authorization_code".into()],
-                response_types: None,
+                response_types: Some(vec!["code".into()]),
                 token_endpoint_auth_method: None,
             })
             .await
@@ -744,7 +744,7 @@ mod tests {
                 client_name: "Test App".into(),
                 redirect_uris: vec!["http://localhost:4040/callback".into()],
                 grant_types: vec!["authorization_code".into()],
-                response_types: None,
+                response_types: Some(vec!["code".into()]),
                 token_endpoint_auth_method: None,
             })
             .await

--- a/crates/web-ui/src/oauth/authorize.rs
+++ b/crates/web-ui/src/oauth/authorize.rs
@@ -44,8 +44,9 @@ pub struct AuthorizeForm {
     security(()),
     params(AuthorizeQuery),
     responses(
-        (status = 200, description = "Login form HTML"),
-        (status = 400, description = "Invalid parameters"),
+        (status = 200, description = "Login form HTML", content_type = "text/html"),
+        (status = 303, description = "Redirect to external IdP (OIDC mode)"),
+        (status = 400, description = "Invalid parameters", content_type = "text/html"),
     )
 )]
 pub async fn authorize_get(
@@ -144,10 +145,12 @@ pub async fn authorize_get(
     path = "/oauth/authorize",
     tag = "oauth",
     security(()),
+    request_body(content = AuthorizeForm, content_type = "application/x-www-form-urlencoded"),
     responses(
         (status = 303, description = "Redirect with authorization code"),
         (status = 400, description = "Invalid request"),
         (status = 401, description = "Invalid credentials"),
+        (status = 500, description = "Internal server error"),
     )
 )]
 pub async fn authorize_post(

--- a/crates/web-ui/src/oauth/callback.rs
+++ b/crates/web-ui/src/oauth/callback.rs
@@ -389,7 +389,7 @@ q2HMPOhMSkWZ+rP+jJ76H6s=
                 client_name: "Test App".into(),
                 redirect_uris: vec!["http://localhost:9999/cb".into()],
                 grant_types: vec!["authorization_code".into()],
-                response_types: None,
+                response_types: Some(vec!["code".into()]),
                 token_endpoint_auth_method: None,
             })
             .await

--- a/crates/web-ui/src/oauth/device.rs
+++ b/crates/web-ui/src/oauth/device.rs
@@ -76,8 +76,7 @@ pub struct VerifyQuery {
     security(()),
     params(VerifyQuery),
     responses(
-        (status = 200, description = "Device verification form HTML"),
-        (status = 400, description = "Bad request"),
+        (status = 200, description = "Device verification form HTML", content_type = "text/html"),
     )
 )]
 pub async fn device_verify_page(Query(params): Query<VerifyQuery>) -> impl IntoResponse {
@@ -131,9 +130,11 @@ pub struct DeviceVerifyForm {
     path = "/oauth/device/verify",
     tag = "oauth",
     security(()),
+    request_body(content = DeviceVerifyForm, content_type = "application/x-www-form-urlencoded"),
     responses(
-        (status = 200, description = "Device authorized"),
-        (status = 400, description = "Invalid or expired code"),
+        (status = 200, description = "Device authorized", content_type = "text/html"),
+        (status = 400, description = "Invalid or expired code", content_type = "text/html"),
+        (status = 401, description = "Invalid credentials", content_type = "text/html"),
     )
 )]
 pub async fn device_verify_submit(

--- a/crates/web-ui/src/oauth/mod.rs
+++ b/crates/web-ui/src/oauth/mod.rs
@@ -301,7 +301,8 @@ mod tests {
         let reg_body = serde_json::json!({
             "client_name": "Form Test",
             "redirect_uris": ["http://localhost/cb"],
-            "grant_types": ["authorization_code"]
+            "grant_types": ["authorization_code"],
+            "response_types": ["code"]
         });
         let resp = app
             .oneshot(
@@ -416,7 +417,8 @@ mod tests {
         let reg_body = serde_json::json!({
             "client_name": "OIDC Test",
             "redirect_uris": ["http://localhost/cb"],
-            "grant_types": ["authorization_code"]
+            "grant_types": ["authorization_code"],
+            "response_types": ["code"]
         });
         let resp = app
             .oneshot(
@@ -474,7 +476,8 @@ mod tests {
         let body = serde_json::json!({
             "client_name": "Test App",
             "redirect_uris": ["http://localhost/cb"],
-            "grant_types": ["authorization_code"]
+            "grant_types": ["authorization_code"],
+            "response_types": ["code"]
         });
 
         let resp = app
@@ -570,7 +573,8 @@ mod tests {
         let reg_body = serde_json::json!({
             "client_name": "Flow Test",
             "redirect_uris": ["http://localhost/cb"],
-            "grant_types": ["authorization_code"]
+            "grant_types": ["authorization_code"],
+            "response_types": ["code"]
         });
         let resp = app
             .oneshot(
@@ -673,7 +677,8 @@ mod tests {
         let reg_body = serde_json::json!({
             "client_name": "Cookie Test",
             "redirect_uris": ["http://localhost/cb"],
-            "grant_types": ["authorization_code"]
+            "grant_types": ["authorization_code"],
+            "response_types": ["code"]
         });
         let resp = app
             .oneshot(
@@ -775,7 +780,8 @@ mod tests {
         let reg_body = serde_json::json!({
             "client_name": "Refresh Cookie Test",
             "redirect_uris": ["http://localhost/cb"],
-            "grant_types": ["authorization_code"]
+            "grant_types": ["authorization_code"],
+            "response_types": ["code"]
         });
         let resp = app
             .oneshot(

--- a/crates/web-ui/src/oauth/revoke.rs
+++ b/crates/web-ui/src/oauth/revoke.rs
@@ -77,7 +77,6 @@ pub struct ServerMetadata {
     security(()),
     responses(
         (status = 200, description = "Authorization server metadata", body = ServerMetadata),
-        (status = 400, description = "Bad request"),
     )
 )]
 pub async fn metadata(State(state): State<OAuthState>) -> Json<ServerMetadata> {

--- a/crates/web-ui/src/oauth/token.rs
+++ b/crates/web-ui/src/oauth/token.rs
@@ -52,6 +52,7 @@ pub struct TokenResponse {
     responses(
         (status = 200, description = "Token issued", body = TokenResponse),
         (status = 400, description = "Invalid grant", body = OAuthErrorResponse),
+        (status = 500, description = "Server error", body = OAuthErrorResponse),
     )
 )]
 pub async fn token(

--- a/openapi.json
+++ b/openapi.json
@@ -58,9 +58,6 @@
                 }
               }
             }
-          },
-          "400": {
-            "description": "Bad request"
           }
         },
         "security": [
@@ -5395,10 +5392,19 @@
         ],
         "responses": {
           "200": {
-            "description": "Login form HTML"
+            "description": "Login form HTML",
+            "content": {
+              "text/html": {}
+            }
+          },
+          "303": {
+            "description": "Redirect to external IdP (OIDC mode)"
           },
           "400": {
-            "description": "Invalid parameters"
+            "description": "Invalid parameters",
+            "content": {
+              "text/html": {}
+            }
           }
         },
         "security": [
@@ -5430,6 +5436,9 @@
           },
           "401": {
             "description": "Invalid credentials"
+          },
+          "500": {
+            "description": "Internal server error"
           }
         },
         "security": [
@@ -5656,10 +5665,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Device verification form HTML"
-          },
-          "400": {
-            "description": "Bad request"
+            "description": "Device verification form HTML",
+            "content": {
+              "text/html": {}
+            }
           }
         },
         "security": [
@@ -5684,10 +5693,22 @@
         },
         "responses": {
           "200": {
-            "description": "Device authorized"
+            "description": "Device authorized",
+            "content": {
+              "text/html": {}
+            }
           },
           "400": {
-            "description": "Invalid or expired code"
+            "description": "Invalid or expired code",
+            "content": {
+              "text/html": {}
+            }
+          },
+          "401": {
+            "description": "Invalid credentials",
+            "content": {
+              "text/html": {}
+            }
           }
         },
         "security": [
@@ -5806,6 +5827,16 @@
           },
           "400": {
             "description": "Invalid grant",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
## Summary

- Fix missing `request_body` annotations on `authorize_post` and `device_verify_submit`
- Add missing response codes: 500 on authorize/token, 401 on device verify, 303 OIDC redirect on authorize_get
- Set correct `content_type = "text/html"` on browser-facing endpoints
- Remove spurious 400 response from metadata endpoint
- Validate `token_endpoint_auth_method` against allow-list per RFC 7591 (rejects unsupported methods like `private_key_jwt`)
- Cross-validate grant_types/response_types consistency (`authorization_code` requires `code` response type)
- Regenerate OpenAPI spec and Flutter client

## Test plan
- [x] All 16 client registration tests pass (3 new)
- [x] All 24 web-ui OAuth integration tests pass
- [x] All 15 Flutter OAuth service tests pass
- [x] clippy clean, fmt clean, pre-commit hooks pass