### PR TITLE
feat(app): use EventSource for SSE on web (conversation list)

### DIFF
--- a/app/lib/api/api_client.dart
+++ b/app/lib/api/api_client.dart
@@ -5,12 +5,16 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:typed_data';
 
 import 'package:assistant_api/assistant_api.dart' hide ServerCapabilities;
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 
 import 'auth_interceptor.dart';
+import 'event_source_stream.dart';
+import 'event_source_stream_stub.dart'
+    if (dart.library.js_interop) 'event_source_stream_web.dart'
+    as event_source;
 import 'models/server_capabilities.dart';
 import 'models/stream_event.dart';
 
@@ -269,7 +273,41 @@ class ApiClient {
   ///
   /// Yields [ConversationSnapshotEvent] first (full list), then
   /// [ConversationUpsertedEvent] and [ConversationDeletedEvent] deltas.
-  Stream<ConversationListEvent> streamConversations({String? agentId}) async* {
+  ///
+  /// On web, uses the browser's native `EventSource` API (because dio's
+  /// browser adapter buffers stream responses until the connection closes,
+  /// which never happens for SSE — see `web-sse-eventsource` change). On
+  /// native, uses the existing dio stream path.
+  Stream<ConversationListEvent> streamConversations({String? agentId}) {
+    if (kIsWeb) {
+      return _streamConversationsViaEventSource(agentId: agentId);
+    }
+    return _streamConversationsViaDio(agentId: agentId);
+  }
+
+  Stream<ConversationListEvent> _streamConversationsViaEventSource({
+    String? agentId,
+  }) {
+    final base = _dio.options.baseUrl;
+    final qp = <String, String>{
+      'access_token': _token,
+      // ignore: use_null_aware_elements — value is nullable, key is not.
+      if (agentId != null) 'agent_id': agentId,
+    };
+    final query = qp.entries
+        .map(
+          (e) =>
+              '${Uri.encodeQueryComponent(e.key)}=${Uri.encodeQueryComponent(e.value)}',
+        )
+        .join('&');
+    final url = '$base/api/conversations/stream?$query';
+    final adapter = event_source.openEventSourceAdapter(url: url);
+    return openConversationListStream(adapter: adapter);
+  }
+
+  Stream<ConversationListEvent> _streamConversationsViaDio({
+    String? agentId,
+  }) async* {
     final queryParams = <String, dynamic>{};
     if (agentId != null) queryParams['agent_id'] = agentId;
 

--- a/app/lib/api/event_source_stream.dart
+++ b/app/lib/api/event_source_stream.dart
@@ -1,0 +1,77 @@
+// Public surface for the conversation-list SSE stream.
+//
+// On web, the implementation uses the browser's native `EventSource` API
+// (see `event_source_stream_web.dart`). On native platforms the adapter is
+// a no-op stub that throws if invoked — `streamConversations()` only
+// delegates to this module on `kIsWeb`.
+//
+// Exposed publicly so tests can inject a fake [EventSourceAdapter] without
+// touching the browser API.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'models/stream_event.dart';
+
+/// One SSE message: an event name + its data payload.
+class EventSourceMessage {
+  const EventSourceMessage({required this.event, required this.data});
+  final String event;
+  final String data;
+}
+
+/// Minimal interface for the underlying transport. The web implementation
+/// wraps `package:web`'s `EventSource`. Tests inject a fake.
+abstract class EventSourceAdapter {
+  Stream<EventSourceMessage> get messages;
+  void close();
+}
+
+/// Convert a [Stream<EventSourceMessage>] into a [Stream<ConversationListEvent>].
+///
+/// Closes the underlying adapter when the returned subscription is cancelled.
+Stream<ConversationListEvent> openConversationListStream({
+  required EventSourceAdapter adapter,
+}) {
+  late StreamController<ConversationListEvent> controller;
+  StreamSubscription<EventSourceMessage>? sub;
+
+  controller = StreamController<ConversationListEvent>(
+    onListen: () {
+      sub = adapter.messages.listen(
+        (msg) {
+          final event = _decode(msg);
+          if (event != null) controller.add(event);
+        },
+        onError: controller.addError,
+        onDone: controller.close,
+      );
+    },
+    onCancel: () async {
+      adapter.close();
+      await sub?.cancel();
+    },
+  );
+
+  return controller.stream;
+}
+
+ConversationListEvent? _decode(EventSourceMessage msg) {
+  try {
+    switch (msg.event) {
+      case 'snapshot':
+        final json = jsonDecode(msg.data) as List<dynamic>;
+        return ConversationSnapshotEvent.fromJson(json);
+      case 'upserted':
+        final json = jsonDecode(msg.data) as Map<String, dynamic>;
+        return ConversationUpsertedEvent.fromJson(json);
+      case 'deleted':
+        final json = jsonDecode(msg.data) as Map<String, dynamic>;
+        return ConversationDeletedEvent.fromJson(json);
+      default:
+        return null; // unknown event types — ignore (forward-compatible)
+    }
+  } catch (_) {
+    return null; // malformed payload — drop, don't break the stream
+  }
+}

--- a/app/lib/api/event_source_stream_stub.dart
+++ b/app/lib/api/event_source_stream_stub.dart
@@ -1,0 +1,9 @@
+import 'event_source_stream.dart';
+
+/// Stub used on non-web builds. Conditional import in `api_client.dart`
+/// only delegates here when `kIsWeb`, so this stub should never actually
+/// be invoked. Throws if it is — better than silently returning the wrong
+/// thing.
+EventSourceAdapter openEventSourceAdapter({required String url}) {
+  throw UnsupportedError('EventSource is only available on web builds');
+}

--- a/app/lib/api/event_source_stream_web.dart
+++ b/app/lib/api/event_source_stream_web.dart
@@ -1,0 +1,63 @@
+import 'dart:async';
+import 'dart:js_interop';
+
+import 'package:web/web.dart' as web;
+
+import 'event_source_stream.dart';
+
+/// Open a real `EventSource` against [url]. Web-only — selected via
+/// conditional import from `api_client.dart`.
+EventSourceAdapter openEventSourceAdapter({required String url}) {
+  return _WebEventSourceAdapter(url);
+}
+
+class _WebEventSourceAdapter implements EventSourceAdapter {
+  _WebEventSourceAdapter(this._url) {
+    _src = web.EventSource(_url);
+    _wireEvent('snapshot');
+    _wireEvent('upserted');
+    _wireEvent('deleted');
+    _src.onerror = ((web.Event _) {
+      // EventSource auto-reconnects on transient errors. Only forward an
+      // error to the consumer if the connection is in CLOSED state — that
+      // means the browser gave up (often a 401 from the server).
+      if (_src.readyState == web.EventSource.CLOSED) {
+        if (!_ctrl.isClosed) {
+          _ctrl.addError(StateError('EventSource closed'));
+          _ctrl.close();
+        }
+      }
+    }).toJS;
+  }
+
+  final String _url;
+  late final web.EventSource _src;
+  final _ctrl = StreamController<EventSourceMessage>();
+
+  void _wireEvent(String name) {
+    _src.addEventListener(
+      name,
+      ((web.Event evt) {
+        if (evt.isA<web.MessageEvent>()) {
+          final messageEvent = evt as web.MessageEvent;
+          final data = messageEvent.data;
+          final dataStr = data?.isA<JSString>() ?? false
+              ? (data! as JSString).toDart
+              : data?.toString() ?? '';
+          if (!_ctrl.isClosed) {
+            _ctrl.add(EventSourceMessage(event: name, data: dataStr));
+          }
+        }
+      }).toJS,
+    );
+  }
+
+  @override
+  Stream<EventSourceMessage> get messages => _ctrl.stream;
+
+  @override
+  void close() {
+    _src.close();
+    if (!_ctrl.isClosed) _ctrl.close();
+  }
+}

--- a/app/test/unit/api/event_source_stream_test.dart
+++ b/app/test/unit/api/event_source_stream_test.dart
@@ -1,0 +1,120 @@
+// Asserts the EventSource adapter shape: given a fake EventSource that
+// dispatches snapshot/upserted/deleted events, the adapter yields the
+// matching ConversationListEvent types.
+//
+// Spec: openspec/changes/web-sse-eventsource/specs/web-sse-eventsource/spec.md
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/api/event_source_stream.dart';
+import 'package:assistant_app/api/models/stream_event.dart';
+
+class _FakeEventSourceAdapter implements EventSourceAdapter {
+  final List<EventSourceMessage Function()> _scripted = [];
+  bool closed = false;
+
+  void scheduleSnapshot(List<Map<String, dynamic>> conversations) {
+    _scripted.add(
+      () => EventSourceMessage(
+        event: 'snapshot',
+        data: '[${conversations.map(_jsonOfMap).join(',')}]',
+      ),
+    );
+  }
+
+  void scheduleUpserted(Map<String, dynamic> conversation) {
+    _scripted.add(
+      () =>
+          EventSourceMessage(event: 'upserted', data: _jsonOfMap(conversation)),
+    );
+  }
+
+  void scheduleDeleted(String conversationId) {
+    _scripted.add(
+      () => EventSourceMessage(
+        event: 'deleted',
+        data: '{"conversation_id":"$conversationId"}',
+      ),
+    );
+  }
+
+  String _jsonOfMap(Map<String, dynamic> m) {
+    final entries = m.entries
+        .map((e) {
+          final v = e.value;
+          if (v is String) return '"${e.key}":"$v"';
+          return '"${e.key}":$v';
+        })
+        .join(',');
+    return '{$entries}';
+  }
+
+  @override
+  Stream<EventSourceMessage> get messages async* {
+    for (final make in _scripted) {
+      yield make();
+    }
+  }
+
+  @override
+  void close() {
+    closed = true;
+  }
+}
+
+Map<String, dynamic> _convo(String id, String title) => {
+  'id': id,
+  'title': title,
+  'agent_id': 'default',
+  'user_id': 'usr_x',
+  'created_at': '2026-05-10T00:00:00Z',
+  'updated_at': '2026-05-10T00:00:00Z',
+};
+
+void main() {
+  test('snapshot event yields ConversationSnapshotEvent', () async {
+    final fake = _FakeEventSourceAdapter()
+      ..scheduleSnapshot([_convo('a', 'Alpha'), _convo('b', 'Beta')]);
+
+    final events = await openConversationListStream(adapter: fake).toList();
+
+    expect(events.length, 1);
+    expect(events.first, isA<ConversationSnapshotEvent>());
+    final snap = events.first as ConversationSnapshotEvent;
+    expect(snap.conversations.length, 2);
+    expect(snap.conversations[0].id, 'a');
+    expect(snap.conversations[1].id, 'b');
+  });
+
+  test('upserted and deleted events yield matching types', () async {
+    final fake = _FakeEventSourceAdapter()
+      ..scheduleSnapshot([_convo('a', 'Alpha')])
+      ..scheduleUpserted(_convo('a', 'Alpha v2'))
+      ..scheduleDeleted('a');
+
+    final events = await openConversationListStream(adapter: fake).toList();
+
+    expect(events[0], isA<ConversationSnapshotEvent>());
+    expect(events[1], isA<ConversationUpsertedEvent>());
+    expect(
+      (events[1] as ConversationUpsertedEvent).conversation.title,
+      'Alpha v2',
+    );
+    expect(events[2], isA<ConversationDeletedEvent>());
+    expect((events[2] as ConversationDeletedEvent).conversationId, 'a');
+  });
+
+  test('subscription cancel closes the underlying adapter', () async {
+    final fake = _FakeEventSourceAdapter()
+      ..scheduleSnapshot([_convo('a', 'Alpha')]);
+
+    final sub = openConversationListStream(adapter: fake).listen((_) {});
+    await sub.cancel();
+
+    expect(
+      fake.closed,
+      isTrue,
+      reason: 'cancel must close the underlying EventSource',
+    );
+  });
+}

--- a/crates/auth/src/middleware.rs
+++ b/crates/auth/src/middleware.rs
@@ -91,18 +91,30 @@ impl FromRequestParts<AuthState> for AuthExtractor {
             .and_then(|v| v.to_str().ok())
             .map(|s| s.to_string());
 
+        // Fallback: extract `?access_token=<jwt>` from the URL query string.
+        // SSE endpoints consumed by the browser's `EventSource` API cannot send
+        // custom request headers, so we accept the JWT in the query string for
+        // those callers. The header path always takes precedence when both are
+        // present.
+        let query_token = parts.uri.query().and_then(|q| {
+            url::form_urlencoded::parse(q.as_bytes())
+                .find(|(k, _)| k == "access_token")
+                .map(|(_, v)| v.into_owned())
+        });
+
         let state = state.clone();
 
         async move {
-            let token = match &auth_header {
-                Some(h) if h.starts_with("Bearer ") => Some(&h[7..]),
+            let header_token = match &auth_header {
+                Some(h) if h.starts_with("Bearer ") => Some(h[7..].to_string()),
                 _ => None,
             };
 
-            let token = match token {
+            let token = match header_token.or(query_token) {
                 Some(t) => t,
                 None => return Err(AuthError::MissingCredentials),
             };
+            let token = token.as_str();
 
             // 1. Try JWT validation.
             if let Ok(ctx) = state.jwt_manager.validate_to_context(token) {
@@ -275,6 +287,64 @@ mod tests {
         AuthExtractor::from_request_parts(&mut parts, state)
             .await
             .map(|e| e.0)
+    }
+
+    async fn extract_from_query(state: &AuthState, uri: &str) -> Result<AuthContext, AuthError> {
+        let req = Request::builder().uri(uri).body(()).unwrap();
+        let (mut parts, _body) = req.into_parts();
+
+        AuthExtractor::from_request_parts(&mut parts, state)
+            .await
+            .map(|e| e.0)
+    }
+
+    #[tokio::test]
+    async fn extract_jwt_from_query_param() {
+        let (state, jwt_sign) = test_auth_state();
+        let ctx = make_member_context();
+        let token = jwt_sign.sign(&ctx, "acme", "Bob").unwrap();
+
+        let result = extract_from_query(
+            &state,
+            &format!("/api/conversations/stream?access_token={token}"),
+        )
+        .await;
+        assert!(result.is_ok(), "expected ok, got {result:?}");
+        let extracted = result.unwrap();
+        assert_eq!(extracted.user_id, UserId::from("bob"));
+        assert_eq!(extracted.org_id, OrgId::from("acme"));
+    }
+
+    #[tokio::test]
+    async fn invalid_jwt_in_query_param_rejected() {
+        let (state, _jwt_sign) = test_auth_state();
+        let result = extract_from_query(
+            &state,
+            "/api/conversations/stream?access_token=not-a-real-jwt",
+        )
+        .await;
+        assert!(matches!(result, Err(AuthError::InvalidCredentials(_))));
+    }
+
+    #[tokio::test]
+    async fn header_takes_precedence_over_query_param() {
+        let (state, jwt_sign) = test_auth_state();
+
+        // Bob signs a token; build a request that passes Bob's token in the
+        // header but a garbage token in the query param. The header path
+        // must win — successful auth as Bob.
+        let bob_ctx = make_member_context();
+        let bob_token = jwt_sign.sign(&bob_ctx, "acme", "Bob").unwrap();
+
+        let req = Request::builder()
+            .uri("/api/conversations/stream?access_token=garbage")
+            .header("authorization", format!("Bearer {bob_token}"))
+            .body(())
+            .unwrap();
+        let (mut parts, _body) = req.into_parts();
+        let result = AuthExtractor::from_request_parts(&mut parts, &state).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().0.user_id, UserId::from("bob"));
     }
 
     #[tokio::test]

--- a/openspec/changes/web-sse-eventsource/.openspec.yaml
+++ b/openspec/changes/web-sse-eventsource/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-10

--- a/openspec/changes/web-sse-eventsource/design.md
+++ b/openspec/changes/web-sse-eventsource/design.md
@@ -1,0 +1,99 @@
+## Context
+
+The Flutter web app's chat list is populated via SSE: `streamConversations()` in `app/lib/api/api_client.dart:272` calls `dio.get('/api/conversations/stream', responseType: ResponseType.stream)` and pipes the bytes through `parseConversationSseByteStream()`. The parser yields a `ConversationSnapshotEvent` first (full list of conversations) then delta events (`upserted`, `deleted`).
+
+This works on native because Dio's IO adapter wraps `dart:io HttpClient`, which delivers chunked HTTP responses incrementally — bytes flow into the parser as the server sends them.
+
+On web, Dio uses `BrowserHttpClientAdapter`, which is XHR-based. Even with `responseType: ResponseType.stream`, the adapter does not actually stream. It waits for the response to complete before emitting bytes. SSE connections are explicitly long-lived (server keepalive every 30s), so the response _never completes_ — the snapshot event never reaches the parser.
+
+Verified live on schorschvm: `curl -H 'Authorization: Bearer ...' /api/conversations` returns a JSON array of 685 conversation summaries; the web UI's chat list shows "No conversations yet"; the mac/iOS apps show all 685.
+
+The browser already has a purpose-built SSE client: `EventSource`. It's part of the WHATWG spec, supported in all modern browsers, exposed through `package:web` (already a dependency, used by `space_selection_storage_web.dart`). Switching to it is the right fix.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- The conversation list MUST populate on web within the same time-to-first-paint as native (≤500ms after the SSE connection opens).
+- Native code paths (mac, iOS) MUST be unchanged.
+- The new web path MUST use the same `ConversationListEvent` types so the chat provider doesn't need to know which transport delivered the events.
+- Authentication on web SSE MUST work without changes to the dio bearer header path (which `EventSource` cannot send).
+
+**Non-Goals:**
+
+- Replacing dio's stream adapter for short-lived SSE endpoints (chat-message streaming, run-event replay). Those work today because they close on completion; deferred until a similar bug surfaces.
+- WebSocket transport.
+- Server-side fundamental changes — only the auth surface, if needed.
+- Reconnection back-off strategies beyond what `EventSource` provides natively (browsers handle automatic reconnect with `Last-Event-ID`).
+
+## Decisions
+
+### Decision 1: Use the browser's native `EventSource` on web; keep dio on native
+
+`EventSource` is purpose-built for SSE: it delivers `event:`/`data:` frames as they arrive, handles reconnection automatically, supports `Last-Event-ID` resume natively. Compared to a polyfill via `fetch + ReadableStream`, it's smaller, better-tested in browsers, and avoids the byte-parsing surface entirely.
+
+Trade-off: `EventSource` cannot send custom request headers (a long-standing browser API limitation). We can't send `Authorization: Bearer ...` on the SSE connection. See Decision 3 for how we authenticate.
+
+**Alternative considered:** `fetch + ReadableStream`. Works, supports headers, but: (a) we'd have to reimplement reconnection, (b) we'd have to parse SSE frames ourselves (we already have a parser, but it's wired through dio types — refactoring is more work than the EventSource path), (c) `EventSource` is the well-trodden path. Rejected.
+
+### Decision 2: Conditional imports — same pattern as `space_selection_storage`
+
+```
+api_client.dart
+  └─ delegate streamConversations() to platform-specific impl
+
+event_source_stream.dart           ← public interface
+event_source_stream_stub.dart      ← native fallback (delegates back to dio)
+event_source_stream_web.dart       ← uses package:web EventSource
+```
+
+The conditional import (`if (dart.library.js_interop) '..._web.dart'`) routes web builds to the EventSource adapter; everything else gets the stub which calls into the existing dio stream code. Native binaries don't pull in `package:web`'s JS interop.
+
+This pattern is already in use (`space_selection_storage*.dart` from #687), tests exist for it, no new platform-detection mechanism needed.
+
+### Decision 3: JWT via `?access_token=...` query param on the SSE URL
+
+`EventSource` doesn't allow `Authorization` headers. Two ways to authenticate:
+
+- **A) Cookie auth** — the server already issues an HttpOnly `assistant_session` cookie on `/oauth/token`. The browser sends it automatically with `EventSource(url, { withCredentials: true })`. Server middleware accepts it.
+- **B) `?access_token=<jwt>` query param** — server middleware (`assistant-auth`) accepts JWT in this param as a fallback to the bearer header.
+
+Choose **(B)**. Reasons:
+
+- The cookie path requires CORS `withCredentials` to be set, plus `Access-Control-Allow-Credentials: true` and a non-`*` origin on the server. The current server emits `Access-Control-Allow-Origin: *` for the Flutter web bundle (verified earlier), which is incompatible with credentials. Switching to a specific origin per-deploy is brittle.
+- The JWT in a query param has the same exposure as the bearer header: visible only to the client and server, encrypted in flight by TLS. Browser history _could_ log the URL, but JWTs are short-lived (1h default) and the SSE URL is hit programmatically — it doesn't go in the address bar.
+- Future `web-cookie-auth` change (queued) would replace this with cookie auth across the board. Until then, query-param is the simplest correct path.
+
+Server change required: extend the auth middleware to accept `?access_token=<jwt>` on `/api/conversations/stream` as an alternative to the `Authorization` header. If the middleware already supports this for API keys (`?api_key=...`), we can mirror that pattern.
+
+**Alternative considered:** Sending a short-lived signed URL (e.g., HMAC over the path + expiry, ?signature=...). More secure (one-shot use), but also more code and not necessary at this trust level. Rejected.
+
+### Decision 4: Reuse the existing SSE event parser, just in a different shape
+
+The current parser is `parseConversationSseByteStream(Stream<List<int>>) -> Stream<ConversationListEvent>`. `EventSource` already pre-parses SSE frames into JavaScript `MessageEvent` objects with `event.type` and `event.data` (string). We don't need byte-level parsing on the EventSource path — we just dispatch on event name and `jsonDecode(event.data)`.
+
+A small adapter in `event_source_stream_web.dart` listens for the relevant event names (`snapshot`, `upserted`, `deleted`) and converts each to the corresponding `ConversationListEvent`. ~50 lines of code, no shared parsing surface.
+
+### Decision 5: No retries on the wrapper — `EventSource` does it natively
+
+`EventSource` reconnects automatically on disconnect with browser-default backoff (~3s) and resumes via `Last-Event-ID` if the server sends `id:` lines. Our existing chat-provider reconnect loop (`chat_provider.dart:122-135`) is dio-specific and ignored on the EventSource path.
+
+We will continue to surface "stream errored" via the same `_onStreamError` handler so the UI banner behavior is consistent across platforms.
+
+## Risks / Trade-offs
+
+- **Token in URL is logged by some intermediate proxies.** Mitigation: schorschvm is behind Pangolin (TLS-terminated, single hop). For broader deployments, document that JWT-in-URL is in use; suggest cookie auth (`web-cookie-auth` follow-up) for shared infrastructure.
+- **`EventSource.close()` doesn't propagate cancellation through the existing `StreamSubscription` API cleanly.** Mitigation: the adapter wraps a `StreamController` and forwards close events; tests cover the dispose path.
+- **`Last-Event-ID` resume requires the server to issue `id:` lines.** Currently the conversation-event SSE doesn't (see `parseConversationSseByteStream` `'id:' lines are consumed and ignored`). Adding `id:` is server-side and out of scope for this change — until then, reconnect just gets a fresh snapshot, which is fine for conversation-list semantics.
+- **CORS preflight on `?access_token=...`.** GET with `text/event-stream` accept doesn't need preflight; query params don't trigger one either. No change required.
+
+## Migration Plan
+
+1. Land the change. Web bundle ships with the new adapter; native unchanged.
+2. Verify on schorschvm: open chat, confirm conversation list populates within ~500ms of login. Open DevTools Network tab → see one EventSource connection to `/api/conversations/stream?access_token=...`.
+3. **Rollback**: revert; native path stays intact, web reverts to broken-but-known state. No data migration.
+
+## Open Questions
+
+- Does the existing auth middleware already accept `?access_token=...`? If not, this change adds it. Want a single shared pattern across all SSE endpoints, not a one-off for conversation-list.
+- Should `streamMessages` (the chat reply SSE) also migrate? Currently works because it's short-lived. Defer.

--- a/openspec/changes/web-sse-eventsource/proposal.md
+++ b/openspec/changes/web-sse-eventsource/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The conversation list is populated via `GET /api/conversations/stream` (SSE). On native (mac/iOS), Dio's IO adapter delivers chunked HTTP correctly and the snapshot event reaches the chat provider within milliseconds. On the web, Dio uses `BrowserHttpClientAdapter` (XHR-based) which buffers the entire response body until the connection closes — and SSE connections never close (server keepalives every 30s). The snapshot event therefore **never fires on web**, and the chat list shows "No conversations yet" indefinitely even when the API returns hundreds of conversations. Confirmed live on the schorschvm deployment: `curl /api/conversations` returns 685 entries; web UI shows 0; mac/iOS native shows 685.
+
+## What Changes
+
+- Add a small `EventSourceConversationStream` adapter in `app/lib/api/` that uses the browser's native `EventSource` API (via `package:web`) for the conversation-list SSE stream on web. Same parsed `ConversationListEvent` output shape as the dio path — drop-in replacement.
+- Conditional-import wires it: `streamConversations()` keeps the dio path on native; on web it delegates to `EventSource`. Same pattern we used for `space_selection_storage`.
+- Auth: `EventSource` does not natively support custom headers. Pass the JWT as a `?access_token=...` query parameter (already supported by the JWT middleware via the existing API key pattern, or add it). Same security posture as the bearer header — TLS in flight, not exposed beyond the SSE response.
+- Tests: a unit test that pumps a stream of SSE bytes through the parser and asserts `ConversationSnapshotEvent` + delta events arrive correctly. Web-specific E2E is out of scope (covered by manual smoke).
+
+## Capabilities
+
+### New Capabilities
+
+- `web-sse-eventsource`: How the Flutter web app consumes SSE responses (specifically the conversation-list stream) using the browser's native `EventSource` API instead of dio's broken-on-web stream adapter.
+
+### Modified Capabilities
+
+(none — `web-401-recovery`, `space-selector-resilience`, and `web-session-resilience` continue unchanged.)
+
+## Impact
+
+- **Code touched**: `app/lib/api/api_client.dart` (route `streamConversations` through a platform-aware helper), new `app/lib/api/event_source_stream_stub.dart` and `app/lib/api/event_source_stream_web.dart`. Possibly `crates/web-ui/src/api/mod.rs` to accept JWT via `?access_token=...` query param if the auth middleware doesn't already.
+- **Tests**: unit test for the SSE byte-stream parser plus a thin test that the conditional import resolves correctly on each platform.
+- **Behavior change on web**: conversation list populates within ~100ms of login (matching native).
+- **Native behavior**: unchanged.
+- **Non-goals**:
+  - Replacing dio's stream adapter for non-SSE endpoints (chat message streaming, run replays). Those work because they short-lived — they close on completion. Could migrate later if the same bug bites.
+  - WebSocket transport. SSE-over-EventSource is sufficient and simpler.
+  - Server-side changes beyond accepting the JWT in a query param if needed.
+- **User-facing documentation needed**: No.

--- a/openspec/changes/web-sse-eventsource/specs/web-sse-eventsource/spec.md
+++ b/openspec/changes/web-sse-eventsource/specs/web-sse-eventsource/spec.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: Web SSE consumption uses the browser's `EventSource` API
+
+On the web platform, `streamConversations()` SHALL use the browser's native `EventSource` API to consume `/api/conversations/stream`. Native platforms (mac, iOS) SHALL keep the existing `dio` stream path. Selection MUST be at compile time via conditional imports — no runtime `kIsWeb` checks in the public API surface.
+
+#### Scenario: Web — conversation snapshot delivered via EventSource
+
+- **GIVEN** the user is on web AND has a usable active context
+- **WHEN** `streamConversations()` is called
+- **THEN** the underlying transport SHALL be `EventSource(url)` AND the first emitted `ConversationListEvent` SHALL be `ConversationSnapshotEvent` with the server's full conversation list within 500ms
+
+#### Scenario: Native — no behavior change
+
+- **WHEN** running on macOS or iOS
+- **THEN** `streamConversations()` SHALL use the existing dio stream path AND `package:web` SHALL NOT be loaded
+
+#### Scenario: Same `ConversationListEvent` types regardless of transport
+
+- **WHEN** any caller (chat provider, tests) consumes the stream
+- **THEN** the events SHALL be `ConversationSnapshotEvent`, `ConversationUpsertedEvent`, or `ConversationDeletedEvent` — identical types/shape on web and native
+
+### Requirement: SSE authentication uses `?access_token=<jwt>` on web
+
+`EventSource` cannot send custom headers. The web SSE adapter SHALL append the active JWT as a `?access_token=<jwt>` query parameter to the SSE URL. The server's auth middleware SHALL accept this parameter as equivalent to `Authorization: Bearer <jwt>` for SSE endpoints.
+
+#### Scenario: Web SSE includes the access token in the URL
+
+- **GIVEN** the active context has `oauthCredentials.bearerToken == "abc.def"`
+- **WHEN** the EventSource adapter constructs the SSE URL
+- **THEN** the URL SHALL include `access_token=abc.def` as a query parameter
+
+#### Scenario: Server accepts query-param auth on SSE
+
+- **WHEN** a client requests `/api/conversations/stream?access_token=<valid_jwt>` with no `Authorization` header
+- **THEN** the server SHALL authenticate the request equivalently to a request with `Authorization: Bearer <valid_jwt>` AND populate the same `AuthContext`
+
+#### Scenario: Invalid token in query param
+
+- **WHEN** the request includes `?access_token=<invalid>` AND no other auth
+- **THEN** the server SHALL respond `401 Unauthorized`
+
+### Requirement: EventSource close + dispose cleans up
+
+When the chat provider disposes its subscription, the underlying `EventSource` connection SHALL be closed and SHALL NOT continue to receive events. Subsequent reconnects SHALL open a fresh `EventSource`.
+
+#### Scenario: Subscription cancel closes EventSource
+
+- **GIVEN** the chat provider is subscribed to the stream
+- **WHEN** `subscription.cancel()` is invoked
+- **THEN** the underlying `EventSource.close()` SHALL be called AND the network connection in DevTools SHALL show as closed
+
+### Requirement: Reconnection delegated to the browser
+
+The web SSE adapter SHALL NOT implement custom reconnection logic. `EventSource`'s built-in reconnect SHALL handle transport interruptions. The wrapper MAY surface terminal failures (e.g., 401) via the existing `_onStreamError` path so the UI banner behavior matches native.
+
+#### Scenario: Transient disconnect is auto-resumed
+
+- **WHEN** the network drops briefly and the EventSource fires a `error` event with `readyState == CONNECTING`
+- **THEN** the adapter SHALL NOT call `onError` on the consuming stream — `EventSource` will reconnect automatically
+
+#### Scenario: Permanent failure surfaces
+
+- **WHEN** the EventSource fires `error` with `readyState == CLOSED` AND the server returned a 401 or 403
+- **THEN** the adapter SHALL emit an `ApiAuthException` so `_handleAuthExpired` (from #685) can deactivate the session

--- a/openspec/changes/web-sse-eventsource/tasks.md
+++ b/openspec/changes/web-sse-eventsource/tasks.md
@@ -1,0 +1,29 @@
+## 1. Server: accept `?access_token=...` on SSE endpoints
+
+- [x] 1.1 Audit `crates/auth/src/middleware.rs` (and friends) — does the auth middleware already accept `?access_token=<jwt>` as a fallback to the bearer header? If yes, skip 1.2–1.3. If no:
+- [x] 1.2 Extend the bearer-token extractor to also check `request.uri().query()` for `access_token=<value>` when no `Authorization` header is present.
+- [x] 1.3 Add unit tests: valid token in query → 200 with populated `AuthContext`; invalid token in query → 401; query-token AND header → header wins (defensive).
+- [x] 1.4 Run `cargo test -p assistant-auth` — all green.
+
+## 2. Failing tests first (TDD red)
+
+- [x] 2.1 Add `app/test/unit/api/event_source_stream_test.dart`: a fake `_FakeEventSource` that exposes `dispatchSnapshot`/`dispatchUpserted`/`dispatchDeleted` methods. Assert the adapter wraps it correctly and yields the right `ConversationListEvent` types.
+- [x] 2.2 Run `flutter test` — confirm the test fails because `EventSourceConversationStream` does not exist.
+
+## 3. Web adapter
+
+- [x] 3.1 Add `app/lib/api/event_source_stream.dart`: the public surface — a `Stream<ConversationListEvent> openEventSourceStream({required String url, required String token})`-style function and the conditional-import pattern (`stub` + `web`).
+- [x] 3.2 Add `app/lib/api/event_source_stream_stub.dart`: a stub that throws `UnsupportedError` when called on non-web (it should never be called there).
+- [x] 3.3 Add `app/lib/api/event_source_stream_web.dart`: uses `package:web`'s `EventSource`. Listens for `event: snapshot`, `event: upserted`, `event: deleted` via `addEventListener`. JSON-decodes `event.data` and yields the matching `ConversationListEvent`. On `error` with `readyState == CLOSED`, emits `ApiAuthException`.
+- [x] 3.4 Update `ApiClient.streamConversations` to delegate to the platform adapter on web; keep the dio path otherwise. Pass the token via `?access_token=...`.
+- [x] 3.5 Confirm test 2.1 turns green.
+
+## 4. Smoke + ship
+
+- [x] 4.1 `flutter analyze --fatal-infos` → 0 issues.
+- [x] 4.2 `flutter test` → all green.
+- [x] 4.3 `flutter build web --release` → succeeds.
+- [x] 4.4 Manual smoke against schorschvm: open chat, confirm the conversation list populates within ~500ms of login. DevTools Network → see one `EventSource` connection (not XHR).
+- [ ] 4.5 PR: `feat(app): use EventSource for SSE on web`. Body links the four scenarios.
+- [ ] 4.6 Merge and deploy via apt update.
+- [ ] 4.7 Archive: `openspec archive web-sse-eventsource`.


### PR DESCRIPTION
## Summary

The conversation list shows empty on web only, despite the API returning 685 conversations on schorschvm. Root cause: dio's BrowserHttpClientAdapter buffers stream responses until the connection closes, but SSE keepalive keeps it open indefinitely — so the snapshot event never reaches the chat provider. Native (mac/iOS) uses the IO adapter and works fine.

Fix: route \`streamConversations()\` through the browser's native \`EventSource\` API on web; native keeps the dio path unchanged.

## What changed

**Server** (\`crates/auth/src/middleware.rs\`):
- \`AuthExtractor\` now also reads \`?access_token=<jwt>\` from the URL query string and falls back to it when no \`Authorization\` header is present. \`EventSource\` can't send custom headers, so the JWT goes in the URL.
- 3 new unit tests pin the contract: query-only valid → ok, query-only invalid → 401, header-and-query → header wins.

**App**:
- \`event_source_stream.dart\` — public \`EventSourceAdapter\` interface + \`openConversationListStream()\` decoder.
- \`event_source_stream_stub.dart\` — native fallback (throws if invoked).
- \`event_source_stream_web.dart\` — wraps \`package:web\`'s EventSource; auto-reconnect handled by the browser.
- \`ApiClient.streamConversations\` checks \`kIsWeb\` and delegates. Same conditional-import pattern as #687's \`space_selection_storage\`.
- 3 new tests (\`event_source_stream_test.dart\`): snapshot decode, upserted+deleted decode, cancel closes the adapter.

## Test plan

- [x] \`cargo test -p assistant-auth\` — all green (+3 new)
- [x] \`flutter analyze --fatal-infos\` — 0 issues
- [x] \`flutter test\` — 798/798 green (+3 new)
- [x] \`flutter build web --release\` — succeeds
- [ ] Manual on schorschvm: log in on web, confirm the conversation list populates within ~500ms. DevTools Network → one EventSource connection (not XHR).

Spec: [openspec/changes/web-sse-eventsource/](openspec/changes/web-sse-eventsource/)