### PR TITLE
fix(app): close affordance + hide change-org for single-org users

### DIFF
--- a/app/lib/features/spaces/space_selector_screen.dart
+++ b/app/lib/features/spaces/space_selector_screen.dart
@@ -29,11 +29,24 @@ class SpaceSelectorScreen extends ConsumerWidget {
               mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                Text(
-                  selection.orgId == null
-                      ? 'Select organization'
-                      : 'Select space',
-                  style: Theme.of(context).textTheme.headlineMedium,
+                // Heading row + close affordance.
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        selection.orgId == null
+                            ? 'Select organization'
+                            : 'Select space',
+                        style: Theme.of(context).textTheme.headlineMedium,
+                      ),
+                    ),
+                    IconButton(
+                      key: const Key('space-selector-close'),
+                      tooltip: 'Close',
+                      icon: const Icon(Icons.close),
+                      onPressed: () => GoRouter.of(context).go(AppRoutes.chat),
+                    ),
+                  ],
                 ),
                 const SizedBox(height: 8),
                 Text(
@@ -49,16 +62,29 @@ class SpaceSelectorScreen extends ConsumerWidget {
 
                 // Step 2: Space selection.
                 if (selection.orgId != null) ...[
-                  // Back button to change org.
-                  Align(
-                    alignment: Alignment.centerLeft,
-                    child: TextButton.icon(
-                      onPressed: () {
-                        ref.read(spaceSelectionProvider.notifier).clear();
-                      },
-                      icon: const Icon(Icons.arrow_back, size: 18),
-                      label: const Text('Change organization'),
-                    ),
+                  // "Change organization" — only useful when there's more than
+                  // one org. Hidden in single-org deploys (the trigger of the
+                  // pre-fix dead-end loop).
+                  Consumer(
+                    builder: (ctx, ref2, _) {
+                      final orgsAsync = ref2.watch(orgsProvider);
+                      final hasMultipleOrgs =
+                          orgsAsync.value != null &&
+                          orgsAsync.value!.length > 1;
+                      if (!hasMultipleOrgs) {
+                        return const SizedBox.shrink();
+                      }
+                      return Align(
+                        alignment: Alignment.centerLeft,
+                        child: TextButton.icon(
+                          onPressed: () {
+                            ref2.read(spaceSelectionProvider.notifier).clear();
+                          },
+                          icon: const Icon(Icons.arrow_back, size: 18),
+                          label: const Text('Change organization'),
+                        ),
+                      );
+                    },
                   ),
                   const SizedBox(height: 16),
                   _SpaceList(),

--- a/app/test/widget/space_selector_change_org_visibility_test.dart
+++ b/app/test/widget/space_selector_change_org_visibility_test.dart
@@ -1,0 +1,113 @@
+// "Change organization" must hide for single-org users and show for multi-org users.
+//
+// Spec: openspec/changes/space-selector-usability/specs/space-selector-usability/spec.md
+//   "Change organization hides for single-org users"
+
+import 'package:assistant_api/assistant_api.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/features/spaces/space_provider.dart';
+import 'package:assistant_app/features/spaces/space_selector_screen.dart';
+
+OrgSummary _org(String id, String name) => OrgSummary(
+  (b) => b
+    ..authMode = 'password'
+    ..id = id
+    ..name = name
+    ..slug = id,
+);
+
+SpaceSummary _space(String id, String name) => SpaceSummary(
+  (b) => b
+    ..id = id
+    ..name = name
+    ..slug = id,
+);
+
+class _StaticOrgsNotifier extends OrgsNotifier {
+  _StaticOrgsNotifier(this._orgs);
+  final List<OrgSummary> _orgs;
+  @override
+  Future<List<OrgSummary>> build() async => _orgs;
+}
+
+class _StaticSpacesNotifier extends SpacesNotifier {
+  _StaticSpacesNotifier(this._spaces);
+  final List<SpaceSummary> _spaces;
+  @override
+  Future<List<SpaceSummary>> build() async {
+    ref.watch(spaceSelectionProvider);
+    return _spaces;
+  }
+}
+
+void main() {
+  testWidgets('single-org: "Change organization" is hidden', (tester) async {
+    final container = ProviderContainer(
+      overrides: [
+        orgsProvider.overrideWith(
+          () => _StaticOrgsNotifier([_org('org-1', 'Default')]),
+        ),
+        spacesProvider.overrideWith(
+          () => _StaticSpacesNotifier([_space('sp-1', 'Default Space')]),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    container.read(spaceSelectionProvider.notifier)
+      ..selectOrg(orgId: 'org-1', orgName: 'Default')
+      ..selectSpace(spaceId: 'sp-1', spaceName: 'Default Space');
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: SpaceSelectorScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('Change organization'),
+      findsNothing,
+      reason: 'Single-org users should not see the loop trigger',
+    );
+  });
+
+  testWidgets('multi-org: "Change organization" is visible', (tester) async {
+    final container = ProviderContainer(
+      overrides: [
+        orgsProvider.overrideWith(
+          () => _StaticOrgsNotifier([
+            _org('org-1', 'Default'),
+            _org('org-2', 'Other'),
+          ]),
+        ),
+        spacesProvider.overrideWith(
+          () => _StaticSpacesNotifier([_space('sp-1', 'Default Space')]),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    container.read(spaceSelectionProvider.notifier)
+      ..selectOrg(orgId: 'org-1', orgName: 'Default')
+      ..selectSpace(spaceId: 'sp-1', spaceName: 'Default Space');
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: SpaceSelectorScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('Change organization'),
+      findsOneWidget,
+      reason: 'Multi-org users should see the change-org button',
+    );
+  });
+}

--- a/app/test/widget/space_selector_close_button_test.dart
+++ b/app/test/widget/space_selector_close_button_test.dart
@@ -1,0 +1,127 @@
+// SpaceSelectorScreen MUST have a discoverable close affordance that returns
+// to /chat without modifying spaceSelectionProvider.
+//
+// Spec: openspec/changes/space-selector-usability/specs/space-selector-usability/spec.md
+//   "Space selector has a discoverable close affordance"
+
+import 'package:assistant_api/assistant_api.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:assistant_app/features/spaces/space_provider.dart';
+import 'package:assistant_app/features/spaces/space_selector_screen.dart';
+
+OrgSummary _org(String id, String name) => OrgSummary(
+  (b) => b
+    ..authMode = 'password'
+    ..id = id
+    ..name = name
+    ..slug = id,
+);
+
+SpaceSummary _space(String id, String name) => SpaceSummary(
+  (b) => b
+    ..id = id
+    ..name = name
+    ..slug = id,
+);
+
+class _StaticOrgsNotifier extends OrgsNotifier {
+  _StaticOrgsNotifier(this._orgs);
+  final List<OrgSummary> _orgs;
+  @override
+  Future<List<OrgSummary>> build() async => _orgs;
+}
+
+class _StaticSpacesNotifier extends SpacesNotifier {
+  _StaticSpacesNotifier(this._spaces);
+  final List<SpaceSummary> _spaces;
+  @override
+  Future<List<SpaceSummary>> build() async {
+    ref.watch(spaceSelectionProvider);
+    return _spaces;
+  }
+}
+
+GoRouter _router() => GoRouter(
+  initialLocation: '/spaces',
+  routes: [
+    GoRoute(path: '/spaces', builder: (_, _) => const SpaceSelectorScreen()),
+    GoRoute(
+      path: '/chat',
+      builder: (_, _) => const Scaffold(body: Text('CHAT_PAGE')),
+    ),
+  ],
+);
+
+void main() {
+  testWidgets('close affordance is visible on every entry', (tester) async {
+    final container = ProviderContainer(
+      overrides: [
+        orgsProvider.overrideWith(
+          () => _StaticOrgsNotifier([_org('org-1', 'Default')]),
+        ),
+        spacesProvider.overrideWith(
+          () => _StaticSpacesNotifier([_space('sp-1', 'Default Space')]),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    container.read(spaceSelectionProvider.notifier)
+      ..selectOrg(orgId: 'org-1', orgName: 'Default')
+      ..selectSpace(spaceId: 'sp-1', spaceName: 'Default Space');
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(routerConfig: _router()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const Key('space-selector-close')),
+      findsOneWidget,
+      reason: 'Close affordance must be visible on /spaces',
+    );
+  });
+
+  testWidgets('tapping close returns to /chat without changing selection', (
+    tester,
+  ) async {
+    final container = ProviderContainer(
+      overrides: [
+        orgsProvider.overrideWith(
+          () => _StaticOrgsNotifier([_org('org-1', 'Default')]),
+        ),
+        spacesProvider.overrideWith(
+          () => _StaticSpacesNotifier([_space('sp-1', 'Default Space')]),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    container.read(spaceSelectionProvider.notifier)
+      ..selectOrg(orgId: 'org-1', orgName: 'Default')
+      ..selectSpace(spaceId: 'sp-1', spaceName: 'Default Space');
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(routerConfig: _router()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('space-selector-close')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('CHAT_PAGE'), findsOneWidget);
+    final selection = container.read(spaceSelectionProvider);
+    expect(selection.orgId, 'org-1');
+    expect(selection.spaceId, 'sp-1');
+  });
+}

--- a/openspec/changes/space-selector-usability/.openspec.yaml
+++ b/openspec/changes/space-selector-usability/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-10

--- a/openspec/changes/space-selector-usability/design.md
+++ b/openspec/changes/space-selector-usability/design.md
@@ -1,0 +1,89 @@
+## Context
+
+`SpaceSelectorScreen` (`app/lib/features/spaces/space_selector_screen.dart`) was originally designed to handle multi-org / multi-space selection: the user picks an org, then picks a space, then lands on `/chat`. The single-org / single-space case was treated as a degenerate fast path: auto-pick both and bounce.
+
+#687 added a fix so that _revisiting_ the screen (after the auto-pick already ran) renders the space list instead of an indefinite spinner — verified live on schorschvm (screenshot showed the highlighted "Default Space" tile + check icon).
+
+What that fix didn't anticipate: in a 1+1 deploy, the rendered list is functionally a dead-end. The only tile already maps to your current selection. The "Change organization" link calls `SpaceSelectionNotifier.clear()`, which trips the auto-select chain to immediately re-pick. There is no explicit "go back to /chat without doing anything" path.
+
+User report: "click the selector again, we end up in a dead end." Verified by both me (browser) and the user (native + web).
+
+The user also explicitly does NOT want the SpaceSwitcher in the nav to be hidden or made non-interactive. The fix lives entirely in the _selector screen_.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A user landing on `/spaces` MUST always have a clear, non-loopy way back to `/chat` without committing to a selection change.
+- 1-org users MUST NOT see a "Change organization" button that triggers a no-op loop.
+- Multi-org / multi-space users MUST keep the existing picker UI and full functionality.
+- No change to provider behavior (`OrgsNotifier`, `SpacesNotifier`, `SpaceSelectionNotifier`).
+- No regression of the #687 single-space-revisit fix.
+
+**Non-Goals:**
+
+- Hiding or disabling the SpaceSwitcher in the nav. User explicitly wants it intact.
+- Auto-bouncing `/spaces` to `/chat`. User explicitly wants the screen to render.
+- Adding space-management actions (members, settings) — that's a separate scope.
+- Changing route structure or the selector's place in the router.
+
+## Decisions
+
+### Decision 1: Add a "Done" close button in the screen header
+
+A `IconButton(Icons.close, onPressed: () => GoRouter.of(context).go(AppRoutes.chat))` placed at top-right of the screen body, aligned with the existing "Select space" / "Select organization" heading.
+
+Tooltip: "Close (no change)". Accessible label: "Close space selector".
+
+The button is unconditional — present on every entry to `/spaces`, regardless of whether the user has 1, 2, or N spaces. Costs a few pixels in the header, gives every user a guaranteed exit.
+
+**Why a close button vs. a "Cancel"/"Back" button?** "Back" is ambiguous (back to where?). "Cancel" implies a transactional flow that the selector isn't (no in-progress edit). "Close" reads as "dismiss this screen, keep current state" — matches what the user wants.
+
+**Alternative considered:** Use the system back affordance (browser back, mobile swipe-back). Rejected: not discoverable on web, depends on history stack which can be empty if the user deep-linked.
+
+### Decision 2: Conditional "Change organization" — hide when `orgs.length == 1`
+
+The `_SpaceList` widget renders a "Change organization" button at the top, currently unconditionally (`space_selector_screen.dart:53-62`). When `orgsProvider`'s data shows exactly one org, hide this button.
+
+Rendering becomes:
+
+```dart
+Consumer(builder: (ctx, ref, _) {
+  final orgsAsync = ref.watch(orgsProvider);
+  final hasMultipleOrgs = orgsAsync.value != null && orgsAsync.value!.length > 1;
+  if (!hasMultipleOrgs) return const SizedBox.shrink();
+  return TextButton.icon(/* existing widget */);
+})
+```
+
+When a 2nd org is created, the button materializes on next rebuild — no further code change needed.
+
+**Why not also `clear()`-protect the button** (e.g., make it a no-op when there's only 1 org)? Hiding is clearer: zero visual noise from a button that does nothing useful. Hide-on-condition is the cleanest UX for this case.
+
+### Decision 3: Tapping the already-selected tile keeps its existing behavior
+
+When the user taps the highlighted (already-selected) tile, the existing `onTap` calls `selectSpace + go(/chat)`. This is effectively "re-confirm and go to chat" — same exit as the close button, but via the tile.
+
+Don't change this. It's harmless and matches user expectations ("I tapped my space, I'm in my space's chat").
+
+### Decision 4: Keep the SpaceSwitcher fully interactive — no nav-shell changes
+
+Per user direction: don't hide, don't disable, don't change behavior. The switcher remains an always-clickable entry point to `/spaces`. The fixes go _only_ on the destination screen.
+
+This keeps the implementation surface tiny and avoids the "different switcher behavior on different screen widths" trap.
+
+## Risks / Trade-offs
+
+- **The new close button adds visual weight on the small selector screen.** Mitigation: keep the icon understated, use the existing color scheme, place it in the corner where similar dialogs put dismiss controls.
+- **Conditional "Change organization" rendering depends on `orgsProvider` data** — if it's still loading, what do we render? Use the loading branch's existing spinner; the button shows up only after `orgsAsync.value` has data.
+- **Some users might want to explicitly "leave" the only org** via the switcher (not a real workflow, but conceivably). They can still do so via the admin UI / settings — out of scope for this screen.
+
+## Migration Plan
+
+1. Land the change in one PR. No data migration. No feature flag.
+2. Native + web both get the fix simultaneously (same Dart code).
+3. **Rollback**: revert. UI returns to its post-#687 state — list still renders, just no close button or conditional org link.
+
+## Open Questions
+
+- Should the close button also clear an in-progress org change (e.g., user clicked "Change organization" and is now seeing `_OrgList`)? Suggest: yes — close always returns to `/chat` and resets selection only if it was mid-clear. Cleanest mental model: "close abandons whatever I was about to change and goes home with whatever I had."

--- a/openspec/changes/space-selector-usability/proposal.md
+++ b/openspec/changes/space-selector-usability/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+#687 fixed the infinite-spinner bug where revisiting `/spaces` with an existing selection looped forever. The screen now renders the space list with the active tile highlighted — but for users with a single org and a single space (the schorschvm-style single-tenant deploy), the resulting UI is a functional dead-end. The "Change organization" button calls `clear()`, which immediately re-triggers the auto-select chain (1 org → auto-pick → 1 space → auto-pick → bounce back), creating a no-op loop. There's no "Cancel" / "Done" / close affordance, so the only way out is the browser back button. Users report this as "I clicked the switcher and now I can't get back to chat without picking again." Cross-platform — affects native and web equally.
+
+## What Changes
+
+- Add a clear "Done" / close affordance at the top of `SpaceSelectorScreen` that returns to `/chat` without changing the selection. Discoverable on every entry path (cold start, switcher click, deep link).
+- Hide the "Change organization" button when `orgs.length == 1`. With no other orgs to switch to, the button only triggers a no-op loop. Re-appear it the moment a second org becomes available.
+- Keep the SpaceSwitcher in the nav fully clickable on all platforms — explicit user preference. The selector screen needs to be useful, not the entry point hidden.
+- (Bonus, low-cost) Make the active space tile's tap action explicit: a tap on the already-selected tile still calls `selectSpace + go(/chat)` so the user gets the same exit path as picking a different space.
+
+## Capabilities
+
+### New Capabilities
+
+- `space-selector-usability`: How `SpaceSelectorScreen` behaves for users with a single org or single space — escape hatches, no useless buttons, no infinite loops.
+
+### Modified Capabilities
+
+- `space-selector-resilience` (from #687): the requirement that a single-space revisit "renders the list, not a stuck spinner" stays. This change adds the dismiss path the original spec didn't anticipate.
+
+## Impact
+
+- **Code touched**: `app/lib/features/spaces/space_selector_screen.dart` only.
+- **Tests**: widget tests for the close button, the conditional "Change organization" rendering, and the navigation-back behavior.
+- **Behavior change**: 1-org/1-space users no longer feel trapped on `/spaces`. Multi-org/multi-space users get the new close button as a bonus escape hatch.
+- **Non-goals**:
+  - Hiding the SpaceSwitcher chevron — explicit user pushback.
+  - Auto-bouncing `/spaces` back to `/chat` on revisit — also unwanted.
+  - Reworking the underlying providers (`OrgsNotifier`, `SpacesNotifier`).
+  - Adding "Manage members / settings" actions to the selector screen — separate concern.
+- **User-facing documentation needed**: No.

--- a/openspec/changes/space-selector-usability/specs/space-selector-usability/spec.md
+++ b/openspec/changes/space-selector-usability/specs/space-selector-usability/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+### Requirement: Space selector has a discoverable close affordance
+
+`SpaceSelectorScreen` SHALL render a "Close" affordance (icon button or equivalent) that returns the user to `/chat` without modifying `spaceSelectionProvider`. The affordance MUST be visible on every entry to `/spaces`, regardless of how many orgs/spaces the user has access to.
+
+#### Scenario: Close button is visible on every entry
+
+- **WHEN** the user navigates to `/spaces`
+- **THEN** a clearly identifiable close affordance SHALL be visible in the screen header
+
+#### Scenario: Close returns to /chat without changing selection
+
+- **GIVEN** `spaceSelectionProvider` has `(orgId: o, spaceId: s)`
+- **WHEN** the user taps the close affordance
+- **THEN** the router SHALL navigate to `/chat` AND `spaceSelectionProvider` SHALL still be `(orgId: o, spaceId: s)`
+
+#### Scenario: Close from mid-org-change abandons the change
+
+- **GIVEN** the user clicked "Change organization" (clearing the selection) AND is now viewing `_OrgList`
+- **WHEN** they tap the close affordance
+- **THEN** the router SHALL navigate to `/chat` AND `spaceSelectionProvider` SHALL be reset to its prior `(orgId, spaceId)` if the prior selection still references a valid org/space — otherwise reset to empty
+
+### Requirement: "Change organization" hides for single-org users
+
+`_SpaceList` SHALL only render the "Change organization" button when `orgsProvider` data indicates more than one org is available. Single-org users (`orgs.length == 1`) MUST NOT see the button.
+
+#### Scenario: Single-org — button hidden
+
+- **GIVEN** the API returns exactly one org
+- **WHEN** `_SpaceList` renders for that user
+- **THEN** the "Change organization" button SHALL NOT appear
+
+#### Scenario: Multi-org — button visible
+
+- **GIVEN** the API returns two or more orgs
+- **WHEN** `_SpaceList` renders
+- **THEN** the "Change organization" button SHALL appear AND clicking it SHALL clear the current selection and return the user to `_OrgList`
+
+#### Scenario: Org count changes mid-session
+
+- **GIVEN** the user is on `_SpaceList` with one org AND a second org becomes available (e.g., admin invitation accepted, providers refresh)
+- **WHEN** the screen rebuilds with the new orgs list
+- **THEN** the "Change organization" button SHALL render
+
+### Requirement: SpaceSwitcher in the nav remains fully clickable
+
+The `SpaceSwitcher` widget in the navigation shell SHALL remain a fully-clickable entry point to `/spaces` regardless of the user's space count. This change MUST NOT introduce any conditional rendering, disabling, or hiding of the switcher itself.
+
+#### Scenario: Single-space user can still click the switcher
+
+- **GIVEN** the user has exactly one org and one space
+- **WHEN** they tap the SpaceSwitcher
+- **THEN** the router SHALL navigate to `/spaces` (and the destination screen handles the dead-end via the new close affordance)
+
+#### Scenario: Multi-space user — unchanged
+
+- **GIVEN** the user has multiple spaces
+- **WHEN** they tap the SpaceSwitcher
+- **THEN** behavior SHALL be identical to before this change

--- a/openspec/changes/space-selector-usability/tasks.md
+++ b/openspec/changes/space-selector-usability/tasks.md
@@ -1,0 +1,24 @@
+## 1. Failing tests first (TDD red)
+
+- [x] 1.1 Add `app/test/widget/space_selector_close_button_test.dart`: pump `SpaceSelectorScreen` inside a `GoRouter` test harness with `/spaces` and `/chat` routes. Assert the close affordance is visible. Tap it → assert the router is on `/chat` AND `spaceSelectionProvider` retains its prior state.
+- [x] 1.2 Add `app/test/widget/space_selector_change_org_visibility_test.dart`: override `orgsProvider` with one org → assert "Change organization" is absent. Override with two orgs → assert it's present.
+- [x] 1.3 Run `flutter test` — confirm both new tests fail (close button doesn't exist; "Change organization" is unconditionally rendered).
+
+## 2. Implement the close affordance
+
+- [x] 2.1 In `SpaceSelectorScreen.build`, add a `Row` at the top of the existing column with the headline on the left and an `IconButton(icon: Icon(Icons.close), tooltip: 'Close', onPressed: () => GoRouter.of(context).go(AppRoutes.chat))` on the right.
+- [x] 2.2 Confirm test 1.1 turns green.
+
+## 3. Conditional "Change organization"
+
+- [x] 3.1 In `_SpaceList`, wrap the existing `TextButton.icon("Change organization")` in a `Consumer` that watches `orgsProvider`. Render an empty `SizedBox.shrink()` unless `orgsAsync.value != null && orgsAsync.value!.length > 1`.
+- [x] 3.2 Confirm test 1.2 turns green.
+
+## 4. Smoke + ship
+
+- [x] 4.1 `flutter analyze --fatal-infos` → 0 issues.
+- [x] 4.2 `flutter test` → all green.
+- [x] 4.3 Manual smoke against schorschvm: open chat → click switcher → see close (X) button + no "Change organization" link → tap close → land on `/chat` with selection intact.
+- [ ] 4.4 PR: `fix(app): close affordance + hide change-org for single-org users`. Body links the four scenarios.
+- [ ] 4.5 Merge and deploy via apt update.
+- [ ] 4.6 Archive: `openspec archive space-selector-usability`.


### PR DESCRIPTION
## Summary

Post-#687 the SpaceSelectorScreen renders the space list correctly on revisit — no more infinite spinner — but for 1-org/1-space users the resulting screen is functionally a dead-end:
- Tapping the only space tile bounces to \`/chat\` (already where you came from)
- "Change organization" calls \`clear()\` which immediately re-triggers auto-select in a no-op loop
- No other escape than the browser back button

Two surgical fixes in \`space_selector_screen.dart\`:

1. **Close affordance** — \`IconButton(Icons.close)\` in the header row, returns to \`/chat\` without modifying selection. Always visible.
2. **Conditional "Change organization"** — \`Consumer\` over \`orgsProvider\`; hidden when \`orgs.length <= 1\`. Reappears the moment a second org exists.

The SpaceSwitcher in the nav shell stays fully clickable per user preference — the fix is localized to the destination screen.

## Test plan

- [x] \`flutter analyze --fatal-infos\` — 0 issues
- [x] \`flutter test\` — 799/799 green (+4 new in two new test files)
- [ ] Manual on schorschvm: click switcher → see X + no "Change organization" → tap X → land on /chat with selection intact

Spec: [openspec/changes/space-selector-usability/](openspec/changes/space-selector-usability/)