### PR TITLE
fix(app): logout button missing on macOS / iOS Cupertino paths

### DIFF
--- a/app/lib/shared/nav_shell.dart
+++ b/app/lib/shared/nav_shell.dart
@@ -306,6 +306,20 @@ class _NavShellState extends ConsumerState<NavShell> {
                       context.go(_settingsDestination.path);
                     },
                   ),
+                  ListTile(
+                    key: const Key('material-more-logout'),
+                    leading: const Icon(Icons.logout),
+                    title: const Text('Log out'),
+                    onTap: () async {
+                      Navigator.of(sheetContext).pop();
+                      await performLogout(
+                        ProviderScope.containerOf(context, listen: false),
+                      );
+                      if (context.mounted) {
+                        context.go(AppRoutes.login);
+                      }
+                    },
+                  ),
                   const SizedBox(height: 8),
                 ],
               ),
@@ -363,6 +377,20 @@ class _NavShellState extends ConsumerState<NavShell> {
                 context.go(_settingsDestination.path);
               },
               child: Text(_settingsDestination.label),
+            ),
+            CupertinoActionSheetAction(
+              key: const Key('cupertino-more-logout'),
+              isDestructiveAction: true,
+              onPressed: () async {
+                Navigator.of(popupContext).pop();
+                await performLogout(
+                  ProviderScope.containerOf(context, listen: false),
+                );
+                if (context.mounted) {
+                  context.go(AppRoutes.login);
+                }
+              },
+              child: const Text('Log out'),
             ),
           ],
           cancelButton: CupertinoActionSheetAction(
@@ -488,6 +516,33 @@ class _NavShellState extends ConsumerState<NavShell> {
                         semanticLabel: collapsed
                             ? 'Expand sidebar'
                             : 'Collapse sidebar',
+                      ),
+                    ),
+                  ),
+                ),
+                // Logout button overlaid at bottom-leading corner of the
+                // Cupertino sidebar — mirrors the Material sidebar slot.
+                Positioned(
+                  left: 4,
+                  bottom: 4,
+                  child: SafeArea(
+                    child: CupertinoButton(
+                      key: const Key('cupertino-logout'),
+                      padding: const EdgeInsets.symmetric(horizontal: 10),
+                      onPressed: () async {
+                        await performLogout(
+                          ProviderScope.containerOf(context, listen: false),
+                        );
+                        if (context.mounted) {
+                          context.go(AppRoutes.login);
+                        }
+                      },
+                      child: const Tooltip(
+                        message: 'Log out',
+                        child: Icon(
+                          CupertinoIcons.square_arrow_right,
+                          semanticLabel: 'Log out',
+                        ),
                       ),
                     ),
                   ),


### PR DESCRIPTION
## Summary

#689 dropped the \`kIsWeb\` gate around \`_LogoutButton\` in the **Material** sidebar — but on macOS / iOS the app takes the **Cupertino** branch (\`isAppleTouch\`, \`nav_shell.dart:424\`) which renders \`CupertinoSidebar\` / \`CupertinoTabBar\` with its own destination list. \`_LogoutButton\` never gets rendered there. Result: native users on 0.1.148 still don't see a logout affordance — confirmed live on the user's Mac post-update.

This adds three native logout entry points so every shell layout has one.

## What changed

1. **Wide Cupertino sidebar (macOS, iPadOS landscape)** — a \`CupertinoButton\` at the bottom-leading corner, mirroring the existing toggle at top-leading. Icon: \`square_arrow_right\` + "Log out" tooltip.
2. **iOS compact (CupertinoTabBar → Cupertino More sheet)** — a destructive \`CupertinoActionSheetAction\` "Log out" appended to the More sheet.
3. **Material mobile More sheet (narrow Android-style)** — a \`ListTile\` with logout icon, after Settings.

All three paths call \`performLogout(container) + context.go(/login)\` — same code path as the Material desktop button from #689.

## Test plan

- [x] \`flutter analyze --fatal-infos\` — 0 issues
- [x] \`flutter test\` — 802/802 green
- [ ] Manual on macOS: open the app → see the logout icon at bottom-left of the sidebar → tap it → land on /login.
- [ ] Manual on iOS: tap More → see "Log out" at the bottom of the sheet (red, destructive style) → tap → land on /login.

Cupertino paths can't run in \`flutter test\` cleanly without \`TargetPlatform\` overrides; manual smoke covers them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added logout option to the navigation menu across all platforms (Material, iOS, and Apple layouts) for convenient account sign-out access.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cedricziel/assistant/pull/693)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->