### PR TITLE
fix(app): handle 401s and space-selector race conditions

### DIFF
--- a/app/lib/api/api_client.dart
+++ b/app/lib/api/api_client.dart
@@ -10,6 +10,7 @@ import 'dart:typed_data';
 import 'package:assistant_api/assistant_api.dart' hide ServerCapabilities;
 import 'package:dio/dio.dart';
 
+import 'auth_interceptor.dart';
 import 'models/server_capabilities.dart';
 import 'models/stream_event.dart';
 
@@ -30,7 +31,12 @@ class ApiAuthException implements Exception {
 
 /// Configured client bundle: generated API instances + SSE streaming helper.
 class ApiClient {
-  ApiClient({required String baseUrl, required String token}) : _token = token {
+  ApiClient({
+    required String baseUrl,
+    required String token,
+    RefreshTokensCallback? refreshTokens,
+    OnAuthExpiredCallback? onAuthExpired,
+  }) : _token = token {
     _dio = Dio(
       BaseOptions(
         baseUrl: baseUrl,
@@ -38,6 +44,15 @@ class ApiClient {
         receiveTimeout: const Duration(minutes: 10),
       ),
     );
+
+    if (refreshTokens != null && onAuthExpired != null) {
+      final interceptor = AuthRecoveryInterceptor(
+        dio: _dio,
+        refreshTokens: refreshTokens,
+        onAuthExpired: onAuthExpired,
+      );
+      _dio.interceptors.add(interceptor);
+    }
 
     _generatedApi = AssistantApi(dio: _dio, basePathOverride: baseUrl);
     _generatedApi.setBearerAuth('bearer_token', token);

--- a/app/lib/api/auth_interceptor.dart
+++ b/app/lib/api/auth_interceptor.dart
@@ -1,0 +1,127 @@
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+
+/// Returns the new bearer token on success, or `null` if refresh failed.
+typedef RefreshTokensCallback = Future<String?> Function();
+
+/// Called when the session is unrecoverable (no refresh token, refresh
+/// rejected, or a second 401 after retry). The wiring layer is expected to
+/// deactivate the active context so the router redirects to `/login`.
+typedef OnAuthExpiredCallback = Future<void> Function();
+
+/// Dio interceptor that recovers from 401 responses by attempting a single
+/// OAuth2 refresh and retrying the request once. If refresh fails — or the
+/// retry itself returns 401 — the interceptor invokes [onAuthExpired] and
+/// propagates the original 401 to the caller.
+///
+/// Concurrent 401s are coalesced onto a single refresh future
+/// (single-flight) to avoid stampeding the token endpoint.
+class AuthRecoveryInterceptor extends Interceptor {
+  AuthRecoveryInterceptor({
+    required this.refreshTokens,
+    required this.onAuthExpired,
+    Dio? dio,
+  }) : _retryDio = dio;
+
+  final RefreshTokensCallback refreshTokens;
+  final OnAuthExpiredCallback onAuthExpired;
+
+  /// Dio used to dispatch the retry. When null, the interceptor lazily
+  /// constructs a fresh Dio per retry — sufficient for the unit test, but
+  /// production wiring (`apiClientProvider`) MUST pass the real Dio so
+  /// adapter overrides and other interceptors still apply on the retry.
+  Dio? _retryDio;
+
+  // ignore: use_setters_to_change_properties
+  /// Used by [ApiClient] to attach the owning Dio after the interceptor is
+  /// constructed (we can't pass it via constructor without a circular ref).
+  void attachRetryDio(Dio dio) {
+    _retryDio = dio;
+  }
+
+  /// In-flight refresh shared by all concurrent 401 handlers.
+  Completer<String?>? _inFlight;
+
+  /// Marker placed in `RequestOptions.extra` to prevent retry loops.
+  static const _retriedKey = 'x-retried';
+
+  @override
+  Future<void> onError(
+    DioException err,
+    ErrorInterceptorHandler handler,
+  ) async {
+    if (err.response?.statusCode != 401) {
+      handler.next(err);
+      return;
+    }
+    if (err.requestOptions.extra[_retriedKey] == true) {
+      // Already retried once — give up and let the router handle the redirect.
+      await onAuthExpired();
+      handler.next(err);
+      return;
+    }
+
+    final newToken = await _refreshOnce();
+    if (newToken == null) {
+      await onAuthExpired();
+      handler.next(err);
+      return;
+    }
+
+    // Retry with the new bearer and a marker so a second 401 falls through.
+    final retryOptions = Options(
+      method: err.requestOptions.method,
+      headers: {
+        ...err.requestOptions.headers,
+        'Authorization': 'Bearer $newToken',
+      },
+      responseType: err.requestOptions.responseType,
+      contentType: err.requestOptions.contentType,
+      sendTimeout: err.requestOptions.sendTimeout,
+      receiveTimeout: err.requestOptions.receiveTimeout,
+      followRedirects: err.requestOptions.followRedirects,
+      validateStatus: err.requestOptions.validateStatus,
+      receiveDataWhenStatusError: err.requestOptions.receiveDataWhenStatusError,
+      extra: {...err.requestOptions.extra, _retriedKey: true},
+    );
+
+    final dio =
+        _retryDio ?? Dio(BaseOptions(baseUrl: err.requestOptions.baseUrl));
+    try {
+      final response = await dio.request<dynamic>(
+        err.requestOptions.path,
+        data: err.requestOptions.data,
+        queryParameters: err.requestOptions.queryParameters,
+        cancelToken: err.requestOptions.cancelToken,
+        options: retryOptions,
+      );
+      handler.resolve(response);
+    } on DioException catch (retryErr) {
+      // The retry runs through this same interceptor chain. If it returns 401,
+      // the inner onError invocation (with `extra[_retriedKey] == true`) has
+      // already called [onAuthExpired]; do NOT call it again here. For all
+      // other failure modes, just propagate.
+      handler.next(retryErr);
+    }
+  }
+
+  Future<String?> _refreshOnce() async {
+    final existing = _inFlight;
+    if (existing != null) {
+      return existing.future;
+    }
+    final completer = Completer<String?>();
+    _inFlight = completer;
+    try {
+      final token = await refreshTokens();
+      completer.complete(token);
+      return token;
+    } catch (_) {
+      completer.complete(null);
+      return null;
+    } finally {
+      _inFlight = null;
+    }
+  }
+}

--- a/app/lib/features/connection/connection_provider.dart
+++ b/app/lib/features/connection/connection_provider.dart
@@ -3,7 +3,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../api/api_client.dart';
 import '../../api/models/server_profile.dart';
+import '../auth/oauth_service.dart';
 import '../contexts/providers/context_providers.dart';
+import '../spaces/space_provider.dart';
 
 /// Runtime connection state derived from the active [AssistantContext].
 class ServerConnectionState {
@@ -56,8 +58,45 @@ final activeProfileProvider = Provider<ServerProfile?>((ref) {
 final apiClientProvider = Provider<ApiClient?>((ref) {
   final profile = ref.watch(activeProfileProvider);
   if (profile == null) return null;
-  return ApiClient(baseUrl: profile.baseUrl, token: profile.token);
+
+  return ApiClient(
+    baseUrl: profile.baseUrl,
+    token: profile.token,
+    refreshTokens: () => _refreshAccessToken(ref),
+    onAuthExpired: () => _handleAuthExpired(ref),
+  );
 });
+
+/// Attempt an OAuth2 refresh for the active context. Returns the new access
+/// token on success, or `null` when the active context has no refresh token,
+/// is not OAuth2, or the refresh request itself fails.
+Future<String?> _refreshAccessToken(Ref ref) async {
+  final ctx = ref.read(activeContextProvider).value;
+  if (ctx == null) return null;
+  final creds = ctx.oauthCredentials;
+  if (creds == null) return null;
+
+  try {
+    final service = OAuthService(serverUrl: ctx.serverUrl);
+    final newCreds = await service.refresh(
+      refreshToken: creds.refreshToken,
+      clientId: creds.clientId,
+    );
+    final updated = ctx.copyWith(oauthCredentials: newCreds);
+    await ref.read(contextsProvider.notifier).saveContext(updated);
+    return newCreds.bearerToken;
+  } catch (_) {
+    return null;
+  }
+}
+
+/// Tear down the session: clear the in-memory space selection then deactivate
+/// the active context. The router redirect on `!hasContext` then sends the
+/// user to `/login`.
+Future<void> _handleAuthExpired(Ref ref) async {
+  ref.read(spaceSelectionProvider.notifier).clear();
+  await ref.read(activeContextProvider.notifier).deactivate();
+}
 
 /// Returns `true` when running in a web browser.
 bool get isWebPlatform => kIsWeb;

--- a/app/lib/features/spaces/space_provider.dart
+++ b/app/lib/features/spaces/space_provider.dart
@@ -66,7 +66,15 @@ final spaceSelectionProvider =
 class OrgsNotifier extends AsyncNotifier<List<OrgSummary>> {
   @override
   Future<List<OrgSummary>> build() async {
-    final api = ref.watch(apiClientProvider);
+    // Wait for the connection to settle before deciding "loading" vs "empty".
+    // While `serverProfileProvider` is in `AsyncLoading`, this await keeps the
+    // notifier in loading state too (so the UI shows a spinner, not the empty
+    // card). Only after the profile resolves do we either return [] (no
+    // active context) or hit the API.
+    final connection = await ref.watch(serverProfileProvider.future);
+    if (connection.profile == null) return [];
+
+    final api = ref.read(apiClientProvider);
     if (api == null) return [];
 
     final response = await api.orgs.listOrgs();
@@ -84,9 +92,14 @@ final orgsProvider = AsyncNotifierProvider<OrgsNotifier, List<OrgSummary>>(
 class SpacesNotifier extends AsyncNotifier<List<SpaceSummary>> {
   @override
   Future<List<SpaceSummary>> build() async {
-    final api = ref.watch(apiClientProvider);
+    // Same loading-vs-empty distinction as OrgsNotifier: stay in AsyncLoading
+    // while the connection is settling.
+    final connection = await ref.watch(serverProfileProvider.future);
     final selection = ref.watch(spaceSelectionProvider);
-    if (api == null || selection.orgId == null) return [];
+    if (connection.profile == null || selection.orgId == null) return [];
+
+    final api = ref.read(apiClientProvider);
+    if (api == null) return [];
 
     final response = await api.spaces.listSpaces(orgId: selection.orgId!);
     return response.data?.toList() ?? [];

--- a/app/lib/features/spaces/space_selector_screen.dart
+++ b/app/lib/features/spaces/space_selector_screen.dart
@@ -149,11 +149,16 @@ class _SpaceList extends ConsumerWidget {
           );
         }
 
-        // If only one space, auto-select and navigate.
-        if (spaces.length == 1) {
+        final selection = ref.watch(spaceSelectionProvider);
+
+        // First-time auto-select on a single-space org: pick it for the user
+        // and bounce to /chat. Only fires when nothing is selected yet —
+        // revisits with `spaceId` already set fall through to the list below
+        // so the user is never stuck on an indefinite spinner.
+        if (spaces.length == 1 && selection.spaceId == null) {
           WidgetsBinding.instance.addPostFrameCallback((_) {
-            final current = ref.read(spaceSelectionProvider);
-            if (current.spaceId == null) {
+            // Re-check inside the callback in case state changed in between.
+            if (ref.read(spaceSelectionProvider).spaceId == null) {
               ref
                   .read(spaceSelectionProvider.notifier)
                   .selectSpace(
@@ -170,7 +175,13 @@ class _SpaceList extends ConsumerWidget {
           children: [
             for (final space in spaces)
               Card(
+                color: space.id == selection.spaceId
+                    ? Theme.of(context).colorScheme.primaryContainer
+                    : null,
                 child: ListTile(
+                  leading: space.id == selection.spaceId
+                      ? const Icon(Icons.check)
+                      : null,
                   title: Text(space.name),
                   subtitle: Text(space.slug),
                   trailing: const Icon(Icons.chevron_right),

--- a/app/lib/shared/auth_actions.dart
+++ b/app/lib/shared/auth_actions.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../features/contexts/providers/context_providers.dart';
+import '../features/spaces/space_provider.dart';
+
+/// Tear down the user's session on the web.
+///
+/// Clears the in-memory space selection BEFORE deactivating the active context
+/// so the next login starts from a clean slate. The router redirect on
+/// `!hasContext` then sends the user to `/login`.
+///
+/// The 401 interceptor wires the same shape into its `onAuthExpired` callback
+/// (see `connection_provider.dart`). Keep them consistent.
+Future<void> performWebLogout(ProviderContainer container) async {
+  container.read(spaceSelectionProvider.notifier).clear();
+  await container.read(activeContextProvider.notifier).deactivate();
+}

--- a/app/lib/shared/nav_shell.dart
+++ b/app/lib/shared/nav_shell.dart
@@ -8,12 +8,12 @@ import 'package:go_router/go_router.dart';
 
 import '../api/connectivity_provider.dart';
 import '../features/chat/chat_provider.dart';
-import '../features/contexts/providers/context_providers.dart';
 import '../features/notifications/agent_event_listener.dart';
 import '../features/pwa/pwa_provider.dart';
 import '../features/spaces/space_provider.dart';
 import '../features/updater/update_banner.dart';
 import '../router/app_router.dart';
+import 'auth_actions.dart';
 import 'platform/platform.dart';
 import 'space_switcher.dart';
 
@@ -652,9 +652,9 @@ class _NavShellState extends ConsumerState<NavShell> {
                       if (kIsWeb)
                         _LogoutButton(
                           onLogout: () async {
-                            await ref
-                                .read(activeContextProvider.notifier)
-                                .deactivate();
+                            await performWebLogout(
+                              ProviderScope.containerOf(context, listen: false),
+                            );
                             if (context.mounted) {
                               context.go(AppRoutes.login);
                             }

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -534,10 +534,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_svg
-      sha256: "1ded017b39c8e15c8948ea855070a5ff8ff8b3d5e83f3446e02d6bb12add7ad9"
+      sha256: "35882981abcbfb8c15b286f0cd690ff25bac12d95eff3e25ee207f37d4c42e7f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.4"
+    version: "2.3.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -1317,10 +1317,10 @@ packages:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: "5e8377564d95166761a968ed96104e0569b6b6cc611faac92a36ab8a169112c3"
+      sha256: f8a08a13fb8f0f8c590df89d745000bed44a673ed94bac846739e1a016875c21
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.6+1"
+    version: "2.5.7"
   sqflite_darwin:
     dependency: transitive
     description:
@@ -1517,10 +1517,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: d0412fcf4c6b31ecfdb7762359b7206ffba3bbffd396c6d9f9c4616ece476c1f
+      sha256: "85c81589622fbc87c1c683aaea164d3604a7777495a79d91e39ffcdec39ddb34"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.3"
   url_launcher_windows:
     dependency: transitive
     description:
@@ -1541,10 +1541,10 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics
-      sha256: "81da85e9ca8885ade47f9685b953cb098970d11be4821ac765580a6607ea4373"
+      sha256: "6409a25046024f0f8c5d8a59fec314081e81f9d436b66ca4015a8b49772bf445"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.21"
+    version: "1.2.0"
   vector_graphics_codec:
     dependency: transitive
     description:
@@ -1557,10 +1557,10 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics_compiler
-      sha256: "5a88dd14c0954a5398af544651c7fb51b457a2a556949bfb25369b210ef73a74"
+      sha256: "06f0c50f88a1a020f95138dcc14ef4d5a039ced3f89b386209e6763dfa2cefa0"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   vector_math:
     dependency: transitive
     description:
@@ -1573,10 +1573,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "046d3928e16fa4dc46e8350415661755ab759d9fc97fc21b5ab295f71e4f0499"
+      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
       url: "https://pub.dev"
     source: hosted
-    version: "15.1.0"
+    version: "15.2.0"
   watcher:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   super_clipboard: ^0.9.1
   connectivity_plus: ^7.1.1
   share_plus: ^12.0.2
-  flutter_svg: ^2.2.4
+  flutter_svg: ^2.3.0
 dev_dependencies:
   flutter_test:
     sdk: flutter
@@ -56,8 +56,8 @@ flutter_launcher_icons:
   web:
     generate: true
     image_path: macos/Runner/Assets.xcassets/AppIcon.appiconset/app_icon_1024.png
-    background_color: '#080C1A'
-    theme_color: '#080C1A'
+    background_color: "#080C1A"
+    theme_color: "#080C1A"
 flutter:
   uses-material-design: true
   assets:

--- a/app/test/unit/api/auth_interceptor_test.dart
+++ b/app/test/unit/api/auth_interceptor_test.dart
@@ -1,0 +1,324 @@
+// Tests for AuthRecoveryInterceptor — refresh-once-then-deactivate on 401.
+//
+// Spec: openspec/specs/web-401-recovery/spec.md
+//
+// Behavior under test:
+// - First 401 triggers a single refresh, then retries the request once.
+// - Second 401 (already retried) calls onAuthExpired, no further refresh.
+// - Refresh failure calls onAuthExpired and propagates the original 401.
+// - Non-401 errors pass through unchanged.
+// - Concurrent 401s share a single refresh future (single-flight).
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/api/auth_interceptor.dart';
+
+/// Canned HTTP reply.
+class _Reply {
+  const _Reply({this.statusCode = 200, this.body = const {}});
+
+  final int statusCode;
+  final Map<String, dynamic> body;
+}
+
+/// HttpClientAdapter that returns a per-path sequence of replies and records
+/// every received [RequestOptions].
+class _SequencedAdapter implements HttpClientAdapter {
+  _SequencedAdapter(this._plan);
+
+  final Map<String, List<_Reply>> _plan;
+  final List<RequestOptions> requests = [];
+
+  int countFor(String path) => requests.where((r) => r.path == path).length;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<dynamic>? cancelFuture,
+  ) async {
+    requests.add(options);
+    final replies = _plan[options.path];
+    if (replies == null) {
+      throw StateError('No mock plan for ${options.path}');
+    }
+    final idx = countFor(options.path) - 1;
+    if (idx >= replies.length) {
+      throw StateError('Plan exhausted for ${options.path} at idx $idx');
+    }
+    final reply = replies[idx];
+    final bytes = utf8.encode(jsonEncode(reply.body));
+    return ResponseBody.fromBytes(
+      bytes,
+      reply.statusCode,
+      headers: {
+        'content-type': ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+Dio _makeDio() {
+  final dio = Dio(BaseOptions(baseUrl: 'http://localhost'));
+  // Match application/json automatically so jsonDecode happens on response.
+  dio.options.responseType = ResponseType.json;
+  dio.options.headers['Authorization'] = 'Bearer old-token';
+  return dio;
+}
+
+void main() {
+  group('AuthRecoveryInterceptor', () {
+    late Dio dio;
+    late int refreshCalls;
+    late int authExpiredCalls;
+
+    setUp(() {
+      dio = _makeDio();
+      refreshCalls = 0;
+      authExpiredCalls = 0;
+    });
+
+    test('first 401 triggers refresh + retry; retry succeeds', () async {
+      Future<String?> refresh() async {
+        refreshCalls++;
+        return 'new-token';
+      }
+
+      Future<void> onAuthExpired() async {
+        authExpiredCalls++;
+      }
+
+      dio.interceptors.add(
+        AuthRecoveryInterceptor(
+          dio: dio,
+          refreshTokens: refresh,
+          onAuthExpired: onAuthExpired,
+        ),
+      );
+      final adapter = _SequencedAdapter({
+        '/foo': [
+          const _Reply(statusCode: 401, body: {'error': 'expired'}),
+          const _Reply(statusCode: 200, body: {'ok': true}),
+        ],
+      });
+      dio.httpClientAdapter = adapter;
+
+      final response = await dio.get<dynamic>('/foo');
+
+      expect(response.statusCode, 200);
+      expect(response.data, {'ok': true});
+      expect(refreshCalls, 1);
+      expect(authExpiredCalls, 0);
+      expect(adapter.countFor('/foo'), 2);
+      // Retry carries the new bearer and the retried marker.
+      expect(adapter.requests[1].extra['x-retried'], true);
+      expect(adapter.requests[1].headers['Authorization'], 'Bearer new-token');
+    });
+
+    test('already-retried 401 calls onAuthExpired and propagates', () async {
+      Future<String?> refresh() async {
+        refreshCalls++;
+        return 'new-token';
+      }
+
+      Future<void> onAuthExpired() async {
+        authExpiredCalls++;
+      }
+
+      dio.interceptors.add(
+        AuthRecoveryInterceptor(
+          dio: dio,
+          refreshTokens: refresh,
+          onAuthExpired: onAuthExpired,
+        ),
+      );
+      // Both attempts return 401 — first triggers refresh, retry triggers expire.
+      final adapter = _SequencedAdapter({
+        '/foo': [
+          const _Reply(statusCode: 401, body: {'error': 'expired'}),
+          const _Reply(statusCode: 401, body: {'error': 'still expired'}),
+        ],
+      });
+      dio.httpClientAdapter = adapter;
+
+      Object? caught;
+      try {
+        await dio.get<dynamic>('/foo');
+      } on DioException catch (e) {
+        caught = e;
+      }
+
+      expect(caught, isA<DioException>());
+      expect((caught! as DioException).response?.statusCode, 401);
+      expect(refreshCalls, 1);
+      expect(authExpiredCalls, 1);
+      expect(adapter.countFor('/foo'), 2);
+    });
+
+    test('refresh returns null → onAuthExpired called, no retry', () async {
+      Future<String?> refresh() async {
+        refreshCalls++;
+        return null; // refresh failed
+      }
+
+      Future<void> onAuthExpired() async {
+        authExpiredCalls++;
+      }
+
+      dio.interceptors.add(
+        AuthRecoveryInterceptor(
+          dio: dio,
+          refreshTokens: refresh,
+          onAuthExpired: onAuthExpired,
+        ),
+      );
+      final adapter = _SequencedAdapter({
+        '/foo': [
+          const _Reply(statusCode: 401, body: {'error': 'expired'}),
+        ],
+      });
+      dio.httpClientAdapter = adapter;
+
+      Object? caught;
+      try {
+        await dio.get<dynamic>('/foo');
+      } on DioException catch (e) {
+        caught = e;
+      }
+
+      expect(caught, isA<DioException>());
+      expect((caught! as DioException).response?.statusCode, 401);
+      expect(refreshCalls, 1);
+      expect(authExpiredCalls, 1);
+      // No retry was attempted.
+      expect(adapter.countFor('/foo'), 1);
+    });
+
+    test('refresh throws → onAuthExpired called, no retry', () async {
+      Future<String?> refresh() async {
+        refreshCalls++;
+        throw StateError('network down');
+      }
+
+      Future<void> onAuthExpired() async {
+        authExpiredCalls++;
+      }
+
+      dio.interceptors.add(
+        AuthRecoveryInterceptor(
+          dio: dio,
+          refreshTokens: refresh,
+          onAuthExpired: onAuthExpired,
+        ),
+      );
+      final adapter = _SequencedAdapter({
+        '/foo': [
+          const _Reply(statusCode: 401, body: {'error': 'expired'}),
+        ],
+      });
+      dio.httpClientAdapter = adapter;
+
+      Object? caught;
+      try {
+        await dio.get<dynamic>('/foo');
+      } on DioException catch (e) {
+        caught = e;
+      }
+
+      expect(caught, isA<DioException>());
+      expect(refreshCalls, 1);
+      expect(authExpiredCalls, 1);
+    });
+
+    test('non-401 error passes through without refresh', () async {
+      Future<String?> refresh() async {
+        refreshCalls++;
+        return 'new';
+      }
+
+      dio.interceptors.add(
+        AuthRecoveryInterceptor(
+          dio: dio,
+          refreshTokens: refresh,
+          onAuthExpired: () async {
+            authExpiredCalls++;
+          },
+        ),
+      );
+      final adapter = _SequencedAdapter({
+        '/foo': [
+          const _Reply(statusCode: 500, body: {'error': 'oops'}),
+        ],
+      });
+      dio.httpClientAdapter = adapter;
+
+      Object? caught;
+      try {
+        await dio.get<dynamic>('/foo');
+      } on DioException catch (e) {
+        caught = e;
+      }
+
+      expect(caught, isA<DioException>());
+      expect((caught! as DioException).response?.statusCode, 500);
+      expect(refreshCalls, 0);
+      expect(authExpiredCalls, 0);
+    });
+
+    test(
+      'concurrent 401s share a single refresh attempt (single-flight)',
+      () async {
+        // Refresh holds a gate so two concurrent 401s overlap on it.
+        final refreshGate = Completer<void>();
+        Future<String?> refresh() async {
+          refreshCalls++;
+          await refreshGate.future;
+          return 'new-token';
+        }
+
+        Future<void> onAuthExpired() async {
+          authExpiredCalls++;
+        }
+
+        dio.interceptors.add(
+          AuthRecoveryInterceptor(
+            dio: dio,
+            refreshTokens: refresh,
+            onAuthExpired: onAuthExpired,
+          ),
+        );
+        final adapter = _SequencedAdapter({
+          '/a': [
+            const _Reply(statusCode: 401, body: {'error': 'a expired'}),
+            const _Reply(statusCode: 200, body: {'a': 1}),
+          ],
+          '/b': [
+            const _Reply(statusCode: 401, body: {'error': 'b expired'}),
+            const _Reply(statusCode: 200, body: {'b': 1}),
+          ],
+        });
+        dio.httpClientAdapter = adapter;
+
+        final futureA = dio.get<dynamic>('/a');
+        final futureB = dio.get<dynamic>('/b');
+        // Yield so both error handlers enter the refresh path before completing.
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+        refreshGate.complete();
+
+        final results = await Future.wait([futureA, futureB]);
+        expect(results[0].data, {'a': 1});
+        expect(results[1].data, {'b': 1});
+        expect(refreshCalls, 1, reason: 'single-flight: only one refresh');
+        expect(authExpiredCalls, 0);
+      },
+    );
+  });
+}

--- a/app/test/unit/spaces/logout_resets_space_selection_test.dart
+++ b/app/test/unit/spaces/logout_resets_space_selection_test.dart
@@ -1,0 +1,78 @@
+// Tests that the web logout helper clears spaceSelectionProvider before
+// deactivating the active context.
+//
+// Spec: openspec/specs/space-selector-resilience/spec.md
+//   "Logout resets in-memory space selection"
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:assistant_app/features/contexts/data/context_repository.dart';
+import 'package:assistant_app/features/contexts/providers/context_providers.dart';
+import 'package:assistant_app/features/spaces/space_provider.dart';
+import 'package:assistant_app/shared/auth_actions.dart';
+
+class _FakeSecureStorage implements SecureKeyValueStorage {
+  final Map<String, String> _data = {};
+  @override
+  Future<String?> read({required String key}) async => _data[key];
+  @override
+  Future<void> write({required String key, required String value}) async {
+    _data[key] = value;
+  }
+
+  @override
+  Future<void> delete({required String key}) async => _data.remove(key);
+}
+
+Future<ContextRepository> _makeRepo() async {
+  SharedPreferences.setMockInitialValues({});
+  final p = await SharedPreferences.getInstance();
+  return ContextRepository(prefs: p, secureStorage: _FakeSecureStorage());
+}
+
+void main() {
+  test(
+    'performWebLogout clears space selection AND deactivates context',
+    () async {
+      final repo = await _makeRepo();
+      await repo.setActiveContextId('ctx-1');
+
+      final container = ProviderContainer(
+        overrides: [contextRepositoryProvider.overrideWithValue(repo)],
+      );
+      addTearDown(container.dispose);
+
+      // Pre-seed a non-empty selection.
+      container.read(spaceSelectionProvider.notifier)
+        ..selectOrg(orgId: 'org-1', orgName: 'Org')
+        ..selectSpace(spaceId: 'sp-1', spaceName: 'Space');
+
+      expect(container.read(spaceSelectionProvider).orgId, 'org-1');
+      expect(container.read(spaceSelectionProvider).spaceId, 'sp-1');
+      expect(repo.getActiveContextId(), 'ctx-1');
+
+      await performWebLogout(container);
+
+      expect(container.read(spaceSelectionProvider).orgId, isNull);
+      expect(container.read(spaceSelectionProvider).spaceId, isNull);
+      expect(repo.getActiveContextId(), isNull);
+    },
+  );
+
+  test('performWebLogout is idempotent on already-empty state', () async {
+    final repo = await _makeRepo();
+
+    final container = ProviderContainer(
+      overrides: [contextRepositoryProvider.overrideWithValue(repo)],
+    );
+    addTearDown(container.dispose);
+
+    await performWebLogout(container);
+    await performWebLogout(container);
+
+    expect(container.read(spaceSelectionProvider).orgId, isNull);
+    expect(repo.getActiveContextId(), isNull);
+  });
+}

--- a/app/test/widget/space_selector_loading_state_test.dart
+++ b/app/test/widget/space_selector_loading_state_test.dart
@@ -1,0 +1,79 @@
+// Asserts the selector distinguishes "API client not yet ready" from
+// "API returned empty" — while the connection (serverProfileProvider) is
+// still resolving, the screen MUST show a spinner, not the empty-state card.
+//
+// Spec: openspec/specs/space-selector-resilience/spec.md
+//   "Selector providers distinguish 'API not ready' from 'API returned empty'"
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/features/connection/connection_provider.dart';
+import 'package:assistant_app/features/spaces/space_selector_screen.dart';
+
+class _PendingServerProfileNotifier extends ServerProfileNotifier {
+  _PendingServerProfileNotifier(this._gate);
+  final Completer<ServerConnectionState> _gate;
+  @override
+  Future<ServerConnectionState> build() => _gate.future;
+}
+
+class _SettledNoProfileNotifier extends ServerProfileNotifier {
+  @override
+  Future<ServerConnectionState> build() async => const ServerConnectionState();
+}
+
+void main() {
+  testWidgets(
+    'OrgList shows a spinner (NOT "No organizations found") while serverProfileProvider is loading',
+    (tester) async {
+      final gate = Completer<ServerConnectionState>();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            // The transient state we're testing: connection still resolving,
+            // apiClient null. The real OrgsNotifier MUST stay in loading,
+            // not short-circuit to AsyncData([]).
+            serverProfileProvider.overrideWith(
+              () => _PendingServerProfileNotifier(gate),
+            ),
+          ],
+          child: const MaterialApp(home: SpaceSelectorScreen()),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.textContaining('No organizations found'), findsNothing);
+      expect(find.textContaining('Failed to load'), findsNothing);
+
+      // Don't leave a dangling future.
+      gate.complete(const ServerConnectionState());
+      await tester.pumpAndSettle();
+    },
+  );
+
+  testWidgets(
+    'OrgList renders empty card when serverProfileProvider settles with no profile',
+    (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            serverProfileProvider.overrideWith(
+              () => _SettledNoProfileNotifier(),
+            ),
+          ],
+          child: const MaterialApp(home: SpaceSelectorScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('No organizations found'), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+    },
+  );
+}

--- a/app/test/widget/space_selector_revisit_test.dart
+++ b/app/test/widget/space_selector_revisit_test.dart
@@ -1,0 +1,127 @@
+// Asserts that revisiting the SpaceSelectorScreen with a single space and
+// a prior selection does NOT leave the user staring at an indefinite spinner.
+// The cold-cache one-space flow still auto-navigates to /chat.
+//
+// Spec: openspec/specs/space-selector-resilience/spec.md
+//   "Single-space revisit does not show an infinite spinner"
+
+import 'package:assistant_api/assistant_api.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:assistant_app/features/spaces/space_provider.dart';
+import 'package:assistant_app/features/spaces/space_selector_screen.dart';
+
+OrgSummary _org() => OrgSummary(
+  (b) => b
+    ..authMode = 'password'
+    ..id = 'org-1'
+    ..name = 'Default Organization'
+    ..slug = 'default',
+);
+
+SpaceSummary _space(String id, String name, String slug) => SpaceSummary(
+  (b) => b
+    ..id = id
+    ..name = name
+    ..slug = slug,
+);
+
+class _StaticOrgsNotifier extends OrgsNotifier {
+  _StaticOrgsNotifier(this._orgs);
+  final List<OrgSummary> _orgs;
+  @override
+  Future<List<OrgSummary>> build() async => _orgs;
+}
+
+class _StaticSpacesNotifier extends SpacesNotifier {
+  _StaticSpacesNotifier(this._spaces);
+  final List<SpaceSummary> _spaces;
+  @override
+  Future<List<SpaceSummary>> build() async {
+    // Mirror the real provider's dependency on selection so it rebuilds when
+    // the user toggles selection.
+    ref.watch(spaceSelectionProvider);
+    return _spaces;
+  }
+}
+
+Widget _harness({
+  required ProviderContainer container,
+  required GoRouter router,
+}) {
+  return UncontrolledProviderScope(
+    container: container,
+    child: MaterialApp.router(routerConfig: router),
+  );
+}
+
+GoRouter _router() => GoRouter(
+  initialLocation: '/spaces',
+  routes: [
+    GoRoute(path: '/spaces', builder: (_, _) => const SpaceSelectorScreen()),
+    GoRoute(
+      path: '/chat',
+      builder: (_, _) => const Scaffold(body: Text('CHAT_PAGE')),
+    ),
+  ],
+);
+
+void main() {
+  testWidgets('first-time auto-select on single-space org navigates to /chat', (
+    tester,
+  ) async {
+    final space = _space('sp-1', 'Default Space', 'default');
+    final container = ProviderContainer(
+      overrides: [
+        orgsProvider.overrideWith(() => _StaticOrgsNotifier([_org()])),
+        spacesProvider.overrideWith(() => _StaticSpacesNotifier([space])),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(_harness(container: container, router: _router()));
+    await tester.pumpAndSettle();
+
+    // Selection has been written by the auto-select callbacks.
+    final selection = container.read(spaceSelectionProvider);
+    expect(selection.orgId, 'org-1');
+    expect(selection.spaceId, 'sp-1');
+    // And the router has navigated to /chat.
+    expect(find.text('CHAT_PAGE'), findsOneWidget);
+  });
+
+  testWidgets(
+    'revisit with single space + existing selection renders the list, not a stuck spinner',
+    (tester) async {
+      final space = _space('sp-1', 'Default Space', 'default');
+      final container = ProviderContainer(
+        overrides: [
+          orgsProvider.overrideWith(() => _StaticOrgsNotifier([_org()])),
+          spacesProvider.overrideWith(() => _StaticSpacesNotifier([space])),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      // Pre-seed the selection — same as if the user had already auto-selected
+      // and is now coming back to the screen via the SpaceSwitcher.
+      container.read(spaceSelectionProvider.notifier)
+        ..selectOrg(orgId: 'org-1', orgName: 'Default Organization')
+        ..selectSpace(spaceId: 'sp-1', spaceName: 'Default Space');
+
+      await tester.pumpWidget(
+        _harness(container: container, router: _router()),
+      );
+      await tester.pumpAndSettle();
+
+      // The space tile is rendered as a Card (selectable list).
+      expect(find.text('Default Space'), findsOneWidget);
+      // And no indefinite spinner.
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      // We did NOT auto-navigate away — still on the selector.
+      expect(find.text('CHAT_PAGE'), findsNothing);
+    },
+  );
+}

--- a/openspec/changes/flutter-401-and-space-selector-fixes/.openspec.yaml
+++ b/openspec/changes/flutter-401-and-space-selector-fixes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-09

--- a/openspec/changes/flutter-401-and-space-selector-fixes/design.md
+++ b/openspec/changes/flutter-401-and-space-selector-fixes/design.md
@@ -1,0 +1,100 @@
+## Context
+
+The Flutter web app (`app/`) uses a generated `dio` client (`assistant_api`) with no shared interceptors. Every API call goes through a `Dio` instance configured only with `baseUrl`, `connectTimeout`, `receiveTimeout`, and a static bearer token (`api_client.dart:33-44`). The only place that distinguishes 401 today is the SSE conversation list stream (`api_client.dart:274-279`), which throws `ApiAuthException`.
+
+Auth state lives in `activeContextProvider` (an `AsyncNotifier<AssistantContext?>`), which only changes via explicit `activate()` / `deactivate()` calls. The router (`app_router.dart:127-135`) gates `/login` and `/setup` on `!hasContext`. This means a stale JWT — token present but server returns 401 — leaves `hasContext == true`, so no redirect fires; every panel just shows an error card.
+
+`SpaceSelectorScreen` has two race-prone branches inside `space_selector_screen.dart`:
+
+- `_OrgList` and `_SpaceList` `await api.orgs.listOrgs()` / `listSpaces()` from inside `AsyncNotifier.build()`, but if `apiClientProvider` is null they short-circuit to `return []`. The UI cannot tell that apart from a real empty result, and renders `_EmptyCard` ("No organizations found").
+- The single-result branch unconditionally returns a spinner and only navigates from a post-frame callback guarded by `current.spaceId == null`. When you revisit the screen with a selection already in memory, the guard fails, the callback no-ops, and the spinner spins forever.
+
+The logout handler in `nav_shell.dart:654-661` clears `activeContextProvider` but leaves `spaceSelectionProvider` untouched, so its in-memory state survives across logout/login.
+
+Stakeholders: anyone using the web UI (currently the schorschvm operator). The recent JWT `org_id` fix (#676) made the symptom more obvious because pre-fix tokens silently mapped every user to `org_id="default"`; post-fix users with stale tokens now hit real 401s that the client cannot recover from.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A 401 from any `assistant_api` endpoint MUST result in either a successful refresh-and-retry, or — if refresh fails — deactivation of the active context and redirect to `/login`. No silent error states for auth failures.
+- The space selector MUST distinguish loading from empty. While `apiClientProvider` is null, the UI shows a spinner, not "No organizations found".
+- Revisiting `/spaces` after a single-org / single-space auto-select MUST either bounce the user back to `/chat` or render a usable list — never a stuck spinner.
+- Logout MUST reset `spaceSelectionProvider` so the next session starts clean.
+- All four behaviors covered by Flutter widget/unit tests so they cannot regress.
+
+**Non-Goals:**
+
+- Proactive token refresh based on `expires_at`. Refresh stays reactive (only on 401).
+- Multi-tab session sharing or cross-tab logout broadcasts.
+- Refactoring `OAuthService` or PKCE flow.
+- Backend changes — the Rust `assistant-web-ui` already returns 401 correctly.
+- Persisting `spaceSelectionProvider` to localStorage.
+
+## Decisions
+
+### Decision 1: Add a single `Dio` interceptor in `ApiClient` that owns 401 handling
+
+The interceptor implements the well-known "refresh once, retry once, otherwise deactivate" pattern:
+
+1. On `onError` with `response?.statusCode == 401`:
+   - If the failed request already has the `x-retried` extra flag → fall through to deactivate (avoid loops).
+   - Else attempt `OAuthService.refresh(refreshToken: …, clientId: …)` using the active context's `oauthCredentials`.
+   - On success: persist the new credentials via `contextsProvider.notifier.saveContext(updated)`, update the bearer header, mark the request as retried, and re-issue it. Return the retry's response.
+   - On failure (refresh throws, or no refresh token available): call `activeContextProvider.notifier.deactivate()`, then `handler.next(err)` so the original caller still sees the 401 (router redirect handles the visible state).
+2. A `Mutex`/single-flight guard ensures only one refresh is in flight at a time; concurrent 401s wait on the same future.
+
+**Why a Dio interceptor instead of wrapping each provider?** Centralizes the rule — every endpoint added in the future inherits it for free. Avoids polluting `OrgsNotifier`, `SpacesNotifier`, `ConversationsNotifier`, etc. with try/catch boilerplate.
+
+**Why reactive refresh instead of proactive?** The token expiry from the server is authoritative; clocks drift. A reactive scheme means we always trust the server's "this is expired" signal. The trade-off is one extra round trip per cold-cache 401, which is negligible.
+
+**Alternatives considered:**
+
+- Per-call try/catch using existing `refreshIfNeeded(ref, ctx)` → noisy, easy to forget on new endpoints. Rejected.
+- Periodic refresh timer → adds a clock dependency, fights the test harness, and wastes the refresh budget while idle. Rejected.
+
+### Decision 2: Plumb a Riverpod `Ref` into `ApiClient` so the interceptor can call `deactivate()`
+
+`ApiClient` is built by `apiClientProvider`, which already has a `Ref`. We pass `ref` (or a narrow callback bag — `onAuthExpired: () async { … }, onTokenRefreshed: (creds) async { … }`) into the constructor. The interceptor calls those callbacks; the provider wires them to `activeContextProvider.notifier.deactivate()` and `contextsProvider.notifier.saveContext(...)` respectively.
+
+**Why callbacks instead of passing `Ref` directly?** Keeps `ApiClient` testable without a full ProviderContainer — a unit test can assert "interceptor called `onAuthExpired` after refresh failed" with two mock closures.
+
+### Decision 3: `OrgsNotifier` / `SpacesNotifier` await the connection instead of returning `[]`
+
+Replace `if (api == null) return [];` with `if (api == null) { state = const AsyncLoading(); return await ref.watch(...).future; }` semantics — concretely, watch `serverProfileProvider.future` to wait for the connection to settle before issuing the API call. If `serverProfileProvider` resolves with `profile == null` (genuinely logged out), then return `[]` — at that point empty is the correct answer.
+
+**Why this over a UI-side check?** Keeps the AsyncNotifier's state machine honest (loading → data, never the data:[] → data:[1] flicker). The UI doesn't need a special case.
+
+### Decision 4: `_SpaceList` revisit — show the list, don't spin
+
+When `spaces.length == 1` AND the selection already has `spaceId == spaces.first.id`, the user is intentionally revisiting the selector. Render the list (single Card) with the current space marked as selected so they can confirm. The auto-navigate-to-`/chat` post-frame callback ONLY fires on the path where `spaceId == null` (first-time auto-select).
+
+`_OrgList` is left as-is (the parent screen short-circuits to `_SpaceList` once `orgId` is set, so the same race doesn't happen there in practice).
+
+**Alternative considered:** Unconditionally `go(/chat)` from the post-frame callback when `spaces.length == 1` regardless of prior selection. Rejected because it makes the switcher useless when the user is on `/chat` and clicks it intentionally — they'd just bounce back.
+
+### Decision 5: Logout resets `spaceSelectionProvider`
+
+`nav_shell.dart` logout handler adds `ref.read(spaceSelectionProvider.notifier).clear()` before `deactivate()`. Same hook fires in the `onAuthExpired` callback path so an interceptor-driven logout also clears selection.
+
+## Risks / Trade-offs
+
+- **Refresh loop on bad refresh token** → mitigated by the `x-retried` extras flag plus single-flight mutex; on second 401 we always fall through to deactivate.
+- **Concurrent 401s during page load** (chat + sidebar + traces fetch in parallel) all hit the interceptor → mitigated by single-flight refresh; only one refresh request leaves the client.
+- **`onAuthExpired` triggered while user is mid-typing in chat** → expected behavior is they get bounced to `/login`. Drafts are not preserved (out of scope; could be a follow-up).
+- **Test coverage of the loading-vs-empty distinction is fragile** (timing-dependent) → use `await tester.pumpAndSettle()` plus explicit container overrides for `apiClientProvider`; assert on the rendered widget, not on internal state transitions.
+- **Breaking the `_SpaceList` revisit behavior for genuinely multi-space users** → covered by both the single-space-revisit and multi-space test cases.
+
+## Migration Plan
+
+This is a client-only change with no backend or schema implications.
+
+1. Land the interceptor + selector fixes behind no flag (these are bug fixes, the old behavior is broken).
+2. Bump the version (`pubspec.yaml` in `app/`), rebuild the embedded web bundle (`make build` or `flutter build web --release`), and ship in the next `assistant` release.
+3. After deploy on schorschvm: have the operator clear browser storage once to drop any pre-existing stale tokens, then verify the four behaviors listed in `tasks.md` Phase 5.
+4. **Rollback**: revert the PR. No data migrations to undo. Old binary will still serve the old web bundle; users who already loaded the new bundle keep behavior until they hard-reload.
+
+## Open Questions
+
+- Should the interceptor preserve the user's pending route and restore it post-login? Currently they always land on `/chat` after login. Suggest deferring to a follow-up — out of scope for this fix.
+- Should `space_selector_screen.dart` highlight the currently-selected space when rendering the list during revisit? Default to yes, using `Theme.colorScheme.primaryContainer` on the matching tile.

--- a/openspec/changes/flutter-401-and-space-selector-fixes/proposal.md
+++ b/openspec/changes/flutter-401-and-space-selector-fixes/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The Flutter web app silently fails when a session goes stale or when the space selector is opened in transient states. Concretely: 401 responses leave the user stranded on `/chat` with broken panels because there is no Dio interceptor that maps "auth gone" to "log out and redirect". And `SpaceSelectorScreen` shows misleading empty/loading states during the post-login race and gets stuck on an infinite spinner when revisited after a single-space org has already been auto-selected. Both turn into "the app looks broken" reports — even though the backend is healthy.
+
+## What Changes
+
+- Add a global Dio interceptor in `ApiClient` (`app/lib/api/api_client.dart`) that: (a) attempts a single OAuth refresh on the first 401, retries the request, and (b) on persistent 401 deactivates the active context so the router redirects to `/login`.
+- In `OrgsNotifier` / `SpacesNotifier` (`app/lib/features/spaces/space_provider.dart`), distinguish "API client not yet available" from "API returned empty". When `apiClientProvider` is null, surface `AsyncLoading`, not an empty `data: []`.
+- In `_SpaceList` (`app/lib/features/spaces/space_selector_screen.dart`), fix the stuck-spinner branch: when revisiting with `spaceId` already set, render the list of spaces (or unconditionally bounce to `/chat` for one-space orgs) instead of an unconditional spinner with a guarded callback that no-ops.
+- In the logout handler (`app/lib/shared/nav_shell.dart`), also reset `spaceSelectionProvider` so a new sign-in starts from a clean selection.
+- Cover all four behaviors with widget/unit tests under `app/test/`.
+
+## Capabilities
+
+### New Capabilities
+
+- `web-401-recovery`: How the Flutter app handles 401 responses from the assistant API — refresh-once-then-deactivate, with redirect-to-login as the terminal state.
+- `space-selector-resilience`: Required behavior of the space selector against transient API states (loading), revisit with prior selection, and reset on logout.
+
+### Modified Capabilities
+
+(none — `web-login` and `router-loading-scaffold` keep their existing requirements; the new capabilities sit alongside them.)
+
+## Impact
+
+- **Code touched**: `app/lib/api/api_client.dart`, `app/lib/features/spaces/space_provider.dart`, `app/lib/features/spaces/space_selector_screen.dart`, `app/lib/shared/nav_shell.dart`, `app/lib/features/auth/auth_provider.dart` (reuse `refreshIfNeeded`).
+- **Tests**: new widget tests for the selector states and a unit test for the interceptor's refresh+retry+deactivate flow.
+- **APIs**: no backend changes — the Rust web-ui already returns 401 correctly; this is a pure client behavior fix.
+- **Dependencies**: none added.
+- **Breaking changes**: none.
+- **Non-goals**:
+  - Implementing token rotation or proactive refresh based on `expires_at`. Refresh is reactive (on 401 only).
+  - Reworking the OAuth login UI or PKCE flow.
+  - Changing the backend `/oauth/token` or membership endpoints.
+  - A multi-space picker UX overhaul — only the broken auto-select / revisit paths are in scope.
+- **User-facing documentation needed**: No. These are bug fixes that restore expected behavior; no new user-visible features or workflows.

--- a/openspec/changes/flutter-401-and-space-selector-fixes/specs/space-selector-resilience/spec.md
+++ b/openspec/changes/flutter-401-and-space-selector-fixes/specs/space-selector-resilience/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: Selector providers distinguish "API not ready" from "API returned empty"
+
+`OrgsNotifier` and `SpacesNotifier` (`app/lib/features/spaces/space_provider.dart`) SHALL stay in `AsyncLoading` while the underlying API client is not yet available. They MUST NOT short-circuit to `AsyncData([])` solely because `apiClientProvider` is null.
+
+#### Scenario: API client not yet available — providers loading
+
+- **WHEN** `OrgsNotifier.build()` runs AND `apiClientProvider` returns `null` because `serverProfileProvider` has not yet settled
+- **THEN** the provider SHALL await the connection (e.g., via `serverProfileProvider.future`) before issuing the network call AND the consumer SHALL observe `AsyncLoading`, not `AsyncData([])`
+
+#### Scenario: Genuinely no profile — providers return empty
+
+- **WHEN** `OrgsNotifier.build()` runs AND `serverProfileProvider` has settled with `profile == null` (no active context)
+- **THEN** the provider SHALL return `AsyncData([])`
+
+#### Scenario: API call returns empty list
+
+- **WHEN** `OrgsNotifier.build()` runs AND the API call succeeds AND the server returns `[]`
+- **THEN** the provider SHALL return `AsyncData([])` AND `_OrgList` SHALL render the "No organizations found" empty card
+
+### Requirement: Single-space revisit does not show an infinite spinner
+
+`_SpaceList` (`app/lib/features/spaces/space_selector_screen.dart`) MUST NOT render an unconditional `CircularProgressIndicator` when the user revisits the selector with a `spaceId` already set in `spaceSelectionProvider`. The list of spaces SHALL be rendered so the user can confirm or change the selection.
+
+#### Scenario: First-time auto-select with one space
+
+- **WHEN** the user reaches `/spaces` AND `spaceSelectionProvider.spaceId` is `null` AND the API returns exactly one space
+- **THEN** the screen SHALL display a brief loading indicator AND the post-frame callback SHALL call `selectSpace(...)` AND navigate to `/chat`
+
+#### Scenario: Revisit with one space and prior selection
+
+- **WHEN** the user navigates to `/spaces` AND `spaceSelectionProvider.spaceId` is already set AND the API returns exactly one space
+- **THEN** the screen SHALL render the list of spaces (a single tile) with the currently-selected space visually marked AND SHALL NOT show a loading spinner indefinitely AND SHALL NOT auto-navigate
+
+#### Scenario: Multi-space revisit unaffected
+
+- **WHEN** the user navigates to `/spaces` AND the API returns more than one space (regardless of prior selection)
+- **THEN** the screen SHALL render the full list of spaces with the currently-selected one visually marked
+
+### Requirement: Logout resets in-memory space selection
+
+The web logout handler (`app/lib/shared/nav_shell.dart`) SHALL reset `spaceSelectionProvider` to its initial empty state before deactivating the active context. The interceptor-driven deactivation path (see `web-401-recovery`) SHALL also clear the selection.
+
+#### Scenario: User clicks logout
+
+- **WHEN** the user taps the logout button in the web nav shell
+- **THEN** the handler SHALL call `spaceSelectionProvider.notifier.clear()` AND THEN `activeContextProvider.notifier.deactivate()` AND THEN navigate to `/login`
+
+#### Scenario: 401 interceptor deactivates the session
+
+- **WHEN** the 401 interceptor's refresh attempt fails AND it calls `deactivate()`
+- **THEN** the same code path SHALL also clear `spaceSelectionProvider`
+
+#### Scenario: Next login starts with empty selection
+
+- **WHEN** the user re-authenticates after a logout (manual or interceptor-driven)
+- **THEN** `spaceSelectionProvider` SHALL be in its initial state with `orgId == null` AND `spaceId == null` AND the auto-select flow on `/spaces` SHALL run from scratch

--- a/openspec/changes/flutter-401-and-space-selector-fixes/specs/web-401-recovery/spec.md
+++ b/openspec/changes/flutter-401-and-space-selector-fixes/specs/web-401-recovery/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: ApiClient intercepts 401 responses with refresh-once-then-deactivate
+
+The Flutter `ApiClient` (`app/lib/api/api_client.dart`) SHALL register a Dio interceptor that, on any response with status `401`, MUST attempt exactly one OAuth2 refresh per failed request and on persistent failure MUST deactivate the active context. The interceptor MUST NOT enter a refresh loop.
+
+#### Scenario: First 401 triggers a single refresh and retry
+
+- **WHEN** any API request to the assistant server returns HTTP 401 AND the active context has OAuth2 credentials with a valid refresh token AND the request has not already been retried
+- **THEN** the interceptor SHALL call `OAuthService.refresh(refreshToken, clientId)`, persist the new credentials to the context (via `contextsProvider.notifier.saveContext`), update the bearer header on the in-flight request, mark the request with an `x-retried` flag in `RequestOptions.extra`, and re-issue the request, returning the retry's response to the caller
+
+#### Scenario: Refresh failure deactivates the active context
+
+- **WHEN** an API request returns HTTP 401 AND the refresh attempt fails (network error, server rejected the refresh token, or the context has no refresh token)
+- **THEN** the interceptor SHALL call `activeContextProvider.notifier.deactivate()` AND propagate the original 401 `DioException` to the caller via `handler.next(err)`
+
+#### Scenario: Already-retried request does not refresh again
+
+- **WHEN** a request returns HTTP 401 AND `RequestOptions.extra['x-retried']` is `true`
+- **THEN** the interceptor SHALL NOT attempt another refresh AND SHALL call `activeContextProvider.notifier.deactivate()` AND propagate the 401 to the caller
+
+### Requirement: Concurrent 401s share a single refresh attempt
+
+When multiple in-flight requests fail with 401 simultaneously, the interceptor SHALL coalesce them onto a single refresh call (single-flight). All waiting requests MUST observe the same refresh outcome.
+
+#### Scenario: Two parallel 401s, refresh succeeds
+
+- **WHEN** two requests A and B both return 401 within a small window AND a refresh is already in flight when B's error handler runs
+- **THEN** B SHALL await the same refresh future as A AND on success both A and B SHALL retry once with the new bearer token
+
+#### Scenario: Two parallel 401s, refresh fails
+
+- **WHEN** two requests A and B both return 401 AND the shared refresh attempt fails
+- **THEN** `deactivate()` SHALL be called exactly once AND both A and B SHALL receive their original 401 errors
+
+### Requirement: Router redirects to login after deactivation
+
+The router (`app_router.dart`) SHALL redirect to `/login` whenever the active context becomes null while the user is on a protected route. This requirement is satisfied by the existing redirect rule at `app_router.dart:128-130`; this spec ratifies that the interceptor's `deactivate()` call MUST be the trigger for that redirect when 401 recovery fails.
+
+#### Scenario: Interceptor deactivation triggers login redirect
+
+- **WHEN** the interceptor calls `activeContextProvider.notifier.deactivate()` while the user is on `/chat` or any other authenticated route
+- **THEN** the next router redirect evaluation SHALL produce `/login` AND the user SHALL be navigated there without manual interaction

--- a/openspec/changes/flutter-401-and-space-selector-fixes/tasks.md
+++ b/openspec/changes/flutter-401-and-space-selector-fixes/tasks.md
@@ -1,0 +1,47 @@
+## 1. Failing tests first (TDD red)
+
+- [x] 1.1 Add `app/test/unit/api/auth_interceptor_test.dart` covering: first 401 → refresh + retry succeeds; second 401 (already-retried) → deactivate; refresh-throws → deactivate; concurrent 401s share a single refresh future. Use Dio's `MockHttpAdapter` (or `package:nock`-style stubs) and inject mock `onAuthExpired` / `onTokenRefreshed` callbacks.
+- [x] 1.2 Add `app/test/widget/space_selector_loading_state_test.dart`: when `apiClientProvider` is overridden to `null` and `serverProfileProvider` is in `AsyncLoading`, `_OrgList` renders a `CircularProgressIndicator` (NOT `_EmptyCard`).
+- [x] 1.3 Add `app/test/widget/space_selector_revisit_test.dart`: with `spaceSelectionProvider` pre-seeded to `(orgId: o, spaceId: s)` and the spaces API returning a single space matching `s`, the screen renders the space tile (visually marked) and does NOT show an indefinite spinner. A separate test asserts the cold-cache one-space flow still auto-navigates to `/chat`.
+- [x] 1.4 Add `app/test/unit/spaces/logout_resets_space_selection_test.dart`: assert `performWebLogout` clears `spaceSelectionProvider` AND deactivates `activeContextProvider`.
+- [x] 1.5 Run `flutter test` — confirmed all four new tests fail for the expected reasons (red bar).
+
+## 2. Implement the Dio 401 interceptor
+
+- [x] 2.1 Defined `AuthRecoveryInterceptor` in new file `app/lib/api/auth_interceptor.dart` taking `refreshTokens: Future<String?> Function()` (returns new bearer or null) and `onAuthExpired: Future<void> Function()` callbacks.
+- [x] 2.2 Single-flight via `Completer<String?>? _inFlight` — concurrent 401s share the same in-flight refresh future. Tested by `concurrent 401s share a single refresh attempt (single-flight)`.
+- [x] 2.3 `onError`: skip non-401; on retried-true 401 → `onAuthExpired` + `handler.next`; else `_refreshOnce`; on null token → `onAuthExpired` + `handler.next`; on success → re-dispatch via the same Dio with new bearer + `extra['x-retried'] = true`. The retry runs through the interceptor chain again so a second 401 is handled by the inner invocation; the outer catch just propagates without double-firing `onAuthExpired`.
+- [x] 2.4 `ApiClient` constructor extended with optional `refreshTokens` / `onAuthExpired` callbacks; registers the interceptor on `_dio.interceptors` when both are provided.
+- [x] 2.5 `apiClientProvider` (`connection_provider.dart`) now constructs the closures: `_refreshAccessToken` calls `OAuthService.refresh`, persists via `contextsProvider.notifier.saveContext`, returns the new bearer; `_handleAuthExpired` clears `spaceSelectionProvider` then deactivates `activeContextProvider`.
+- [x] 2.6 6 interceptor tests green; `flutter analyze --fatal-infos` clean.
+
+## 3. Selector loading-vs-empty distinction
+
+- [x] 3.1 `OrgsNotifier.build()` and `SpacesNotifier.build()` now `await ref.watch(serverProfileProvider.future)` first; only after the connection settles do they decide between `[]` (no profile) and the API call.
+- [x] 3.2 `OrgList shows a spinner ... while serverProfileProvider is loading` and `OrgList renders empty card when serverProfileProvider settles with no profile` both green.
+
+## 4. Selector revisit fix
+
+- [x] 4.1 `_SpaceList` now only enters the spinner-with-postframe branch when `selection.spaceId == null`; revisits with `spaceId` already set fall through to the list-rendering branch.
+- [x] 4.2 List-rendering Column highlights the active space with `colorScheme.primaryContainer` background and a leading check icon.
+- [x] 4.3 Both revisit tests green (`first-time auto-select on single-space org navigates to /chat`, `revisit with single space + existing selection renders the list, not a stuck spinner`).
+
+## 5. Logout resets selection
+
+- [x] 5.1 Extracted `performWebLogout(ProviderContainer)` in new file `app/lib/shared/auth_actions.dart`. `_LogoutButton.onLogout` in `nav_shell.dart` now calls it via `ProviderScope.containerOf(context, listen: false)` then navigates to `/login`.
+- [x] 5.2 The interceptor's `_handleAuthExpired` (in `connection_provider.dart`) mirrors `performWebLogout`: clear selection then deactivate. Both paths produce the same end state.
+- [x] 5.3 Both logout tests green (`performWebLogout clears space selection AND deactivates context`, `performWebLogout is idempotent on already-empty state`).
+
+## 6. Manual smoke + regenerate web bundle
+
+- [x] 6.1 `flutter analyze --fatal-infos` → 0 issues.
+- [x] 6.2 `flutter test` → 782 tests all green.
+- [ ] 6.3 `flutter run -d chrome` against a local `assistant webui serve`. Walk through: fresh login → land on `/chat`, no flicker; click space switcher → see the single space, no spinner; click logout → land on `/login`; revoke the JWT in DB, hit a refresh on `/chat` → 401 handled, redirected to `/login` after one refresh attempt (or instantly if no refresh token). **(Manual — operator action)**
+- [x] 6.4 `flutter build web --release` succeeds (38.3s); the embed-into-Rust step (`cargo build -p assistant-cli` via `make build`) is left for release time.
+
+## 7. Ship
+
+- [ ] 7.1 Open PR with title `fix(app): handle 401s and space-selector race conditions`. Body links the four scenarios from the spec deltas.
+- [ ] 7.2 Merge and cut a release.
+- [ ] 7.3 Deploy to schorschvm; have the operator clear browser storage once and verify the four behaviors on the live host.
+- [ ] 7.4 Archive this change with `openspec archive flutter-401-and-space-selector-fixes` after deploy verification.


### PR DESCRIPTION
## Summary

Two user-visible bugs that turn the web UI into "everything looks broken":

- **Stale JWTs trapped users on `/chat`** with every panel in error state. `ApiClient` had no Dio interceptor, so 401s surfaced as plain `DioException`s; the router only redirects on `!hasContext`, never on a stale token.
- **Space selector raced with login** — `OrgsNotifier`/`SpacesNotifier` short-circuited to `AsyncData([])` while `apiClientProvider` was momentarily null, rendering "No organizations found" instead of a spinner.
- **Single-space revisit hung on a spinner** — `_SpaceList` returned an unconditional `CircularProgressIndicator` when `spaces.length == 1`, but the post-frame callback was guarded by `spaceId == null`. Coming back to `/spaces` after auto-select silently no-op'd the callback.
- **Logout left in-memory selection stale** across logout/login.

## What changed

- New `AuthRecoveryInterceptor` (`app/lib/api/auth_interceptor.dart`) — single-flight refresh, retry-once with `extra['x-retried']` marker, deactivate on persistent failure. Wired into `ApiClient` + `apiClientProvider`.
- `OrgsNotifier` / `SpacesNotifier` now `await ref.watch(serverProfileProvider.future)` before deciding empty.
- `_SpaceList` only auto-selects when `selection.spaceId == null`; revisits render the list with the active tile highlighted (`primaryContainer` + check icon).
- New `performWebLogout(ProviderContainer)` in `app/lib/shared/auth_actions.dart`. Both the nav-shell logout button and the interceptor's `onAuthExpired` use it.

Spec, design, and tasks live under `openspec/changes/flutter-401-and-space-selector-fixes/`.

## Test plan

- [x] `flutter analyze --fatal-infos` — 0 issues
- [x] `flutter test` — **782/782** green, including:
  - 6 cases in `auth_interceptor_test.dart` (refresh+retry, already-retried fallthrough, refresh-null, refresh-throws, non-401 passthrough, concurrent 401s share one refresh)
  - `space_selector_loading_state_test.dart` (loading vs empty)
  - `space_selector_revisit_test.dart` (cold-cache + revisit)
  - `logout_resets_space_selection_test.dart` (clears selection + deactivates; idempotent)
- [x] `flutter build web --release` — succeeds (~38s)
- [ ] Manual chrome smoke against schorschvm: fresh login → `/chat` no flicker; click space switcher → see single space, no spinner; click logout → land on `/login`; revoke JWT → 401 handled, redirected to `/login` after one refresh attempt
- [ ] Operator clears browser storage once on schorschvm to drop any pre-existing stale tokens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic session recovery when authentication expires, with seamless token refresh and request retry.
  * Added visual indication of currently selected space in the space selector.

* **Bug Fixes**
  * Fixed space selector displaying empty state during initial loading.
  * Fixed space selector spinner when revisiting with a pre-selected space.
  * Improved logout flow to properly clear all session and selection data.

* **Tests**
  * Added comprehensive test coverage for authentication recovery and space selector behavior.

* **Chores**
  * Updated dependency versions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cedricziel/assistant/pull/685)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->