### PR TITLE
fix(chat): drop empty bubbles for tool-only assistant history rows

### DIFF
--- a/app/lib/features/chat/chat_provider.dart
+++ b/app/lib/features/chat/chat_provider.dart
@@ -580,16 +580,6 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
     return statusMessage;
   }
 
-  /// Map a [ToolResultEvent.status] string to a [ToolCallStatus] value.
-  static ToolCallStatus _parseToolStatus(String status) {
-    return switch (status) {
-      'ok' => ToolCallStatus.ok,
-      'error' => ToolCallStatus.error,
-      'denied' => ToolCallStatus.denied,
-      _ => ToolCallStatus.ok,
-    };
-  }
-
   /// Mark all currently-active timeline entries (thinking, subagent) as
   /// complete. Called when a new timeline entry starts, so the previous one
   /// auto-collapses.
@@ -658,7 +648,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
   /// Resolve the pending tool-call timeline entry for [event] and update state.
   /// Called from both [_streamMessage] and [_streamVoiceMessage].
   void _onToolResultEvent(ChatState chatState, ToolResultEvent event) {
-    final resolvedStatus = _parseToolStatus(event.status);
+    final resolvedStatus = _parseToolStatusString(event.status);
     final msgs = List<ChatMessage>.from(chatState.messages);
 
     // Match by toolCallId when available (stable), fall back to tool name.
@@ -854,7 +844,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
       msgs[idx].subagentToolCalls.add(
         ToolCallRecord(
           toolName: event.toolName,
-          status: _parseToolStatus(event.status),
+          status: _parseToolStatusString(event.status),
           arguments: event.arguments,
           result: event.result,
         ),
@@ -945,48 +935,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
         id: conversationId,
       );
       final detail = response.data!;
-      final messages = <ChatMessage>[];
-      for (final m in detail.messages) {
-        // Convert persisted tool calls into separate timeline entries so
-        // they render identically to the streaming path.
-        final toolCalls = m.toolCalls?.toList() ?? <dynamic>[];
-        for (final tc in toolCalls) {
-          messages.add(
-            ChatMessage(
-              id: 'toolcall-${tc.name}-${m.id}',
-              role: 'assistant',
-              content: '',
-              timelineType: TimelineEntryType.toolCall,
-              toolCalls: [
-                ToolCallRecord(
-                  toolName: tc.name,
-                  status: _parseToolStatus(tc.status),
-                  arguments: tc.arguments?.asMap.cast<String, dynamic>(),
-                  result: tc.result,
-                ),
-              ],
-            ),
-          );
-        }
-        messages.add(
-          ChatMessage(
-            id: m.id,
-            role: m.role,
-            content: m.content,
-            ttsAvailable: m.ttsAvailable,
-            attachments: m.attachments
-                ?.map(
-                  (a) => ChatAttachment(
-                    id: a.id,
-                    filename: a.filename,
-                    mimeType: a.mimeType,
-                    url: a.url,
-                  ),
-                )
-                .toList(),
-          ),
-        );
-      }
+      final messages = chatMessagesFromHistory(detail.messages);
 
       state = AsyncData(
         ChatState(conversationId: conversationId, messages: messages),
@@ -1883,3 +1832,81 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
 final chatProvider = AsyncNotifierProvider.autoDispose<ChatNotifier, ChatState>(
   ChatNotifier.new,
 );
+
+ToolCallStatus _parseToolStatusString(String status) {
+  return switch (status) {
+    'ok' => ToolCallStatus.ok,
+    'error' => ToolCallStatus.error,
+    'denied' => ToolCallStatus.denied,
+    _ => ToolCallStatus.ok,
+  };
+}
+
+/// Map a list of persisted [MessageSummary] history rows into the flat
+/// [ChatMessage] list the UI renders.
+///
+/// Each persisted assistant row may carry tool calls. The OpenAI-style wire
+/// format stores each tool invocation as its own assistant message with
+/// `content == ""` and a single entry in `tool_calls` — this is required so
+/// the subsequent `tool` role row can reference it via `tool_call_id`.
+///
+/// We split such a row into a standalone [TimelineEntryType.toolCall] chip
+/// entry and *skip* the underlying empty message bubble: the chip already
+/// fully represents that ReAct step. Without the skip, every tool-only turn
+/// renders as an empty grey pill next to its chip.
+///
+/// Rows that carry user-visible content (or attachments) are always preserved
+/// as a [TimelineEntryType.message] entry, even if they also have tool calls.
+List<ChatMessage> chatMessagesFromHistory(Iterable<MessageSummary> source) {
+  final messages = <ChatMessage>[];
+  for (final m in source) {
+    final toolCalls = m.toolCalls?.toList() ?? const [];
+    for (final tc in toolCalls) {
+      messages.add(
+        ChatMessage(
+          id: 'toolcall-${tc.name}-${m.id}',
+          role: 'assistant',
+          content: '',
+          timelineType: TimelineEntryType.toolCall,
+          toolCalls: [
+            ToolCallRecord(
+              toolName: tc.name,
+              status: _parseToolStatusString(tc.status),
+              arguments: tc.arguments?.asMap.cast<String, dynamic>(),
+              result: tc.result,
+            ),
+          ],
+        ),
+      );
+    }
+
+    final attachments = m.attachments;
+    final hasAttachments = attachments != null && attachments.isNotEmpty;
+    final isAssistantToolOnly =
+        m.role == 'assistant' &&
+        m.content.isEmpty &&
+        toolCalls.isNotEmpty &&
+        !hasAttachments;
+    if (isAssistantToolOnly) continue;
+
+    messages.add(
+      ChatMessage(
+        id: m.id,
+        role: m.role,
+        content: m.content,
+        ttsAvailable: m.ttsAvailable,
+        attachments: attachments
+            ?.map(
+              (a) => ChatAttachment(
+                id: a.id,
+                filename: a.filename,
+                mimeType: a.mimeType,
+                url: a.url,
+              ),
+            )
+            .toList(),
+      ),
+    );
+  }
+  return messages;
+}

--- a/app/lib/features/chat/chat_provider.dart
+++ b/app/lib/features/chat/chat_provider.dart
@@ -1835,6 +1835,7 @@ final chatProvider = AsyncNotifierProvider.autoDispose<ChatNotifier, ChatState>(
 
 ToolCallStatus _parseToolStatusString(String status) {
   return switch (status) {
+    'pending' => ToolCallStatus.pending,
     'ok' => ToolCallStatus.ok,
     'error' => ToolCallStatus.error,
     'denied' => ToolCallStatus.denied,
@@ -1861,10 +1862,13 @@ List<ChatMessage> chatMessagesFromHistory(Iterable<MessageSummary> source) {
   final messages = <ChatMessage>[];
   for (final m in source) {
     final toolCalls = m.toolCalls?.toList() ?? const [];
-    for (final tc in toolCalls) {
+    for (var i = 0; i < toolCalls.length; i++) {
+      final tc = toolCalls[i];
       messages.add(
         ChatMessage(
-          id: 'toolcall-${tc.name}-${m.id}',
+          // Include the index so multiple invocations of the same tool on a
+          // single assistant row produce distinct widget keys.
+          id: 'toolcall-${tc.name}-${m.id}-$i',
           role: 'assistant',
           content: '',
           timelineType: TimelineEntryType.toolCall,

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -486,10 +486,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_secure_storage_darwin
-      sha256: "3af15a3cb2bf5b8b776832bd01776f8018766aece55623176e28b406481fb320"
+      sha256: "67cd1ff671add31dc13e45194398187a04bb63804b37fa47866afae296d73fcb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.1"
   flutter_secure_storage_linux:
     dependency: transitive
     description:
@@ -704,10 +704,10 @@ packages:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: cb09e7dac6210041fad964ed7fbee004f14258b4eca4040f72d1234062ace4c8
+      sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
       url: "https://pub.dev"
     source: hosted
-    version: "4.11.0"
+    version: "4.12.0"
   leak_tracker:
     dependency: transitive
     description:
@@ -1541,10 +1541,10 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics
-      sha256: "6409a25046024f0f8c5d8a59fec314081e81f9d436b66ca4015a8b49772bf445"
+      sha256: "4d35a36400983c3457c289d4d553b5308f506ea84f7e51c7a564651b5525209a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   vector_graphics_codec:
     dependency: transitive
     description:
@@ -1557,10 +1557,10 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics_compiler
-      sha256: "06f0c50f88a1a020f95138dcc14ef4d5a039ced3f89b386209e6763dfa2cefa0"
+      sha256: "98e7e94de127b46a86ef46197fff84ff99f3d3b80a708390d717ad731efef598"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   vector_math:
     dependency: transitive
     description:

--- a/app/test/unit/chat/chat_history_mapping_test.dart
+++ b/app/test/unit/chat/chat_history_mapping_test.dart
@@ -9,6 +9,9 @@ MessageSummary _msg({
   required String content,
   int turn = 0,
   List<({String name, String status, String? result})> toolCalls = const [],
+  List<({String id, String filename, String mimeType, String url})>
+      attachments =
+      const [],
 }) {
   return MessageSummary(
     (b) => b
@@ -27,6 +30,21 @@ MessageSummary _msg({
                     ..name = tc.name
                     ..status = tc.status
                     ..result = tc.result,
+                ),
+              ),
+            )
+      ..attachments = attachments.isEmpty
+          ? null
+          : ListBuilder<AttachmentMetaResponse>(
+              attachments.map(
+                (a) => AttachmentMetaResponse(
+                  (x) => x
+                    ..id = a.id
+                    ..filename = a.filename
+                    ..mimeType = a.mimeType
+                    ..url = a.url
+                    ..sizeBytes = 1
+                    ..createdAt = DateTime.parse('2026-05-16T00:00:00Z'),
                 ),
               ),
             ),
@@ -165,6 +183,88 @@ void main() {
       expect(chips[1].toolCalls.single.toolName, 'web-fetch');
       expect(chips[1].toolCalls.single.status, ToolCallStatus.error);
       expect(chips[1].toolCalls.single.result, '404');
+    });
+
+    test(
+      'tool-only assistant row WITH attachments keeps the bubble for thumbnails',
+      () {
+        // Edge case: the model invoked a tool AND produced an image attachment
+        // but no reply text. The bubble must remain so the attachment renders.
+        final history = [
+          _msg(
+            id: 'a1',
+            role: 'assistant',
+            content: '',
+            toolCalls: [(name: 'image-gen', status: 'ok', result: 'ok')],
+            attachments: [
+              (
+                id: 'att1',
+                filename: 'render.png',
+                mimeType: 'image/png',
+                url: 'https://example/render.png',
+              ),
+            ],
+          ),
+        ];
+
+        final mapped = chatMessagesFromHistory(history);
+        final bubbles = mapped
+            .where((m) => m.timelineType == TimelineEntryType.message)
+            .toList();
+        expect(bubbles, hasLength(1));
+        expect(bubbles.single.role, 'assistant');
+        expect(bubbles.single.content, '');
+        expect(bubbles.single.attachments, hasLength(1));
+        expect(bubbles.single.attachments.single.filename, 'render.png');
+        expect(
+          mapped.where((m) => m.timelineType == TimelineEntryType.toolCall),
+          hasLength(1),
+        );
+      },
+    );
+
+    test('pending tool-call status round-trips (not coerced to ok)', () {
+      // A persisted row could carry a non-terminal status if the orchestrator
+      // crashed mid-call. The mapper must surface it as `pending` instead of
+      // silently treating it as a successful invocation.
+      final history = [
+        _msg(
+          id: 'a1',
+          role: 'assistant',
+          content: '',
+          toolCalls: [(name: 'bash', status: 'pending', result: null)],
+        ),
+      ];
+
+      final chips = chatMessagesFromHistory(
+        history,
+      ).where((m) => m.timelineType == TimelineEntryType.toolCall).toList();
+      expect(chips, hasLength(1));
+      expect(chips.single.toolCalls.single.status, ToolCallStatus.pending);
+    });
+
+    test('multiple invocations of the same tool produce distinct chip ids', () {
+      // Defensive: if a single assistant row carries two `bash` invocations,
+      // both chips must have unique ids so Flutter widget keying does not
+      // collide.
+      final history = [
+        _msg(
+          id: 'a1',
+          role: 'assistant',
+          content: '',
+          toolCalls: [
+            (name: 'bash', status: 'ok', result: 'first'),
+            (name: 'bash', status: 'ok', result: 'second'),
+          ],
+        ),
+      ];
+
+      final ids = chatMessagesFromHistory(history)
+          .where((m) => m.timelineType == TimelineEntryType.toolCall)
+          .map((m) => m.id)
+          .toList();
+      expect(ids, hasLength(2));
+      expect(ids.toSet(), hasLength(2), reason: 'chip ids must be unique');
     });
   });
 }

--- a/app/test/unit/chat/chat_history_mapping_test.dart
+++ b/app/test/unit/chat/chat_history_mapping_test.dart
@@ -1,0 +1,170 @@
+import 'package:assistant_api/assistant_api.dart';
+import 'package:assistant_app/features/chat/chat_provider.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+MessageSummary _msg({
+  required String id,
+  required String role,
+  required String content,
+  int turn = 0,
+  List<({String name, String status, String? result})> toolCalls = const [],
+}) {
+  return MessageSummary(
+    (b) => b
+      ..id = id
+      ..role = role
+      ..content = content
+      ..turn = turn
+      ..createdAt = DateTime.parse('2026-05-16T00:00:00Z')
+      ..ttsAvailable = false
+      ..toolCalls = toolCalls.isEmpty
+          ? null
+          : ListBuilder<ToolCallSummary>(
+              toolCalls.map(
+                (tc) => ToolCallSummary(
+                  (t) => t
+                    ..name = tc.name
+                    ..status = tc.status
+                    ..result = tc.result,
+                ),
+              ),
+            ),
+  );
+}
+
+void main() {
+  group('chatMessagesFromHistory', () {
+    test(
+      'assistant tool-call-only turns render as chips, not empty bubbles',
+      () {
+        // Mirrors the actual schorschvm conversation shape: 3 ReAct iterations
+        // each persisted as `assistant(content="", tool_calls=[X])` followed
+        // by a `tool` result row, terminated by an assistant final answer.
+        final history = [
+          _msg(id: 'u1', role: 'user', content: 'Hello', turn: 0),
+          _msg(
+            id: 'a1',
+            role: 'assistant',
+            content: '',
+            turn: 1,
+            toolCalls: [(name: 'bash', status: 'ok', result: 'ok')],
+          ),
+          _msg(
+            id: 'a2',
+            role: 'assistant',
+            content: '',
+            turn: 2,
+            toolCalls: [(name: 'web-fetch', status: 'ok', result: 'ok')],
+          ),
+          _msg(
+            id: 'a3',
+            role: 'assistant',
+            content: '',
+            turn: 3,
+            toolCalls: [(name: 'slack-post', status: 'ok', result: 'ok')],
+          ),
+          _msg(id: 'a4', role: 'assistant', content: 'Done.', turn: 4),
+        ];
+
+        final mapped = chatMessagesFromHistory(history);
+
+        // For each tool-only assistant row we expect exactly one toolCall
+        // timeline entry and *no* accompanying message bubble.
+        final toolCallEntries = mapped
+            .where((m) => m.timelineType == TimelineEntryType.toolCall)
+            .toList();
+        expect(toolCallEntries, hasLength(3));
+        expect(
+          toolCallEntries.map((m) => m.toolCalls.single.toolName).toList(),
+          ['bash', 'web-fetch', 'slack-post'],
+        );
+
+        // No empty assistant message bubbles. The user row, three chips,
+        // and the final-answer row are the only entries we expect.
+        final messageBubbles = mapped
+            .where((m) => m.timelineType == TimelineEntryType.message)
+            .toList();
+        expect(messageBubbles, hasLength(2));
+        expect(messageBubbles[0].role, 'user');
+        expect(messageBubbles[0].content, 'Hello');
+        expect(messageBubbles[1].role, 'assistant');
+        expect(messageBubbles[1].content, 'Done.');
+
+        for (final m in messageBubbles) {
+          expect(
+            m.content.isEmpty && m.role == 'assistant',
+            isFalse,
+            reason: 'Empty assistant content bubble leaked through',
+          );
+        }
+      },
+    );
+
+    test(
+      'assistant message with both content and tool calls keeps the bubble',
+      () {
+        final history = [
+          _msg(
+            id: 'a1',
+            role: 'assistant',
+            content: 'Calling tool first.',
+            toolCalls: [(name: 'bash', status: 'ok', result: 'ok')],
+          ),
+        ];
+
+        final mapped = chatMessagesFromHistory(history);
+
+        expect(
+          mapped.where((m) => m.timelineType == TimelineEntryType.toolCall),
+          hasLength(1),
+        );
+        final bubbles = mapped
+            .where((m) => m.timelineType == TimelineEntryType.message)
+            .toList();
+        expect(bubbles, hasLength(1));
+        expect(bubbles.single.content, 'Calling tool first.');
+      },
+    );
+
+    test('user messages are always preserved as bubbles', () {
+      final history = [
+        _msg(id: 'u1', role: 'user', content: 'Hi'),
+        _msg(id: 'u2', role: 'user', content: ''),
+      ];
+
+      final mapped = chatMessagesFromHistory(history);
+      final bubbles = mapped
+          .where((m) => m.timelineType == TimelineEntryType.message)
+          .toList();
+      expect(bubbles, hasLength(2));
+      expect(bubbles.every((m) => m.role == 'user'), isTrue);
+    });
+
+    test('toolCall chip entries carry name, status, and result', () {
+      final history = [
+        _msg(
+          id: 'a1',
+          role: 'assistant',
+          content: '',
+          toolCalls: [
+            (name: 'bash', status: 'ok', result: 'stdout: ok'),
+            (name: 'web-fetch', status: 'error', result: '404'),
+          ],
+        ),
+      ];
+
+      final mapped = chatMessagesFromHistory(history);
+      final chips = mapped
+          .where((m) => m.timelineType == TimelineEntryType.toolCall)
+          .toList();
+      expect(chips, hasLength(2));
+      expect(chips[0].toolCalls.single.toolName, 'bash');
+      expect(chips[0].toolCalls.single.status, ToolCallStatus.ok);
+      expect(chips[0].toolCalls.single.result, 'stdout: ok');
+      expect(chips[1].toolCalls.single.toolName, 'web-fetch');
+      expect(chips[1].toolCalls.single.status, ToolCallStatus.error);
+      expect(chips[1].toolCalls.single.result, '404');
+    });
+  });
+}

--- a/openspec/changes/archive/2026-05-16-chat-history-skip-tool-only-bubbles/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-16-chat-history-skip-tool-only-bubbles/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/archive/2026-05-16-chat-history-skip-tool-only-bubbles/README.md
+++ b/openspec/changes/archive/2026-05-16-chat-history-skip-tool-only-bubbles/README.md
@@ -1,0 +1,3 @@
+# chat-history-skip-tool-only-bubbles
+
+Skip rendering empty assistant message bubbles for tool-call-only ReAct turns in conversation history

--- a/openspec/changes/archive/2026-05-16-chat-history-skip-tool-only-bubbles/design.md
+++ b/openspec/changes/archive/2026-05-16-chat-history-skip-tool-only-bubbles/design.md
@@ -1,0 +1,74 @@
+## Context
+
+The Flutter chat timeline blends two render paths over the same `ChatMessage` model:
+
+1. **Streaming path** (`ChatNotifier._streamMessage` and friends). A single `assistant-streaming` placeholder bubble is appended on send; `StatusEvent`s push tool-call timeline entries; `TokenEvent`s flow into the placeholder; `DoneEvent.content` becomes the final answer. Empty bubbles never arise because the placeholder is collapsed once `DoneEvent` arrives — if there is no final-answer text, it stays empty for the duration of the stream and is harmlessly hidden by the streaming dots indicator.
+
+2. **History-replay path** (`ChatNotifier.loadConversation`). Reads `GET /api/conversations/{id}` and walks `detail.messages`. For each persisted row the loader:
+   - emits one `TimelineEntryType.toolCall` chip per entry in `m.tool_calls`,
+   - then emits a `TimelineEntryType.message` bubble using `m.content`.
+
+Persisted assistant rows for ReAct tool-only steps have `content == ""` by protocol: each tool invocation is its own assistant message so the next `role == 'tool'` row can reference it via `tool_call_id`. Data sample from `schorschvm` confirms this is the dominant shape: in one inspected conversation, turns 1–6 are all `assistant(content="", tool_calls=[X])` followed by `tool(content="<result>")`, with turn 7 carrying the only natural-language reply.
+
+In the existing rendering rules, every `TimelineEntryType.message` row paints the rounded `surfaceContainerHighest` container unconditionally — the inner markdown is gated on `content.isNotEmpty`, but the bubble shell is not. The result is one redundant grey pill per tool-only ReAct step.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Stop emitting empty `TimelineEntryType.message` rows from the history-replay path when the underlying persisted row is an assistant tool-only step.
+- Keep the mapping pure (no state, no I/O) so the contract is unit-testable without mocking the API client.
+- Preserve every other case verbatim: chips, user rows, tool result rows (`role == 'tool'`), and assistant rows that carry text or attachments.
+
+**Non-Goals**
+
+- Changing what the server persists or how the orchestrator constructs the assistant messages. The wire format remains canonical OpenAI tool-calling shape.
+- Reworking the streaming path. It already collapses correctly on `DoneEvent`.
+- Filtering or restyling `role == 'tool'` rows — those carry user-meaningful content (the tool result) and have their own rendering concerns.
+- Introducing a new spec capability. This is an additive requirement on the existing `tool-call-display` capability.
+
+## Decisions
+
+### 1. Extract the mapping into a top-level pure function
+
+`loadConversation` mixed Riverpod state mutation, API I/O, and message reshaping. The reshaping is the only piece that needs new behaviour and the only piece that benefits from a unit test. Extracting it to a top-level `List<ChatMessage> chatMessagesFromHistory(Iterable<MessageSummary>)` keeps the patch surface minimal and the test fast.
+
+**Alternative considered:** `@visibleForTesting static` method on `ChatNotifier`. Rejected because callers would need to instantiate the notifier (which requires a `Ref`) — the function has no notifier state to access, so a top-level function is more honest about its inputs.
+
+### 2. Gate the bubble emission on `role + content + tool_calls + attachments`
+
+The skip predicate is intentionally narrow:
+
+```
+role == 'assistant'
+  && content.isEmpty
+  && toolCalls.isNotEmpty
+  && (attachments == null || attachments.isEmpty)
+```
+
+Each clause defends a real shape:
+
+- `role == 'assistant'` — never silently drop a user or tool row; user rows in particular are user-authored and must always be visible.
+- `content.isEmpty` — if the model produced any reply text we render it.
+- `toolCalls.isNotEmpty` — if there are no chips to stand in for the row, dropping it would erase the turn entirely. (An empty-content assistant row with no tool calls shouldn't occur in practice, but if it does we keep it visible as a debugging signal.)
+- `attachments` empty — assistant rows can carry image attachments produced by the model. Their bubble must remain to host the thumbnails.
+
+**Alternative considered:** Skip purely on `content.isEmpty && role == 'assistant'`. Rejected because it would suppress empty-but-attachment-bearing rows.
+
+### 3. Decide at mapping time, not render time
+
+The bubble shell could equally be suppressed in `_MessageBubble.build()` by returning `SizedBox.shrink()` for an empty assistant message with no attachments. The mapping-time fix is preferred because:
+
+- It keeps the local `messages` list honest — what is in the list is what gets rendered. Adjacent-message logic in `chat_screen.dart` (the `prevMsg.role == msg.role` grouping check) does not need to learn to skip invisible siblings.
+- The bubble widget remains simple; a future maintainer reading `_MessageBubble` doesn't need to know that some `ChatMessage`s render as nothing.
+- Render-time skipping leaves a `ChatMessage` in the list whose only purpose is to be invisible — a footgun for any future iteration that builds on the list (counting, scrolling, retry actions).
+
+## Risks / Trade-offs
+
+- **Risk:** A future server change starts persisting empty-content assistant rows with semantically meaningful state (e.g. just attachments, no text, no tool calls). → **Mitigation:** the predicate requires `toolCalls.isNotEmpty`, so attachments-only and pure-empty assistant rows are still rendered. The skip is opt-in to a specific protocol shape.
+- **Risk:** The pure function diverges from the streaming render path. → **Mitigation:** the streaming path already converges on the same `ChatMessage` shape (it constructs `TimelineEntryType.toolCall` entries via `_onStatusEvent`); the new function preserves the same `id` convention (`'toolcall-${tc.name}-${m.id}'`) and `ToolCallRecord` mapping it had before extraction, so the only behavioural delta is the skip.
+- **Trade-off:** A consumer that wanted to count "assistant turns" by walking the timeline list will now under-count tool-only iterations. There are no such consumers today, and counting ReAct iterations by `TimelineEntryType.toolCall` is more meaningful anyway.
+
+## Migration Plan
+
+No data migration. The change is a pure client-side rendering rule. Old persisted conversations and new conversations render identically under the new rule. Rollback is a code revert with no follow-up state changes.

--- a/openspec/changes/archive/2026-05-16-chat-history-skip-tool-only-bubbles/proposal.md
+++ b/openspec/changes/archive/2026-05-16-chat-history-skip-tool-only-bubbles/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+When the assistant invokes tools across multiple ReAct iterations, each iteration is persisted as a separate `assistant` message row with `content = ""` and a single entry in `tool_calls` — this is mandated by the OpenAI-style wire format so the following `tool` role row can reference it via `tool_call_id`. On the deployed instance (`schorschvm`), 18 of the 20 most recent assistant messages in a real conversation match this shape.
+
+Today the Flutter history loader splits each persisted row into a tool-call timeline chip **and** an underlying message bubble. For tool-call-only turns, the bubble is rendered with empty content, producing a stack of small grey rounded pills sitting beside their chips. The chips already fully represent each ReAct step, so the bubble is redundant noise that visually fragments the timeline.
+
+## What Changes
+
+- The conversation history → chat timeline mapper SHALL omit the message bubble for an assistant row whose `content` is empty, whose `tool_calls` list is non-empty, and which carries no attachments. The tool-call chip(s) already represent the turn.
+- Assistant rows that carry user-visible content (text or attachments) continue to render as a bubble even when they also have tool calls (final-answer turns that interleave a chip with a reply).
+- User rows are unconditionally rendered as bubbles, including empty user rows (defensive — should not occur in practice).
+- The mapping logic is extracted into a pure, file-scope function (`chatMessagesFromHistory`) so its contract can be exercised by unit tests without mocking the API client.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `tool-call-display`: add a requirement covering history reconstruction — tool-call-only assistant rows must surface as chips only, never as redundant empty bubbles.
+
+## Impact
+
+- **Code**: `app/lib/features/chat/chat_provider.dart` (extract & gate the bubble emission), `app/test/unit/chat/chat_history_mapping_test.dart` (new tests).
+- **APIs / data**: none. Wire format and persistence are unchanged; this is purely a client-side rendering rule.
+- **Compatibility**: no breaking change. Existing tool-call chip rendering is preserved verbatim.
+
+## Non-goals
+
+- Changing how the orchestrator persists assistant messages or how it threads `tool_call_id` linkage.
+- Reworking the live-streaming render path. The streaming side already routes the final `DoneEvent.content` into a single placeholder bubble; only the history-replay path produces the empty pills.
+- Surfacing `role == 'tool'` result rows differently — they are out of scope here.
+- Reordering chips or merging adjacent tool calls into a single grouped chip.
+
+## User-facing documentation
+
+Not required. The change is a defect fix in the chat timeline; no user-visible feature is added or removed, and no operator setting is introduced.

--- a/openspec/changes/archive/2026-05-16-chat-history-skip-tool-only-bubbles/specs/tool-call-display/spec.md
+++ b/openspec/changes/archive/2026-05-16-chat-history-skip-tool-only-bubbles/specs/tool-call-display/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Tool-call-only assistant rows render chips without an empty message bubble
+
+When reconstructing a conversation from history, the chat timeline SHALL NOT render a message bubble shell for an assistant row whose `content` is empty, whose `tool_calls` list is non-empty, and which carries no attachments. The tool-call chip(s) derived from that row already represent the ReAct step fully; an additional empty bubble is redundant and visually fragments the timeline.
+
+#### Scenario: Persisted assistant tool-only row produces only chips
+
+- **WHEN** conversation history contains an `assistant` message with `content == ""`, one or more entries in `tool_calls`, and no attachments
+- **THEN** the chat timeline contains one tool-call chip entry per `tool_calls` entry
+- **AND** the chat timeline contains no `TimelineEntryType.message` entry corresponding to that persisted row
+
+#### Scenario: Mixed turn with content and tool calls keeps the bubble
+
+- **WHEN** conversation history contains an `assistant` message with non-empty `content` and one or more entries in `tool_calls`
+- **THEN** the chat timeline contains one tool-call chip per `tool_calls` entry
+- **AND** the chat timeline contains a `TimelineEntryType.message` entry rendering the reply text
+
+#### Scenario: Assistant row with attachments but no content keeps the bubble
+
+- **WHEN** conversation history contains an `assistant` message with `content == ""`, one or more entries in `tool_calls`, and at least one attachment
+- **THEN** the chat timeline contains a `TimelineEntryType.message` entry so the attachment thumbnails are rendered
+
+#### Scenario: User rows are always preserved
+
+- **WHEN** conversation history contains a `user` message, regardless of `content` being empty
+- **THEN** the chat timeline contains a `TimelineEntryType.message` entry for that row
+- **AND** the bubble shell is rendered (the user-authored turn must remain visible)
+
+#### Scenario: Final-answer assistant row after tool-only iterations renders normally
+
+- **WHEN** conversation history contains a sequence of `assistant(content="", tool_calls=[X])` rows followed by an `assistant` row with non-empty `content`
+- **THEN** only the chips appear for the tool-only iterations
+- **AND** the final assistant row renders as a normal message bubble with its reply text

--- a/openspec/changes/archive/2026-05-16-chat-history-skip-tool-only-bubbles/tasks.md
+++ b/openspec/changes/archive/2026-05-16-chat-history-skip-tool-only-bubbles/tasks.md
@@ -1,0 +1,31 @@
+# Tasks: Chat History — Skip Tool-Only Bubbles
+
+This change captures work that has already landed on `worktree-snazzy-dazzling-nest`. Task boxes reflect implementation state at proposal time.
+
+## 1. Extract the history → ChatMessage mapping into a pure function
+
+- [x] 1.1 Add a file-scope `chatMessagesFromHistory(Iterable<MessageSummary>)` function in `app/lib/features/chat/chat_provider.dart` that returns the flat `List<ChatMessage>` the chat screen consumes.
+- [x] 1.2 Move the tool-call chip emission (synthetic `id: 'toolcall-${tc.name}-${m.id}'`, `TimelineEntryType.toolCall`, mapped `ToolCallRecord`) into the new function unchanged.
+- [x] 1.3 Move the message-bubble emission into the new function, preserving `id`, `role`, `content`, `ttsAvailable`, and attachment mapping.
+- [x] 1.4 Extract the `_parseToolStatus` switch into a top-level `_parseToolStatusString` used by both the streaming path and the new helper. Remove the now-unused private wrapper.
+- [x] 1.5 Replace the inline loop in `ChatNotifier.loadConversation` with a single call to `chatMessagesFromHistory(detail.messages)`.
+
+## 2. Gate the empty bubble emission
+
+- [x] 2.1 Inside `chatMessagesFromHistory`, compute `isAssistantToolOnly = role == 'assistant' && content.isEmpty && toolCalls.isNotEmpty && attachments empty`.
+- [x] 2.2 When `isAssistantToolOnly` is true, `continue` past the bubble emission while still emitting the chips.
+- [x] 2.3 Document the OpenAI-protocol rationale in the function's doc comment so the next maintainer can match the predicate to the wire format.
+
+## 3. Test coverage
+
+- [x] 3.1 Add `app/test/unit/chat/chat_history_mapping_test.dart` with a fixture matching the schorschvm shape (user → 3 × `assistant(content="", tool_calls=[X])` → final `assistant(content="Done.")`).
+- [x] 3.2 Assert that tool-only assistant rows produce three `TimelineEntryType.toolCall` entries and no corresponding `TimelineEntryType.message` entries.
+- [x] 3.3 Assert that a mixed assistant row (non-empty content + tool calls) produces both a chip and a bubble.
+- [x] 3.4 Assert user rows are always preserved (including the defensive empty-user-content case).
+- [x] 3.5 Assert chip `toolName`, `status`, and `result` round-trip correctly from `ToolCallSummary` → `ToolCallRecord`.
+
+## 4. Validate
+
+- [x] 4.1 `flutter analyze` — zero issues.
+- [x] 4.2 `flutter test` — full suite green (811 tests).
+- [x] 4.3 Verify against the deployed instance (`schorschvm`) that the persisted shape matches the fixture (one assistant row per ReAct iteration with `content=""` and `tool_calls=[…]`).

--- a/openspec/specs/tool-call-display/spec.md
+++ b/openspec/specs/tool-call-display/spec.md
@@ -1,4 +1,8 @@
-## ADDED Requirements
+## Purpose
+
+Define how tool invocations performed by the assistant are surfaced in the chat UI: when chips appear, what status states they carry, how they relate to reply text, and how they survive across streaming and history reconstruction.
+
+## Requirements
 
 ### Requirement: Tool calls render as inline chips inside the assistant bubble
 
@@ -64,3 +68,36 @@ Each status SHALL use a distinct icon and colour so users can differentiate outc
 
 - **WHEN** a tool call chip has status `denied`
 - **THEN** a prohibition icon (⊘) with a warning colour (amber) is shown
+
+### Requirement: Tool-call-only assistant rows render chips without an empty message bubble
+
+When reconstructing a conversation from history, the chat timeline SHALL NOT render a message bubble shell for an assistant row whose `content` is empty, whose `tool_calls` list is non-empty, and which carries no attachments. The tool-call chip(s) derived from that row already represent the ReAct step fully; an additional empty bubble is redundant and visually fragments the timeline.
+
+#### Scenario: Persisted assistant tool-only row produces only chips
+
+- **WHEN** conversation history contains an `assistant` message with `content == ""`, one or more entries in `tool_calls`, and no attachments
+- **THEN** the chat timeline contains one tool-call chip entry per `tool_calls` entry
+- **AND** the chat timeline contains no `TimelineEntryType.message` entry corresponding to that persisted row
+
+#### Scenario: Mixed turn with content and tool calls keeps the bubble
+
+- **WHEN** conversation history contains an `assistant` message with non-empty `content` and one or more entries in `tool_calls`
+- **THEN** the chat timeline contains one tool-call chip per `tool_calls` entry
+- **AND** the chat timeline contains a `TimelineEntryType.message` entry rendering the reply text
+
+#### Scenario: Assistant row with attachments but no content keeps the bubble
+
+- **WHEN** conversation history contains an `assistant` message with `content == ""`, one or more entries in `tool_calls`, and at least one attachment
+- **THEN** the chat timeline contains a `TimelineEntryType.message` entry so the attachment thumbnails are rendered
+
+#### Scenario: User rows are always preserved
+
+- **WHEN** conversation history contains a `user` message, regardless of `content` being empty
+- **THEN** the chat timeline contains a `TimelineEntryType.message` entry for that row
+- **AND** the bubble shell is rendered (the user-authored turn must remain visible)
+
+#### Scenario: Final-answer assistant row after tool-only iterations renders normally
+
+- **WHEN** conversation history contains a sequence of `assistant(content="", tool_calls=[X])` rows followed by an `assistant` row with non-empty `content`
+- **THEN** only the chips appear for the tool-only iterations
+- **AND** the final assistant row renders as a normal message bubble with its reply text


### PR DESCRIPTION
## Summary

- Empty grey pills appearing next to tool-call chips in conversation history were duplicate renderings: the history loader emitted *both* a chip and an empty message bubble for each persisted assistant row that only invoked tools (`content=""`, `tool_calls=[…]`). That shape is canonical OpenAI tool-calling: each ReAct iteration is its own assistant row so the following `role: tool` row can attach via `tool_call_id`. Confirmed on the deployed instance (`schorschvm`): 18 of the 20 most recent assistant rows in one inspected conversation match this shape.
- Extract the history → `ChatMessage` mapping into a pure top-level `chatMessagesFromHistory` and skip the bubble when the row is an assistant tool-only step with no attachments. Chips already represent the turn fully; mixed turns (content + tool_calls), user rows, and attachment-bearing rows continue to render as bubbles.
- Capture the rule as an openspec change (`chat-history-skip-tool-only-bubbles`) and merge a new requirement into the `tool-call-display` capability. Repaired the main spec, which was stuck in delta-header format and missing a `## Purpose` section.

## Test plan

- [x] `flutter test test/unit/chat/chat_history_mapping_test.dart` — 4 new cases (tool-only chips no-bubble, mixed turn keeps bubble, user rows preserved, chip fields round-trip)
- [x] `flutter test` — full Flutter suite, 811 tests green
- [x] `flutter analyze` — no issues
- [x] `openspec validate tool-call-display --type spec` — passes (was structurally invalid before this PR)
- [ ] Manual: load a conversation with multiple tool-call iterations in the Flutter app and confirm chips render without empty grey pills between them

## Commits

1. `chore(app): bump 4 transitive deps for pre-commit currency` — `flutter_secure_storage_darwin`, `json_annotation`, `vector_graphics`, `vector_graphics_compiler`. Required to unblock `dart_pre_commit`; no source changes.
2. `fix(chat): drop empty bubbles for tool-only assistant history rows` — the actual fix, tests, and openspec change archive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Chat history now displays more cleanly by avoiding empty message bubbles for assistant steps that only contain tool invocations, while tool calls remain visible as separate entries.

* **Tests**
  * Added unit tests validating chat history message mapping and tool-call rendering behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cedricziel/assistant/pull/717?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->