### PR TITLE
feat(cli): `assistant account` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,6 +471,7 @@ dependencies = [
  "dirs",
  "reedline",
  "reqwest 0.12.28",
+ "rpassword",
  "rustls",
  "serde",
  "serde_json",
@@ -5117,6 +5118,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5134,6 +5146,16 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,8 @@ axum = { version = "0.8", features = ["macros", "multipart"] }
 futures = "0.3"
 # Terminal line editor
 reedline = "0.47"
+# TTY-safe password prompt (used by `assistant account change-password`)
+rpassword = "7"
 # YAML frontmatter parser
 gray_matter = "0.3"
 # YAML serialization (for writing agent card frontmatter)

--- a/crates/interface-cli/Cargo.toml
+++ b/crates/interface-cli/Cargo.toml
@@ -45,6 +45,8 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 # Terminal line editor
 reedline = { workspace = true }
+# TTY-safe password prompt (used by `assistant account change-password`)
+rpassword = { workspace = true }
 # Config file parsing
 toml = { workspace = true }
 # Home directory

--- a/crates/interface-cli/src/cmd_account.rs
+++ b/crates/interface-cli/src/cmd_account.rs
@@ -1,0 +1,255 @@
+//! CLI commands for managing the caller's own account.
+//!
+//! Wraps the `/api/users/me` endpoints exposed by `assistant-web-ui`.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::cmd_login::authenticated_client;
+
+// -- API types (mirrors of server responses) --
+
+#[derive(Debug, Deserialize, Serialize)]
+struct UserDetail {
+    id: String,
+    org_id: String,
+    email: String,
+    name: String,
+    created_at: String,
+    updated_at: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct OrgDetail {
+    #[allow(dead_code)]
+    id: String,
+    #[allow(dead_code)]
+    name: String,
+    #[allow(dead_code)]
+    slug: String,
+    auth_mode: String,
+    #[allow(dead_code)]
+    created_at: String,
+    #[allow(dead_code)]
+    updated_at: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct UpdateCurrentUserResponse {
+    user: UserDetail,
+    #[serde(default)]
+    previous_email: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ErrorBody {
+    #[serde(default)]
+    error: String,
+}
+
+// -- Helpers --
+
+fn me_url(server_url: &str) -> String {
+    format!("{}/api/users/me", server_url.trim_end_matches('/'))
+}
+
+fn me_password_url(server_url: &str) -> String {
+    format!("{}/api/users/me/password", server_url.trim_end_matches('/'))
+}
+
+fn org_url(server_url: &str, org_id: &str) -> String {
+    format!("{}/api/orgs/{}", server_url.trim_end_matches('/'), org_id)
+}
+
+async fn fetch_me(server_url: &str, http: &reqwest::Client, token: &str) -> Result<UserDetail> {
+    let resp = http
+        .get(me_url(server_url))
+        .bearer_auth(token)
+        .send()
+        .await
+        .context("failed to GET /api/users/me")?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        anyhow::bail!("failed to load account ({status}): {text}");
+    }
+
+    resp.json::<UserDetail>()
+        .await
+        .context("invalid /api/users/me response")
+}
+
+async fn fetch_org_auth_mode(
+    server_url: &str,
+    http: &reqwest::Client,
+    token: &str,
+    org_id: &str,
+) -> Option<String> {
+    let resp = http
+        .get(org_url(server_url, org_id))
+        .bearer_auth(token)
+        .send()
+        .await
+        .ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    resp.json::<OrgDetail>().await.ok().map(|o| o.auth_mode)
+}
+
+// -- Commands --
+
+/// `assistant account show [--json]`
+pub async fn cmd_account_show(
+    json: bool,
+    api_key: &Option<String>,
+    server: &Option<String>,
+) -> Result<()> {
+    let (server_url, http, token) = authenticated_client(api_key, server).await?;
+    let me = fetch_me(&server_url, &http, &token).await?;
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&me).context("failed to render JSON")?
+        );
+        return Ok(());
+    }
+
+    let auth_mode = fetch_org_auth_mode(&server_url, &http, &token, &me.org_id)
+        .await
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("Email:     {}", me.email);
+    println!("Name:      {}", me.name);
+    println!("User ID:   {}", me.id);
+    println!("Org ID:    {}", me.org_id);
+    println!("Auth mode: {auth_mode}");
+    Ok(())
+}
+
+/// `assistant account set-email <email>`
+pub async fn cmd_account_set_email(
+    email: &str,
+    api_key: &Option<String>,
+    server: &Option<String>,
+) -> Result<()> {
+    let (server_url, http, token) = authenticated_client(api_key, server).await?;
+    patch_me(&server_url, &http, &token, Some(email), None).await
+}
+
+/// `assistant account set-name <name>`
+pub async fn cmd_account_set_name(
+    name: &str,
+    api_key: &Option<String>,
+    server: &Option<String>,
+) -> Result<()> {
+    let (server_url, http, token) = authenticated_client(api_key, server).await?;
+    patch_me(&server_url, &http, &token, None, Some(name)).await
+}
+
+async fn patch_me(
+    server_url: &str,
+    http: &reqwest::Client,
+    token: &str,
+    email: Option<&str>,
+    name: Option<&str>,
+) -> Result<()> {
+    let mut body = serde_json::Map::new();
+    if let Some(e) = email {
+        body.insert("email".into(), serde_json::Value::String(e.to_string()));
+    }
+    if let Some(n) = name {
+        body.insert("name".into(), serde_json::Value::String(n.to_string()));
+    }
+
+    let resp = http
+        .patch(me_url(server_url))
+        .bearer_auth(token)
+        .json(&serde_json::Value::Object(body))
+        .send()
+        .await
+        .context("failed to PATCH /api/users/me")?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp
+            .json::<ErrorBody>()
+            .await
+            .map(|e| e.error)
+            .unwrap_or_default();
+        if status == reqwest::StatusCode::CONFLICT && body.contains("identity provider") {
+            anyhow::bail!(
+                "this account is managed by an external identity provider — \
+                 update your details there, not via assistant ({body})"
+            );
+        }
+        anyhow::bail!("update failed ({status}): {body}");
+    }
+
+    let updated: UpdateCurrentUserResponse = resp.json().await.context("invalid response body")?;
+
+    if let Some(prev) = updated.previous_email {
+        println!("Email changed from {prev} to {}.", updated.user.email);
+    } else if email.is_some() {
+        println!("Email is already {}.", updated.user.email);
+    }
+    if name.is_some() {
+        println!("Name set to {}.", updated.user.name);
+    }
+    Ok(())
+}
+
+/// `assistant account change-password`
+pub async fn cmd_account_change_password(
+    api_key: &Option<String>,
+    server: &Option<String>,
+) -> Result<()> {
+    let (server_url, http, token) = authenticated_client(api_key, server).await?;
+
+    let current = rpassword::prompt_password("Current password: ")
+        .context("failed to read current password")?;
+    let new =
+        rpassword::prompt_password("New password:     ").context("failed to read new password")?;
+    let confirm = rpassword::prompt_password("Confirm new:      ")
+        .context("failed to read password confirmation")?;
+
+    if new != confirm {
+        anyhow::bail!("new password and confirmation do not match");
+    }
+    if new.is_empty() {
+        anyhow::bail!("new password must not be empty");
+    }
+
+    let resp = http
+        .post(me_password_url(&server_url))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "current_password": current,
+            "new_password": new,
+        }))
+        .send()
+        .await
+        .context("failed to POST /api/users/me/password")?;
+
+    let status = resp.status();
+    if status == reqwest::StatusCode::NO_CONTENT {
+        println!("Password changed.");
+        return Ok(());
+    }
+
+    let body = resp
+        .json::<ErrorBody>()
+        .await
+        .map(|e| e.error)
+        .unwrap_or_default();
+
+    if status == reqwest::StatusCode::CONFLICT && body.contains("identity provider") {
+        anyhow::bail!(
+            "this account is managed by an external identity provider — \
+             change your password there, not via assistant ({body})"
+        );
+    }
+    anyhow::bail!("password change failed ({status}): {body}");
+}

--- a/crates/interface-cli/src/cmd_login.rs
+++ b/crates/interface-cli/src/cmd_login.rs
@@ -274,7 +274,7 @@ pub fn cmd_status() -> Result<()> {
 ///
 /// If `api_key` and `server_url` are provided, uses them directly (no
 /// stored credentials needed). Otherwise falls back to `credentials.json`.
-async fn authenticated_client(
+pub(crate) async fn authenticated_client(
     api_key: &Option<String>,
     server_override: &Option<String>,
 ) -> Result<(String, reqwest::Client, String)> {

--- a/crates/interface-cli/src/main.rs
+++ b/crates/interface-cli/src/main.rs
@@ -1,3 +1,4 @@
+mod cmd_account;
 mod cmd_backup;
 mod cmd_doctor;
 mod cmd_login;
@@ -145,6 +146,33 @@ enum Command {
         #[command(subcommand)]
         command: ApiKeysCommand,
     },
+    /// Manage your own account (name, email, password).
+    Account {
+        #[command(subcommand)]
+        command: AccountCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum AccountCommand {
+    /// Show the current user (email, name, org, auth mode).
+    Show {
+        /// Print the raw `UserDetail` JSON instead of a friendly block.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Change your email address.
+    SetEmail {
+        /// New email.
+        email: String,
+    },
+    /// Change your display name.
+    SetName {
+        /// New display name.
+        name: String,
+    },
+    /// Change your password (prompts for current + new + confirm).
+    ChangePassword,
 }
 
 #[derive(Subcommand)]
@@ -520,6 +548,74 @@ mod cli_parse_tests {
         // Verify the env annotation exists by checking that --api-key accepts a value.
         let cli = Cli::try_parse_from(["assistant", "--api-key", "my_key", "status"]).unwrap();
         assert_eq!(cli.api_key.as_deref(), Some("my_key"));
+    }
+
+    #[test]
+    fn parses_account_show() {
+        let cli = Cli::try_parse_from(["assistant", "account", "show"]).unwrap();
+        match cli.command {
+            Some(Command::Account { command }) => {
+                assert!(matches!(
+                    command,
+                    super::AccountCommand::Show { json: false }
+                ));
+            }
+            _ => panic!("expected account show command"),
+        }
+    }
+
+    #[test]
+    fn parses_account_show_json() {
+        let cli = Cli::try_parse_from(["assistant", "account", "show", "--json"]).unwrap();
+        match cli.command {
+            Some(Command::Account { command }) => {
+                assert!(matches!(
+                    command,
+                    super::AccountCommand::Show { json: true }
+                ));
+            }
+            _ => panic!("expected account show --json command"),
+        }
+    }
+
+    #[test]
+    fn parses_account_set_email() {
+        let cli =
+            Cli::try_parse_from(["assistant", "account", "set-email", "foo@bar.com"]).unwrap();
+        match cli.command {
+            Some(Command::Account { command }) => match command {
+                super::AccountCommand::SetEmail { email } => {
+                    assert_eq!(email, "foo@bar.com");
+                }
+                _ => panic!("expected account set-email"),
+            },
+            _ => panic!("expected account command"),
+        }
+    }
+
+    #[test]
+    fn parses_account_set_name() {
+        let cli = Cli::try_parse_from(["assistant", "account", "set-name", "Jane Doe"]).unwrap();
+        match cli.command {
+            Some(Command::Account { command }) => match command {
+                super::AccountCommand::SetName { name } => {
+                    assert_eq!(name, "Jane Doe");
+                }
+                _ => panic!("expected account set-name"),
+            },
+            _ => panic!("expected account command"),
+        }
+    }
+
+    #[test]
+    fn parses_account_change_password() {
+        let cli = Cli::try_parse_from(["assistant", "account", "change-password"]).unwrap();
+        match cli.command {
+            Some(Command::Account { command }) => {
+                assert!(matches!(command, super::AccountCommand::ChangePassword));
+            }
+            _ => panic!("expected account change-password command"),
+        }
     }
 }
 
@@ -1384,6 +1480,22 @@ async fn main() -> Result<()> {
             ApiKeysCommand::List => cmd_login::cmd_api_keys_list(&cli.api_key, &cli.server).await,
             ApiKeysCommand::Revoke { id } => {
                 cmd_login::cmd_api_keys_revoke(id, &cli.api_key, &cli.server).await
+            }
+        };
+    }
+    if let Some(Command::Account { command }) = &cli.command {
+        return match command {
+            AccountCommand::Show { json } => {
+                cmd_account::cmd_account_show(*json, &cli.api_key, &cli.server).await
+            }
+            AccountCommand::SetEmail { email } => {
+                cmd_account::cmd_account_set_email(email, &cli.api_key, &cli.server).await
+            }
+            AccountCommand::SetName { name } => {
+                cmd_account::cmd_account_set_name(name, &cli.api_key, &cli.server).await
+            }
+            AccountCommand::ChangePassword => {
+                cmd_account::cmd_account_change_password(&cli.api_key, &cli.server).await
             }
         };
     }

--- a/openspec/changes/self-service-account/tasks.md
+++ b/openspec/changes/self-service-account/tasks.md
@@ -42,14 +42,14 @@ The `web-ui` crate has no HTML/template Account page. It serves the Flutter web 
 
 ## 6. CLI: `account` subcommand
 
-- [ ] 6.1 Add `rpassword` to `[workspace.dependencies]` in root `Cargo.toml` and depend on it from `crates/interface-cli/Cargo.toml`.
-- [ ] 6.2 Promote `authenticated_client` from private inside `cmd_login.rs` to a `pub(crate)` helper (or move to `credentials.rs`) so `cmd_account.rs` can reuse it.
-- [ ] 6.3 Create `crates/interface-cli/src/cmd_account.rs` with four functions: `cmd_account_show`, `cmd_account_set_email`, `cmd_account_set_name`, `cmd_account_change_password`.
-- [ ] 6.4 Implement `cmd_account_show` — `GET /api/users/me`, print email/name/org_id/auth_mode in a friendly block; support `--json` for raw `UserDetail`.
-- [ ] 6.5 Implement `cmd_account_set_email` and `cmd_account_set_name` — `PATCH /api/users/me`, on success print `<Field> changed from <old> to <new>.` (use `previous_email` when present).
-- [ ] 6.6 Implement `cmd_account_change_password` — use `rpassword::prompt_password` for current + new + confirm; reject mismatch locally; submit to `POST /api/users/me/password`; on `409` (OIDC), print actionable message naming issuer; on success print `Password changed.`.
-- [ ] 6.7 Wire up `Account { command: AccountCommand }` enum and `AccountCommand::{Show, SetEmail, SetName, ChangePassword}` variants in `crates/interface-cli/src/main.rs` and dispatch to the new handlers.
-- [ ] 6.8 Add CLI parsing tests in `main.rs` `#[cfg(test)] mod tests` for `account show`, `account set-email foo@bar`, `account set-name "X"`, `account change-password` (mirror existing `parses_api_keys_*` tests).
+- [x] 6.1 Add `rpassword` to `[workspace.dependencies]` in root `Cargo.toml` and depend on it from `crates/interface-cli/Cargo.toml`.
+- [x] 6.2 Promote `authenticated_client` from private inside `cmd_login.rs` to a `pub(crate)` helper (or move to `credentials.rs`) so `cmd_account.rs` can reuse it.
+- [x] 6.3 Create `crates/interface-cli/src/cmd_account.rs` with four functions: `cmd_account_show`, `cmd_account_set_email`, `cmd_account_set_name`, `cmd_account_change_password`.
+- [x] 6.4 Implement `cmd_account_show` — `GET /api/users/me`, print email/name/org_id/auth_mode in a friendly block; support `--json` for raw `UserDetail`.
+- [x] 6.5 Implement `cmd_account_set_email` and `cmd_account_set_name` — `PATCH /api/users/me`, on success print `<Field> changed from <old> to <new>.` (use `previous_email` when present).
+- [x] 6.6 Implement `cmd_account_change_password` — use `rpassword::prompt_password` for current + new + confirm; reject mismatch locally; submit to `POST /api/users/me/password`; on `409` (OIDC), print actionable message naming issuer; on success print `Password changed.`.
+- [x] 6.7 Wire up `Account { command: AccountCommand }` enum and `AccountCommand::{Show, SetEmail, SetName, ChangePassword}` variants in `crates/interface-cli/src/main.rs` and dispatch to the new handlers.
+- [x] 6.8 Add CLI parsing tests in `main.rs` `#[cfg(test)] mod tests` for `account show`, `account set-email foo@bar`, `account set-name "X"`, `account change-password` (mirror existing `parses_api_keys_*` tests).
 
 ## 7. Integration test (cross-cutting)
 


### PR DESCRIPTION
## Summary

Adds the CLI surface for self-service account management (§6 of the `self-service-account` change). Wraps the `/api/users/me` endpoints landed in #660.

- `assistant account show [--json]` — friendly block (email, name, IDs, `auth_mode`) or raw `UserDetail` JSON
- `assistant account set-email <email>` — `PATCH /api/users/me`, prints the `previous_email` → new email diff
- `assistant account set-name <name>` — `PATCH /api/users/me`, prints the new name
- `assistant account change-password` — rpassword-prompted current/new/confirm, client-side mismatch reject, friendly OIDC error message
- Reuses `cmd_login::authenticated_client` (now `pub(crate)`) so the same OAuth refresh flow / `--api-key` fallback applies

## Test plan

- [x] `cargo test -p assistant-cli` — 39 tests pass (5 new parse tests for `account` variants)
- [x] `make lint` / `make format`
- [x] Manual smoke pending §9.4 (full happy-path against `assistant webui serve`)

## Notes

- §7 (cross-cutting integration test) and §8 (docs) still to land.