### PR TITLE
fix(app): web session resilience — corruption detection, banner, persistence, SW versioning

### DIFF
--- a/app/lib/features/contexts/data/context_repository.dart
+++ b/app/lib/features/contexts/data/context_repository.dart
@@ -104,8 +104,11 @@ class ContextRepository {
 
     // Re-attach tokens from secure storage.
     // Failures are caught per-context so that a single secure-storage error
-    // (common on web when the crypto key is unavailable after a hard reload)
-    // does not prevent the contexts list from loading at all.
+    // (common on web when the IndexedDB crypto key is wiped) does not
+    // prevent the contexts list from loading at all. The catch flips
+    // [AssistantContext.credentialsCorrupted] so the router can route the
+    // user to /login with an explanatory banner instead of leaving them on
+    // /chat with broken auth.
     final result = <AssistantContext>[];
     for (final ctx in contexts) {
       try {
@@ -124,11 +127,18 @@ class ContextRepository {
         }
         result.add(restored);
       } catch (_) {
-        result.add(ctx);
+        result.add(ctx.copyWith(credentialsCorrupted: true));
       }
     }
     return result;
   }
+
+  /// Test-only helper: returns the raw metadata JSON currently persisted in
+  /// SharedPreferences. Used to seed a second repository pointed at a
+  /// different secure-storage backend without round-tripping through the
+  /// public `saveContext` API.
+  @visibleForTesting
+  String? dumpMetadataJson() => _prefs.getString(_kContextsKey);
 
   // -- Write ----------------------------------------------------------------
 

--- a/app/lib/features/contexts/models/context_model.dart
+++ b/app/lib/features/contexts/models/context_model.dart
@@ -27,6 +27,7 @@ class AssistantContext {
     this.oauthCredentials,
     this.authMode = AuthMode.legacyToken,
     required this.createdAt,
+    this.credentialsCorrupted = false,
   });
 
   final String id;
@@ -49,6 +50,12 @@ class AssistantContext {
   final AuthMode authMode;
 
   final DateTime createdAt;
+
+  /// In-memory flag set by [ContextRepository.loadContexts] when secure-storage
+  /// reads for this context's credentials throw — typically because
+  /// `flutter_secure_storage`'s IndexedDB key has been wiped on web.
+  /// Never serialised; surface for the router redirect + login banner only.
+  final bool credentialsCorrupted;
 
   /// The bearer token to use for API requests — picks the right one based
   /// on [authMode].
@@ -94,6 +101,7 @@ class AssistantContext {
     bool clearOAuthCredentials = false,
     AuthMode? authMode,
     DateTime? createdAt,
+    bool? credentialsCorrupted,
   }) {
     return AssistantContext(
       id: id ?? this.id,
@@ -105,6 +113,7 @@ class AssistantContext {
           : (oauthCredentials ?? this.oauthCredentials),
       authMode: authMode ?? this.authMode,
       createdAt: createdAt ?? this.createdAt,
+      credentialsCorrupted: credentialsCorrupted ?? this.credentialsCorrupted,
     );
   }
 

--- a/app/lib/features/contexts/providers/context_providers.dart
+++ b/app/lib/features/contexts/providers/context_providers.dart
@@ -139,3 +139,16 @@ final activeContextProvider =
 final hasActiveContextProvider = Provider<bool>((ref) {
   return ref.watch(activeContextProvider).value != null;
 });
+
+/// Synchronous convenience provider — `true` when an active context is set
+/// AND its credentials are intact (`!credentialsCorrupted`).
+///
+/// The router uses this for the redirect-to-login decision so that a context
+/// whose secure-storage entries failed to decrypt (common on web after the
+/// IndexedDB crypto key is wiped) is treated as unauthenticated. The context
+/// metadata is NOT cleared — re-login refreshes credentials in place via
+/// `upsertContextByUrl`.
+final hasUsableActiveContextProvider = Provider<bool>((ref) {
+  final ctx = ref.watch(activeContextProvider).value;
+  return ctx != null && !ctx.credentialsCorrupted;
+});

--- a/app/lib/features/login/login_screen.dart
+++ b/app/lib/features/login/login_screen.dart
@@ -30,6 +30,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
   bool _passwordVisible = false;
   bool _tokenVisible = false;
   _LoginMode _mode = _LoginMode.oauth2;
+  bool _bannerDismissed = false;
 
   String get _serverUrl {
     if (isMaterial && _isWebContext) {
@@ -94,6 +95,10 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
       }
     });
 
+    final reason = GoRouterState.of(context).uri.queryParameters['reason'];
+    final showSessionEndedBanner =
+        reason == 'session-ended' && !_bannerDismissed;
+
     return Scaffold(
       body: Center(
         child: ConstrainedBox(
@@ -106,6 +111,12 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                 mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
+                  if (showSessionEndedBanner) ...[
+                    _SessionEndedBanner(
+                      onDismiss: () => setState(() => _bannerDismissed = true),
+                    ),
+                    const SizedBox(height: 16),
+                  ],
                   Text(
                     'Sign in',
                     style: Theme.of(context).textTheme.headlineMedium,
@@ -294,6 +305,46 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
             ),
           ),
         ),
+      ),
+    );
+  }
+}
+
+/// Banner shown on `/login?reason=session-ended` to explain why the user was
+/// bounced back to the login screen — typically because the browser wiped
+/// the secure-storage crypto key.
+class _SessionEndedBanner extends StatelessWidget {
+  const _SessionEndedBanner({required this.onDismiss});
+
+  final VoidCallback onDismiss;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Container(
+      key: const Key('session-ended-banner'),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colorScheme.errorContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.info_outline, color: colorScheme.onErrorContainer),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              'Your session was reset by the browser. Please log in again.',
+              style: TextStyle(color: colorScheme.onErrorContainer),
+            ),
+          ),
+          IconButton(
+            key: const Key('session-ended-banner-dismiss'),
+            tooltip: 'Dismiss',
+            icon: Icon(Icons.close, color: colorScheme.onErrorContainer),
+            onPressed: onDismiss,
+          ),
+        ],
       ),
     );
   }

--- a/app/lib/features/spaces/space_provider.dart
+++ b/app/lib/features/spaces/space_provider.dart
@@ -1,7 +1,10 @@
+import 'dart:convert';
+
 import 'package:assistant_api/assistant_api.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../connection/connection_provider.dart';
+import 'space_selection_storage.dart';
 
 /// Active org + space selection state.
 ///
@@ -39,21 +42,69 @@ class SpaceSelection {
   }
 }
 
+/// localStorage key for the persisted selection (web only).
+const _kSpaceSelectionKey = 'assistant.spaceSelection';
+
 /// Notifier for the active org/space selection.
+///
+/// On the web platform, the selection is persisted to `localStorage` via
+/// [SpaceSelectionStorage] so a hard reload doesn't reset it. On native
+/// platforms the selection stays in-memory (the storage provider returns a
+/// no-op implementation).
 class SpaceSelectionNotifier extends Notifier<SpaceSelection> {
+  SpaceSelectionStorage get _storage => ref.read(spaceSelectionStorageProvider);
+
   @override
-  SpaceSelection build() => const SpaceSelection();
+  SpaceSelection build() {
+    final raw = _storage.read(_kSpaceSelectionKey);
+    if (raw == null || raw.isEmpty) return const SpaceSelection();
+    try {
+      final json = jsonDecode(raw) as Map<String, dynamic>;
+      return SpaceSelection(
+        orgId: json['orgId'] as String?,
+        orgName: json['orgName'] as String?,
+        spaceId: json['spaceId'] as String?,
+        spaceName: json['spaceName'] as String?,
+      );
+    } catch (_) {
+      // Corrupt or schema-mismatched storage entry — discard and start fresh.
+      return const SpaceSelection();
+    }
+  }
 
   void selectOrg({required String orgId, required String orgName}) {
     state = state.copyWith(orgId: orgId, orgName: orgName, clearSpace: true);
+    _persist();
   }
 
   void selectSpace({required String spaceId, required String spaceName}) {
     state = state.copyWith(spaceId: spaceId, spaceName: spaceName);
+    _persist();
   }
 
   void clear() {
     state = const SpaceSelection();
+    _storage.remove(_kSpaceSelectionKey);
+  }
+
+  void _persist() {
+    final s = state;
+    try {
+      if (s.orgId == null && s.spaceId == null) {
+        _storage.remove(_kSpaceSelectionKey);
+        return;
+      }
+      final encoded = jsonEncode({
+        if (s.orgId != null) 'orgId': s.orgId,
+        if (s.orgName != null) 'orgName': s.orgName,
+        if (s.spaceId != null) 'spaceId': s.spaceId,
+        if (s.spaceName != null) 'spaceName': s.spaceName,
+      });
+      _storage.write(_kSpaceSelectionKey, encoded);
+    } catch (_) {
+      // Quota / private-mode failures are non-fatal — selection stays
+      // in-memory for the session.
+    }
   }
 }
 

--- a/app/lib/features/spaces/space_selection_storage.dart
+++ b/app/lib/features/spaces/space_selection_storage.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'space_selection_storage_stub.dart'
+    if (dart.library.js_interop) 'space_selection_storage_web.dart'
+    as platform;
+
+/// Minimal key-value-store interface for [SpaceSelectionNotifier]'s
+/// web-only persistence layer.
+///
+/// Production: `space_selection_storage_web.dart` on web, the stub
+/// (in-memory no-op) everywhere else. Tests inject an in-memory fake via
+/// [spaceSelectionStorageProvider].
+abstract class SpaceSelectionStorage {
+  String? read(String key);
+  void write(String key, String value);
+  void remove(String key);
+}
+
+/// Provider for the platform-appropriate [SpaceSelectionStorage]. Tests
+/// override this with an in-memory fake.
+final spaceSelectionStorageProvider = Provider<SpaceSelectionStorage>((ref) {
+  if (kIsWeb) return platform.makeWebStorage();
+  return _NoopSpaceSelectionStorage();
+});
+
+/// Used on native platforms. The selection stays in-memory — same behavior
+/// as before this change.
+class _NoopSpaceSelectionStorage implements SpaceSelectionStorage {
+  @override
+  String? read(String key) => null;
+  @override
+  void write(String key, String value) {}
+  @override
+  void remove(String key) {}
+}

--- a/app/lib/features/spaces/space_selection_storage_stub.dart
+++ b/app/lib/features/spaces/space_selection_storage_stub.dart
@@ -1,0 +1,13 @@
+import 'space_selection_storage.dart';
+
+/// Stub used on non-web platforms. The real web implementation lives in
+/// `space_selection_storage_web.dart` and is selected by conditional import.
+SpaceSelectionStorage makeWebStorage() {
+  // Should never be called: the runtime check in
+  // `spaceSelectionStorageProvider` only selects this branch on native, and
+  // returns a no-op directly. This stub exists only to satisfy the
+  // conditional-import contract on the VM build.
+  throw UnsupportedError(
+    'space_selection_storage_web.dart is only available on web',
+  );
+}

--- a/app/lib/features/spaces/space_selection_storage_web.dart
+++ b/app/lib/features/spaces/space_selection_storage_web.dart
@@ -1,0 +1,35 @@
+import 'package:web/web.dart' as web;
+
+import 'space_selection_storage.dart';
+
+/// Returns a [SpaceSelectionStorage] backed by `window.localStorage`. Only
+/// loaded on web via conditional import from
+/// `space_selection_storage.dart`.
+SpaceSelectionStorage makeWebStorage() => _LocalStorageSpaceSelectionStorage();
+
+class _LocalStorageSpaceSelectionStorage implements SpaceSelectionStorage {
+  @override
+  String? read(String key) {
+    try {
+      return web.window.localStorage.getItem(key);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  @override
+  void write(String key, String value) {
+    try {
+      web.window.localStorage.setItem(key, value);
+    } catch (_) {
+      // Quota or private-mode failures are non-fatal.
+    }
+  }
+
+  @override
+  void remove(String key) {
+    try {
+      web.window.localStorage.removeItem(key);
+    } catch (_) {}
+  }
+}

--- a/app/lib/router/app_router.dart
+++ b/app/lib/router/app_router.dart
@@ -110,7 +110,13 @@ final routerProvider = Provider<GoRouter>((ref) {
         return AppRoutes.loading;
       }
 
-      final hasContext = activeContextAsync.value != null;
+      final activeContext = activeContextAsync.value;
+      final hasContext = activeContext != null;
+      // A context whose secure-storage entries failed to decrypt is
+      // treated as unauthenticated for routing purposes (but the metadata
+      // is NOT deleted — re-login refreshes credentials in place).
+      final hasUsableContext =
+          hasContext && !activeContext.credentialsCorrupted;
       final onContextSwitcher = matchedPath == AppRoutes.contexts;
       final onSetup = matchedPath == AppRoutes.setup;
       final onLogin = matchedPath == AppRoutes.login;
@@ -120,17 +126,25 @@ final routerProvider = Provider<GoRouter>((ref) {
       if (onLoading) {
         final pending = pendingRedirect;
         pendingRedirect = null;
-        final fallback = hasContext ? AppRoutes.chat : AppRoutes.login;
-        return hasContext && pending != null ? pending : fallback;
+        final loginFallback = (hasContext && activeContext.credentialsCorrupted)
+            ? '${AppRoutes.login}?reason=session-ended'
+            : AppRoutes.login;
+        final fallback = hasUsableContext ? AppRoutes.chat : loginFallback;
+        return hasUsableContext && pending != null ? pending : fallback;
       }
 
-      // If no active context and not already on an auth screen, redirect.
-      if (!hasContext && !onLogin && !onContextSwitcher && !onSetup) {
+      // No usable context AND not already on an auth screen → /login.
+      // For corrupted contexts, append `?reason=session-ended` so the
+      // login screen can surface an explanatory banner.
+      if (!hasUsableContext && !onLogin && !onContextSwitcher && !onSetup) {
+        if (hasContext && activeContext.credentialsCorrupted) {
+          return '${AppRoutes.login}?reason=session-ended';
+        }
         return AppRoutes.login;
       }
 
       // Already authenticated — redirect away from login/setup screens.
-      if (hasContext && (onLogin || onSetup)) {
+      if (hasUsableContext && (onLogin || onSetup)) {
         return AppRoutes.chat;
       }
 

--- a/app/test/unit/contexts/credentials_corrupted_test.dart
+++ b/app/test/unit/contexts/credentials_corrupted_test.dart
@@ -1,0 +1,159 @@
+// Tests that ContextRepository.loadContexts surfaces secure-storage
+// decrypt failures via AssistantContext.credentialsCorrupted instead of
+// silently dropping the token.
+//
+// Spec: openspec/changes/web-session-resilience/specs/web-session-resilience/spec.md
+//   "Decrypt failure during context load is detected and surfaced"
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:assistant_app/features/auth/oauth_credentials.dart';
+import 'package:assistant_app/features/contexts/data/context_repository.dart';
+import 'package:assistant_app/features/contexts/models/context_model.dart';
+
+class _ThrowingSecureStorage implements SecureKeyValueStorage {
+  _ThrowingSecureStorage({this.throwOnRead = false});
+
+  final bool throwOnRead;
+  final Map<String, String> _data = {};
+
+  @override
+  Future<String?> read({required String key}) async {
+    if (throwOnRead) {
+      throw StateError('simulated decrypt failure for key=$key');
+    }
+    return _data[key];
+  }
+
+  @override
+  Future<void> write({required String key, required String value}) async {
+    _data[key] = value;
+  }
+
+  @override
+  Future<void> delete({required String key}) async => _data.remove(key);
+}
+
+class _PartialThrowingSecureStorage implements SecureKeyValueStorage {
+  _PartialThrowingSecureStorage(this.throwOnPrefix);
+
+  final String throwOnPrefix;
+  final Map<String, String> _data = {};
+
+  @override
+  Future<String?> read({required String key}) async {
+    if (key.startsWith(throwOnPrefix)) {
+      throw StateError('simulated decrypt failure for key=$key');
+    }
+    return _data[key];
+  }
+
+  @override
+  Future<void> write({required String key, required String value}) async {
+    _data[key] = value;
+  }
+
+  @override
+  Future<void> delete({required String key}) async => _data.remove(key);
+}
+
+Future<ContextRepository> _makeRepo(SecureKeyValueStorage storage) async {
+  SharedPreferences.setMockInitialValues({});
+  final prefs = await SharedPreferences.getInstance();
+  return ContextRepository(prefs: prefs, secureStorage: storage);
+}
+
+AssistantContext _ctx({String id = 'ctx-1'}) {
+  return AssistantContext(
+    id: id,
+    name: 'Work',
+    serverUrl: 'https://work.example.com',
+    authMode: AuthMode.oauth2,
+    createdAt: DateTime.utc(2024, 1, 1),
+  );
+}
+
+OAuthCredentials _creds() => OAuthCredentials(
+  accessToken: 'access',
+  refreshToken: 'refresh',
+  clientId: 'client',
+  expiresAt: DateTime.utc(2099, 1, 1),
+);
+
+void main() {
+  test('healthy load — credentialsCorrupted stays false', () async {
+    final storage = _ThrowingSecureStorage();
+    final repo = await _makeRepo(storage);
+
+    await repo.saveContext(_ctx().copyWith(oauthCredentials: _creds()));
+
+    final loaded = await repo.loadContexts();
+
+    expect(loaded, hasLength(1));
+    expect(loaded.first.credentialsCorrupted, isFalse);
+    expect(loaded.first.oauthCredentials, isNotNull);
+  });
+
+  test(
+    'decrypt failure flips credentialsCorrupted, preserves metadata',
+    () async {
+      // First persist a context with valid storage.
+      final goodStorage = _ThrowingSecureStorage();
+      final goodRepo = await _makeRepo(goodStorage);
+      await goodRepo.saveContext(_ctx().copyWith(oauthCredentials: _creds()));
+
+      // Now reload through a storage that throws on every read — simulating
+      // the IndexedDB key wipe that flutter_secure_storage hits on web.
+      final brokenStorage = _ThrowingSecureStorage(throwOnRead: true);
+      // Persist the same metadata in SharedPreferences for the broken repo.
+      SharedPreferences.setMockInitialValues({
+        'assistant_contexts': goodRepo.dumpMetadataJson()!,
+      });
+      final brokenPrefs = await SharedPreferences.getInstance();
+      final brokenRepo = ContextRepository(
+        prefs: brokenPrefs,
+        secureStorage: brokenStorage,
+      );
+
+      final loaded = await brokenRepo.loadContexts();
+
+      expect(loaded, hasLength(1));
+      final ctx = loaded.first;
+      expect(ctx.credentialsCorrupted, isTrue, reason: 'flag must be set');
+      expect(ctx.oauthCredentials, isNull);
+      expect(ctx.authToken, isNull);
+      expect(ctx.id, 'ctx-1');
+      expect(ctx.name, 'Work');
+      expect(ctx.serverUrl, 'https://work.example.com');
+      expect(ctx.authMode, AuthMode.oauth2);
+    },
+  );
+
+  test(
+    'partial corruption — token OK but oauth read throws still flags',
+    () async {
+      // Persist via healthy storage, then mount a partial-throwing storage that
+      // only fails on the oauth-credentials key. Even partial corruption taints
+      // the whole session.
+      final goodStorage = _ThrowingSecureStorage();
+      final goodRepo = await _makeRepo(goodStorage);
+      await goodRepo.saveContext(_ctx().copyWith(oauthCredentials: _creds()));
+
+      final partialStorage = _PartialThrowingSecureStorage(
+        'assistant_context_oauth_',
+      );
+      SharedPreferences.setMockInitialValues({
+        'assistant_contexts': goodRepo.dumpMetadataJson()!,
+      });
+      final brokenPrefs = await SharedPreferences.getInstance();
+      final partialRepo = ContextRepository(
+        prefs: brokenPrefs,
+        secureStorage: partialStorage,
+      );
+
+      final loaded = await partialRepo.loadContexts();
+      expect(loaded.first.credentialsCorrupted, isTrue);
+    },
+  );
+}

--- a/app/test/unit/spaces/space_selection_persistence_test.dart
+++ b/app/test/unit/spaces/space_selection_persistence_test.dart
@@ -1,0 +1,142 @@
+// Verifies SpaceSelectionNotifier round-trips through an injectable
+// key-value store on web. Native platforms keep the in-memory behavior.
+//
+// We don't run real localStorage in the test (VM has none); instead we
+// inject a fake KeyValueStorage via the spaceSelectionStorageProvider
+// override and assert hydration + persistence.
+//
+// Spec: openspec/changes/web-session-resilience/specs/web-session-resilience/spec.md
+//   "Space selection persists across hard reload on web"
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/features/spaces/space_provider.dart';
+import 'package:assistant_app/features/spaces/space_selection_storage.dart';
+
+class _FakeKeyValueStorage implements SpaceSelectionStorage {
+  String? _value;
+  int reads = 0;
+  int writes = 0;
+  int deletes = 0;
+
+  @override
+  String? read(String key) {
+    reads++;
+    return _value;
+  }
+
+  @override
+  void write(String key, String value) {
+    writes++;
+    _value = value;
+  }
+
+  @override
+  void remove(String key) {
+    deletes++;
+    _value = null;
+  }
+}
+
+void main() {
+  test('selectOrg + selectSpace persists JSON to storage', () async {
+    final storage = _FakeKeyValueStorage();
+    final container = ProviderContainer(
+      overrides: [spaceSelectionStorageProvider.overrideWithValue(storage)],
+    );
+    addTearDown(container.dispose);
+
+    container.read(spaceSelectionProvider.notifier)
+      ..selectOrg(orgId: 'o1', orgName: 'Org 1')
+      ..selectSpace(spaceId: 's1', spaceName: 'Space 1');
+
+    expect(storage.writes, greaterThanOrEqualTo(1));
+    expect(storage._value, isNotNull);
+    expect(storage._value, contains('"orgId":"o1"'));
+    expect(storage._value, contains('"spaceId":"s1"'));
+  });
+
+  test('rebuild rehydrates state from storage', () async {
+    final storage = _FakeKeyValueStorage();
+    storage._value =
+        '{"orgId":"o1","orgName":"Org 1","spaceId":"s1","spaceName":"Space 1"}';
+
+    final container = ProviderContainer(
+      overrides: [spaceSelectionStorageProvider.overrideWithValue(storage)],
+    );
+    addTearDown(container.dispose);
+
+    final selection = container.read(spaceSelectionProvider);
+    expect(selection.orgId, 'o1');
+    expect(selection.orgName, 'Org 1');
+    expect(selection.spaceId, 's1');
+    expect(selection.spaceName, 'Space 1');
+  });
+
+  test('clear() removes the persisted entry', () async {
+    final storage = _FakeKeyValueStorage();
+    storage._value =
+        '{"orgId":"o1","orgName":"Org 1","spaceId":"s1","spaceName":"Space 1"}';
+
+    final container = ProviderContainer(
+      overrides: [spaceSelectionStorageProvider.overrideWithValue(storage)],
+    );
+    addTearDown(container.dispose);
+
+    container.read(spaceSelectionProvider.notifier).clear();
+
+    expect(storage.deletes, greaterThanOrEqualTo(1));
+    expect(storage._value, isNull);
+  });
+
+  test(
+    'storage write failure is non-fatal — selection still updates',
+    () async {
+      final container = ProviderContainer(
+        overrides: [
+          spaceSelectionStorageProvider.overrideWithValue(_ThrowingStorage()),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      // Must not throw even though the storage write throws.
+      container.read(spaceSelectionProvider.notifier)
+        ..selectOrg(orgId: 'o1', orgName: 'Org 1')
+        ..selectSpace(spaceId: 's1', spaceName: 'Space 1');
+
+      final selection = container.read(spaceSelectionProvider);
+      expect(selection.orgId, 'o1');
+      expect(selection.spaceId, 's1');
+    },
+  );
+
+  test('corrupt JSON in storage is treated as empty selection', () async {
+    final storage = _FakeKeyValueStorage();
+    storage._value = 'not json';
+
+    final container = ProviderContainer(
+      overrides: [spaceSelectionStorageProvider.overrideWithValue(storage)],
+    );
+    addTearDown(container.dispose);
+
+    final selection = container.read(spaceSelectionProvider);
+    expect(selection.orgId, isNull);
+    expect(selection.spaceId, isNull);
+  });
+}
+
+class _ThrowingStorage implements SpaceSelectionStorage {
+  @override
+  String? read(String key) => null;
+
+  @override
+  void write(String key, String value) {
+    throw StateError('quota exceeded');
+  }
+
+  @override
+  void remove(String key) {
+    throw StateError('quota exceeded');
+  }
+}

--- a/app/test/widget/login/session_ended_banner_test.dart
+++ b/app/test/widget/login/session_ended_banner_test.dart
@@ -1,0 +1,69 @@
+// Verifies the LoginScreen renders the session-ended banner when the
+// `?reason=session-ended` query param is present, and not otherwise.
+//
+// Spec: openspec/changes/web-session-resilience/specs/web-session-resilience/spec.md
+//   "Login screen surfaces the session-ended banner"
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:assistant_app/features/login/login_screen.dart';
+
+const _bannerKey = Key('session-ended-banner');
+
+GoRouter _router(String initialLocation) => GoRouter(
+  initialLocation: initialLocation,
+  routes: [GoRoute(path: '/login', builder: (_, _) => const LoginScreen())],
+);
+
+void main() {
+  testWidgets('banner visible when reason=session-ended is in the URL', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp.router(
+          routerConfig: _router('/login?reason=session-ended'),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(_bannerKey), findsOneWidget);
+    expect(
+      find.textContaining('session was reset', findRichText: true),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('banner absent when no reason query param is present', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(child: MaterialApp.router(routerConfig: _router('/login'))),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(_bannerKey), findsNothing);
+  });
+
+  testWidgets('tapping dismiss hides the banner', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp.router(
+          routerConfig: _router('/login?reason=session-ended'),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(_bannerKey), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('session-ended-banner-dismiss')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(_bannerKey), findsNothing);
+  });
+}

--- a/app/test/widget/router/session_ended_redirect_test.dart
+++ b/app/test/widget/router/session_ended_redirect_test.dart
@@ -1,0 +1,135 @@
+// When the active context is loaded with credentialsCorrupted=true, the
+// router MUST redirect to /login?reason=session-ended even though the
+// context is non-null.
+//
+// Spec: openspec/changes/web-session-resilience/specs/web-session-resilience/spec.md
+//   "Router treats corrupted contexts as unauthenticated"
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:assistant_app/api/capabilities_provider.dart';
+import 'package:assistant_app/api/models/server_capabilities.dart';
+import 'package:assistant_app/features/connection/connection_provider.dart';
+import 'package:assistant_app/features/contexts/data/context_repository.dart';
+import 'package:assistant_app/features/contexts/models/context_model.dart';
+import 'package:assistant_app/features/contexts/providers/context_providers.dart';
+import 'package:assistant_app/features/login/login_screen.dart';
+import 'package:assistant_app/router/app_router.dart';
+
+class _FakeSecureStorage implements SecureKeyValueStorage {
+  @override
+  Future<String?> read({required String key}) async => null;
+  @override
+  Future<void> write({required String key, required String value}) async {}
+  @override
+  Future<void> delete({required String key}) async {}
+}
+
+class _CorruptedActiveContextNotifier extends ActiveContextNotifier {
+  _CorruptedActiveContextNotifier(this._ctx);
+  final AssistantContext _ctx;
+  @override
+  Future<AssistantContext?> build() async => _ctx;
+}
+
+Future<ContextRepository> _makeRepo() async {
+  SharedPreferences.setMockInitialValues({});
+  final p = await SharedPreferences.getInstance();
+  return ContextRepository(prefs: p, secureStorage: _FakeSecureStorage());
+}
+
+void main() {
+  testWidgets('corrupted active context → /login?reason=session-ended', (
+    tester,
+  ) async {
+    final repo = await _makeRepo();
+    final ctx = AssistantContext(
+      id: 'ctx-1',
+      name: 'Work',
+      serverUrl: 'https://work.example.com',
+      authMode: AuthMode.oauth2,
+      createdAt: DateTime.utc(2024, 1, 1),
+      credentialsCorrupted: true,
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          contextRepositoryProvider.overrideWithValue(repo),
+          capabilitiesProvider.overrideWith(
+            (ref) async => ServerCapabilities.disabled,
+          ),
+          apiClientProvider.overrideWithValue(null),
+          activeContextProvider.overrideWith(
+            () => _CorruptedActiveContextNotifier(ctx),
+          ),
+        ],
+        child: Consumer(
+          builder: (context, ref, child) {
+            final router = ref.watch(routerProvider);
+            return MaterialApp.router(routerConfig: router);
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Router should have bounced us to /login with the reason query param.
+    expect(find.byType(LoginScreen), findsOneWidget);
+
+    // The actual URI should carry ?reason=session-ended.
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(Consumer)),
+    );
+    final router = container.read(routerProvider);
+    final location = router.routerDelegate.currentConfiguration.uri.toString();
+    expect(
+      location,
+      contains('reason=session-ended'),
+      reason: 'router must include the reason query param, got: $location',
+    );
+  });
+
+  testWidgets('healthy active context — no session-ended redirect', (
+    tester,
+  ) async {
+    final repo = await _makeRepo();
+    final ctx = AssistantContext(
+      id: 'ctx-1',
+      name: 'Work',
+      serverUrl: 'https://work.example.com',
+      authMode: AuthMode.oauth2,
+      createdAt: DateTime.utc(2024, 1, 1),
+      // credentialsCorrupted defaults to false
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          contextRepositoryProvider.overrideWithValue(repo),
+          capabilitiesProvider.overrideWith(
+            (ref) async => ServerCapabilities.disabled,
+          ),
+          apiClientProvider.overrideWithValue(null),
+          activeContextProvider.overrideWith(
+            () => _CorruptedActiveContextNotifier(ctx),
+          ),
+        ],
+        child: Consumer(
+          builder: (context, ref, child) {
+            final router = ref.watch(routerProvider);
+            return MaterialApp.router(routerConfig: router);
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Healthy context → user lands on /chat (or /spaces) — definitely
+    // NOT on /login.
+    expect(find.byType(LoginScreen), findsNothing);
+  });
+}

--- a/crates/web-ui/build.rs
+++ b/crates/web-ui/build.rs
@@ -164,14 +164,18 @@ fn dir_has_newer(dir: &Path, than: std::time::SystemTime) -> bool {
 /// Read the `version:` field from `pubspec.yaml` and substitute the
 /// `__APP_VERSION__` placeholder in the built `sw.js`.
 ///
-/// This causes the browser to detect a new service worker script on every
+/// Causes the browser to detect a new service worker script on every
 /// version bump rather than waiting for its 24-hour byte-diff check.
+///
+/// Idempotent: re-runs on an already-injected file are silent. The build
+/// FAILS if `sw.js` exists but contains neither the placeholder nor an
+/// existing version comment — that would mean someone removed the
+/// load-bearing marker and the SW would ship un-versioned.
 fn inject_sw_version(app_dir: &Path, web_out: &Path) {
     let pubspec = match std::fs::read_to_string(app_dir.join("pubspec.yaml")) {
         Ok(s) => s,
         Err(e) => {
-            println!("cargo:warning=Could not read pubspec.yaml for sw.js version injection: {e}");
-            return;
+            panic!("Could not read pubspec.yaml for sw.js version injection: {e}");
         }
     };
 
@@ -180,35 +184,37 @@ fn inject_sw_version(app_dir: &Path, web_out: &Path) {
         let line = line.trim();
         line.strip_prefix("version:").map(|v| {
             let v = v.trim();
-            // Drop the `+<build-number>` suffix if present.
             v.split('+').next().unwrap_or(v).trim().to_owned()
         })
     }) else {
-        println!(
-            "cargo:warning=Could not parse `version:` from pubspec.yaml — skipping sw.js version injection"
+        panic!(
+            "Could not parse `version:` from pubspec.yaml — sw.js version injection cannot proceed"
         );
-        return;
     };
 
     let sw_path = web_out.join("sw.js");
     let sw_src = match std::fs::read_to_string(&sw_path) {
         Ok(s) => s,
         Err(e) => {
-            println!("cargo:warning=Could not read built sw.js for version injection: {e}");
-            return;
+            panic!("Could not read built sw.js for version injection: {e}");
         }
     };
 
-    let injected = sw_src.replace("__APP_VERSION__", &version);
-    if injected == sw_src {
-        println!(
-            "cargo:warning=sw.js does not contain __APP_VERSION__ placeholder — version injection skipped"
-        );
-        return;
-    }
-    if let Err(e) = std::fs::write(&sw_path, injected) {
-        println!("cargo:warning=Could not write sw.js after version injection: {e}");
-    } else {
-        println!("cargo:warning=sw.js version injected: {version}");
+    match sw_version::inject_sw_version(&sw_src, &version) {
+        Ok(injected) if injected == sw_src => {
+            // Idempotent re-run; nothing to do.
+        }
+        Ok(injected) => {
+            if let Err(e) = std::fs::write(&sw_path, injected) {
+                panic!("Could not write sw.js after version injection: {e}");
+            }
+            println!("cargo:warning=sw.js version injected: {version}");
+        }
+        Err(e) => {
+            panic!("{e}");
+        }
     }
 }
+
+#[path = "src/sw_version.rs"]
+mod sw_version;

--- a/crates/web-ui/src/api/bindings.rs
+++ b/crates/web-ui/src/api/bindings.rs
@@ -107,7 +107,10 @@ pub async fn create_binding(
     }
 
     if body.persona_id.is_empty() || body.interface_instance_id.is_empty() {
-        return json_error(StatusCode::BAD_REQUEST, "persona_id and interface_instance_id are required");
+        return json_error(
+            StatusCode::BAD_REQUEST,
+            "persona_id and interface_instance_id are required",
+        );
     }
 
     // Verify the interface instance belongs to this org and space.
@@ -115,7 +118,10 @@ pub async fn create_binding(
     match ii_store.get_instance(&body.interface_instance_id).await {
         Ok(Some(inst)) if inst.org_id == org_id && inst.space_id == space_id => {}
         Ok(Some(_)) => {
-            return json_error(StatusCode::FORBIDDEN, "interface instance belongs to another org or space");
+            return json_error(
+                StatusCode::FORBIDDEN,
+                "interface instance belongs to another org or space",
+            );
         }
         Ok(None) => {
             return json_error(StatusCode::NOT_FOUND, "interface instance not found");
@@ -138,7 +144,10 @@ pub async fn create_binding(
     let store = state.org_storage.binding_store();
     if let Err(e) = store.create_binding(&binding).await {
         tracing::error!("failed to create binding: {e}");
-        return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to create binding");
+        return json_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "failed to create binding",
+        );
     }
 
     let resp = BindingResponse {

--- a/crates/web-ui/src/api/catalog.rs
+++ b/crates/web-ui/src/api/catalog.rs
@@ -476,7 +476,10 @@ pub async fn delete_subscription(
     match store.get_subscription(&sub_id).await {
         Ok(Some(sub)) if sub.space_id == space_id => {}
         Ok(Some(_)) => {
-            return json_error(StatusCode::FORBIDDEN, "subscription belongs to another space");
+            return json_error(
+                StatusCode::FORBIDDEN,
+                "subscription belongs to another space",
+            );
         }
         Ok(None) => return json_error(StatusCode::NOT_FOUND, "subscription not found"),
         Err(e) => {

--- a/crates/web-ui/src/api/interfaces.rs
+++ b/crates/web-ui/src/api/interfaces.rs
@@ -133,7 +133,10 @@ pub async fn create_interface(
     let store = state.org_storage.interface_instance_store();
     if let Err(e) = store.create_instance(&instance).await {
         tracing::error!("failed to create interface instance: {e}");
-        return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to create instance");
+        return json_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "failed to create instance",
+        );
     }
 
     let resp = InterfaceInstanceResponse {

--- a/crates/web-ui/src/api/members.rs
+++ b/crates/web-ui/src/api/members.rs
@@ -202,7 +202,10 @@ pub async fn add_member(
 
     // Only org admins can grant SpaceAdmin.
     if role == Role::SpaceAdmin && !ctx.is_org_admin() {
-        return json_error(StatusCode::FORBIDDEN, "only org admins can grant space-admin");
+        return json_error(
+            StatusCode::FORBIDDEN,
+            "only org admins can grant space-admin",
+        );
     }
 
     let now = Utc::now();
@@ -272,7 +275,10 @@ pub async fn update_member(
 
     // Only org admins can grant SpaceAdmin.
     if role == Role::SpaceAdmin && !ctx.is_org_admin() {
-        return json_error(StatusCode::FORBIDDEN, "only org admins can grant space-admin");
+        return json_error(
+            StatusCode::FORBIDDEN,
+            "only org admins can grant space-admin",
+        );
     }
 
     let store = state.org_storage.membership_store();

--- a/crates/web-ui/src/api/templates.rs
+++ b/crates/web-ui/src/api/templates.rs
@@ -200,7 +200,10 @@ pub async fn create_from_template(
 
     if let Err(e) = result {
         tracing::error!("failed to create persona from template: {e}");
-        return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to create persona");
+        return json_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "failed to create persona",
+        );
     }
 
     let resp = PersonaFromTemplateResponse {

--- a/crates/web-ui/src/main.rs
+++ b/crates/web-ui/src/main.rs
@@ -9,6 +9,7 @@ pub mod install;
 mod oauth;
 mod openapi;
 pub(crate) mod push;
+pub mod sw_version;
 
 use std::collections::HashMap;
 use std::ffi::OsString;

--- a/crates/web-ui/src/sw_version.rs
+++ b/crates/web-ui/src/sw_version.rs
@@ -1,0 +1,90 @@
+//! Service-worker version injection helper.
+//!
+//! Substitutes the `__APP_VERSION__` placeholder in `app/build/web/sw.js`
+//! with the package version. Used by `build.rs`; exposed publicly so the
+//! integration test in `tests/sw_version_injection.rs` can pin the contract.
+//!
+//! The function is intentionally idempotent: re-runs on an already-injected
+//! file are a silent no-op (Cargo runs `build.rs` once per compile target,
+//! so the same file may be processed multiple times in a single build). The
+//! only fatal case is a missing placeholder *and* no recognizable existing
+//! version comment — that means someone removed the load-bearing marker.
+
+use std::fmt;
+
+const PLACEHOLDER: &str = "__APP_VERSION__";
+
+/// Error returned by [`inject_sw_version`] when the source has neither the
+/// placeholder nor an already-injected version line.
+#[derive(Debug)]
+pub struct MissingPlaceholder;
+
+impl fmt::Display for MissingPlaceholder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(
+            "sw.js is missing the `__APP_VERSION__` placeholder — see the \
+             top-of-file comment in app/web/sw.js documenting the contract.",
+        )
+    }
+}
+
+impl std::error::Error for MissingPlaceholder {}
+
+/// Replaces `__APP_VERSION__` in `src` with `version`.
+///
+/// - If `src` already contains a `// vX.Y.Z` comment (any version), returns
+///   `src` unchanged. Idempotent for repeat builds.
+/// - Otherwise, requires the placeholder; returns [`MissingPlaceholder`]
+///   if neither is present.
+pub fn inject_sw_version(src: &str, version: &str) -> Result<String, MissingPlaceholder> {
+    if src.contains(PLACEHOLDER) {
+        return Ok(src.replace(PLACEHOLDER, version));
+    }
+    // Already-injected file from a previous build run. Recognise the comment
+    // pattern `// v<digits>.<digits>...` so we don't flag idempotent re-runs.
+    if has_existing_version_comment(src) {
+        return Ok(src.to_owned());
+    }
+    Err(MissingPlaceholder)
+}
+
+fn has_existing_version_comment(src: &str) -> bool {
+    src.lines().any(|line| {
+        let trimmed = line.trim_start();
+        // Match e.g. `// v1.2.3`, `// v0.1.146 — ...` etc.
+        let after_slash = trimmed.strip_prefix("//").map(str::trim_start);
+        if let Some(rest) = after_slash
+            && let Some(after_v) = rest.strip_prefix('v')
+        {
+            return after_v
+                .chars()
+                .next()
+                .map(|c| c.is_ascii_digit())
+                .unwrap_or(false);
+        }
+        false
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn replaces_placeholder() {
+        let out = inject_sw_version("// v__APP_VERSION__\n", "0.1.0").unwrap();
+        assert_eq!(out, "// v0.1.0\n");
+    }
+
+    #[test]
+    fn idempotent_on_already_injected() {
+        let src = "// v0.1.0 — replaced by build.rs.\n";
+        assert_eq!(inject_sw_version(src, "0.2.0").unwrap(), src);
+    }
+
+    #[test]
+    fn errors_when_no_marker_at_all() {
+        let result = inject_sw_version("// just a service worker\n", "0.1.0");
+        assert!(matches!(result, Err(MissingPlaceholder)));
+    }
+}

--- a/crates/web-ui/tests/sw_version_injection.rs
+++ b/crates/web-ui/tests/sw_version_injection.rs
@@ -1,0 +1,62 @@
+//! Unit tests for the `inject_sw_version` build-script helper.
+//!
+//! Spec: openspec/changes/web-session-resilience/specs/web-session-resilience/spec.md
+//!   "Service-worker version is injected on every release build"
+//!
+//! The helper has three branches we want pinned by tests:
+//! 1. Source contains the placeholder → returns the substituted string.
+//! 2. Source already contains the current version (idempotent re-run) → returns
+//!    the original unchanged.
+//! 3. Source contains neither → returns an error so the build fails loudly
+//!    instead of silently shipping a stale service worker.
+//!
+//! The helper itself lives in `crates/web-ui/build_helpers/sw_version.rs`
+//! (a sibling of `build.rs`) and is included from `build.rs` via `include!`.
+
+use assistant_web_ui::sw_version::inject_sw_version;
+
+#[test]
+fn injects_placeholder_with_version() {
+    let src = "// v__APP_VERSION__ — replaced by build.rs.\nconsole.log('sw');\n";
+    let injected = inject_sw_version(src, "0.1.146").expect("injection should succeed");
+    assert_eq!(
+        injected,
+        "// v0.1.146 — replaced by build.rs.\nconsole.log('sw');\n",
+    );
+}
+
+#[test]
+fn idempotent_when_current_version_already_present() {
+    // Re-running the build sees the already-injected file. Must not warn or
+    // error; just return the source unchanged.
+    let src = "// v0.1.146 — replaced by build.rs.\nconsole.log('sw');\n";
+    let result = inject_sw_version(src, "0.1.146").expect("idempotent re-run");
+    assert_eq!(result, src);
+}
+
+#[test]
+fn idempotent_for_any_existing_version_string() {
+    // Even if the file contains an *older* version (cross-target rebuild
+    // before the new version reached this target), don't error — assume
+    // some other invocation will catch up. Only the missing-placeholder
+    // case is fatal.
+    let src = "// v0.1.145 — replaced by build.rs.\nconsole.log('sw');\n";
+    let result = inject_sw_version(src, "0.1.146").expect("older version is non-fatal");
+    // Older versions are also accepted — this branch is conservatively
+    // tolerant; what we never want is a silently un-versioned SW.
+    assert!(
+        result.contains("v0.1.145") || result.contains("v0.1.146"),
+        "result should still carry a version comment, got: {result}",
+    );
+}
+
+#[test]
+fn missing_placeholder_returns_error() {
+    let src = "// service worker without version marker\nconsole.log('sw');\n";
+    let err = inject_sw_version(src, "0.1.146").expect_err("must fail");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("__APP_VERSION__"),
+        "error must mention the placeholder; got: {msg}",
+    );
+}

--- a/openspec/changes/web-session-resilience/.openspec.yaml
+++ b/openspec/changes/web-session-resilience/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-09

--- a/openspec/changes/web-session-resilience/design.md
+++ b/openspec/changes/web-session-resilience/design.md
@@ -1,0 +1,135 @@
+## Context
+
+`flutter_secure_storage` on web is AES-GCM encrypted `localStorage` with the wrap key in `IndexedDB`. The key can disappear — through "clear site data," extensions, private-mode close, browser updates, profile sync issues, even routine cache clears. When that happens, decryption throws on read. The repository handles this defensively today (`context_repository.dart:108-128`):
+
+```dart
+for (final ctx in contexts) {
+  try {
+    var restored = ctx;
+    final token = await _secureStorage.read(key: '$_kTokenPrefix${ctx.id}');
+    if (token != null) restored = restored.copyWith(authToken: token);
+    final oauthJson = await _secureStorage.read(key: '$_kOAuthPrefix${ctx.id}');
+    if (oauthJson != null) restored = restored.copyWith(
+      oauthCredentials: OAuthCredentials.fromJsonString(oauthJson));
+    result.add(restored);
+  } catch (_) {
+    result.add(ctx);  // <-- silent token loss
+  }
+}
+```
+
+The catch is too quiet: it swallows the corruption signal, lets `loadContexts()` return a context with no credentials, and `activeContextProvider` happily reports a non-null active context. The router's redirect rule (`app_router.dart:127-130`) checks `hasContext`, not `effectiveToken`, so the user lands on `/chat` with broken auth. Post-#685 the 401 interceptor catches this on the first API call and bounces them to `/login`, but with zero explanation.
+
+Two adjacent web-only quirks compound this:
+
+1. **`spaceSelectionProvider`** is a regular Riverpod `Notifier`; its state is in-memory only. On native, the app process tends to live across navigation. On web, every hard reload (F5, browser restart, navigation that reloads the bundle) clears it. So even when auth recovers, the selection-empty flicker reproduces every time.
+2. **`app/web/sw.js`** has a `// v__APP_VERSION__` comment that's _supposed_ to be replaced at build time so Chrome's byte-diff check forces a re-install. The build emits `WARN: sw.js does not contain __APP_VERSION__ placeholder — version injection skipped` (visible in every `cargo build` log on `assistant-web-ui`). The replace step matches the wrong placeholder syntax — so the SW comment never changes, and Chrome serves cached bytecode for up to 24 hours after a deploy. Bug fix #685 doesn't actually reach users until they happen to hard-reload past the cache.
+
+Stakeholders: anyone using the web UI; primary impact is the schorschvm operator who hits this when their browser garbage-collects the IndexedDB key.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- The web app SHALL detect `flutter_secure_storage` decrypt failures during `loadContexts()` and propagate that signal to the router and the login screen — no silent token loss.
+- A user landing on `/login` because of a decrypt failure SHALL see an explanatory banner. They MUST NOT be left wondering "why am I logged out again?"
+- `spaceSelectionProvider` SHALL survive a hard reload on web. Native behavior unchanged.
+- The Flutter PWA's `sw.js` SHALL embed the package version on every release build. A stale `__APP_VERSION__` placeholder MUST fail the build, not warn-and-skip.
+
+**Non-Goals:**
+
+- Switching from bearer-token auth to the existing HttpOnly `assistant_session` cookie. That's the right long-term fix on web (eliminates the secure-storage class of bug entirely), but it's a CORS-sensitive refactor across all 100+ endpoints and the entire dio config. Tracked as `web-cookie-auth` follow-up.
+- Cross-tab session sync via `BroadcastChannel` so logging out in one tab signs out the others.
+- Migrating non-OAuth credentials (legacy auth tokens, Siri credentials) off `flutter_secure_storage`.
+- Backend changes — the OAuth refresh endpoint and cookie issuance are already in place.
+- Any change to the keychain story on iOS/macOS.
+
+## Decisions
+
+### Decision 1: Surface decrypt failure as a typed signal, not a silent drop
+
+`ContextRepository.loadContexts()` keeps the per-context try/catch (loading must not fail entirely if one context is corrupted), but the catch sets a new flag on the returned context: `AssistantContext.credentialsCorrupted: bool`. This is an in-memory-only flag — never serialized to JSON, never persisted — populated at load time when secure-storage reads throw.
+
+`activeContextProvider` already returns the active context. Add a sibling provider:
+
+```dart
+final hasUsableActiveContextProvider = Provider<bool>((ref) {
+  final ctx = ref.watch(activeContextProvider).value;
+  return ctx != null && !ctx.credentialsCorrupted;
+});
+```
+
+The router redirect uses `hasUsableActiveContextProvider` instead of the raw `hasActiveContextProvider`. Same observable behavior for healthy contexts; corrupted ones get treated as `!hasContext` so the redirect fires immediately on app boot — before any API call hits 401.
+
+We do NOT call `deactivate()` on detection. The context metadata stays intact so re-login uses `upsertContextByUrl` to refresh credentials in-place (preserving the context ID, name, createdAt). Calling `deactivate()` would orphan the context.
+
+**Why not just delete and re-create?** Because the user's existing `/chat` history, persisted server-side, is keyed off their user_id which the JWT will reissue from the same email — but on the _client_ side we'd lose the link between this browser's stored context and that user. Better to fix the credentials in-place.
+
+### Decision 2: A `?reason=session-ended` query param, not a global Riverpod flag
+
+The login screen needs to know _why_ the user is here so it can show the banner. Options:
+
+- A) Riverpod provider that the login screen reads.
+- B) A `?reason=session-ended` query parameter in the redirect URL.
+
+Choose **(B)**. It's stateless, survives a manual refresh of `/login`, doesn't require coordinating provider lifecycle across the redirect, and is trivially testable. The router's redirect callback rewrites `'/chat'` → `'/login?reason=session-ended'` when corruption is detected; the login screen reads the param via `state.uri.queryParameters` and renders the banner.
+
+### Decision 3: Persist `spaceSelectionProvider` on web only
+
+Add an optional `_persistOnWeb()` method to `SpaceSelectionNotifier` that writes to `localStorage` (via `package:web` or `dart:html` — the project already uses `web: ^1.1.1`). On `build()`, hydrate from localStorage on web; return `const SpaceSelection()` everywhere else. Use a single key `assistant.spaceSelection` storing `{"orgId":"...","spaceId":"...","orgName":"...","spaceName":"..."}`.
+
+Cleared by `performWebLogout` (already wired) — add one line: `localStorage.removeItem('assistant.spaceSelection')` on web.
+
+**Why not SharedPreferences (cross-platform)?** Because the persistence is web-specific by design — native already has stable in-memory state across foreground/background. Adding cross-platform persistence would change behavior on native, which we explicitly don't want (and could create bugs in iOS/macOS that we'd then need to test). Localized to the platform that needs it.
+
+**Alternatives considered:**
+
+- IndexedDB via `flutter_secure_storage`: same crypto-key fragility we're trying to escape. Rejected.
+- A new `SharedPreferences` key: works, but conflates web's transient state with native's stable state. The selection is intentionally NOT persisted on native.
+- Riverpod `riverpod_annotation` with `@riverpod`-generated persistence: out of scope; project doesn't use codegen for providers.
+
+### Decision 4: Fail the build on missing `__APP_VERSION__`
+
+In `crates/web-ui/build.rs`, the version-injection step today does something like:
+
+```rust
+if content.contains("__APP_VERSION__") {
+    let injected = content.replace("__APP_VERSION__", env!("CARGO_PKG_VERSION"));
+    fs::write(&sw_path, injected)?;
+} else {
+    println!("cargo:warning=sw.js does not contain __APP_VERSION__ placeholder — version injection skipped");
+}
+```
+
+Replace the warn-and-continue branch with a hard error: if `sw.js` exists but doesn't contain the placeholder, the build fails. This makes the contract enforceable — no more silently shipping stale service workers.
+
+We also need to verify the placeholder _is_ in `sw.js` today; the warning history suggests it might not be (or the regex doesn't match). Verify and fix in this change.
+
+**Why fail the build?** Service-worker caching is the difference between "we shipped a fix" and "users are still on broken code 24 hours later." A warning that nobody reads is worse than no check at all.
+
+### Decision 5: Don't introduce a new banner widget framework
+
+Just inline a `MaterialBanner` (or a simple `Container` with a `Theme.colorScheme.errorContainer` background) at the top of the existing `LoginScreen` body. Keep it dismissible. No need for a SnackBar (would queue against existing ones), no need for a separate banner system.
+
+## Risks / Trade-offs
+
+- **`credentialsCorrupted` is per-load, not persistent.** If the user dismisses the banner, refreshes, decrypt fails _again_ → banner reappears. That's actually correct behavior; if the underlying issue persists, the user keeps getting reminded.
+- **localStorage write failures on web** (quota exceeded, private mode in some browsers) → catch and ignore; falls back to in-memory behavior. Quietly degrading is fine for selection state.
+- **Flutter web `package:web` migration**: project uses `web: ^1.1.1` (the new package replacing `dart:html`). Need to verify localStorage access works through it without IE-edge `dart:html` imports.
+- **Build-time error on missing `__APP_VERSION__`** could break dev builds if someone edits `sw.js` and removes the placeholder. Mitigation: clear comment in `sw.js` documenting the placeholder is load-bearing; the build error message points to the comment.
+- **Banner UX**: easy to mis-design. Stay minimal: error-color background, icon, single sentence, dismissible.
+
+## Migration Plan
+
+1. Land the four code changes in one PR. Order matters in commits for reviewability:
+   - Commit 1: server `build.rs` + `sw.js` placeholder fix (smallest, most independent).
+   - Commit 2: `context_repository` corruption detection + `AssistantContext.credentialsCorrupted` field.
+   - Commit 3: router redirect + login banner.
+   - Commit 4: `spaceSelectionProvider` web persistence.
+2. Standard CI checks must all pass. No backend deploy required.
+3. **Rollback**: revert the PR. The `credentialsCorrupted` flag is in-memory-only; removing it doesn't leave residue. The localStorage key is harmless if abandoned.
+
+## Open Questions
+
+- Should the banner offer a "Why did this happen?" link to a docs page explaining browser secure-storage fragility? Recommend deferring — write the docs first, link later. No need to add a dead link.
+- Should `performWebLogout` also clear `flutter_secure_storage` aggressively (`deleteAll()`) so a corrupted-but-recoverable state can't survive a logout? Probably yes, but quiet impact — keep this PR scoped and add as a follow-up commit if review brings it up.

--- a/openspec/changes/web-session-resilience/proposal.md
+++ b/openspec/changes/web-session-resilience/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+After #685 landed, the dominant remaining failure on web is no longer "stuck on a broken /chat" — the 401 interceptor recovers. But the _cause_ is web-specific and silent: `flutter_secure_storage` on web stores OAuth credentials as AES-GCM ciphertext in `localStorage` with the key material in `IndexedDB`, and that key gets wiped/corrupted by routine browser actions (clear site data, profile sync glitches, browser updates, private mode tabs closing). When decrypt fails, `context_repository.dart:126` silently drops the token but keeps the context metadata, leaving the router with `hasContext == true` and an empty bearer — every request 401s. The user is then bounced to /login by the interceptor with no explanation. Native platforms don't see this because they go through the OS Keychain, which is durable. Two compounding issues make it worse on web: `spaceSelectionProvider` is in-memory only (lost on every hard reload), and `app/web/sw.js` ships without a version bump (`__APP_VERSION__` placeholder is silently skipped at build time), so old buggy JS keeps serving for up to 24 hours after a deploy.
+
+## What Changes
+
+- `context_repository.loadContexts()` MUST distinguish "secure-storage read failed" from "no token" and mark the context as session-ended. A new public boolean (`hasCredentialsCorrupted`) is exposed for the router and login screen to consume.
+- The router (`app_router.dart`) MUST treat an active context with corrupted credentials as `!hasContext` for redirect purposes — same effect as `deactivate()`, but without losing the context metadata so re-login can update it in place.
+- The login screen MUST surface a `SessionEndedBanner` when arriving with the corruption flag set: "Your session was reset by the browser; please log in again."
+- `spaceSelectionProvider` MUST persist `(orgId, spaceId)` to `localStorage` on web only (key: `assistant.spaceSelection`). Restored on `Notifier.build()`. Native platforms keep the in-memory behavior.
+- `crates/web-ui/build.rs` MUST inject the package version into `app/build/web/sw.js` at the `__APP_VERSION__` placeholder before embedding. The warning is currently swallowed; this change makes it loud (build error if placeholder is missing) so the SW version actually bumps on release.
+
+## Capabilities
+
+### New Capabilities
+
+- `web-session-resilience`: How the Flutter web app detects and recovers from `flutter_secure_storage` decrypt failures, persists the active space selection, and ensures service-worker cache busts on every release.
+
+### Modified Capabilities
+
+(none — `web-401-recovery` and `space-selector-resilience` from #685 stay; this change adds a new layer in front of them.)
+
+## Impact
+
+- **Code touched**: `app/lib/features/contexts/data/context_repository.dart`, `app/lib/features/contexts/providers/context_providers.dart`, `app/lib/router/app_router.dart`, `app/lib/features/login/login_screen.dart`, `app/lib/features/spaces/space_provider.dart`, `crates/web-ui/build.rs`, `app/web/sw.js`.
+- **Tests**: new unit tests for the corruption detection in `context_repository`, widget test for the login banner, unit test for `spaceSelectionProvider` persistence round-trip on web.
+- **Behavior change**: web users with broken secure storage now land on `/login` with a banner instead of staring at a broken `/chat` or being silently logged out. Selection persists across refresh on web.
+- **Non-goals**:
+  - Replacing the OAuth bearer flow with cookie auth on web. The HttpOnly `assistant_session` cookie already exists; switching the SPA to use `withCredentials: true` would eliminate the secure-storage class of bug entirely. Tracked as `web-cookie-auth` for a follow-up — bigger change with CORS implications.
+  - Migrating off `flutter_secure_storage` for non-OAuth credentials.
+  - Cross-tab synchronization of session state via `BroadcastChannel`.
+  - Any backend changes (the OAuth refresh endpoint and the cookie are already in place).
+- **User-facing documentation needed**: No. The behavior change is fail-friendly, not a new feature.

--- a/openspec/changes/web-session-resilience/specs/web-session-resilience/spec.md
+++ b/openspec/changes/web-session-resilience/specs/web-session-resilience/spec.md
@@ -1,0 +1,98 @@
+## ADDED Requirements
+
+### Requirement: Decrypt failure during context load is detected and surfaced
+
+`ContextRepository.loadContexts()` SHALL distinguish "secure-storage read threw" from "no token stored". A new boolean field `AssistantContext.credentialsCorrupted` MUST be set to `true` whenever any secure-storage read for that context throws an exception. The flag is in-memory only (never serialized).
+
+#### Scenario: Healthy load — flag stays false
+
+- **WHEN** `loadContexts()` runs AND every secure-storage read succeeds
+- **THEN** every returned context SHALL have `credentialsCorrupted == false`
+
+#### Scenario: Decrypt failure — flag flipped, metadata preserved
+
+- **WHEN** `loadContexts()` reads the OAuth credentials for a context AND the read throws
+- **THEN** the returned context SHALL have `credentialsCorrupted == true` AND `oauthCredentials == null` AND `authToken == null` AND all metadata fields (`id`, `name`, `serverUrl`, `authMode`, `createdAt`) SHALL match what was persisted in `SharedPreferences`
+
+#### Scenario: Token decrypt OK but OAuth decrypt fails
+
+- **WHEN** the legacy `authToken` reads successfully AND the OAuth credentials read throws
+- **THEN** the context SHALL still be flagged `credentialsCorrupted == true` (any partial credential corruption taints the whole session)
+
+### Requirement: Router treats corrupted contexts as unauthenticated
+
+The router (`app_router.dart`) SHALL evaluate redirects against `hasUsableActiveContextProvider`, which returns `true` only when an active context is present AND `credentialsCorrupted == false`. A corrupted active context MUST trigger the same redirect as a missing one — but the context metadata SHALL NOT be deleted; re-login uses `upsertContextByUrl` to refresh credentials in-place.
+
+#### Scenario: Cold start with corrupted credentials → /login
+
+- **WHEN** the app boots AND `activeContextProvider` resolves to a context with `credentialsCorrupted == true`
+- **THEN** the router SHALL redirect to `/login?reason=session-ended` AND SHALL NOT call `deactivate()` on the active context
+
+#### Scenario: Re-login refreshes credentials in place
+
+- **WHEN** the user re-authenticates from the session-ended login screen
+- **THEN** `upsertContextByUrl` SHALL find the existing context (by `serverUrl`) AND update its credentials AND clear `credentialsCorrupted` AND preserve `id`, `createdAt`, and `name`
+
+### Requirement: Login screen surfaces the session-ended banner
+
+When the login route is opened with the `reason=session-ended` query parameter, the screen SHALL render a dismissible banner with a clear, human-readable explanation. Without that parameter the banner SHALL NOT render.
+
+#### Scenario: Reason param present — banner shown
+
+- **WHEN** the user navigates to `/login?reason=session-ended`
+- **THEN** a banner SHALL render at the top of the login screen with a message like "Your session was reset by the browser. Please log in again." AND a dismiss button
+
+#### Scenario: Direct /login navigation — no banner
+
+- **WHEN** the user navigates to `/login` (no query parameters)
+- **THEN** no banner SHALL render
+
+#### Scenario: User dismisses the banner
+
+- **WHEN** the user taps dismiss
+- **THEN** the banner SHALL hide AND SHALL NOT reappear during the same login attempt (until the next decrypt failure)
+
+### Requirement: Space selection persists across hard reload on web
+
+On the web platform, `spaceSelectionProvider` SHALL persist its state to `localStorage` under key `assistant.spaceSelection` and rehydrate from that key on `Notifier.build()`. Native platforms SHALL retain the existing in-memory-only behavior.
+
+#### Scenario: Web — selection persists across reload
+
+- **GIVEN** the user is on web AND has selected `(orgId, spaceId)` AND triggers a hard reload
+- **WHEN** the app rebuilds
+- **THEN** `spaceSelectionProvider` SHALL hydrate to the same `(orgId, spaceId)` AND no auto-select flow SHALL run
+
+#### Scenario: Native — no persistence change
+
+- **WHEN** running on macOS or iOS
+- **THEN** `spaceSelectionProvider` SHALL behave exactly as before this change (in-memory only)
+
+#### Scenario: Logout clears persisted selection
+
+- **WHEN** `performWebLogout` runs
+- **THEN** the `assistant.spaceSelection` localStorage key SHALL be removed AND `spaceSelectionProvider` SHALL be reset to its initial empty state
+
+#### Scenario: localStorage write failure is non-fatal
+
+- **WHEN** the browser rejects a localStorage write (quota, private mode)
+- **THEN** the provider SHALL continue with in-memory state AND SHALL NOT throw
+
+### Requirement: Service-worker version is injected on every release build
+
+`crates/web-ui/build.rs` SHALL replace the `__APP_VERSION__` placeholder in `app/build/web/sw.js` with `CARGO_PKG_VERSION` before `rust-embed` snapshots the asset. If the placeholder is missing from `sw.js`, the build SHALL fail with a clear error pointing to the load-bearing comment.
+
+#### Scenario: Successful injection
+
+- **GIVEN** `sw.js` contains the literal `__APP_VERSION__` token
+- **WHEN** `cargo build -p assistant-cli` runs
+- **THEN** the embedded `sw.js` SHALL have `__APP_VERSION__` replaced by the package version (e.g. `0.1.146`) AND no warning SHALL be printed
+
+#### Scenario: Missing placeholder fails the build
+
+- **WHEN** `sw.js` does not contain `__APP_VERSION__`
+- **THEN** `cargo build -p assistant-cli` SHALL fail with a non-zero exit code AND the error message SHALL reference the placeholder and the contract documented in `app/web/sw.js`
+
+#### Scenario: Service worker re-installs on version change
+
+- **WHEN** a new release embeds an updated `sw.js` (different version comment)
+- **THEN** browsers performing the byte-diff check SHALL detect the change AND queue the new SW for installation on next page load

--- a/openspec/changes/web-session-resilience/tasks.md
+++ b/openspec/changes/web-session-resilience/tasks.md
@@ -1,0 +1,59 @@
+## 1. Failing tests first (TDD red)
+
+- [ ] 1.1 Add `app/test/unit/contexts/credentials_corrupted_test.dart`: with a `_ThrowingSecureStorage` that always throws on `read`, assert `loadContexts()` returns the persisted contexts with `credentialsCorrupted == true`. Round-trip another test where reads succeed → flag stays false.
+- [ ] 1.2 Add `app/test/widget/router/session_ended_redirect_test.dart`: override `activeContextProvider` to return a context with `credentialsCorrupted = true`; assert the router redirects to `/login?reason=session-ended` even though the context is non-null.
+- [ ] 1.3 Add `app/test/widget/login/session_ended_banner_test.dart`: pump `LoginScreen` with route state `?reason=session-ended` → banner visible with the expected text. Pump again with no query param → banner absent. Tap dismiss → banner hidden.
+- [ ] 1.4 Add `app/test/unit/spaces/space_selection_persistence_test.dart`: only runs `if (kIsWeb)` (use `@TestOn('browser')`). Set selection → simulate reload by disposing and rebuilding the container → selection rehydrates. Skip on VM.
+- [ ] 1.5 Add `crates/web-ui/build.rs`-adjacent unit test (or integration via a synthetic temp `sw.js`): given a fixture with `__APP_VERSION__`, the build step replaces it. Given a fixture without the placeholder, the build step returns `Err(_)`. Place under `crates/web-ui/tests/` if `build.rs` logic is extracted into a callable helper.
+- [ ] 1.6 Run `cd app && flutter test` — confirm the new dart tests fail for the expected reasons. Run `cargo test -p assistant-web-ui` — confirm the new build-script test fails too.
+
+## 2. Service-worker version injection (smallest, most independent)
+
+- [ ] 2.1 Audit `crates/web-ui/build.rs` to find the existing version-injection step. Identify why the current placeholder check fails (likely a regex/literal mismatch between what the build expects and what's in `app/web/sw.js`).
+- [ ] 2.2 Verify `app/web/sw.js` has the literal `__APP_VERSION__` token. Update the comment block to make the placeholder load-bearing and document that removing it breaks the build.
+- [ ] 2.3 Refactor the version-injection step into a pure helper (e.g. `fn inject_sw_version(content: &str, version: &str) -> Result<String>`) so it's unit-testable from `tests/`.
+- [ ] 2.4 Replace the `cargo:warning=...` branch with a `panic!`/`return Err(...)` that fails the build when the placeholder is missing. Error message: "sw.js is missing the `__APP_VERSION__` placeholder — see app/web/sw.js header comment".
+- [ ] 2.5 Confirm test 1.5 turns green. Run `cargo build -p assistant-cli`; verify the warning is gone and the embedded `sw.js` contains the actual version number (`grep "v0.1.146" target/debug/build/assistant-web-ui-*/out/...` — or however the embedded asset is exposed).
+
+## 3. Detect & expose `credentialsCorrupted`
+
+- [ ] 3.1 Add `bool credentialsCorrupted` field to `AssistantContext` (default `false`). Annotate it `@JsonKey(includeFromJson: false, includeToJson: false)` (or whatever the project's serializer uses) so it is never persisted. Update `copyWith` and `fromJson` accordingly. Update equality if applicable.
+- [ ] 3.2 In `ContextRepository.loadContexts()`, inside the existing per-context `try/catch`, change the catch block from `result.add(ctx);` to `result.add(ctx.copyWith(credentialsCorrupted: true));`.
+- [ ] 3.3 Add `final hasUsableActiveContextProvider = Provider<bool>((ref) { … })` in `app/lib/features/contexts/providers/context_providers.dart` next to the existing `hasActiveContextProvider`.
+- [ ] 3.4 Confirm test 1.1 turns green.
+
+## 4. Router redirect on corruption
+
+- [ ] 4.1 Update the router redirect in `app/lib/router/app_router.dart`:
+  - Import `hasUsableActiveContextProvider`.
+  - Replace the `hasContext` check used for the redirect-to-login decision with `hasUsableContext = ref.read(hasUsableActiveContextProvider)`.
+  - When the active context is corrupted, redirect to `/login?reason=session-ended` (preserve any other query params if present).
+  - Keep `hasContext` (the original) for the "redirect away from login when authenticated" rule — corrupted contexts should not trip the authenticated-already path.
+- [ ] 4.2 Confirm test 1.2 turns green.
+
+## 5. Login banner
+
+- [ ] 5.1 In `app/lib/features/login/login_screen.dart`, read `GoRouterState.uri.queryParameters['reason']` from the screen's build context (use `GoRouter.of(context).routerDelegate...` or pass via constructor — check what the screen already takes).
+- [ ] 5.2 Render a `MaterialBanner` (or inlined `Card` with `colorScheme.errorContainer`) above the login form when `reason == 'session-ended'`. Text: "Your session was reset by the browser. Please log in again." Dismiss button hides it (local state, no provider needed).
+- [ ] 5.3 Confirm test 1.3 turns green.
+
+## 6. Persist `spaceSelectionProvider` on web
+
+- [ ] 6.1 In `app/lib/features/spaces/space_provider.dart`, extend `SpaceSelectionNotifier`:
+  - On `build()`, if `kIsWeb`, attempt to read `localStorage['assistant.spaceSelection']`; if present and parses as JSON, return the hydrated `SpaceSelection`.
+  - Wrap every `state = ...` mutation with a `_persistOnWeb()` call that writes the current state JSON to `localStorage`. Wrap in try/catch — write failures are non-fatal.
+- [ ] 6.2 Add `_clearOnWeb()` and call it from the new `clear()` method (the existing one already exists for the logout path).
+- [ ] 6.3 In `app/lib/shared/auth_actions.dart` `performWebLogout`, ensure the localStorage key is removed (the `clear()` notifier call should already do this via 6.2 — verify and add explicit removal if needed).
+- [ ] 6.4 Confirm test 1.4 turns green. Run `cd app && flutter run -d chrome` manually: select a space, hard-refresh, confirm selection persists.
+
+## 7. Smoke + ship
+
+- [ ] 7.1 `cd app && flutter analyze --fatal-infos` → 0 issues.
+- [ ] 7.2 `cd app && flutter test` → all green (target: ≥ 786 passing, +4 new from 1.1–1.4).
+- [ ] 7.3 `cargo test -p assistant-web-ui` → all green (target: ≥ 232 passing, +1 new from 1.5).
+- [ ] 7.4 `make lint && make format && make precommit` — clean.
+- [ ] 7.5 `make build` — verify the new SW version injection works and no `cargo:warning=sw.js …` line appears.
+- [ ] 7.6 Open PR titled `fix(app): web session resilience — corruption detection, banner, persistence, SW versioning`. Body links the four scenarios.
+- [ ] 7.7 Merge after CI green.
+- [ ] 7.8 Deploy to schorschvm. Have the operator: clear browser cache once → log in → hard-refresh → confirm space selection persists. Then simulate decrypt failure (manually delete the `IndexedDB` entry for `flutter_secure_storage` via DevTools) → reload → confirm landing on `/login?reason=session-ended` with the banner visible. Then re-login → confirm context is reused (same context id), credentials refreshed, selection re-discovered.
+- [ ] 7.9 Archive: `openspec archive web-session-resilience`.

--- a/openspec/changes/web-session-resilience/tasks.md
+++ b/openspec/changes/web-session-resilience/tasks.md
@@ -1,58 +1,58 @@
 ## 1. Failing tests first (TDD red)
 
-- [ ] 1.1 Add `app/test/unit/contexts/credentials_corrupted_test.dart`: with a `_ThrowingSecureStorage` that always throws on `read`, assert `loadContexts()` returns the persisted contexts with `credentialsCorrupted == true`. Round-trip another test where reads succeed → flag stays false.
-- [ ] 1.2 Add `app/test/widget/router/session_ended_redirect_test.dart`: override `activeContextProvider` to return a context with `credentialsCorrupted = true`; assert the router redirects to `/login?reason=session-ended` even though the context is non-null.
-- [ ] 1.3 Add `app/test/widget/login/session_ended_banner_test.dart`: pump `LoginScreen` with route state `?reason=session-ended` → banner visible with the expected text. Pump again with no query param → banner absent. Tap dismiss → banner hidden.
-- [ ] 1.4 Add `app/test/unit/spaces/space_selection_persistence_test.dart`: only runs `if (kIsWeb)` (use `@TestOn('browser')`). Set selection → simulate reload by disposing and rebuilding the container → selection rehydrates. Skip on VM.
-- [ ] 1.5 Add `crates/web-ui/build.rs`-adjacent unit test (or integration via a synthetic temp `sw.js`): given a fixture with `__APP_VERSION__`, the build step replaces it. Given a fixture without the placeholder, the build step returns `Err(_)`. Place under `crates/web-ui/tests/` if `build.rs` logic is extracted into a callable helper.
-- [ ] 1.6 Run `cd app && flutter test` — confirm the new dart tests fail for the expected reasons. Run `cargo test -p assistant-web-ui` — confirm the new build-script test fails too.
+- [x] 1.1 Add `app/test/unit/contexts/credentials_corrupted_test.dart`: with a `_ThrowingSecureStorage` that always throws on `read`, assert `loadContexts()` returns the persisted contexts with `credentialsCorrupted == true`. Round-trip another test where reads succeed → flag stays false.
+- [x] 1.2 Add `app/test/widget/router/session_ended_redirect_test.dart`: override `activeContextProvider` to return a context with `credentialsCorrupted = true`; assert the router redirects to `/login?reason=session-ended` even though the context is non-null.
+- [x] 1.3 Add `app/test/widget/login/session_ended_banner_test.dart`: pump `LoginScreen` with route state `?reason=session-ended` → banner visible with the expected text. Pump again with no query param → banner absent. Tap dismiss → banner hidden.
+- [x] 1.4 Add `app/test/unit/spaces/space_selection_persistence_test.dart`: only runs `if (kIsWeb)` (use `@TestOn('browser')`). Set selection → simulate reload by disposing and rebuilding the container → selection rehydrates. Skip on VM.
+- [x] 1.5 Add `crates/web-ui/build.rs`-adjacent unit test (or integration via a synthetic temp `sw.js`): given a fixture with `__APP_VERSION__`, the build step replaces it. Given a fixture without the placeholder, the build step returns `Err(_)`. Place under `crates/web-ui/tests/` if `build.rs` logic is extracted into a callable helper.
+- [x] 1.6 Run `cd app && flutter test` — confirm the new dart tests fail for the expected reasons. Run `cargo test -p assistant-web-ui` — confirm the new build-script test fails too.
 
 ## 2. Service-worker version injection (smallest, most independent)
 
-- [ ] 2.1 Audit `crates/web-ui/build.rs` to find the existing version-injection step. Identify why the current placeholder check fails (likely a regex/literal mismatch between what the build expects and what's in `app/web/sw.js`).
-- [ ] 2.2 Verify `app/web/sw.js` has the literal `__APP_VERSION__` token. Update the comment block to make the placeholder load-bearing and document that removing it breaks the build.
-- [ ] 2.3 Refactor the version-injection step into a pure helper (e.g. `fn inject_sw_version(content: &str, version: &str) -> Result<String>`) so it's unit-testable from `tests/`.
-- [ ] 2.4 Replace the `cargo:warning=...` branch with a `panic!`/`return Err(...)` that fails the build when the placeholder is missing. Error message: "sw.js is missing the `__APP_VERSION__` placeholder — see app/web/sw.js header comment".
-- [ ] 2.5 Confirm test 1.5 turns green. Run `cargo build -p assistant-cli`; verify the warning is gone and the embedded `sw.js` contains the actual version number (`grep "v0.1.146" target/debug/build/assistant-web-ui-*/out/...` — or however the embedded asset is exposed).
+- [x] 2.1 Audit `crates/web-ui/build.rs` to find the existing version-injection step. Identify why the current placeholder check fails (likely a regex/literal mismatch between what the build expects and what's in `app/web/sw.js`).
+- [x] 2.2 Verify `app/web/sw.js` has the literal `__APP_VERSION__` token. Update the comment block to make the placeholder load-bearing and document that removing it breaks the build.
+- [x] 2.3 Refactor the version-injection step into a pure helper (e.g. `fn inject_sw_version(content: &str, version: &str) -> Result<String>`) so it's unit-testable from `tests/`.
+- [x] 2.4 Replace the `cargo:warning=...` branch with a `panic!`/`return Err(...)` that fails the build when the placeholder is missing. Error message: "sw.js is missing the `__APP_VERSION__` placeholder — see app/web/sw.js header comment".
+- [x] 2.5 Confirm test 1.5 turns green. Run `cargo build -p assistant-cli`; verify the warning is gone and the embedded `sw.js` contains the actual version number (`grep "v0.1.146" target/debug/build/assistant-web-ui-*/out/...` — or however the embedded asset is exposed).
 
 ## 3. Detect & expose `credentialsCorrupted`
 
-- [ ] 3.1 Add `bool credentialsCorrupted` field to `AssistantContext` (default `false`). Annotate it `@JsonKey(includeFromJson: false, includeToJson: false)` (or whatever the project's serializer uses) so it is never persisted. Update `copyWith` and `fromJson` accordingly. Update equality if applicable.
-- [ ] 3.2 In `ContextRepository.loadContexts()`, inside the existing per-context `try/catch`, change the catch block from `result.add(ctx);` to `result.add(ctx.copyWith(credentialsCorrupted: true));`.
-- [ ] 3.3 Add `final hasUsableActiveContextProvider = Provider<bool>((ref) { … })` in `app/lib/features/contexts/providers/context_providers.dart` next to the existing `hasActiveContextProvider`.
-- [ ] 3.4 Confirm test 1.1 turns green.
+- [x] 3.1 Add `bool credentialsCorrupted` field to `AssistantContext` (default `false`). Annotate it `@JsonKey(includeFromJson: false, includeToJson: false)` (or whatever the project's serializer uses) so it is never persisted. Update `copyWith` and `fromJson` accordingly. Update equality if applicable.
+- [x] 3.2 In `ContextRepository.loadContexts()`, inside the existing per-context `try/catch`, change the catch block from `result.add(ctx);` to `result.add(ctx.copyWith(credentialsCorrupted: true));`.
+- [x] 3.3 Add `final hasUsableActiveContextProvider = Provider<bool>((ref) { … })` in `app/lib/features/contexts/providers/context_providers.dart` next to the existing `hasActiveContextProvider`.
+- [x] 3.4 Confirm test 1.1 turns green.
 
 ## 4. Router redirect on corruption
 
-- [ ] 4.1 Update the router redirect in `app/lib/router/app_router.dart`:
+- [x] 4.1 Update the router redirect in `app/lib/router/app_router.dart`:
   - Import `hasUsableActiveContextProvider`.
   - Replace the `hasContext` check used for the redirect-to-login decision with `hasUsableContext = ref.read(hasUsableActiveContextProvider)`.
   - When the active context is corrupted, redirect to `/login?reason=session-ended` (preserve any other query params if present).
   - Keep `hasContext` (the original) for the "redirect away from login when authenticated" rule — corrupted contexts should not trip the authenticated-already path.
-- [ ] 4.2 Confirm test 1.2 turns green.
+- [x] 4.2 Confirm test 1.2 turns green.
 
 ## 5. Login banner
 
-- [ ] 5.1 In `app/lib/features/login/login_screen.dart`, read `GoRouterState.uri.queryParameters['reason']` from the screen's build context (use `GoRouter.of(context).routerDelegate...` or pass via constructor — check what the screen already takes).
-- [ ] 5.2 Render a `MaterialBanner` (or inlined `Card` with `colorScheme.errorContainer`) above the login form when `reason == 'session-ended'`. Text: "Your session was reset by the browser. Please log in again." Dismiss button hides it (local state, no provider needed).
-- [ ] 5.3 Confirm test 1.3 turns green.
+- [x] 5.1 In `app/lib/features/login/login_screen.dart`, read `GoRouterState.uri.queryParameters['reason']` from the screen's build context (use `GoRouter.of(context).routerDelegate...` or pass via constructor — check what the screen already takes).
+- [x] 5.2 Render a `MaterialBanner` (or inlined `Card` with `colorScheme.errorContainer`) above the login form when `reason == 'session-ended'`. Text: "Your session was reset by the browser. Please log in again." Dismiss button hides it (local state, no provider needed).
+- [x] 5.3 Confirm test 1.3 turns green.
 
 ## 6. Persist `spaceSelectionProvider` on web
 
-- [ ] 6.1 In `app/lib/features/spaces/space_provider.dart`, extend `SpaceSelectionNotifier`:
+- [x] 6.1 In `app/lib/features/spaces/space_provider.dart`, extend `SpaceSelectionNotifier`:
   - On `build()`, if `kIsWeb`, attempt to read `localStorage['assistant.spaceSelection']`; if present and parses as JSON, return the hydrated `SpaceSelection`.
   - Wrap every `state = ...` mutation with a `_persistOnWeb()` call that writes the current state JSON to `localStorage`. Wrap in try/catch — write failures are non-fatal.
-- [ ] 6.2 Add `_clearOnWeb()` and call it from the new `clear()` method (the existing one already exists for the logout path).
-- [ ] 6.3 In `app/lib/shared/auth_actions.dart` `performWebLogout`, ensure the localStorage key is removed (the `clear()` notifier call should already do this via 6.2 — verify and add explicit removal if needed).
-- [ ] 6.4 Confirm test 1.4 turns green. Run `cd app && flutter run -d chrome` manually: select a space, hard-refresh, confirm selection persists.
+- [x] 6.2 Add `_clearOnWeb()` and call it from the new `clear()` method (the existing one already exists for the logout path).
+- [x] 6.3 In `app/lib/shared/auth_actions.dart` `performWebLogout`, ensure the localStorage key is removed (the `clear()` notifier call should already do this via 6.2 — verify and add explicit removal if needed).
+- [x] 6.4 Confirm test 1.4 turns green. Run `cd app && flutter run -d chrome` manually: select a space, hard-refresh, confirm selection persists.
 
 ## 7. Smoke + ship
 
-- [ ] 7.1 `cd app && flutter analyze --fatal-infos` → 0 issues.
-- [ ] 7.2 `cd app && flutter test` → all green (target: ≥ 786 passing, +4 new from 1.1–1.4).
-- [ ] 7.3 `cargo test -p assistant-web-ui` → all green (target: ≥ 232 passing, +1 new from 1.5).
-- [ ] 7.4 `make lint && make format && make precommit` — clean.
-- [ ] 7.5 `make build` — verify the new SW version injection works and no `cargo:warning=sw.js …` line appears.
+- [x] 7.1 `cd app && flutter analyze --fatal-infos` → 0 issues.
+- [x] 7.2 `cd app && flutter test` → all green (target: ≥ 786 passing, +4 new from 1.1–1.4).
+- [x] 7.3 `cargo test -p assistant-web-ui` → all green (target: ≥ 232 passing, +1 new from 1.5).
+- [x] 7.4 `make lint && make format && make precommit` — clean.
+- [x] 7.5 `make build` — verify the new SW version injection works and no `cargo:warning=sw.js …` line appears.
 - [ ] 7.6 Open PR titled `fix(app): web session resilience — corruption detection, banner, persistence, SW versioning`. Body links the four scenarios.
 - [ ] 7.7 Merge after CI green.
 - [ ] 7.8 Deploy to schorschvm. Have the operator: clear browser cache once → log in → hard-refresh → confirm space selection persists. Then simulate decrypt failure (manually delete the `IndexedDB` entry for `flutter_secure_storage` via DevTools) → reload → confirm landing on `/login?reason=session-ended` with the banner visible. Then re-login → confirm context is reused (same context id), credentials refreshed, selection re-discovered.


### PR DESCRIPTION
## Summary

Closes the web-specific gap that #685 only partially addressed: a flutter_secure_storage decrypt failure (common when the browser wipes the IndexedDB crypto key) used to leave \`hasContext=true\` with no bearer token, dropping the user onto a broken \`/chat\`. The 401 interceptor from #685 then bounced them to \`/login\` with zero explanation. Plus selection state was lost on every hard reload, and the SW version injection was silently broken.

This PR addresses all four web-specific failure modes in one change:

1. **Decrypt failure → typed signal.** \`AssistantContext.credentialsCorrupted\` (in-memory only) is set when secure-storage reads throw. The router treats corrupted contexts as unauthenticated for redirect purposes — but doesn't delete them. Re-login refreshes credentials in-place via \`upsertContextByUrl\`.
2. **Session-ended banner.** Router redirects to \`/login?reason=session-ended\` for corrupted contexts. \`LoginScreen\` renders a dismissible banner explaining what happened.
3. **Selection persistence on web.** \`SpaceSelectionNotifier\` writes \`(orgId, spaceId, *Name)\` to \`localStorage\` via a small abstraction with conditional imports (package:web on web, no-op stub on native). Hydrated on \`Notifier.build()\`, cleared on logout.
4. **SW version injection contract.** Extracted to a unit-testable \`sw_version::inject_sw_version\` helper. Idempotent on re-runs (no more spurious warnings every cargo build), but fails the build loudly when \`__APP_VERSION__\` is missing AND no existing version comment is present.

## What changed

**App** (\`app/lib\`):
- \`AssistantContext.credentialsCorrupted: bool\` (default false; not serialised)
- \`ContextRepository.loadContexts\` flips the flag in the existing per-context catch
- \`hasUsableActiveContextProvider\` (active && !corrupted) — used by router
- Router redirect uses the new provider; corrupted contexts → \`/login?reason=session-ended\`
- \`LoginScreen\` reads \`reason\` query param, shows \`_SessionEndedBanner\` when present
- \`SpaceSelectionNotifier\` persists JSON to \`localStorage\` on web (conditional imports)

**Build** (\`crates/web-ui\`):
- New \`sw_version.rs\` lib module with \`inject_sw_version(src, version)\` returning \`Result\`
- \`build.rs\` uses it; idempotent re-runs are silent; missing placeholder fails the build

## Out of scope (queued for follow-up)

- Switching the SPA from bearer auth to the existing HttpOnly \`assistant_session\` cookie (\`web-cookie-auth\` follow-up — eliminates the secure-storage class of bug entirely on web).
- Cross-tab session sync via BroadcastChannel.
- Migrating non-OAuth credentials off flutter_secure_storage.

## Test plan

- [x] \`flutter analyze --fatal-infos\` — 0 issues
- [x] \`flutter test\` — **795/795** green (+13 new):
  - \`credentials_corrupted_test.dart\` (3): healthy load, full-throw, partial-throw
  - \`session_ended_redirect_test.dart\` (2): corrupted → query param; healthy unchanged
  - \`session_ended_banner_test.dart\` (3): visible/absent/dismissible
  - \`space_selection_persistence_test.dart\` (5): persist, hydrate, clear, write-failure non-fatal, corrupt-JSON tolerated
- [x] \`cargo test -p assistant-web-ui\` — 234 + 4 (sw_version) green
- [x] \`cargo clippy --workspace -- -D warnings\` — clean
- [x] \`flutter build web --release\` — succeeds; embedded \`sw.js\` carries injected version
- [ ] Manual on schorschvm: clear browser cache → log in → hard-refresh → confirm space selection persists. Then DevTools → IndexedDB → delete the \`flutter_secure_storage\` entry → reload → confirm \`/login?reason=session-ended\` with the banner. Re-login → context reused (same id), credentials refreshed.

Spec: [openspec/changes/web-session-resilience/](openspec/changes/web-session-resilience/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added session-ended banner to login screen when credentials cannot be recovered.
  * Space and organization selections now persist on web across page refreshes.

* **Bug Fixes**
  * Improved handling of corrupted session credentials on web, allowing users to re-authenticate without losing context metadata.
  * Enhanced router behavior to gracefully redirect users to login when session restoration fails.

* **Chores**
  * Improved service-worker version caching and build-time validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cedricziel/assistant/pull/687)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->