### PR TITLE
feat(auth): self-service-account proposal + bulk refresh-token revocation

### DIFF
--- a/crates/auth/src/oauth2/server.rs
+++ b/crates/auth/src/oauth2/server.rs
@@ -74,6 +74,12 @@ pub trait RefreshTokenStore: Send + Sync {
     /// Revoke all refresh tokens for a user+client pair (security measure
     /// when replay is detected).
     async fn revoke_all(&self, user_id: &str, client_id: &str) -> Result<()>;
+
+    /// Revoke all refresh tokens belonging to a user except the specified
+    /// token. Used after a self-service password change to log the user out
+    /// of every other session while keeping the current one alive. Returns
+    /// the number of tokens revoked.
+    async fn revoke_for_user_except(&self, user_id: &str, except_token: &str) -> Result<u64>;
 }
 
 // -- In-memory implementations --
@@ -126,6 +132,13 @@ impl RefreshTokenStore for InMemoryRefreshTokenStore {
             .await
             .retain(|_, t| !(t.user_id == user_id && t.client_id == client_id));
         Ok(())
+    }
+
+    async fn revoke_for_user_except(&self, user_id: &str, except_token: &str) -> Result<u64> {
+        let mut tokens = self.tokens.write().await;
+        let before = tokens.len();
+        tokens.retain(|tok, t| !(t.user_id == user_id && tok != except_token));
+        Ok((before - tokens.len()) as u64)
     }
 }
 
@@ -591,6 +604,70 @@ mod tests {
         // Even the new token is now revoked.
         let err2 = server.refresh(&pair2.refresh_token, "webui").await;
         assert!(err2.is_err(), "all tokens should be revoked after replay");
+    }
+
+    #[tokio::test]
+    async fn revoke_for_user_except_keeps_calling_token() {
+        let store = InMemoryRefreshTokenStore::default();
+        let user = "usr_alice";
+        let now = Utc::now();
+
+        // Three tokens for the same user across different "sessions".
+        let tokens: Vec<String> = (0..3).map(|_| generate_random_token()).collect();
+        for (i, t) in tokens.iter().enumerate() {
+            store
+                .store_token(StoredRefreshToken {
+                    token: t.clone(),
+                    user_id: user.into(),
+                    client_id: format!("client_{i}"),
+                    scopes: vec![],
+                    expires_at: now + Duration::days(30),
+                    consumed: false,
+                })
+                .await
+                .unwrap();
+        }
+
+        // Also a token for a different user — must be untouched.
+        let other_token = generate_random_token();
+        store
+            .store_token(StoredRefreshToken {
+                token: other_token.clone(),
+                user_id: "usr_bob".into(),
+                client_id: "client_x".into(),
+                scopes: vec![],
+                expires_at: now + Duration::days(30),
+                consumed: false,
+            })
+            .await
+            .unwrap();
+
+        // Revoke all of alice's except tokens[1] (the "current" session).
+        let n = store
+            .revoke_for_user_except(user, &tokens[1])
+            .await
+            .unwrap();
+        assert_eq!(n, 2, "should revoke the two non-excepted tokens");
+
+        // Excepted token survives.
+        assert!(
+            store.get_token(&tokens[1]).await.unwrap().is_some(),
+            "excepted token must still validate"
+        );
+        // The two siblings are gone.
+        assert!(
+            store.get_token(&tokens[0]).await.unwrap().is_none(),
+            "non-excepted token must be revoked"
+        );
+        assert!(
+            store.get_token(&tokens[2]).await.unwrap().is_none(),
+            "non-excepted token must be revoked"
+        );
+        // Other user's token untouched.
+        assert!(
+            store.get_token(&other_token).await.unwrap().is_some(),
+            "other user's token must not be touched"
+        );
     }
 
     #[tokio::test]

--- a/crates/storage/src/auth_state_store.rs
+++ b/crates/storage/src/auth_state_store.rs
@@ -241,6 +241,16 @@ impl RefreshTokenStore for SqliteRefreshTokenStore {
             .await?;
         Ok(())
     }
+
+    async fn revoke_for_user_except(&self, user_id: &str, except_token: &str) -> Result<u64> {
+        let result =
+            sqlx::query("DELETE FROM refresh_tokens WHERE user_id = ? AND token_hash != ?")
+                .bind(user_id)
+                .bind(except_token)
+                .execute(&self.pool)
+                .await?;
+        Ok(result.rows_affected())
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -525,6 +535,61 @@ mod tests {
             let found = store.get_token(&format!("tok_{i}")).await.unwrap();
             assert!(found.is_none(), "token tok_{i} should be revoked");
         }
+    }
+
+    #[tokio::test]
+    async fn refresh_token_revoke_for_user_except() {
+        let layer = setup().await;
+        let store = layer.refresh_token_store();
+
+        // Three sessions for usr_1, one for usr_2.
+        for i in 0..3 {
+            store
+                .store_token(StoredRefreshToken {
+                    token: format!("alice_tok_{i}"),
+                    user_id: "usr_1".into(),
+                    client_id: format!("cli_{i}"),
+                    scopes: vec![],
+                    expires_at: Utc::now() + Duration::days(30),
+                    consumed: false,
+                })
+                .await
+                .unwrap();
+        }
+        store
+            .store_token(StoredRefreshToken {
+                token: "bob_tok".into(),
+                user_id: "usr_2".into(),
+                client_id: "cli_x".into(),
+                scopes: vec![],
+                expires_at: Utc::now() + Duration::days(30),
+                consumed: false,
+            })
+            .await
+            .unwrap();
+
+        let n = store
+            .revoke_for_user_except("usr_1", "alice_tok_1")
+            .await
+            .unwrap();
+        assert_eq!(n, 2, "should revoke two of alice's three tokens");
+
+        assert!(
+            store.get_token("alice_tok_1").await.unwrap().is_some(),
+            "excepted token survives"
+        );
+        assert!(
+            store.get_token("alice_tok_0").await.unwrap().is_none(),
+            "non-excepted token revoked"
+        );
+        assert!(
+            store.get_token("alice_tok_2").await.unwrap().is_none(),
+            "non-excepted token revoked"
+        );
+        assert!(
+            store.get_token("bob_tok").await.unwrap().is_some(),
+            "other user's token untouched"
+        );
     }
 
     // -- DeviceCodeStore --

--- a/openspec/changes/self-service-account/.openspec.yaml
+++ b/openspec/changes/self-service-account/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-25

--- a/openspec/changes/self-service-account/design.md
+++ b/openspec/changes/self-service-account/design.md
@@ -1,0 +1,121 @@
+## Context
+
+User-account management today is split awkwardly across the codebase:
+
+- `crates/web-ui/src/api/users.rs` exposes `PATCH /api/orgs/{org_id}/users/{id}` with name + email, but it's only reachable through the org-admin Admin screen and requires the caller to know its own `user_id` and `org_id`.
+- `crates/auth/src/password.rs` has working `hash_password` / `verify_password` (argon2id) but the only call site is user creation in `users.rs:179`. There is no change-password endpoint.
+- `crates/interface-cli/src/cmd_login.rs` already establishes the pattern of self-service via `/api/users/me/...` (used for API keys), and `crates/web-ui/src/api/api_keys.rs` shows how an authenticated handler reads the caller from `AuthContext` and operates on "me" without an ID in the URL.
+- The Flutter `app/lib/features/settings/settings_screen.dart` only contains notification toggles. There is no `/account` route in `app_router.dart`.
+
+The `multi-user-orgs` change (in-progress, 99/110 tasks) is bringing real non-admin users to the system. Without self-service account management, every name/email/password change requires an org-admin — which is the wrong default for a deployed multi-user instance.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One coherent `/api/users/me` capability covering view, edit, and password change.
+- Surface it identically across web UI, Flutter app, and CLI so the user's mental model is the same regardless of client.
+- Do not lock a user out of their own session when they change their password.
+- Cleanly degrade for OIDC-managed orgs: the controls are invisible/disabled and the API rejects writes with a clear message pointing at the IdP.
+
+**Non-Goals:**
+
+- Password reset for forgotten passwords (needs email delivery infra we don't have).
+- Email-verification round-trip on email change (same reason).
+- 2FA / WebAuthn / passkeys.
+- Account deletion or self-service org leave.
+- Username/handle as a separate field.
+
+## Decisions
+
+### Decision 1: New `/api/users/me` capability instead of reusing org-scoped routes
+
+**Choice**: Add `GET`, `PATCH /api/users/me` and `POST /api/users/me/password` rather than reusing or generalising the existing `/api/orgs/{org_id}/users/{id}` routes.
+
+**Why**:
+
+- The CLI already needs a way to act without knowing its own `org_id`; `/users/me` is the existing pattern (see `api_keys.rs`, `templates.rs`).
+- Keeps admin authorization (`is_org_admin()` checks) cleanly separated from self-service authorization (just "is logged in as this user").
+- The org-scoped route survives unchanged for the Admin screen — no risk of regressing it.
+
+**Alternative considered**: Reuse `PATCH /api/orgs/{org_id}/users/{id}` with caller-equals-target as the authorization rule. Rejected because every client would need to round-trip through `GET /me` first to learn its own IDs, and we'd still have to add the password endpoint somewhere new.
+
+### Decision 2: Password change verifies current password and revokes other refresh tokens
+
+**Choice**: `POST /api/users/me/password` requires `{ current_password, new_password }`. On success: hash + persist new, then revoke all of the user's refresh tokens **except** the one underlying the current request. API keys are not touched.
+
+**Why**:
+
+- Verifying current password defends against a stolen access token being used to take over the account permanently (attacker doesn't know the current password).
+- Revoking other sessions is the user-expected outcome ("I changed my password, my old laptop is now logged out").
+- Keeping the current session alive avoids the kick-myself-out footgun (Web UI would need to re-login after every change).
+- API keys are a separate trust path (named, scoped, individually revocable); coupling them to password changes would surprise users.
+
+**Alternative considered**: Revoke everything including current session, force re-login. Rejected as user-hostile — the user just proved they know the password.
+
+**Alternative considered**: Don't revoke other tokens. Rejected because the typical reason for changing a password is suspected compromise; not revoking would defeat the purpose.
+
+### Decision 3: OIDC orgs reject self-service writes with `409 Conflict`
+
+**Choice**: When the caller's org has `auth_mode = "oidc"`, the `PATCH` and password endpoints return `409 Conflict` with `{ "error": "account managed by identity provider <issuer>" }`. `GET /api/users/me` still works (read-only is always safe).
+
+**Why**:
+
+- Email and password live at the IdP for OIDC users; we have no way to push them upstream.
+- `409` (rather than `403`) signals "the resource is in a state where this operation can't apply", which is exactly the case here. `403` would imply "you're not allowed", which is misleading.
+- The error body names the IdP so the UI can render an actionable link.
+
+**Alternative considered**: Hide endpoints entirely (404). Rejected because clients (CLI, app) need a deterministic way to detect "managed elsewhere" without out-of-band knowledge.
+
+### Decision 4: Email change is immediate; no verification mailer
+
+**Choice**: A `PATCH /api/users/me` with a new email writes immediately and returns the new value. The response body includes a `previous_email` field so clients can render a confirmation banner ("Email changed from X to Y").
+
+**Why**:
+
+- The codebase has no SMTP/transactional-email integration. Adding one is a much larger scope.
+- Self-hosted single-org deployments (the most common deployment today per `~/.assistant/` layout) generally don't need verification — the operator knows the user.
+- The proposal explicitly defers email-verification.
+
+**Mitigation**: The Settings UI shows a clear "this takes effect immediately" hint and the response shape lets us layer verification on later without breaking the API.
+
+### Decision 5: CLI uses `assistant account` subcommand group
+
+**Choice**: New top-level subcommand `account` with children `show`, `set-email <email>`, `set-name <name>`, `change-password`. Implementation in `crates/interface-cli/src/cmd_account.rs`, mirroring `cmd_login.rs` style and reusing its `authenticated_client` helper.
+
+**Why**:
+
+- Mirrors existing `api-keys` subcommand layout exactly (see `main.rs:142-147`), so users who know one know the other.
+- `change-password` is interactive (TTY prompts using `rpassword` — the standard Rust hidden-input crate) since accepting passwords on the command line leaks them into shell history.
+
+**Alternative considered**: Flat commands like `assistant set-email`. Rejected as cluttering the top-level namespace and inconsistent with `api-keys`/`persona`/`skill`.
+
+### Decision 6: Flutter app gets a new `/account` route nested under Settings
+
+**Choice**: New screen at `app/lib/features/account/account_screen.dart` reachable via a tile in `settings_screen.dart` ("Account" → arrow). Route `/settings/account` registered in `app_router.dart`.
+
+**Why**:
+
+- Settings is the natural home; surfacing it as a sub-screen avoids overloading the Settings root with three forms.
+- Cupertino sub-page navigation is the iOS-native pattern (`CupertinoPageRoute`); Material gets a standard pushed route.
+- A separate screen keeps form state, validation, and "managed by IdP" banner logic isolated from notification toggles.
+
+## Risks / Trade-offs
+
+- **[Risk] Email-change immediate-write enables a typo lockout** → Mitigation: client-side double-entry confirmation in all three UIs; `previous_email` in response so an admin can manually correct via the org-scoped PATCH if needed.
+- **[Risk] Password-change without rate limiting could enable brute-forcing the _current_ password via the API** → Mitigation: add a per-user rate limit (e.g. 5 attempts / 15 min) at the handler level. Already a TODO for `/oauth/authorize`; consolidate.
+- **[Risk] Refresh-token revocation logic gets it wrong and kicks the user out anyway** → Mitigation: integration test that asserts the calling refresh token survives while a sibling token is revoked. `crates/integration-tests` is the right place.
+- **[Trade-off] No email verification means a malicious actor with a stolen access token could change the user's email and lock them out (then change password)** → Accepted because they'd need both the access token AND the current password; verifying current password is the primary defence. Adding email verification is tracked as a non-goal but a future capability.
+- **[Trade-off] OIDC orgs see read-only Account screen, which may confuse users who don't realise their org is OIDC-managed** → Mitigation: explanatory banner naming the IdP issuer.
+
+## Migration Plan
+
+1. Ship the new endpoints first behind no flag — they're additive and unauthenticated callers get `401` from the existing auth middleware.
+2. Regenerate `app/packages/assistant_api/` and merge in the same PR (per `make generate-flutter-client` discipline).
+3. Ship UI/CLI surfaces in follow-up PRs — backend works standalone for `curl` users.
+4. Rollback is `git revert`; no data migration, no schema change.
+
+## Open Questions
+
+- Should the CLI `account show` print the full `UserDetail` (including `created_at`/`updated_at`) or a trimmed view? Leaning trimmed by default with `--json` for the full payload, matching `api-keys list`'s style.
+- Where does refresh-token-by-user revocation actually live in `crates/auth`? Need to confirm whether to add a new method on the token store or compose existing single-token revocation. Will be answered while implementing.

--- a/openspec/changes/self-service-account/proposal.md
+++ b/openspec/changes/self-service-account/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+Today users have no way to manage their own account. The `PATCH /api/orgs/{org_id}/users/{id}` endpoint exists but is hidden behind the org-admin tab; the Flutter Settings screen only exposes notification toggles; the CLI has no `account` command. There is **no password-change endpoint at all** — once a user is created, their password is fixed. As `multi-user-orgs` (PR-in-progress) ships and we onboard non-admin users, this becomes a basic blocker.
+
+## What Changes
+
+- Add `GET /api/users/me` returning `UserDetail` for the caller (no `org_id` in URL).
+- Add `PATCH /api/users/me` accepting `{ name?, email? }` for self-service profile edits.
+- Add `POST /api/users/me/password` accepting `{ current_password, new_password }`. Verifies current with argon2id, hashes new, **revokes all OTHER refresh tokens** for the user (current session keeps working; API keys are untouched).
+- For orgs in `auth_mode = "oidc"`: all three endpoints return `409 Conflict` with body `{ "error": "account managed by identity provider <issuer>" }`. The `GET` still works.
+- **Web UI / Flutter app**: new "Account" section in Settings with three forms (name, email, change password). Hidden / disabled with an explanatory banner when the org is OIDC-managed.
+- **CLI**: new `assistant account` subcommand group — `show`, `set-email <email>`, `set-name <name>`, `change-password` (interactive prompt for current + new + confirm).
+
+Email change is **immediate** (no verification mailer is wired up in the project today); the response includes a `previous_email` field so the UI can display a "we just changed your email from X to Y" confirmation. Adding email-confirmation flow is explicitly deferred.
+
+## Capabilities
+
+### New Capabilities
+
+- `self-service-account`: HTTP API + UI/CLI surfaces letting a user view and modify their own profile (name, email, password) without org-admin privileges.
+
+### Modified Capabilities
+
+<!-- None. The existing org-scoped admin endpoints in crates/web-ui/src/api/users.rs are unchanged; this adds a new /users/me capability alongside them. notification-settings is the only existing settings-related spec and it covers a different concern. -->
+
+## Impact
+
+- **Code**: new handlers in `crates/web-ui/src/api/` (likely `account.rs`); router wire-up in `crates/web-ui/src/main.rs`; new Flutter screen under `app/lib/features/account/` plus a route in `app/lib/router/app_router.dart`; new `cmd_account.rs` in `crates/interface-cli/src/` plus subcommand wiring in `main.rs`.
+- **OpenAPI**: three new operations (`get_current_user`, `update_current_user`, `change_password`) added to `openapi.json`; regenerate `app/packages/assistant_api/` via `make generate-flutter-client`.
+- **Auth**: needs a way to revoke all refresh tokens for a user except the caller's. `crates/auth` already has revocation primitives (`/oauth/revoke`); needs a bulk-by-user variant.
+- **Storage**: no schema changes — `users.password_hash` already exists.
+- **Docs**: `docs/authentication.md` gets a "Changing your password" section. **User-facing documentation: YES** — needed for both end-users (settings UI) and operators (CLI command + OIDC behavior).
+
+## Non-goals
+
+- Email-verification flow on email change (no mailer infra exists).
+- Password reset for a forgotten password (separate flow, requires email delivery).
+- Two-factor authentication / WebAuthn / passkeys.
+- Account deletion / self-service org leave (org-admin still owns user lifecycle).
+- Username / handle changes (we don't have usernames, only email + name).
+- Changing email/password for users in OIDC-managed orgs (delegated to the IdP by design).

--- a/openspec/changes/self-service-account/specs/self-service-account/spec.md
+++ b/openspec/changes/self-service-account/specs/self-service-account/spec.md
@@ -1,0 +1,152 @@
+## ADDED Requirements
+
+### Requirement: Caller can retrieve their own user record
+
+The system SHALL expose `GET /api/users/me` returning a `UserDetail` for the authenticated caller. The endpoint MUST work regardless of the caller's organization auth mode.
+
+#### Scenario: Authenticated user retrieves own profile
+
+- **WHEN** a logged-in user issues `GET /api/users/me` with a valid bearer token
+- **THEN** the response is `200 OK` with a `UserDetail` body containing `id`, `org_id`, `email`, `name`, `created_at`, `updated_at`
+
+#### Scenario: Unauthenticated request is rejected
+
+- **WHEN** a request to `GET /api/users/me` arrives without a valid bearer token or API key
+- **THEN** the response is `401 Unauthorized`
+
+#### Scenario: Endpoint works for OIDC-managed users
+
+- **WHEN** a user whose org has `auth_mode = "oidc"` issues `GET /api/users/me`
+- **THEN** the response is `200 OK` with the same `UserDetail` shape as a password-mode user
+
+### Requirement: Caller can update own name and email
+
+The system SHALL expose `PATCH /api/users/me` accepting an `UpdateCurrentUserRequest` of the shape `{ name?: string, email?: string }`. On success the system SHALL persist the new values and return the updated `UserDetail` plus a `previous_email` field when email changed.
+
+#### Scenario: User updates own name
+
+- **WHEN** an authenticated user submits `PATCH /api/users/me` with `{"name": "New Name"}`
+- **THEN** the response is `200 OK`, the user's name is updated in storage, and the response body shows `name: "New Name"`
+
+#### Scenario: User updates own email
+
+- **WHEN** an authenticated user submits `PATCH /api/users/me` with `{"email": "new@example.com"}`
+- **AND** no other user in the same org already has that email
+- **THEN** the response is `200 OK`, the email is updated in storage, and the response body includes `email: "new@example.com"` and `previous_email: "<old>"`
+
+#### Scenario: Email collides with existing user in same org
+
+- **WHEN** a user submits `PATCH /api/users/me` with an email already used by another user in the same org
+- **THEN** the response is `409 Conflict` with body `{"error": "email already exists in this org"}` and storage is unchanged
+
+#### Scenario: Empty body is a no-op
+
+- **WHEN** a user submits `PATCH /api/users/me` with `{}`
+- **THEN** the response is `200 OK` with the unchanged `UserDetail` and no `previous_email` field
+
+#### Scenario: OIDC org rejects the update
+
+- **WHEN** a user whose org has `auth_mode = "oidc"` submits `PATCH /api/users/me` with any body
+- **THEN** the response is `409 Conflict` with body `{"error": "account managed by identity provider <issuer>"}` and storage is unchanged
+
+#### Scenario: Invalid email format is rejected
+
+- **WHEN** a user submits `PATCH /api/users/me` with an email failing basic validation (no `@`, empty)
+- **THEN** the response is `400 Bad Request` with body `{"error": "<reason>"}`
+
+### Requirement: Caller can change own password
+
+The system SHALL expose `POST /api/users/me/password` accepting a `ChangePasswordRequest` of the shape `{ current_password: string, new_password: string }`. The system MUST verify the current password against the stored argon2id hash, hash the new password, persist it, and revoke all of the user's refresh tokens **except** the one underlying the current request. API keys MUST NOT be affected.
+
+#### Scenario: Successful password change
+
+- **WHEN** an authenticated user submits a correct `current_password` and a non-empty `new_password`
+- **THEN** the response is `204 No Content`, the stored hash is updated, the calling session's refresh token still works, and all of the user's other refresh tokens are revoked
+
+#### Scenario: Wrong current password
+
+- **WHEN** an authenticated user submits a `current_password` that does not match the stored hash
+- **THEN** the response is `401 Unauthorized` with body `{"error": "current password is incorrect"}` and the stored hash is unchanged
+
+#### Scenario: Empty new password
+
+- **WHEN** an authenticated user submits a `new_password` of empty string
+- **THEN** the response is `400 Bad Request` with body `{"error": "new password must not be empty"}`
+
+#### Scenario: API keys survive password change
+
+- **WHEN** a user with at least one active API key successfully changes their password
+- **THEN** that API key still authenticates subsequent requests
+
+#### Scenario: OIDC org rejects password change
+
+- **WHEN** a user whose org has `auth_mode = "oidc"` submits `POST /api/users/me/password`
+- **THEN** the response is `409 Conflict` with body `{"error": "account managed by identity provider <issuer>"}` and the stored hash is unchanged
+
+### Requirement: Web UI exposes an Account section
+
+The Web UI SHALL render an "Account" section on the Settings page containing three controls: edit name, edit email (with confirm-email field), change password (current + new + confirm new). On submit each control SHALL call the corresponding `/api/users/me` endpoint.
+
+#### Scenario: Account section visible for password-mode org
+
+- **WHEN** a user whose org has `auth_mode = "password"` opens the Settings page
+- **THEN** the Account section is visible with name, email, and change-password controls enabled
+
+#### Scenario: Account section read-only for OIDC org
+
+- **WHEN** a user whose org has `auth_mode = "oidc"` opens the Settings page
+- **THEN** the Account section displays the user's current name and email as read-only fields with a banner reading "Managed by your identity provider (<issuer>)" and the change-password control is hidden
+
+#### Scenario: Email confirmation typo blocks submission
+
+- **WHEN** a user enters a new email and a different value in the confirm-email field
+- **THEN** the form prevents submission and shows an inline error
+
+### Requirement: Flutter app exposes an Account screen
+
+The Flutter app SHALL register a route at `/settings/account` reachable via a tile on the Settings screen. The screen SHALL contain the same three controls as the Web UI Account section and call the same endpoints via the generated `assistant_api` client.
+
+#### Scenario: Account tile navigates to Account screen
+
+- **WHEN** a user taps the "Account" tile on the Settings screen
+- **THEN** the app pushes the Account screen using the platform-appropriate navigator (Cupertino on Apple Touch, Material elsewhere)
+
+#### Scenario: Account screen forms call /api/users/me
+
+- **WHEN** a user submits the email-change form on the Account screen with a new value
+- **THEN** the app issues `PATCH /api/users/me` and on success updates the displayed value and shows a confirmation snackbar/banner naming the previous email
+
+#### Scenario: OIDC org disables write controls
+
+- **WHEN** the current user's org has `auth_mode = "oidc"`
+- **THEN** the Account screen shows name and email as read-only and hides the change-password form, with a banner naming the IdP issuer
+
+### Requirement: CLI exposes an `account` subcommand group
+
+The `assistant` CLI SHALL expose a top-level subcommand `account` with children `show`, `set-email <email>`, `set-name <name>`, and `change-password`. Each subcommand SHALL use the existing authenticated-client helper (refreshes credentials, supports `--api-key`/`--server` overrides).
+
+#### Scenario: `assistant account show` prints current profile
+
+- **WHEN** a logged-in user runs `assistant account show`
+- **THEN** the command prints email, name, org_id, and auth mode and exits `0`
+
+#### Scenario: `assistant account set-email` updates email
+
+- **WHEN** a logged-in user runs `assistant account set-email new@example.com`
+- **THEN** the command issues `PATCH /api/users/me` and prints `Email changed from <old> to new@example.com.` on success
+
+#### Scenario: `assistant account change-password` prompts interactively
+
+- **WHEN** a logged-in user runs `assistant account change-password` from a TTY
+- **THEN** the command prompts for current password, new password, and confirmation (all hidden), submits to `POST /api/users/me/password`, and prints `Password changed.` on success
+- **AND** the prompt values never appear in shell history or process arguments
+
+#### Scenario: CLI surfaces OIDC-managed error clearly
+
+- **WHEN** a logged-in user in an OIDC-managed org runs `assistant account change-password`
+- **THEN** the command exits non-zero and prints `Your org's accounts are managed by <issuer>. Change your password there instead.`
+
+#### Scenario: Not-logged-in shows actionable message
+
+- **WHEN** a user with no stored credentials and no `--api-key` runs `assistant account show`
+- **THEN** the command exits non-zero and prints `Not logged in — run \`assistant login <server-url>\` first.`

--- a/openspec/changes/self-service-account/tasks.md
+++ b/openspec/changes/self-service-account/tasks.md
@@ -1,8 +1,8 @@
 ## 1. Auth: bulk refresh-token revocation
 
-- [ ] 1.1 Locate the refresh-token store/repo in `crates/auth` and identify how single-token revocation works today (`/oauth/revoke` handler call site).
-- [ ] 1.2 Add a method `revoke_user_refresh_tokens_except(user_id, except_jti)` (or equivalent) to the token store, returning the count revoked.
-- [ ] 1.3 Write a unit test: create three refresh tokens for one user, call the new method excepting one, assert the excepted token still validates and the others do not.
+- [x] 1.1 Locate the refresh-token store/repo in `crates/auth` and identify how single-token revocation works today (`/oauth/revoke` handler call site).
+- [x] 1.2 Add a method `revoke_user_refresh_tokens_except(user_id, except_jti)` (or equivalent) to the token store, returning the count revoked.
+- [x] 1.3 Write a unit test: create three refresh tokens for one user, call the new method excepting one, assert the excepted token still validates and the others do not.
 
 ## 2. Backend: `/api/users/me` capability
 

--- a/openspec/changes/self-service-account/tasks.md
+++ b/openspec/changes/self-service-account/tasks.md
@@ -1,0 +1,67 @@
+## 1. Auth: bulk refresh-token revocation
+
+- [ ] 1.1 Locate the refresh-token store/repo in `crates/auth` and identify how single-token revocation works today (`/oauth/revoke` handler call site).
+- [ ] 1.2 Add a method `revoke_user_refresh_tokens_except(user_id, except_jti)` (or equivalent) to the token store, returning the count revoked.
+- [ ] 1.3 Write a unit test: create three refresh tokens for one user, call the new method excepting one, assert the excepted token still validates and the others do not.
+
+## 2. Backend: `/api/users/me` capability
+
+- [ ] 2.1 Create `crates/web-ui/src/api/account.rs` with module-level docs listing the three routes (mirror `users.rs:1-11` style).
+- [ ] 2.2 Define request/response types: `UpdateCurrentUserRequest { name?, email? }`, `UpdateCurrentUserResponse` (a `UserDetail` plus optional `previous_email`), `ChangePasswordRequest { current_password, new_password }`. Use `utoipa::ToSchema` derives.
+- [ ] 2.3 Implement `get_current_user` handler — read `AuthContext`, look up user, return `UserDetail`. Include `#[utoipa::path]` annotation with `operation_id = "get_current_user"`.
+- [ ] 2.4 Implement `update_current_user` handler — apply name/email patch, dedupe email within org (return 409), reject empty/invalid email (400), include `previous_email` in response when changed. `operation_id = "update_current_user"`.
+- [ ] 2.5 Implement `change_password` handler — verify current via `assistant_auth::password::verify_password`, hash new via `hash_password`, persist, then call the bulk revocation from §1.2 excepting the current refresh token's jti. Return `204 No Content`. `operation_id = "change_password"`.
+- [ ] 2.6 Add OIDC-mode guard to `update_current_user` and `change_password`: if the user's org has `auth_mode == "oidc"`, return `409` with `{"error": "account managed by identity provider <issuer>"}`. `get_current_user` is unguarded.
+- [ ] 2.7 Wire the router in `crates/web-ui/src/main.rs` (or wherever `users_api_router` is mounted) under `/api`.
+- [ ] 2.8 Write handler tests in `account.rs` `#[cfg(test)] mod tests` covering every scenario in `specs/self-service-account/spec.md` for the three endpoints (success paths, OIDC rejection, email collision, wrong current password, empty new password, API-key survives, calling-token survives + sibling revoked).
+
+## 3. OpenAPI + generated Flutter client
+
+- [ ] 3.1 Register the three new operations in `crates/web-ui/src/openapi.rs` `paths(...)` and `schemas(...)` sections.
+- [ ] 3.2 Run `make dump-openapi` and verify `openapi.json` now contains the three operations with snake_case operationIds.
+- [ ] 3.3 Run `make generate-flutter-client` and verify `app/packages/assistant_api/lib/src/api/users_api.dart` (or a new `account_api.dart`) exposes `getCurrentUser`, `updateCurrentUser`, `changePassword`.
+- [ ] 3.4 Add a generated-client smoke test under `app/packages/assistant_api/test/` that calls the three operations against a mocked dio and asserts request shapes.
+
+## 4. Web UI: Account section in Settings
+
+- [ ] 4.1 Identify where the existing web Settings page lives (web-ui crate's HTML templates if applicable, or note that the Web UI = the Flutter web build and §5 covers it).
+- [ ] 4.2 If a separate Web UI HTML/template exists, add an "Account" section with name, email (with confirm), and change-password (current + new + confirm) forms; otherwise mark this group as N/A and document why.
+- [ ] 4.3 Wire OIDC banner display when `auth_mode == "oidc"` (read from `GET /api/users/me` + `GET /api/orgs/<id>` or equivalent).
+- [ ] 4.4 Manually test in browser: change name, change email (verify previous-email banner), change password (verify other browser session is logged out, current stays in).
+
+## 5. Flutter app: Account screen
+
+- [ ] 5.1 Create `app/lib/features/account/account_provider.dart` with an `AsyncNotifier` exposing the current user and methods `updateName`, `updateEmail`, `changePassword` that call the generated client.
+- [ ] 5.2 Create `app/lib/features/account/account_screen.dart` with three sections: Name (text field + save), Email (new + confirm + save), Password (current + new + confirm + save). Use adaptive widgets per project convention.
+- [ ] 5.3 Render OIDC banner (read-only fields, hidden password section, "Managed by <issuer>" text) when the org's `auth_mode == "oidc"`.
+- [ ] 5.4 Add an "Account" tile to `app/lib/features/settings/settings_screen.dart` with `Icons.person_outline` / `CupertinoIcons.person` that navigates to `/settings/account`.
+- [ ] 5.5 Register the `/settings/account` route in `app/lib/router/app_router.dart` (after the existing `/settings` entry).
+- [ ] 5.6 Add a widget test under `app/test/widget/account_screen_test.dart` covering: form rendering, OIDC banner toggle, email-confirmation mismatch blocks submit, successful save shows confirmation.
+
+## 6. CLI: `account` subcommand
+
+- [ ] 6.1 Add `rpassword` to `[workspace.dependencies]` in root `Cargo.toml` and depend on it from `crates/interface-cli/Cargo.toml`.
+- [ ] 6.2 Promote `authenticated_client` from private inside `cmd_login.rs` to a `pub(crate)` helper (or move to `credentials.rs`) so `cmd_account.rs` can reuse it.
+- [ ] 6.3 Create `crates/interface-cli/src/cmd_account.rs` with four functions: `cmd_account_show`, `cmd_account_set_email`, `cmd_account_set_name`, `cmd_account_change_password`.
+- [ ] 6.4 Implement `cmd_account_show` — `GET /api/users/me`, print email/name/org_id/auth_mode in a friendly block; support `--json` for raw `UserDetail`.
+- [ ] 6.5 Implement `cmd_account_set_email` and `cmd_account_set_name` — `PATCH /api/users/me`, on success print `<Field> changed from <old> to <new>.` (use `previous_email` when present).
+- [ ] 6.6 Implement `cmd_account_change_password` — use `rpassword::prompt_password` for current + new + confirm; reject mismatch locally; submit to `POST /api/users/me/password`; on `409` (OIDC), print actionable message naming issuer; on success print `Password changed.`.
+- [ ] 6.7 Wire up `Account { command: AccountCommand }` enum and `AccountCommand::{Show, SetEmail, SetName, ChangePassword}` variants in `crates/interface-cli/src/main.rs` and dispatch to the new handlers.
+- [ ] 6.8 Add CLI parsing tests in `main.rs` `#[cfg(test)] mod tests` for `account show`, `account set-email foo@bar`, `account set-name "X"`, `account change-password` (mirror existing `parses_api_keys_*` tests).
+
+## 7. Integration test (cross-cutting)
+
+- [ ] 7.1 Add `crates/integration-tests/tests/account.rs` (or extend `smoke.rs`) covering: log in, get-me, patch email, patch name, change password, verify old refresh token is revoked but current session continues, verify API keys still work.
+
+## 8. Documentation
+
+- [ ] 8.1 Add a "Changing your account" section to `docs/authentication.md` describing the three endpoints, OIDC behavior, and refresh-token revocation semantics.
+- [ ] 8.2 Add a CLI usage block to whatever README/CLI doc covers `assistant login` (likely `crates/interface-cli/README.md` or top-level `README.md`).
+- [ ] 8.3 Note the new Account screen in user-facing app documentation (if `docs/` has an app-tour section, otherwise skip).
+
+## 9. Polish & verification
+
+- [ ] 9.1 Run `make lint` and `make format` — fix any issues.
+- [ ] 9.2 Run `make test` and `make test-flutter` — all green.
+- [ ] 9.3 Run `make precommit` — all hooks pass.
+- [ ] 9.4 Manually exercise CLI happy path against a local `assistant webui serve` instance: `assistant account show`, `set-email`, `set-name`, `change-password`. Verify the next `assistant login` (or session refresh) on a second machine fails until re-login.


### PR DESCRIPTION
## Summary

Two small commits that lay the groundwork for letting users manage their own account:

- **`docs(openspec)`** — Adds the `self-service-account` OpenSpec change proposal (proposal, design, specs, 41-task checklist) covering `/api/users/me` GET/PATCH/change-password endpoints plus matching Web UI, Flutter app, and CLI surfaces. OIDC-managed orgs get read-only access with a 409 + IdP-pointer on writes. Email change is immediate (no mailer infra); password change verifies current and revokes other refresh tokens while keeping the calling session alive.

- **`feat(auth)`** — Implements §1 of that change: a new `RefreshTokenStore::revoke_for_user_except(user_id, except_token)` method that revokes every refresh token belonging to a user except one. Both store backends (`InMemoryRefreshTokenStore` in `assistant-auth`, `SqliteRefreshTokenStore` in `assistant-storage`) implement it, each covered by a unit test asserting the excepted token survives, siblings are revoked, and other users' tokens are untouched.

The auth change is independently useful (admins could later use it for "force logout all sessions") but exists here to unblock the `POST /api/users/me/password` handler in the next PR.

The remaining 38 tasks in the proposal (handlers, OpenAPI registration, generated Flutter client, Account screen, `assistant account` CLI subcommand, integration tests, docs) will follow as separate PRs.

## Test plan

- [x] `cargo test -p assistant-auth revoke_for_user_except` — green
- [x] `cargo test -p assistant-storage refresh_token_revoke_for_user_except` — green
- [x] `make lint` (clippy `-D warnings`) — clean
- [x] `make format` — clean
- [x] `cargo machete` — no unused deps
- [ ] Reviewer: spot-check `openspec/changes/self-service-account/{proposal,design}.md` for the call on email-change-immediate vs. verification round-trip and OIDC-org `409` semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)