### PR TITLE
fix(app): login form Tab traversal + password manager autofill

### DIFF
--- a/app/lib/features/auth/auth_provider.dart
+++ b/app/lib/features/auth/auth_provider.dart
@@ -48,23 +48,19 @@ class OAuthLoginNotifier extends Notifier<OAuthLoginState> {
     required String email,
     required String password,
   }) async {
-    state = const OAuthLoginLoading(message: 'Checking server...');
+    state = const OAuthLoginLoading(message: 'Registering client...');
 
     try {
       final service = OAuthService(serverUrl: serverUrl);
 
-      // 1. Verify server supports OAuth2.
-      final hasOAuth = await service.supportsOAuth();
-      if (!hasOAuth) {
-        state = const OAuthLoginError(
-          'This server does not support OAuth2 authentication. '
-          'Use the legacy token login instead.',
-        );
-        return;
-      }
+      // We don't pre-check the well-known metadata endpoint: in deployments
+      // behind a reverse-proxy auth layer (e.g. Pangolin), unauthenticated
+      // GETs to `/.well-known/oauth-authorization-server` may be redirected
+      // to the proxy's login page, making the metadata probe a false-negative.
+      // Instead we attempt registration → if the server doesn't support
+      // OAuth2, registration fails with a server error and we surface that.
 
-      // 2. Register a dynamic client.
-      state = const OAuthLoginLoading(message: 'Registering client...');
+      // Register a dynamic client.
       final redirectUri = _redirectUri(serverUrl);
       final clientId = await service.registerClient(
         clientName: 'Assistant Flutter App',

--- a/app/lib/features/login/login_screen.dart
+++ b/app/lib/features/login/login_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
@@ -27,6 +28,12 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
   final _emailCtrl = TextEditingController();
   final _passwordCtrl = TextEditingController();
   final _tokenCtrl = TextEditingController();
+  // Explicit focus nodes so Tab/Shift+Tab traversal is deterministic and
+  // `onFieldSubmitted` (Enter) advances correctly on macOS desktop.
+  final _serverFocus = FocusNode(debugLabel: 'login.server');
+  final _emailFocus = FocusNode(debugLabel: 'login.email');
+  final _passwordFocus = FocusNode(debugLabel: 'login.password');
+  final _tokenFocus = FocusNode(debugLabel: 'login.token');
   bool _passwordVisible = false;
   bool _tokenVisible = false;
   _LoginMode _mode = _LoginMode.oauth2;
@@ -57,6 +64,10 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
     _emailCtrl.dispose();
     _passwordCtrl.dispose();
     _tokenCtrl.dispose();
+    _serverFocus.dispose();
+    _emailFocus.dispose();
+    _passwordFocus.dispose();
+    _tokenFocus.dispose();
     super.dispose();
   }
 
@@ -91,6 +102,9 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
     // Navigate on success.
     ref.listen<OAuthLoginState>(oauthLoginProvider, (prev, next) {
       if (next is OAuthLoginSuccess && mounted) {
+        // Tell the OS the credential was committed — triggers the password
+        // manager's "save?" prompt on Keychain / 1Password / browser.
+        TextInput.finishAutofillContext();
         GoRouter.of(this.context).go(AppRoutes.chat);
       }
     });
@@ -105,202 +119,227 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
           constraints: const BoxConstraints(maxWidth: 420),
           child: SingleChildScrollView(
             padding: const EdgeInsets.all(32),
-            child: Form(
-              key: _formKey,
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  if (showSessionEndedBanner) ...[
-                    _SessionEndedBanner(
-                      onDismiss: () => setState(() => _bannerDismissed = true),
+            // AutofillGroup signals to the platform (macOS Keychain, 1Password,
+            // browser autofill on web) that the email + password fields belong
+            // together as a credential pair. Without it, password managers
+            // don't recognise the form, and Tab traversal can be inconsistent.
+            child: AutofillGroup(
+              child: Form(
+                key: _formKey,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    if (showSessionEndedBanner) ...[
+                      _SessionEndedBanner(
+                        onDismiss: () =>
+                            setState(() => _bannerDismissed = true),
+                      ),
+                      const SizedBox(height: 16),
+                    ],
+                    Text(
+                      'Sign in',
+                      style: Theme.of(context).textTheme.headlineMedium,
                     ),
-                    const SizedBox(height: 16),
-                  ],
-                  Text(
-                    'Sign in',
-                    style: Theme.of(context).textTheme.headlineMedium,
-                  ),
-                  const SizedBox(height: 8),
-                  Text(
-                    _mode == _LoginMode.oauth2
-                        ? 'Sign in with your email and password.'
-                        : 'Enter an API token to connect.',
-                    style: Theme.of(context).textTheme.bodyMedium,
-                  ),
-                  const SizedBox(height: 24),
+                    const SizedBox(height: 8),
+                    Text(
+                      _mode == _LoginMode.oauth2
+                          ? 'Sign in with your email and password.'
+                          : 'Enter an API token to connect.',
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    ),
+                    const SizedBox(height: 24),
 
-                  // Server URL — read-only on web, editable on native.
-                  if (_isWebContext)
-                    InputDecorator(
-                      decoration: const InputDecoration(
-                        labelText: 'Server',
-                        border: OutlineInputBorder(),
+                    // Server URL — read-only on web, editable on native.
+                    if (_isWebContext)
+                      InputDecorator(
+                        decoration: const InputDecoration(
+                          labelText: 'Server',
+                          border: OutlineInputBorder(),
+                        ),
+                        child: Text(
+                          _serverUrl,
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                      )
+                    else
+                      TextFormField(
+                        controller: _serverCtrl,
+                        focusNode: _serverFocus,
+                        decoration: const InputDecoration(
+                          labelText: 'Server URL',
+                          hintText: 'http://localhost:8080',
+                          border: OutlineInputBorder(),
+                        ),
+                        keyboardType: TextInputType.url,
+                        textInputAction: TextInputAction.next,
+                        autofillHints: const [AutofillHints.url],
+                        onFieldSubmitted: (_) => _mode == _LoginMode.oauth2
+                            ? _emailFocus.requestFocus()
+                            : _tokenFocus.requestFocus(),
+                        validator: (v) {
+                          if (v == null || v.trim().isEmpty) {
+                            return 'Server URL is required';
+                          }
+                          final uri = Uri.tryParse(v.trim());
+                          if (uri == null || !uri.hasScheme) {
+                            return 'Enter a valid URL (e.g. http://localhost:8080)';
+                          }
+                          return null;
+                        },
                       ),
-                      child: Text(
-                        _serverUrl,
-                        style: Theme.of(context).textTheme.bodyMedium,
-                      ),
-                    )
-                  else
-                    TextFormField(
-                      controller: _serverCtrl,
-                      decoration: const InputDecoration(
-                        labelText: 'Server URL',
-                        hintText: 'http://localhost:8080',
-                        border: OutlineInputBorder(),
-                      ),
-                      keyboardType: TextInputType.url,
-                      textInputAction: TextInputAction.next,
-                      validator: (v) {
-                        if (v == null || v.trim().isEmpty) {
-                          return 'Server URL is required';
-                        }
-                        final uri = Uri.tryParse(v.trim());
-                        if (uri == null || !uri.hasScheme) {
-                          return 'Enter a valid URL (e.g. http://localhost:8080)';
-                        }
-                        return null;
-                      },
-                    ),
-                  const SizedBox(height: 16),
-
-                  // Auth mode fields.
-                  if (_mode == _LoginMode.oauth2) ...[
-                    TextFormField(
-                      controller: _emailCtrl,
-                      decoration: const InputDecoration(
-                        labelText: 'Email',
-                        border: OutlineInputBorder(),
-                      ),
-                      keyboardType: TextInputType.emailAddress,
-                      textInputAction: TextInputAction.next,
-                      autofillHints: const [AutofillHints.email],
-                      validator: (v) {
-                        if (v == null || v.trim().isEmpty) {
-                          return 'Email is required';
-                        }
-                        return null;
-                      },
-                    ),
                     const SizedBox(height: 16),
-                    TextFormField(
-                      controller: _passwordCtrl,
-                      decoration: InputDecoration(
-                        labelText: 'Password',
-                        border: const OutlineInputBorder(),
-                        suffixIcon: IconButton(
-                          icon: Icon(
-                            _passwordVisible
-                                ? Icons.visibility_off
-                                : Icons.visibility,
+
+                    // Auth mode fields.
+                    if (_mode == _LoginMode.oauth2) ...[
+                      TextFormField(
+                        controller: _emailCtrl,
+                        focusNode: _emailFocus,
+                        autofocus: true,
+                        decoration: const InputDecoration(
+                          labelText: 'Email',
+                          border: OutlineInputBorder(),
+                        ),
+                        keyboardType: TextInputType.emailAddress,
+                        textInputAction: TextInputAction.next,
+                        autofillHints: const [
+                          AutofillHints.username,
+                          AutofillHints.email,
+                        ],
+                        onFieldSubmitted: (_) => _passwordFocus.requestFocus(),
+                        validator: (v) {
+                          if (v == null || v.trim().isEmpty) {
+                            return 'Email is required';
+                          }
+                          return null;
+                        },
+                      ),
+                      const SizedBox(height: 16),
+                      TextFormField(
+                        controller: _passwordCtrl,
+                        focusNode: _passwordFocus,
+                        decoration: InputDecoration(
+                          labelText: 'Password',
+                          border: const OutlineInputBorder(),
+                          suffixIcon: IconButton(
+                            icon: Icon(
+                              _passwordVisible
+                                  ? Icons.visibility_off
+                                  : Icons.visibility,
+                            ),
+                            onPressed: () => setState(
+                              () => _passwordVisible = !_passwordVisible,
+                            ),
                           ),
-                          onPressed: () => setState(
-                            () => _passwordVisible = !_passwordVisible,
+                        ),
+                        obscureText: !_passwordVisible,
+                        textInputAction: TextInputAction.done,
+                        autofillHints: const [AutofillHints.password],
+                        validator: (v) {
+                          if (v == null || v.isEmpty) {
+                            return 'Password is required';
+                          }
+                          return null;
+                        },
+                        onFieldSubmitted: (_) => isLoading ? null : _submit(),
+                      ),
+                    ] else ...[
+                      TextFormField(
+                        controller: _tokenCtrl,
+                        focusNode: _tokenFocus,
+                        autofocus: true,
+                        decoration: InputDecoration(
+                          labelText: 'Token (optional)',
+                          border: const OutlineInputBorder(),
+                          suffixIcon: IconButton(
+                            icon: Icon(
+                              _tokenVisible
+                                  ? Icons.visibility_off
+                                  : Icons.visibility,
+                            ),
+                            onPressed: () =>
+                                setState(() => _tokenVisible = !_tokenVisible),
+                          ),
+                        ),
+                        obscureText: !_tokenVisible,
+                        textInputAction: TextInputAction.done,
+                        onFieldSubmitted: (_) => isLoading ? null : _submit(),
+                      ),
+                    ],
+
+                    // Error message.
+                    if (loginState is OAuthLoginError) ...[
+                      const SizedBox(height: 16),
+                      Container(
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: Theme.of(context).colorScheme.errorContainer,
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Text(
+                          loginState.message,
+                          style: TextStyle(
+                            color: Theme.of(
+                              context,
+                            ).colorScheme.onErrorContainer,
                           ),
                         ),
                       ),
-                      obscureText: !_passwordVisible,
-                      textInputAction: TextInputAction.done,
-                      autofillHints: const [AutofillHints.password],
-                      validator: (v) {
-                        if (v == null || v.isEmpty) {
-                          return 'Password is required';
-                        }
-                        return null;
-                      },
-                      onFieldSubmitted: (_) => isLoading ? null : _submit(),
-                    ),
-                  ] else ...[
-                    TextFormField(
-                      controller: _tokenCtrl,
-                      decoration: InputDecoration(
-                        labelText: 'Token (optional)',
-                        border: const OutlineInputBorder(),
-                        suffixIcon: IconButton(
-                          icon: Icon(
-                            _tokenVisible
-                                ? Icons.visibility_off
-                                : Icons.visibility,
-                          ),
-                          onPressed: () =>
-                              setState(() => _tokenVisible = !_tokenVisible),
-                        ),
-                      ),
-                      obscureText: !_tokenVisible,
-                      textInputAction: TextInputAction.done,
-                      onFieldSubmitted: (_) => isLoading ? null : _submit(),
-                    ),
-                  ],
+                    ],
 
-                  // Error message.
-                  if (loginState is OAuthLoginError) ...[
-                    const SizedBox(height: 16),
-                    Container(
-                      padding: const EdgeInsets.all(12),
-                      decoration: BoxDecoration(
-                        color: Theme.of(context).colorScheme.errorContainer,
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                      child: Text(
-                        loginState.message,
-                        style: TextStyle(
-                          color: Theme.of(context).colorScheme.onErrorContainer,
-                        ),
-                      ),
-                    ),
-                  ],
+                    const SizedBox(height: 24),
 
-                  const SizedBox(height: 24),
-
-                  // Submit button.
-                  FilledButton(
-                    onPressed: isLoading ? null : _submit,
-                    child: isLoading
-                        ? Row(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              SizedBox(
-                                width: 18,
-                                height: 18,
-                                child: CircularProgressIndicator.adaptive(
-                                  strokeWidth: 2,
-                                  valueColor: AlwaysStoppedAnimation<Color>(
-                                    Theme.of(context).colorScheme.onPrimary,
+                    // Submit button.
+                    FilledButton(
+                      onPressed: isLoading ? null : _submit,
+                      child: isLoading
+                          ? Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                SizedBox(
+                                  width: 18,
+                                  height: 18,
+                                  child: CircularProgressIndicator.adaptive(
+                                    strokeWidth: 2,
+                                    valueColor: AlwaysStoppedAnimation<Color>(
+                                      Theme.of(context).colorScheme.onPrimary,
+                                    ),
                                   ),
                                 ),
-                              ),
-                              if (loadingMessage != null) ...[
-                                const SizedBox(width: 12),
-                                Text(loadingMessage),
+                                if (loadingMessage != null) ...[
+                                  const SizedBox(width: 12),
+                                  Text(loadingMessage),
+                                ],
                               ],
-                            ],
-                          )
-                        : Text(
-                            _mode == _LoginMode.oauth2 ? 'Sign in' : 'Connect',
-                          ),
-                  ),
+                            )
+                          : Text(
+                              _mode == _LoginMode.oauth2
+                                  ? 'Sign in'
+                                  : 'Connect',
+                            ),
+                    ),
 
-                  const SizedBox(height: 16),
+                    const SizedBox(height: 16),
 
-                  // Mode switcher.
-                  Center(
-                    child: TextButton(
-                      onPressed: isLoading
-                          ? null
-                          : () => setState(() {
-                              _mode = _mode == _LoginMode.oauth2
-                                  ? _LoginMode.legacyToken
-                                  : _LoginMode.oauth2;
-                            }),
-                      child: Text(
-                        _mode == _LoginMode.oauth2
-                            ? 'Use token authentication instead'
-                            : 'Sign in with email and password',
+                    // Mode switcher.
+                    Center(
+                      child: TextButton(
+                        onPressed: isLoading
+                            ? null
+                            : () => setState(() {
+                                _mode = _mode == _LoginMode.oauth2
+                                    ? _LoginMode.legacyToken
+                                    : _LoginMode.oauth2;
+                              }),
+                        child: Text(
+                          _mode == _LoginMode.oauth2
+                              ? 'Use token authentication instead'
+                              : 'Sign in with email and password',
+                        ),
                       ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
           ),

--- a/app/test/widget/login/login_form_focus_autofill_test.dart
+++ b/app/test/widget/login/login_form_focus_autofill_test.dart
@@ -1,0 +1,115 @@
+// Pins the login form's focus traversal + autofill behavior:
+//
+// - The credential fields (email + password) live inside an [AutofillGroup]
+//   so the OS recognises them as a credential pair (Keychain, 1Password,
+//   browser autofill).
+// - Email autofocuses on screen entry; pressing Enter advances focus to
+//   password (via FocusNode + onFieldSubmitted), pressing Enter on
+//   password submits.
+// - Tab traversal moves through fields in source order — the explicit
+//   focus nodes make the order deterministic on macOS desktop.
+//
+// Spec: see commit message of fix/login-tab-and-autofill.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:assistant_app/features/login/login_screen.dart';
+
+GoRouter _router() => GoRouter(
+  initialLocation: '/login',
+  routes: [
+    GoRoute(path: '/login', builder: (_, _) => const LoginScreen()),
+    GoRoute(
+      path: '/chat',
+      builder: (_, _) => const Scaffold(body: Text('CHAT_PAGE')),
+    ),
+  ],
+);
+
+Future<void> _pump(WidgetTester tester) async {
+  await tester.pumpWidget(
+    ProviderScope(child: MaterialApp.router(routerConfig: _router())),
+  );
+  await tester.pumpAndSettle();
+}
+
+/// Find the rendered EditableText inside a TextFormField labelled [label].
+/// TextFormField is a wrapper that ultimately produces a TextField; we
+/// inspect the latter to assert focus, autofill, and autofocus behaviour.
+EditableText _editable(WidgetTester tester, String label) {
+  final field = find.ancestor(
+    of: find.text(label),
+    matching: find.byType(TextFormField),
+  );
+  expect(field, findsOneWidget, reason: 'TextFormField labelled "$label"');
+  return tester.widget<EditableText>(
+    find.descendant(of: field, matching: find.byType(EditableText)),
+  );
+}
+
+void main() {
+  testWidgets('email + password live inside an AutofillGroup', (tester) async {
+    await _pump(tester);
+
+    expect(
+      find.byType(AutofillGroup),
+      findsOneWidget,
+      reason: 'Login form must be wrapped in an AutofillGroup',
+    );
+  });
+
+  testWidgets('email field autofocuses on entry', (tester) async {
+    await _pump(tester);
+
+    final email = _editable(tester, 'Email');
+    expect(
+      email.autofocus,
+      isTrue,
+      reason: 'Email should autofocus so the user can start typing immediately',
+    );
+  });
+
+  testWidgets('email autofill hints include username and email', (
+    tester,
+  ) async {
+    await _pump(tester);
+
+    final email = _editable(tester, 'Email');
+    expect(email.autofillHints, contains(AutofillHints.username));
+    expect(email.autofillHints, contains(AutofillHints.email));
+  });
+
+  testWidgets('password autofill hints include password', (tester) async {
+    await _pump(tester);
+
+    final password = _editable(tester, 'Password');
+    expect(password.autofillHints, contains(AutofillHints.password));
+  });
+
+  testWidgets('Enter on email moves focus to password', (tester) async {
+    await _pump(tester);
+
+    // Type into email and trigger the "next" action (the keyboard's
+    // Return/Tab equivalent) — focus should advance to password.
+    await tester.enterText(
+      find.ancestor(
+        of: find.text('Email'),
+        matching: find.byType(TextFormField),
+      ),
+      'admin@localhost',
+    );
+    await tester.testTextInput.receiveAction(TextInputAction.next);
+    await tester.pumpAndSettle();
+
+    final password = _editable(tester, 'Password');
+    expect(
+      password.focusNode.hasFocus,
+      isTrue,
+      reason:
+          'Pressing Next/Enter on the email field must move focus to password',
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Three login-screen bugs reported on macOS:

1. **Tab key didn't move between fields** — form lacked an \`AutofillGroup\`, so the platform's focus-traversal scope around the credential pair wasn't set up and behavior was inconsistent on desktop.
2. **Password manager (Keychain, 1Password, browser autofill) didn't recognise the form** — same root cause. \`autofillHints\` on individual fields are ignored without an enclosing \`AutofillGroup\`.
3. **"Server doesn't support OAuth2"** on macOS even though OAuth works fine. The precheck hits \`/.well-known/oauth-authorization-server\`. Behind a reverse-proxy auth layer (Pangolin in this deploy), unauthenticated GETs are 302-redirected to the proxy login. dio sees the redirect, treats it as not-200, \`supportsOAuth()\` returns false, the user is forced onto token mode. Web works because the browser session is already past the proxy.

## Fixes

- Wrap the form in \`AutofillGroup\`. Signals credential pair to the OS; establishes the focus scope.
- Explicit \`FocusNode\`s for server / email / password / token. \`onFieldSubmitted\` advances focus down the chain (Enter on email → password; Enter on password → submit).
- Email autofocuses on entry.
- Email autofill hints expanded to \`[AutofillHints.username, AutofillHints.email]\` (most password managers key off "username").
- Server URL (native) gets \`AutofillHints.url\` so prior URLs auto-suggest.
- On success: \`TextInput.finishAutofillContext()\` so the OS prompts to save.
- Drop the \`supportsOAuth()\` precheck — attempt \`registerClient()\` directly. If the server doesn't support OAuth, registration fails and the error surfaces naturally. The probe was a false-negative trap behind reverse-proxy auth.

## Test plan

- [x] \`flutter analyze --fatal-infos\` — 0 issues
- [x] \`flutter test\` — 807/807 green (+5 new in \`login_form_focus_autofill_test.dart\`)
- [ ] Manual on macOS: open the app → email field is focused → tab/enter → password field gets focus → password manager prompts on save.
- [ ] Manual on web: same OAuth flow as before, no regression.

Note: deploy-side fix is also recommended — Pangolin should let \`/.well-known/*\` through unauthenticated per RFC 8414, but the app no longer depends on it.