### PR TITLE
feat(app): expose logout on native (rename performWebLogout → performLogout)

### DIFF
--- a/app/lib/shared/auth_actions.dart
+++ b/app/lib/shared/auth_actions.dart
@@ -3,15 +3,17 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../features/contexts/providers/context_providers.dart';
 import '../features/spaces/space_provider.dart';
 
-/// Tear down the user's session on the web.
+/// Tear down the user's session.
 ///
 /// Clears the in-memory space selection BEFORE deactivating the active context
 /// so the next login starts from a clean slate. The router redirect on
 /// `!hasContext` then sends the user to `/login`.
 ///
-/// The 401 interceptor wires the same shape into its `onAuthExpired` callback
-/// (see `connection_provider.dart`). Keep them consistent.
-Future<void> performWebLogout(ProviderContainer container) async {
+/// Used by:
+/// - The nav-shell logout button on every platform.
+/// - The 401 interceptor's `onAuthExpired` callback (see
+///   `connection_provider.dart`). Both paths must produce the same end state.
+Future<void> performLogout(ProviderContainer container) async {
   container.read(spaceSelectionProvider.notifier).clear();
   await container.read(activeContextProvider.notifier).deactivate();
 }

--- a/app/lib/shared/nav_shell.dart
+++ b/app/lib/shared/nav_shell.dart
@@ -649,17 +649,16 @@ class _NavShellState extends ConsumerState<NavShell> {
                           collapsed: collapsed,
                           onTap: () => context.go(_contextsDestination.path),
                         ),
-                      if (kIsWeb)
-                        _LogoutButton(
-                          onLogout: () async {
-                            await performWebLogout(
-                              ProviderScope.containerOf(context, listen: false),
-                            );
-                            if (context.mounted) {
-                              context.go(AppRoutes.login);
-                            }
-                          },
-                        ),
+                      _LogoutButton(
+                        onLogout: () async {
+                          await performLogout(
+                            ProviderScope.containerOf(context, listen: false),
+                          );
+                          if (context.mounted) {
+                            context.go(AppRoutes.login);
+                          }
+                        },
+                      ),
                       _MaterialSidebarItem(
                         icon: _settingsDestination.icon,
                         selectedIcon: _settingsDestination.selectedIcon,

--- a/app/test/unit/spaces/logout_resets_space_selection_test.dart
+++ b/app/test/unit/spaces/logout_resets_space_selection_test.dart
@@ -34,7 +34,7 @@ Future<ContextRepository> _makeRepo() async {
 
 void main() {
   test(
-    'performWebLogout clears space selection AND deactivates context',
+    'performLogout clears space selection AND deactivates context',
     () async {
       final repo = await _makeRepo();
       await repo.setActiveContextId('ctx-1');
@@ -53,7 +53,7 @@ void main() {
       expect(container.read(spaceSelectionProvider).spaceId, 'sp-1');
       expect(repo.getActiveContextId(), 'ctx-1');
 
-      await performWebLogout(container);
+      await performLogout(container);
 
       expect(container.read(spaceSelectionProvider).orgId, isNull);
       expect(container.read(spaceSelectionProvider).spaceId, isNull);
@@ -61,7 +61,7 @@ void main() {
     },
   );
 
-  test('performWebLogout is idempotent on already-empty state', () async {
+  test('performLogout is idempotent on already-empty state', () async {
     final repo = await _makeRepo();
 
     final container = ProviderContainer(
@@ -69,8 +69,8 @@ void main() {
     );
     addTearDown(container.dispose);
 
-    await performWebLogout(container);
-    await performWebLogout(container);
+    await performLogout(container);
+    await performLogout(container);
 
     expect(container.read(spaceSelectionProvider).orgId, isNull);
     expect(repo.getActiveContextId(), isNull);

--- a/app/test/widget/nav_shell_test.dart
+++ b/app/test/widget/nav_shell_test.dart
@@ -299,13 +299,12 @@ void main() {
       );
     });
 
-    // 5.4 — non-web: contexts button present, logout button absent.
+    // 5.8 — every platform: Contexts AND Logout button visible.
     //
     // kIsWeb is a compile-time constant; in tests it is always false (non-web).
-    // The web path (5.3 — logout present, contexts absent) requires a web
-    // build and is verified by manual testing or a dedicated web integration
-    // test run.
-    testWidgets('5.8 non-web desktop shows Contexts and no Logout button', (
+    // Pre-#688 the logout button was gated `if (kIsWeb)` and therefore absent
+    // on native — that gate is now gone. Both Contexts and Logout coexist.
+    testWidgets('5.8 desktop shows both Contexts and Logout button', (
       tester,
     ) async {
       tester.view.physicalSize = const Size(1024, 768);
@@ -319,14 +318,14 @@ void main() {
       expect(
         find.text('Contexts'),
         findsOneWidget,
-        reason: 'Non-web: Contexts switcher should be present',
+        reason: 'Contexts switcher should be present',
       );
 
-      // Logout button must NOT appear on non-web.
+      // Logout button must now appear on every platform.
       expect(
         find.byTooltip('Log out'),
-        findsNothing,
-        reason: 'Non-web: Logout button should be absent',
+        findsOneWidget,
+        reason: 'Logout button should be present on every platform',
       );
     });
   });

--- a/openspec/changes/logout-on-native/.openspec.yaml
+++ b/openspec/changes/logout-on-native/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-10

--- a/openspec/changes/logout-on-native/design.md
+++ b/openspec/changes/logout-on-native/design.md
@@ -1,0 +1,81 @@
+## Context
+
+`_LogoutButton` was added to `nav_shell.dart` as part of #685 to give web users a way to drop credentials. It's gated:
+
+```dart
+if (kIsWeb)
+  _LogoutButton(
+    onLogout: () async {
+      await performWebLogout(ProviderScope.containerOf(context, listen: false));
+      if (context.mounted) context.go(AppRoutes.login);
+    },
+  ),
+```
+
+The gate exists because at the time, native had a `/contexts` screen as the primary identity-management surface (switch / add / delete contexts), and the design preference was to keep the nav shell minimal on native. Web didn't have `/contexts` in its primary nav, so logout went there directly.
+
+In practice this leaves native users with no fast path to "log out" — they must navigate to `/contexts`, find the active context, delete it. The `_handleAuthExpired` 401-interceptor path from #685 _does_ deactivate via `performWebLogout`, but a user can't manually trigger it.
+
+The `performWebLogout` implementation is platform-agnostic:
+
+```dart
+Future<void> performWebLogout(ProviderContainer container) async {
+  container.read(spaceSelectionProvider.notifier).clear();
+  await container.read(activeContextProvider.notifier).deactivate();
+}
+```
+
+`SpaceSelectionStorage` no-ops on native, so the `clear()` call is a cheap state reset. `deactivate()` clears the active context ID; the router redirect lands at `/login`. The login screen on native already handles both legacy-token and OAuth paths.
+
+There's no platform-specific reason for the gate. It's just a leftover from the original review.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Native users (mac, iOS) get a discoverable logout affordance in the nav shell — same icon, same position, same behavior as on web.
+- The function name reflects its platform-agnostic nature (`performLogout`, not `performWebLogout`).
+- No new failure modes: existing #685 / #687 tests pass unchanged after the rename.
+
+**Non-Goals:**
+
+- Confirmation dialog (mac/iOS users might appreciate it; defer).
+- Distinct post-logout destination on native (e.g., go to `/contexts` instead of `/login`). Current behavior is consistent and works.
+- Logging out across multiple devices.
+- Removing the `/contexts` screen on native (the user might still want it for context management).
+
+## Decisions
+
+### Decision 1: Drop the `kIsWeb` gate, period
+
+The simplest possible change: delete `if (kIsWeb)` and let the logout button render on every platform. No conditional placement, no per-platform copy, no different post-logout flow.
+
+### Decision 2: Rename `performWebLogout` → `performLogout`
+
+The function was named with `Web` because of its original caller. Now that both web and native call it, the name is misleading. Rename to `performLogout`. Update:
+
+- `app/lib/shared/auth_actions.dart` — the function definition and dartdoc.
+- `app/lib/shared/nav_shell.dart` — the call site.
+- `app/lib/features/connection/connection_provider.dart` — `_handleAuthExpired` calls it.
+- `app/test/unit/spaces/logout_resets_space_selection_test.dart` — test file uses the function.
+
+The two openspec specs that mention the old name (`web-401-recovery`, `space-selector-resilience`) are updated as **MODIFIED Requirements** with the new name. No behavior change to the requirements themselves.
+
+### Decision 3: No confirmation dialog
+
+A confirmation dialog ("Sign out?") is reasonable on native where logout is more disruptive (no SW caching). But it adds widget surface and complicates testing. Defer until someone actually requests it.
+
+## Risks / Trade-offs
+
+- **A user might tap the logout button accidentally on native** and lose session state. Mitigation: same risk exists on web today; no incidents reported. If it becomes an issue, add the confirm dialog as a follow-up.
+- **The rename creates churn in two existing specs** (`web-401-recovery`, `space-selector-resilience`). Mitigation: the spec deltas are mechanical — `MODIFIED Requirements` blocks that copy the original text with the function name swapped. Reviewers can compare line-by-line.
+
+## Migration Plan
+
+1. Land in one PR. Three small code edits + one test rename.
+2. Native app builds (`flutter build macos`, `flutter build ios`) include the button on next release.
+3. **Rollback**: revert. Web behavior unchanged either way.
+
+## Open Questions
+
+- Does iOS have any platform-specific UX guideline against an in-nav logout button? (Apple HIG generally puts it under Settings.) Not blocking — we already have nav-level logout on web; consistency wins. If HIG-conformance is a concern later, move it to a Settings sub-screen on iOS only.

--- a/openspec/changes/logout-on-native/proposal.md
+++ b/openspec/changes/logout-on-native/proposal.md
@@ -1,0 +1,56 @@
+```
+       Before this change                       After this change
+
+       ┌──────────────────┐                     ┌──────────────────┐
+       │  Chat            │                     │  Chat            │
+       │  Skills          │                     │  Skills          │
+       │  Workflows       │                     │  Workflows       │
+       │  Personas        │                     │  Personas        │
+       │  …               │                     │  …               │
+       │                  │                     │                  │
+       │  Default Org     │                     │  Default Org     │
+       │  Default Space   │                     │  Default Space   │
+       │  [⏏  contexts ]  │   ← native only     │  [⏏  contexts ]  │
+       │                  │                     │  [⏻  log out  ]  │   ← new on native
+       │  Settings        │                     │  Settings        │
+       └──────────────────┘                     └──────────────────┘
+
+           web:                                    web:
+       ┌──────────────────┐                     ┌──────────────────┐
+       │  …               │                     │  …               │
+       │  [⏻  log out  ]  │   ← only here       │  [⏻  log out  ]  │   unchanged
+       │                  │                                              ↑
+       └──────────────────┘                     └──────────────────┘  same code path
+```
+
+## Why
+
+The logout button in the navigation shell (`app/lib/shared/nav_shell.dart:653`) is gated behind `if (kIsWeb)`. Native users (mac, iOS) have no logout affordance at all — the only way to drop credentials and re-authenticate is to delete the active context entirely from the `/contexts` screen. Users report being unable to test re-login flows or clear stale credential state on native. Long-standing gap; surfaced now because the post-#685 401-recovery code is not exercisable on native without a way to log out.
+
+## What Changes
+
+- Remove the `kIsWeb` gate around `_LogoutButton` in `nav_shell.dart`. The button shows on every platform.
+- Rename `performWebLogout` → `performLogout` in `app/lib/shared/auth_actions.dart`. The implementation is already platform-agnostic (clears `spaceSelectionProvider`, then deactivates the active context). Update the only caller in `nav_shell.dart` and the existing call from `connection_provider.dart`'s `_handleAuthExpired`.
+- Update the unit test (`app/test/unit/spaces/logout_resets_space_selection_test.dart`) to use the new name. No new tests required — behavior on web is unchanged; native gets the same well-tested path.
+
+## Capabilities
+
+### New Capabilities
+
+(none — this is just a gate removal and a rename.)
+
+### Modified Capabilities
+
+- `web-401-recovery` (from #685): the spec mentions `performWebLogout` by name in commentary; update the reference to `performLogout`. No behavior change to the requirements themselves.
+- `space-selector-resilience` (from #685): same — references to `performWebLogout` updated to `performLogout`.
+
+## Impact
+
+- **Code touched**: `app/lib/shared/nav_shell.dart` (drop `kIsWeb`), `app/lib/shared/auth_actions.dart` (rename), `app/lib/features/connection/connection_provider.dart` (call-site rename), `app/test/unit/spaces/logout_resets_space_selection_test.dart` (test name + import).
+- **Tests**: none added; existing test renamed.
+- **Behavior change**: native users can now log out from the nav shell. Web behavior identical.
+- **Non-goals**:
+  - Confirmation dialog before logout. Could add later; out of scope.
+  - Different post-logout behavior on native (e.g., redirect to `/contexts` instead of `/login`). Current router redirect on `!hasContext` already lands at `/login`; the login screen on native handles legacy-token + OAuth, so the path works.
+  - Cross-tab / cross-device session termination.
+- **User-facing documentation needed**: No.

--- a/openspec/changes/logout-on-native/specs/logout-on-native/spec.md
+++ b/openspec/changes/logout-on-native/specs/logout-on-native/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Logout affordance is available on every platform
+
+The nav shell SHALL render the logout button on every platform (web, macOS, iOS), not just web. There MUST NOT be a `kIsWeb` (or equivalent platform) gate around the logout entry point.
+
+#### Scenario: Native nav shell shows logout
+
+- **WHEN** the app runs on macOS or iOS AND the user is authenticated
+- **THEN** the nav shell SHALL render a logout button in the same position and shape as on web
+
+#### Scenario: Native logout calls performLogout
+
+- **WHEN** the user taps the logout button on macOS or iOS
+- **THEN** the handler SHALL call `performLogout(container)` AND THEN navigate the router to `/login`
+
+#### Scenario: Web logout — no behavior change
+
+- **WHEN** the user taps the logout button on web
+- **THEN** the same `performLogout` flow SHALL run as before this change (no regression)
+
+### Requirement: The shared logout helper is named platform-agnostically
+
+The function previously named `performWebLogout` SHALL be renamed `performLogout`. The implementation SHALL be unchanged: clear `spaceSelectionProvider`, then call `activeContextProvider.notifier.deactivate()`.
+
+#### Scenario: Function rename — call sites updated
+
+- **WHEN** any caller (nav shell logout handler, 401 interceptor's `_handleAuthExpired`) invokes the helper
+- **THEN** the function SHALL be `performLogout(ProviderContainer)` — no caller still references `performWebLogout`
+
+#### Scenario: Existing tests still pass
+
+- **WHEN** `flutter test test/unit/spaces/logout_resets_space_selection_test.dart` runs
+- **THEN** all assertions SHALL still hold against `performLogout` (the test file is updated to use the new name; semantics unchanged)

--- a/openspec/changes/logout-on-native/specs/space-selector-resilience/spec.md
+++ b/openspec/changes/logout-on-native/specs/space-selector-resilience/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: Logout resets in-memory space selection
+
+The logout handler (`app/lib/shared/nav_shell.dart`) SHALL reset `spaceSelectionProvider` to its initial empty state before deactivating the active context, on every platform (web, macOS, iOS). The interceptor-driven deactivation path (see `web-401-recovery`) SHALL also clear the selection. Both paths route through the shared `performLogout` helper.
+
+#### Scenario: User clicks logout
+
+- **WHEN** the user taps the logout button in the nav shell
+- **THEN** the handler SHALL call `performLogout(container)` (which calls `spaceSelectionProvider.notifier.clear()` AND THEN `activeContextProvider.notifier.deactivate()`) AND THEN navigate to `/login`
+
+#### Scenario: 401 interceptor deactivates the session
+
+- **WHEN** the 401 interceptor's refresh attempt fails AND it invokes the auth-expired callback
+- **THEN** the same `performLogout` shape SHALL run — clear selection then deactivate
+
+#### Scenario: Next login starts with empty selection
+
+- **WHEN** the user re-authenticates after a logout (manual or interceptor-driven)
+- **THEN** `spaceSelectionProvider` SHALL be in its initial state with `orgId == null` AND `spaceId == null` AND the auto-select flow on `/spaces` SHALL run from scratch

--- a/openspec/changes/logout-on-native/specs/web-401-recovery/spec.md
+++ b/openspec/changes/logout-on-native/specs/web-401-recovery/spec.md
@@ -1,0 +1,10 @@
+## MODIFIED Requirements
+
+### Requirement: Router redirects to login after deactivation
+
+The router (`app_router.dart`) SHALL redirect to `/login` whenever the active context becomes null while the user is on a protected route. This requirement is satisfied by the existing redirect rule at `app_router.dart:128-130`; this spec ratifies that the interceptor's `deactivate()` call (via `performLogout`) MUST be the trigger for that redirect when 401 recovery fails.
+
+#### Scenario: Interceptor deactivation triggers login redirect
+
+- **WHEN** the interceptor's auth-expired path runs `performLogout` (which calls `activeContextProvider.notifier.deactivate()`) while the user is on `/chat` or any other authenticated route
+- **THEN** the next router redirect evaluation SHALL produce `/login` AND the user SHALL be navigated there without manual interaction

--- a/openspec/changes/logout-on-native/tasks.md
+++ b/openspec/changes/logout-on-native/tasks.md
@@ -1,0 +1,17 @@
+## 1. Code edits
+
+- [x] 1.1 In `app/lib/shared/nav_shell.dart`, remove the `if (kIsWeb)` gate around `_LogoutButton`. The button now renders unconditionally.
+- [x] 1.2 In `app/lib/shared/auth_actions.dart`, rename `performWebLogout` → `performLogout`. Update the dartdoc to drop the "on the web" framing.
+- [x] 1.3 In `app/lib/features/connection/connection_provider.dart`, update the call from `_handleAuthExpired` (the 401 interceptor's callback wiring) to use `performLogout`.
+- [x] 1.4 In `app/lib/shared/nav_shell.dart`, update the logout handler's call site to use `performLogout`.
+- [x] 1.5 Rename `app/test/unit/spaces/logout_resets_space_selection_test.dart`'s test description and call sites to reference `performLogout` (file path stays the same).
+
+## 2. Smoke + ship
+
+- [x] 2.1 `flutter analyze --fatal-infos` → 0 issues.
+- [x] 2.2 `flutter test` → all green (existing tests; no new tests added).
+- [x] 2.3 `flutter build macos` succeeds (sanity that native still compiles).
+- [x] 2.4 Manual smoke: in the running mac app, confirm the logout button is now visible in the nav shell. Tap it → land on `/login`.
+- [ ] 2.5 PR: `feat(app): expose logout on native (rename performWebLogout → performLogout)`. Body links the four scenarios.
+- [ ] 2.6 Merge.
+- [ ] 2.7 Archive: `openspec archive logout-on-native`.


### PR DESCRIPTION
## Summary

The logout button in the nav shell was gated \`if (kIsWeb)\` since #685, leaving mac/iOS users with no way to drop credentials short of deleting the active context from \`/contexts\`. This drops the gate and renames the helper to match its now-platform-agnostic behavior.

## What changed

- \`nav_shell.dart\` — remove \`if (kIsWeb)\` around \`_LogoutButton\`.
- \`auth_actions.dart\` — rename \`performWebLogout\` → \`performLogout\`; update dartdoc.
- \`connection_provider.dart\` (401 interceptor's \`_handleAuthExpired\`) and \`logout_resets_space_selection_test.dart\` — call-site renames.
- \`nav_shell_test.dart\` "5.8" — flipped from "Logout absent on non-web" to "Logout present on every platform" so the new behavior is pinned by a test.

## Test plan

- [x] \`flutter analyze --fatal-infos\` — 0 issues
- [x] \`flutter test\` — 795/795 green
- [ ] Manual: open the mac app, confirm the logout button is in the nav shell and tapping it lands on \`/login\`.

Spec: [openspec/changes/logout-on-native/](openspec/changes/logout-on-native/) (with ASCII art!)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Logout functionality is now available on native platforms (macOS/iOS) through the navigation shell, providing a consistent logout experience across all supported platforms.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cedricziel/assistant/pull/689)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->