### PR TITLE
openspec: propose four web-ui bug fixes (#619 #620 #265 #266)

### DIFF
--- a/openspec/changes/fix-web-ui-ipad-sidebar-collapse/.openspec.yaml
+++ b/openspec/changes/fix-web-ui-ipad-sidebar-collapse/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/fix-web-ui-ipad-sidebar-collapse/README.md
+++ b/openspec/changes/fix-web-ui-ipad-sidebar-collapse/README.md
@@ -1,0 +1,3 @@
+# fix-web-ui-ipad-sidebar-collapse
+
+Sidebar must be collapsible and persistent on iPad landscape and web tablet sizes

--- a/openspec/changes/fix-web-ui-ipad-sidebar-collapse/design.md
+++ b/openspec/changes/fix-web-ui-ipad-sidebar-collapse/design.md
@@ -1,0 +1,81 @@
+## Context
+
+`NavShell` (`app/lib/shared/nav_shell.dart`) has three render branches gated on `isAppleTouch` and `isWide` (width >= 768):
+
+1. **Apple touch + wide** (native iPad / Mac Catalyst): renders `CupertinoSidebarCollapsible` plus a Cupertino toggle button overlaid in a `Stack` at top-leading. Already collapsible.
+2. **Apple touch + compact** (iPhone): `CupertinoTabBar`. No sidebar.
+3. **Material + wide** (web, Android tablet, macOS native): renders an `AnimatedContainer` sidebar with an in-sidebar toggle (`IconButton(Icons.menu_open)`, line 627). **This is the branch iPad Safari and iPad PWA hit** because `platformStyle` resolves to `material` whenever `kIsWeb` is true (`app/lib/shared/platform/platform.dart:33`).
+
+The shared state is `sidebarCollapsedProvider` — a `Notifier<bool>` whose `build()` returns `false` and which is never persisted.
+
+So the bug has two real causes for the iPad case:
+
+- The Material wide branch's toggle is inside the rail itself; on a 1024×768 iPad the rail is on the left edge of the screen and the icon button is hard to spot above the destination list.
+- Even when found, toggling does not survive a refresh.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Sidebar collapse state survives hard reload on every platform.
+- A clearly visible toggle exists on iPad landscape (both PWA / Safari Material branch and native Cupertino branch).
+- Swipe-from-left-edge toggles the sidebar on touch input.
+- Default state remains `expanded` for first-time users.
+
+**Non-goals**
+
+- Auto-collapse at narrow widths (kept manual).
+- Different default per platform.
+- Multi-pane / split-view navigation.
+
+## Decisions
+
+### D1: Persist via `SharedPreferences` under `assistant.sidebarCollapsed`
+
+**Choice:** Replace `SidebarCollapsedNotifier` with an `AsyncNotifier<bool>` that reads `SharedPreferences` on `build()` and writes on every `toggle()`. Default to `false` if the key is missing or read fails.
+
+**Why:** Other UI state in the app uses `SharedPreferences` (per `web-session-resilience` for `assistant.spaceSelection`). Consistent storage keeps the persistence story uniform. `SharedPreferences` also works identically on web (localStorage backed) and native.
+
+**Alternative considered:** Use `hydrated_riverpod` or a dedicated package. Rejected — single value, not worth a new dep.
+
+### D2: Promote toggle to the main content's top bar on Material wide
+
+**Choice:** Render the toggle button in a thin top-leading slot **inside the main content `Expanded` area**, not only inside the sidebar. The in-sidebar toggle stays (some users will rediscover it after the first collapse). The new toggle is unconditional on the Material wide branch.
+
+**Layout:**
+
+```
+┌─────────┬──────────────────────────────────┐
+│ sidebar │ [☰] page header              … │
+│  …      │ ─────────────────────────────── │
+│         │ page body                       │
+```
+
+**Why:** Mirrors the Cupertino branch's overlay button and matches mainstream desktop apps (VS Code, Linear, Slack). The button stays visible whether the sidebar is collapsed or expanded.
+
+**Alternative considered:** A floating action button. Rejected — clashes with chat composer FAB and uses too much vertical real estate.
+
+### D3: Swipe-from-left-edge on touch input
+
+**Choice:** Wrap the main content `Expanded` in a `GestureDetector` listening to `onHorizontalDragUpdate` at the left edge (first 20 logical pixels). A rightward drag of ≥ 40 px expands; a leftward drag collapses. Only active when the primary pointer is touch — gated on `defaultTargetPlatform` plus the `kIsWeb && touch` check.
+
+**Why:** Matches the gesture requested in #444. Implementing it now means #444 mostly resolves alongside this fix.
+
+**Alternative considered:** `Dismissible` widget — wrong semantics (it dismisses, not toggles). Rejected.
+
+### D4: Promote the in-sidebar Material toggle from `IconButton` to a labelled `TextButton.icon`
+
+**Choice:** When the sidebar is expanded, the in-sidebar toggle gets a small `"Collapse"` label next to the icon so it reads as a discoverable affordance. When collapsed (rail = 72px), the icon-only `IconButton` is retained.
+
+**Why:** First-run discoverability. The label costs us ~24 px of width inside a 240 px sidebar.
+
+## Risks / Trade-offs
+
+- **Top-bar toggle conflicts with screen-specific app bars:** Several screens (`/traces`, `/logs`) already render an `AppBar` with a back button. We render the new toggle as the first item in the row alongside the existing app bar — `NavShell` already wraps each screen, so we add a slim `Row` above the child. Where children already render their own `AppBar`, we need the toggle to live _outside_ the screen's scaffold. Implementation note: render the toggle as an overlay in `Positioned` rather than nesting into screen scaffolds.
+- **Swipe gesture vs. horizontal scroll:** Some screens (timeline scrubbers, table views) use horizontal scrolling. We constrain the swipe-detect zone to the left 20 px of the viewport so it doesn't intercept content scrolling.
+- **`AsyncNotifier` initial value race:** While SharedPreferences is loading, the sidebar should show its previous state, not flash open then closed. We render based on `AsyncValue.value ?? false` — first-paint defaults to expanded, hydrated state replaces it within one frame.
+
+## Migration Plan
+
+- No data migration. First time the new code runs, the `assistant.sidebarCollapsed` key is absent → defaults to expanded — identical to today's behaviour.
+- `sidebarCollapsedProvider` keeps the same public name to avoid touching every call site.

--- a/openspec/changes/fix-web-ui-ipad-sidebar-collapse/proposal.md
+++ b/openspec/changes/fix-web-ui-ipad-sidebar-collapse/proposal.md
@@ -1,0 +1,50 @@
+## Why
+
+On iPad in landscape orientation, users cannot meaningfully collapse the navigation sidebar:
+
+- iPad Safari and iPad PWA report `kIsWeb == true`, so the app falls into the **Material wide** branch of `NavShell`, not the Cupertino branch. The Material wide branch _does_ render a toggle button inside the sidebar (`Icons.menu_open`, `nav_shell.dart:627`), but it sits on top of the sidebar list — visually small, easy to miss, and pinned to the right edge of an already-narrow rail.
+- `SidebarCollapsedNotifier` (`nav_shell.dart:29`) is a plain `Notifier<bool>` that starts at `false` and lives in memory only. Every page reload re-expands the sidebar, undoing the user's preference.
+- Native iPad (Catalyst / iOS app) takes the Cupertino branch, which has a Cupertino toggle button overlaid at the top-leading corner — but that toggle only renders inside the `Stack` above the sidebar and is easy to confuse with the conversation header.
+
+The result is exactly what the bug report describes: on iPad landscape the sidebar feels permanently fixed, eats screen real estate, and doesn't remember what the user wanted.
+
+## What Changes
+
+- Persist `sidebarCollapsedProvider` across reloads via `SharedPreferences` (key `assistant.sidebarCollapsed`). State rehydrates on first `build()` so refresh keeps the user's choice.
+- On the Material wide branch, surface a primary collapse / expand affordance in the **app bar / top-leading area of the main content** (not buried inside the sidebar), matching the Cupertino branch's overlay position. Keep the existing in-sidebar toggle for discoverability.
+- Add a swipe-from-left-edge gesture on touch platforms (`iOS`, iPad PWA via touch input) that toggles the sidebar — wired into the same `sidebarCollapsedProvider`.
+- Verify the Material wide branch actually triggers at the iPad-landscape width (1024px, well above 768px breakpoint) and that the sidebar can shrink to `_kSidebarCollapsedWidth` (72px) without overflow.
+- Add Playwright + widget coverage for the iPad-landscape viewport (1180×820) verifying the toggle is visible, tappable, and that the persisted state survives a reload.
+
+## Non-goals
+
+- Redesigning the sidebar's contents.
+- Adding multi-pane layouts (independent navigation + chat panes).
+- Persisting other UI state (theme, density, etc.) — this change limits itself to sidebar collapse.
+- Replacing `cupertino_sidebar` / `CupertinoSidebarCollapsible` — we reuse the existing collapsible widget.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `adaptive-shell` — REQ-2 already mandates the iPad sidebar exists; new requirements pin down its collapse behaviour and persistence.
+
+### Added Capabilities
+
+- `sidebar-collapse-state` (new spec) — the rules around persistence and the toggle affordance.
+
+## Impact
+
+- `app/lib/shared/nav_shell.dart` — extract the collapse toggle into a reusable widget, render it in the main content top bar in addition to the in-sidebar location, and add swipe-gesture handling.
+- `app/lib/shared/nav_shell.dart` — replace `SidebarCollapsedNotifier` with an `AsyncNotifier<bool>` (or hydrated `Notifier`) backed by `SharedPreferences`.
+- `app/test/widget/nav_shell_test.dart` — widget tests for the new toggle and persistence behaviour.
+- `app/test/e2e/sidebar_collapse_ipad_test.dart` (Playwright) — visual + state regression at iPad-landscape viewport.
+- No backend changes.
+
+## Visual / UI change
+
+Yes — the main content area gains a top-leading toggle button on the Material wide branch. Playwright iPad-landscape baselines for routes that render `NavShell` will move. Sidebar visuals otherwise unchanged.
+
+## User-facing documentation
+
+Brief note in `docs/operations/web-ui-shortcuts.md` (or the closest existing reference) describing the toggle and the new swipe gesture. No standalone docs page needed.

--- a/openspec/changes/fix-web-ui-ipad-sidebar-collapse/specs/adaptive-shell/spec.md
+++ b/openspec/changes/fix-web-ui-ipad-sidebar-collapse/specs/adaptive-shell/spec.md
@@ -1,0 +1,16 @@
+## MODIFIED Requirements
+
+### Requirement: REQ-2 sidebar on Apple touch wide is collapsible with a persistent state
+
+On Apple touch platforms at regular width (>= 768 dp), the shell SHALL render a sidebar with all destinations using `CupertinoSidebarCollapsible`. Collapse / expand SHALL be driven by `sidebarCollapsedProvider`, which SHALL persist its state across app launches as defined in the `sidebar-collapse-state` capability. The Cupertino toggle button at the top-leading corner SHALL be rendered for every Apple touch wide configuration (native iPad app, Mac Catalyst).
+
+#### Scenario: Native iPad-landscape sidebar starts collapsed when previously collapsed
+
+- **GIVEN** `assistant.sidebarCollapsed == true` is persisted
+- **WHEN** the native iPad app launches in landscape
+- **THEN** `CupertinoSidebarCollapsible.isExpanded` SHALL be `false` on first frame
+
+#### Scenario: Cupertino toggle button uses the persisted notifier
+
+- **WHEN** the user taps the Cupertino top-leading toggle
+- **THEN** `sidebarCollapsedProvider.notifier.toggle()` SHALL run AND the new value SHALL be written to `SharedPreferences`

--- a/openspec/changes/fix-web-ui-ipad-sidebar-collapse/specs/sidebar-collapse-state/spec.md
+++ b/openspec/changes/fix-web-ui-ipad-sidebar-collapse/specs/sidebar-collapse-state/spec.md
@@ -47,7 +47,7 @@ On the Material wide branch of `NavShell` (web/macOS, viewport >= 768 dp), the s
 
 ### Requirement: Swipe-from-left-edge toggles the sidebar on touch input
 
-On touch input devices (`defaultTargetPlatform` is `iOS` or `android`, or pointerKind is `touch` on web), a horizontal drag originating in the left 20 logical pixels of the viewport SHALL toggle `sidebarCollapsedProvider` when the drag exceeds 40 logical pixels in either direction.
+On touch input devices (`PointerDeviceKind.touch`), a horizontal drag originating in the left 20 logical pixels of the viewport SHALL toggle `sidebarCollapsedProvider` when the drag exceeds 40 logical pixels in either direction within a single continuous gesture (no time cap — slow drags also qualify; the `within 250 ms` reading in the scenarios below is illustrative of a typical swipe, not a normative constraint). The toggle SHALL fire at most once per gesture so a long drag does not flip the state repeatedly.
 
 #### Scenario: Drag right from left edge expands the sidebar
 

--- a/openspec/changes/fix-web-ui-ipad-sidebar-collapse/specs/sidebar-collapse-state/spec.md
+++ b/openspec/changes/fix-web-ui-ipad-sidebar-collapse/specs/sidebar-collapse-state/spec.md
@@ -1,0 +1,74 @@
+## ADDED Requirements
+
+### Requirement: Sidebar collapse state persists across reloads
+
+`sidebarCollapsedProvider` SHALL read its initial value from `SharedPreferences` under the key `assistant.sidebarCollapsed` and SHALL write back on every state change. A missing key SHALL default to `false` (expanded). Read or write failures SHALL be non-fatal: the provider continues with in-memory state.
+
+#### Scenario: Cold start with no stored value
+
+- **GIVEN** `assistant.sidebarCollapsed` is absent from `SharedPreferences`
+- **WHEN** `sidebarCollapsedProvider.build()` runs
+- **THEN** the resolved state SHALL be `false` (expanded)
+
+#### Scenario: Hard reload after collapse
+
+- **GIVEN** the user has toggled the sidebar to collapsed AND `assistant.sidebarCollapsed == true` is persisted
+- **WHEN** the app is reloaded
+- **THEN** `sidebarCollapsedProvider` SHALL resolve to `true` AND the sidebar SHALL render in its collapsed form on first paint
+
+#### Scenario: Toggle writes through to storage
+
+- **WHEN** any code calls `sidebarCollapsedProvider.notifier.toggle()`
+- **THEN** the new boolean value SHALL be written to `SharedPreferences` under `assistant.sidebarCollapsed`
+
+#### Scenario: Storage write failure is non-fatal
+
+- **WHEN** the platform rejects the SharedPreferences write
+- **THEN** the provider SHALL continue with the updated in-memory state AND SHALL NOT throw
+
+### Requirement: Sidebar exposes a top-leading toggle on Material wide layouts
+
+On the Material wide branch of `NavShell` (web/macOS, viewport >= 768 dp), the shell SHALL render an unconditional toggle affordance in the **main content area's top-leading corner**, in addition to the existing toggle inside the sidebar. The button SHALL show `Icons.menu` when collapsed and `Icons.menu_open` when expanded with a tooltip reading `"Expand sidebar"` / `"Collapse sidebar"`.
+
+#### Scenario: iPad-landscape viewport shows the top-leading toggle
+
+- **GIVEN** the app is rendered at 1180×820 (iPad landscape) on the web platform
+- **THEN** an `IconButton` with semantic label `"Collapse sidebar"` SHALL be visible at the top-leading corner of the main content area (outside the sidebar)
+
+#### Scenario: Tapping the top-leading toggle collapses the sidebar
+
+- **WHEN** the user taps the top-leading toggle while the sidebar is expanded
+- **THEN** `sidebarCollapsedProvider` SHALL transition to `true` AND the sidebar SHALL animate to its 72 dp collapsed width
+
+#### Scenario: Toggle remains visible while collapsed
+
+- **GIVEN** the sidebar is collapsed
+- **THEN** the top-leading toggle SHALL still be visible AND its tooltip SHALL be `"Expand sidebar"`
+
+### Requirement: Swipe-from-left-edge toggles the sidebar on touch input
+
+On touch input devices (`defaultTargetPlatform` is `iOS` or `android`, or pointerKind is `touch` on web), a horizontal drag originating in the left 20 logical pixels of the viewport SHALL toggle `sidebarCollapsedProvider` when the drag exceeds 40 logical pixels in either direction.
+
+#### Scenario: Drag right from left edge expands the sidebar
+
+- **GIVEN** the sidebar is collapsed AND the user touches at x=10
+- **WHEN** the touch drags to x=80 within 250 ms
+- **THEN** `sidebarCollapsedProvider` SHALL transition to `false`
+
+#### Scenario: Drag left from left edge collapses the sidebar
+
+- **GIVEN** the sidebar is expanded AND the user touches at x=18
+- **WHEN** the touch drags to x=-40 (off-screen) within 250 ms
+- **THEN** `sidebarCollapsedProvider` SHALL transition to `true`
+
+#### Scenario: Drag starting outside the edge zone is ignored
+
+- **GIVEN** the user touches at x=200 (well past the edge zone)
+- **WHEN** the touch drags horizontally
+- **THEN** `sidebarCollapsedProvider` SHALL NOT change AND the underlying scrollable SHALL handle the gesture normally
+
+#### Scenario: Mouse drag is ignored on non-touch platforms
+
+- **GIVEN** the user is on web with a mouse-only pointer
+- **WHEN** the cursor performs a horizontal drag from x=5
+- **THEN** the sidebar state SHALL NOT change (mouse users have the top-leading toggle)

--- a/openspec/changes/fix-web-ui-ipad-sidebar-collapse/tasks.md
+++ b/openspec/changes/fix-web-ui-ipad-sidebar-collapse/tasks.md
@@ -1,0 +1,41 @@
+## Tasks
+
+### Phase 1 — Failing tests
+
+- [ ] Add `app/test/unit/shared/sidebar_collapsed_provider_test.dart` covering: - default is `false` when key is absent - reads persisted `true` from a fake `SharedPreferences` - `toggle()` writes the new value through - SharedPreferences write rejection does not throw
+- [ ] Add `app/test/widget/nav_shell_test.dart` (or extend existing) covering: - at viewport 1180×820 with `kIsWeb=true`, a top-leading `IconButton` with semantic label `"Collapse sidebar"` is visible - tapping it toggles `sidebarCollapsedProvider` - tooltip flips between `"Collapse sidebar"` and `"Expand sidebar"`
+- [ ] Add gesture widget test: simulated touch drag from x=10 → x=80 toggles the provider; drag from x=200 does not.
+- [ ] Add Playwright test `app/test_e2e/sidebar_collapse_ipad.spec.ts` at the iPad-landscape viewport (1180×820) that: - captures the expanded baseline - taps the top-leading toggle - captures the collapsed baseline - reloads the page and asserts the sidebar is still collapsed
+- [ ] Run `flutter test` and `npm run e2e -- --grep sidebar_collapse_ipad` (or project equivalent) and confirm RED on the new specs.
+
+### Phase 2 — Persistent provider
+
+- [ ] Convert `SidebarCollapsedNotifier` in `app/lib/shared/nav_shell.dart` to an `AsyncNotifier<bool>` backed by `SharedPreferences` under `assistant.sidebarCollapsed`.
+- [ ] Update every `ref.watch(sidebarCollapsedProvider)` call to read `AsyncValue.value ?? false` so first-paint defaults to expanded.
+- [ ] Run `flutter test`; confirm Phase-1 provider tests now GREEN.
+
+### Phase 3 — Top-leading toggle on Material wide
+
+- [ ] Extract the toggle UI into a `SidebarToggleButton` widget in `app/lib/shared/sidebar_toggle_button.dart` (with its own widget test).
+- [ ] In `NavShell._buildBody` Material wide branch, render `SidebarToggleButton` as a `Positioned` overlay at top-leading of the main content `Expanded`, outside any screen-owned `AppBar`.
+- [ ] Keep the existing in-sidebar `IconButton`; upgrade the expanded-state copy to read `Collapse` next to the icon.
+- [ ] Confirm widget tests GREEN at 1180×820.
+
+### Phase 4 — Swipe-from-left-edge gesture
+
+- [ ] Wrap the main content `Expanded` (Material wide and Apple touch wide) in a `GestureDetector` listening to `onHorizontalDragUpdate` / `onHorizontalDragEnd`.
+- [ ] Gate the gesture on touch input: combine `defaultTargetPlatform` (`iOS`, `android`) with a runtime pointer check on web (`PointerDeviceKind.touch`).
+- [ ] Edge zone = first 20 logical pixels; threshold = 40 px in either direction.
+- [ ] Confirm gesture test GREEN.
+
+### Phase 5 — Playwright + screenshot baselines
+
+- [ ] Update Playwright baselines for the iPad-landscape viewport on every route that renders `NavShell` (chat, traces, logs, skills, personas).
+- [ ] Document the intentional baseline movement in the PR description.
+
+### Phase 6 — Wrap-up
+
+- [ ] `make lint-flutter && make test-flutter && make lint && make format`.
+- [ ] Manual smoke on web at 1180×820 (Chrome devtools iPad mode): expand → collapse → reload → still collapsed.
+- [ ] Manual smoke on native iPad (or Simulator): tap Cupertino toggle → reload → state persists.
+- [ ] Add a brief paragraph to `docs/operations/web-ui-shortcuts.md` describing the toggle and the swipe gesture.

--- a/openspec/changes/fix-web-ui-markdown-links/.openspec.yaml
+++ b/openspec/changes/fix-web-ui-markdown-links/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/fix-web-ui-markdown-links/README.md
+++ b/openspec/changes/fix-web-ui-markdown-links/README.md
@@ -1,0 +1,3 @@
+# fix-web-ui-markdown-links
+
+Make markdown hyperlinks clickable in the web UI chat renderer

--- a/openspec/changes/fix-web-ui-markdown-links/design.md
+++ b/openspec/changes/fix-web-ui-markdown-links/design.md
@@ -10,7 +10,7 @@ The chat bubble renderer is in `chat_screen.dart` (around line 774). It instanti
 
 - Tapping `[text](url)` opens the URL.
 - One handler, used by both the streaming and finalised `SmoothMarkdown` blocks.
-- The handler is unit-testable without a `WidgetTester` — pure function with an injectable launcher.
+- The URL decision/launch path is unit-testable on the Dart VM via an injectable launcher (no `url_launcher` platform channel binding needed). UI feedback (snackbar) belongs to the widget layer and is covered by widget tests instead.
 - Unsupported / dangerous schemes are rejected loudly (snackbar) rather than silently.
 
 **Non-goals**
@@ -39,7 +39,12 @@ class MarkdownLinkHandler {
 typedef UrlLauncher = Future<bool> Function(Uri uri, {LaunchMode mode});
 ```
 
-Why a class and not a free function: the helper needs a `BuildContext` for the snackbar fallback. Injecting the launcher keeps the unit test free of plugin platform channels.
+**Decision split — pure scheme/launch logic vs. UI feedback:**
+
+- The scheme allow-list + `_launcher` invocation is the _contract_ of the handler. It is fully testable on the Dart VM by injecting a recording `UrlLauncher` — no `WidgetTester`, no `BuildContext`.
+- Snackbar rendering happens via `ScaffoldMessenger.maybeOf(context)` inside the same class for ergonomic call-site usage (callers don't have to thread a callback through). Tests that exercise the snackbar path use a `WidgetTester` wrapping a `MaterialApp + Scaffold` so `ScaffoldMessenger` is available. The handler is robust to a missing messenger (no-op), so the launch path can be tested in isolation when feedback rendering isn't of interest.
+
+This split keeps both halves verifiable: the launch contract via cheap VM tests, the snackbar feedback via widget tests. The two test styles live side-by-side in `markdown_link_handler_test.dart`.
 
 ### D2: Scheme allow-list
 

--- a/openspec/changes/fix-web-ui-markdown-links/design.md
+++ b/openspec/changes/fix-web-ui-markdown-links/design.md
@@ -1,0 +1,63 @@
+## Context
+
+The chat bubble renderer is in `chat_screen.dart` (around line 774). It instantiates two `SmoothMarkdown` widgets — one for the streaming message and one for finalised history rows — neither of which sets `onTapLink`. The `flutter_smooth_markdown` package (0.7.2 in `app/pubspec.yaml`) exposes `final void Function(String url)? onTapLink;` on both `SmoothMarkdown` and `StreamMarkdown` (verified in `.pub-cache/.../widgets/smooth_markdown.dart` and `widgets/stream_markdown.dart`).
+
+`url_launcher: ^6.3.2` is already a dependency, so no new packages are needed.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Tapping `[text](url)` opens the URL.
+- One handler, used by both the streaming and finalised `SmoothMarkdown` blocks.
+- The handler is unit-testable without a `WidgetTester` — pure function with an injectable launcher.
+- Unsupported / dangerous schemes are rejected loudly (snackbar) rather than silently.
+
+**Non-goals**
+
+- In-app web view, custom URL schemes (`assistant://...`), or telemetry on link clicks.
+
+## Decisions
+
+### D1: Extract `MarkdownLinkHandler` helper
+
+**Choice:** Add `app/lib/features/chat/markdown_link_handler.dart` exposing a small class:
+
+```dart
+class MarkdownLinkHandler {
+  MarkdownLinkHandler({
+    required this.context,
+    UrlLauncher launcher = defaultUrlLauncher,
+  }) : _launcher = launcher;
+
+  final BuildContext context;
+  final UrlLauncher _launcher;
+
+  Future<void> onTap(String url) async { ... }
+}
+
+typedef UrlLauncher = Future<bool> Function(Uri uri, {LaunchMode mode});
+```
+
+Why a class and not a free function: the helper needs a `BuildContext` for the snackbar fallback. Injecting the launcher keeps the unit test free of plugin platform channels.
+
+### D2: Scheme allow-list
+
+**Choice:** Allow `http`, `https`, `mailto`. Everything else is rejected with a snackbar `"Cannot open link: <url>"`. We deliberately reject `javascript:`, `data:`, `file:`, and other schemes that have caused XSS in markdown ecosystems.
+
+**Why:** The renderer is told the URL by the model, which means a prompt-injected response could plant a `javascript:` link. The allow-list is the cheapest mitigation. Unknown schemes that are legitimate (e.g. `slack://`) can be added later behind feature flags.
+
+### D3: Launch mode
+
+**Choice:** `LaunchMode.externalApplication` on every platform. On web the plugin already maps that to opening a new tab.
+
+**Why:** Users expect external link clicks to leave the chat surface (or open a new tab). No in-app browser today, no plan to add one in this change.
+
+## Risks / Trade-offs
+
+- **Prompt-injected links to malicious sites:** the renderer cannot judge intent. The user still has to click. We accept the same risk that every chat surface accepts; the allow-list closes the loudest foot-guns.
+- **Test coverage of the streaming branch:** the streaming bubble re-creates `SmoothMarkdown` repeatedly during stream ticks. We need one widget test that fires `tester.tap` on a rendered anchor and asserts the handler ran — that covers both bubbles because they share the helper.
+
+## Migration Plan
+
+None. Behavioural change only, no stored state.

--- a/openspec/changes/fix-web-ui-markdown-links/proposal.md
+++ b/openspec/changes/fix-web-ui-markdown-links/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+Hyperlinks rendered from markdown in the chat (`[text](https://example.com)`) do not open when tapped. The `SmoothMarkdown` widget in `app/lib/features/chat/chat_screen.dart` supports an `onTapLink` callback but the chat screen does not wire one up, so anchor taps are silently swallowed. Users see hyperlinks, taps register, and nothing happens — they have to copy the URL out of the bubble manually.
+
+## What Changes
+
+- Wire an `onTapLink` handler into every `SmoothMarkdown` usage in the chat screen (streaming and historical messages).
+- Use `url_launcher` (already a dependency) to open the URL in an external application on native platforms and in a new tab on web.
+- Reject obviously unsafe schemes (only allow `http`, `https`, and `mailto`).
+- Show a snackbar / toast when the URL cannot be opened, so failures are visible rather than silent.
+
+## Non-goals
+
+- Custom in-app web view — links open in the platform browser.
+- Rewriting the markdown stack (we keep `flutter_smooth_markdown`).
+- Handling links in other markdown surfaces (skills, logs) — those can adopt the same shared helper later but are out of scope for this fix.
+- Deep-link interception (e.g. `assistant://...`) — covered by other proposals.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `chat-markdown-rendering` (new spec) — anchor taps in chat markdown open the target URL through the platform browser.
+
+## Impact
+
+- `app/lib/features/chat/chat_screen.dart` — pass `onTapLink` to both `SmoothMarkdown` blocks.
+- New helper `app/lib/features/chat/markdown_link_handler.dart` so the tap callback is testable in isolation and reusable.
+- Widget test for the chat bubble verifying that a tap on a markdown anchor invokes the handler with the expected URL.
+- No backend changes. No spec changes outside the new `chat-markdown-rendering` capability.
+
+## Visual / UI change
+
+Behavioural only. No new pixels — anchor styling is unchanged. Playwright screenshot baselines unaffected.
+
+## User-facing documentation
+
+Not required. Behaviour matches the user's expectation of a markdown renderer; no separate docs page warranted.

--- a/openspec/changes/fix-web-ui-markdown-links/specs/chat-markdown-rendering/spec.md
+++ b/openspec/changes/fix-web-ui-markdown-links/specs/chat-markdown-rendering/spec.md
@@ -46,12 +46,18 @@ When `launchUrl` returns `false` (or throws), the handler SHALL show a snackbar 
 - **WHEN** `onTap` runs
 - **THEN** the exception SHALL be caught AND a snackbar `"Could not open link"` SHALL be shown AND the error SHALL be logged via `debugPrint`
 
-### Requirement: Handler is unit-testable without plugins
+### Requirement: Scheme/launch logic is unit-testable without plugins
 
-The `MarkdownLinkHandler` SHALL accept an injectable launcher function so unit tests can run on the Dart VM without binding `url_launcher` platform channels.
+The `MarkdownLinkHandler` SHALL accept an injectable launcher function so the scheme allow-list and launch invocation can be verified on the Dart VM without binding `url_launcher` platform channels. The snackbar feedback requirements above are a separate concern, exercised via `WidgetTester` against a wrapping `MaterialApp + Scaffold` rather than via VM unit tests.
 
 #### Scenario: Test injects a fake launcher
 
 - **GIVEN** a `MarkdownLinkHandler` constructed with a fake launcher recording its arguments
 - **WHEN** `onTap("https://example.com")` is invoked
 - **THEN** the fake SHALL record one call to `Uri.parse('https://example.com')` with `LaunchMode.externalApplication`
+
+#### Scenario: Handler is robust to a missing ScaffoldMessenger
+
+- **GIVEN** the handler is invoked inside a tree without a `ScaffoldMessenger` ancestor (e.g. a bare-VM test)
+- **WHEN** a snackbar would otherwise be shown
+- **THEN** the handler SHALL skip the snackbar without throwing AND the launch/decision behaviour SHALL be unchanged

--- a/openspec/changes/fix-web-ui-markdown-links/specs/chat-markdown-rendering/spec.md
+++ b/openspec/changes/fix-web-ui-markdown-links/specs/chat-markdown-rendering/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: Markdown anchor taps open the target URL
+
+Both the streaming and finalised chat message bubbles SHALL pass an `onTapLink` callback to every `SmoothMarkdown` (and `StreamMarkdown`) instance they render. The callback SHALL open the target URL using `url_launcher` with `LaunchMode.externalApplication` so links escape the chat surface on every platform (new tab on web, system browser on native).
+
+#### Scenario: Tapping a markdown link opens it externally
+
+- **GIVEN** an assistant message containing `[Example](https://example.com)`
+- **WHEN** the user taps the rendered anchor
+- **THEN** `launchUrl(Uri.parse('https://example.com'), mode: LaunchMode.externalApplication)` SHALL be invoked exactly once
+
+#### Scenario: Streaming bubble also handles taps
+
+- **GIVEN** an in-progress assistant message that contains a markdown link
+- **WHEN** the user taps the link before the stream completes
+- **THEN** the same `MarkdownLinkHandler.onTap` SHALL run AND the launch result SHALL match the finalised-bubble behaviour
+
+### Requirement: Only safe URL schemes are launched
+
+The link handler SHALL only launch URLs whose scheme is `http`, `https`, or `mailto`. Any other scheme (including `javascript`, `data`, `file`, and unknown custom schemes) SHALL be rejected without calling the launcher AND a snackbar with text matching `"Cannot open link"` SHALL be shown.
+
+#### Scenario: javascript: is rejected
+
+- **WHEN** the handler receives `"javascript:alert(1)"`
+- **THEN** `launchUrl` SHALL NOT be called AND a snackbar `"Cannot open link: javascript:alert(1)"` SHALL be displayed
+
+#### Scenario: mailto is allowed
+
+- **WHEN** the handler receives `"mailto:hi@example.com"`
+- **THEN** `launchUrl` SHALL be called once with that URI AND no snackbar SHALL be shown
+
+### Requirement: Launch failure surfaces to the user
+
+When `launchUrl` returns `false` (or throws), the handler SHALL show a snackbar with text matching `"Could not open link"` so the user understands the click was not silently dropped.
+
+#### Scenario: Launcher returns false
+
+- **GIVEN** the injected launcher returns `false` for an `https://` URL
+- **WHEN** `onTap` runs
+- **THEN** a snackbar `"Could not open link: https://example.com"` SHALL be shown
+
+#### Scenario: Launcher throws
+
+- **GIVEN** the injected launcher throws a `PlatformException`
+- **WHEN** `onTap` runs
+- **THEN** the exception SHALL be caught AND a snackbar `"Could not open link"` SHALL be shown AND the error SHALL be logged via `debugPrint`
+
+### Requirement: Handler is unit-testable without plugins
+
+The `MarkdownLinkHandler` SHALL accept an injectable launcher function so unit tests can run on the Dart VM without binding `url_launcher` platform channels.
+
+#### Scenario: Test injects a fake launcher
+
+- **GIVEN** a `MarkdownLinkHandler` constructed with a fake launcher recording its arguments
+- **WHEN** `onTap("https://example.com")` is invoked
+- **THEN** the fake SHALL record one call to `Uri.parse('https://example.com')` with `LaunchMode.externalApplication`

--- a/openspec/changes/fix-web-ui-markdown-links/tasks.md
+++ b/openspec/changes/fix-web-ui-markdown-links/tasks.md
@@ -1,0 +1,21 @@
+## Tasks
+
+### Phase 1 — Failing tests
+
+- [ ] Add `app/test/unit/features/chat/markdown_link_handler_test.dart` covering: - allowed schemes (`http`, `https`, `mailto`) trigger the injected launcher exactly once with `LaunchMode.externalApplication` - blocked schemes (`javascript:`, `data:`, `file:`, `assistant:`) do not call the launcher - launcher returning `false` surfaces a `"Could not open link"` snackbar - launcher throwing is caught, snackbar shown, error logged via `debugPrint`
+- [ ] Add `app/test/widget/chat/chat_message_link_test.dart` that pumps a chat bubble containing `[Example](https://example.com)` and verifies a tap routes through the injected handler exactly once.
+- [ ] Run `flutter test` and confirm RED (handler does not exist yet).
+
+### Phase 2 — Implementation
+
+- [ ] Create `app/lib/features/chat/markdown_link_handler.dart` exposing `MarkdownLinkHandler` with an injectable `UrlLauncher` typedef and a `defaultUrlLauncher` that forwards to `url_launcher.launchUrl`.
+- [ ] Implement the scheme allow-list (`http`, `https`, `mailto`) and snackbar fallback inside the handler.
+- [ ] Wire `onTapLink` on both `SmoothMarkdown` blocks in `app/lib/features/chat/chat_screen.dart` to delegate to the handler.
+- [ ] Run `flutter test` and confirm GREEN.
+
+### Phase 3 — Verification
+
+- [ ] Manual check on web: open a chat, send `Visit [example](https://example.com)`, tap the link, confirm new tab opens.
+- [ ] Manual check on macOS: same flow, confirm the system browser opens.
+- [ ] `make lint-flutter && make test-flutter` (Flutter lints + tests).
+- [ ] No Playwright baseline changes expected (behavioural-only); confirm baselines still match.

--- a/openspec/changes/fix-web-ui-theme-quality/.openspec.yaml
+++ b/openspec/changes/fix-web-ui-theme-quality/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/fix-web-ui-theme-quality/README.md
+++ b/openspec/changes/fix-web-ui-theme-quality/README.md
@@ -1,0 +1,3 @@
+# fix-web-ui-theme-quality
+
+Audit and improve web UI theme tokens, typography, and contrast for a more cohesive look

--- a/openspec/changes/fix-web-ui-theme-quality/design.md
+++ b/openspec/changes/fix-web-ui-theme-quality/design.md
@@ -1,0 +1,112 @@
+## Context
+
+Today's theme story:
+
+- `adaptive_app.dart` calls `ColorScheme.fromSeed(seedColor: Color(0xFF1A73E8))` once for Material and once for Cupertino, with `useMaterial3: true` and nothing else customised.
+- No top-level typography overrides — Flutter's default Roboto applies on web/Android and SF on iOS via Cupertino.
+- Screens inline ad-hoc colour values (chat bubble `surfaceContainerLowest`, trace cards via `colorScheme.outlineVariant`, sidebar items with literal `IconButton` styling) and ad-hoc spacing (`EdgeInsets.all(12)`, `EdgeInsets.all(16)`, `SizedBox(height: 6)`).
+- Dark mode is enabled but no surface-tint contrast verification has happened.
+
+The risk of "just fix the theme" turning into endless scope creep is real, so this change defines a strict perimeter: theme module + four screens + lint enforcement. Other surfaces stay default-themed and will adopt tokens incrementally in follow-up work.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- A single source of truth for colour, typography, spacing, radius, and elevation in `app/lib/shared/theme/`.
+- Both light and dark themes meet WCAG AA contrast on the four migrated screens.
+- A lint that prevents new code from regressing the policy (raw `Color` literals, `Colors.X` references) outside the theme module.
+- Token names are stable; future screens can adopt them without renames.
+
+**Non-goals**
+
+- Visual identity / brand redesign.
+- Migrating every screen at once (only chat, sidebar, traces, logs).
+- iOS-native (Cupertino) restyling beyond what the shared Material theme cascades through.
+- A user-facing theme picker UI.
+
+## Decisions
+
+### D1: Named-seed palette instead of single seed
+
+**Choice:** Build `ColorScheme.fromSeed` with explicit overrides:
+
+```dart
+ColorScheme.fromSeed(
+  seedColor: AssistantColors.brand,            // primary
+  brightness: brightness,
+).copyWith(
+  secondary: AssistantColors.accentSecondary,
+  tertiary:  AssistantColors.accentTertiary,
+  // Surface tints kept algorithmic.
+);
+```
+
+Three intentional accent roles (success, info, warning) are derived from `tertiary`, `secondary`, and a new `warning` token (Material 3 doesn't have a built-in warning role).
+
+**Why:** Lets us match accent colours to semantic meaning (success-tertiary, warning-amber) rather than whatever the seed algorithm produces. Keeps Material 3's surface tint generation since that part works well.
+
+### D2: Typography — Inter + JetBrains Mono, vendored
+
+**Choice:** Vendor two open-licence fonts under `app/assets/fonts/`: Inter (UI) and JetBrains Mono (code / monospace). Declare them in `pubspec.yaml`. Build a `TextTheme` from `Typography.material2021()` with Inter as the default and JetBrains Mono on `bodySmall.copyWith(fontFamily: 'JetBrainsMono')` exposed via `AssistantTypography.mono`.
+
+**Why:** No network-loaded fonts (PWA / offline correctness). Both fonts have permissive licences (OFL). Inter is the de-facto modern UI font; JetBrains Mono renders code well at all sizes.
+
+**Alternative considered:** Google Fonts package — rejected because it does a runtime fetch on first use; that breaks offline-first.
+
+### D3: Spacing tokens — multiplicative, 4 dp base
+
+**Choice:** Define `AssistantSpacing` as a class with named constants:
+
+```dart
+abstract class AssistantSpacing {
+  static const double xs = 4;
+  static const double sm = 8;
+  static const double md = 12;
+  static const double lg = 16;
+  static const double xl = 24;
+  static const double xxl = 32;
+}
+```
+
+Plus a small set of radius and elevation constants. All values are multiples of 4 dp — Material's grid base.
+
+**Why:** Token names communicate intent; magic numbers don't. A future change can adjust the base unit without touching every screen.
+
+### D4: Lint enforcement
+
+**Choice:** Add a custom lint rule via `custom_lint` (or, if that's heavyweight, a CI-side `grep` check that fails on `Color(0x` / `Colors\.` matches outside `app/lib/shared/theme/`). Allow-list the theme module.
+
+**Why:** Without enforcement, "use the tokens" decays in three PRs. The grep version is dirt-cheap and good enough — we can upgrade to `custom_lint` later.
+
+### D5: Contrast audit — top four offenders
+
+**Choice:** Run a contrast audit on:
+
+1. Chat bubble background vs. body text (light + dark).
+2. Inline code background vs. inline code text (uses `surfaceContainerLowest` today).
+3. Sidebar selected-state highlight vs. label.
+4. Trace status pill text vs. pill background (the chips this change introduces — verify against AA before merging #265 dependencies).
+
+For each failing pair, adjust the affected token (not the consumer). Document the resulting contrast ratios in `docs/design/theme.md`.
+
+**Why:** Auditing every surface is a lot. The four above are the highest-density user-facing surfaces. Other regressions can be filed as follow-ups.
+
+### D6: No Cupertino theme override beyond what cascades
+
+**Choice:** The Cupertino branch still gets its own `CupertinoApp.router` with the default Cupertino theme. The `Theme(data: materialTheme, child: Material(...))` wrapper inside `CupertinoApp.builder` (`adaptive_app.dart:60`) gives any Material widgets (which we use heavily inside the chat shell) the new tokens automatically.
+
+**Why:** Keeping system styling on Apple touch was a deliberate decision in the `adaptive-shell` spec. We don't want to fight it here.
+
+## Risks / Trade-offs
+
+- **Token churn:** Renaming a token after release means a coordinated PR. The proposed names (`xs`/`sm`/`md`/`lg`, `brand`/`accentSecondary`/`accentTertiary`/`warning`) are conventional enough that we don't expect churn, but we accept the risk.
+- **Vendored fonts inflate bundle size:** Inter + JetBrains Mono add ~600 KB to the web bundle (after gzip). We accept this for offline-first; if it becomes a problem we can subset.
+- **Custom lint maintenance:** `custom_lint` adds build complexity. We start with a grep-based CI check (zero dep) and revisit if violations slip through.
+- **Theme work blocks other UI changes:** While this change is in flight, other contributors will collide on the four migrated screens. We sequence #266 to land **after** #619, #620, #265 — those three touch the same files but with focused diffs. This change picks up cleanly afterwards.
+
+## Migration Plan
+
+- No data migration. UI only.
+- Bundle size impact is on first deploy; subsequent updates re-use the cached fonts via service worker.
+- Document the token system in `docs/design/theme.md`. Reference it from the `ux-principles` skill so future agents land on the new patterns.

--- a/openspec/changes/fix-web-ui-theme-quality/proposal.md
+++ b/openspec/changes/fix-web-ui-theme-quality/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+The Flutter app's Material theme is currently a one-line `ColorScheme.fromSeed(seedColor: 0xFF1A73E8)` (`app/lib/shared/platform/adaptive_app.dart:39-83`) with no token customisation, no typography overrides, and no surface tinting strategy. The result is exactly what issue #266 reports:
+
+- Surface colours derived from the seed look generic and read as "default Flutter app", not "this product".
+- Typography defaults to `Roboto` everywhere — no display / body distinction, no monospace pairing for code.
+- Several places (chat bubbles, sidebar items, trace cards) inline custom colours and spacing values, so the look is inconsistent across screens.
+- Light mode contrast is acceptable; dark mode contrast on `surfaceContainerLowest` (used for inline code, message backgrounds) drops below WCAG AA in several spots.
+
+This is the kind of polish that compounds: every other UI change after this lands on better foundations.
+
+## What Changes
+
+- Define an explicit `AssistantTheme` module in `app/lib/shared/theme/` that exports light + dark `ThemeData` built from:
+  - A small, named seed palette (primary, secondary, tertiary) rather than a single seed colour, so accents are intentional rather than algorithmically derived.
+  - A typography ramp that pairs Inter (or Geist) for UI with JetBrains Mono for code blocks and trace attributes.
+  - Centralised spacing / radius / elevation tokens (`AssistantSpacing`, `AssistantRadius`) replacing magic numbers in the screens.
+- Replace inline `Color(0x...)` / hard-coded `EdgeInsets.all(16)` usages in the highest-traffic screens (chat, sidebar, traces, logs) with token references. Other screens stay on the new theme defaults for now.
+- Audit dark-mode contrast on the chat bubble, inline code, sidebar selection state, and trace status pills. Fix the four worst offenders identified in the audit.
+- Lock the theme by adding a static-analysis lint that fails CI when a non-test file imports `Colors` or uses raw `Color(0x...)` literals outside `app/lib/shared/theme/`.
+
+## Non-goals
+
+- A full visual redesign — typography, base palette, and shape feel stay roughly familiar.
+- New iconography or illustration work.
+- Restyling Cupertino chrome (we keep system styling on iOS / iPadOS).
+- Adding theme switcher UI (already exists at OS level; in-app toggle is a later change).
+- Touching every screen — only the four high-traffic surfaces are migrated in this change.
+
+## Capabilities
+
+### Added Capabilities
+
+- `app-theme-tokens` (new spec) — defines the theme module's shape (named tokens, accessibility floor, file location, lint enforcement).
+
+## Impact
+
+- New files:
+  - `app/lib/shared/theme/assistant_theme.dart` — light + dark `ThemeData` builders.
+  - `app/lib/shared/theme/assistant_colors.dart` — colour roles (seed + tints).
+  - `app/lib/shared/theme/assistant_typography.dart` — text styles.
+  - `app/lib/shared/theme/assistant_spacing.dart` — spacing / radius / elevation constants.
+- Refactor `app/lib/shared/platform/adaptive_app.dart` to consume the new theme builders.
+- Touch the high-traffic screens to use tokens:
+  - `app/lib/features/chat/chat_screen.dart`
+  - `app/lib/shared/nav_shell.dart`
+  - `app/lib/features/traces/trace_detail_screen.dart`
+  - `app/lib/features/logs/`
+- Add `pubspec.yaml` font assets for Inter + JetBrains Mono (vendored under `app/assets/fonts/`).
+- Add `analysis_options.yaml` lint rule (custom or via `linter_extras`) banning raw `Color` outside the theme module.
+- Update Playwright baselines on every screen we touched.
+
+## Visual / UI change
+
+Yes — substantial. Typography ramp moves, surface tints change, spacing on chat bubbles and trace cards shifts. Playwright baselines on the four high-traffic screens will move significantly. All other screens retain Material 3 defaults applied through the new theme.
+
+## User-facing documentation
+
+- Add `docs/design/theme.md` describing the token system, the named seed palette, and how to add a new screen that consumes the tokens (so future contributors don't fall back to raw `Color` values).
+- Update the existing `ux-principles` skill notes if any token names are referenced there.

--- a/openspec/changes/fix-web-ui-theme-quality/proposal.md
+++ b/openspec/changes/fix-web-ui-theme-quality/proposal.md
@@ -13,7 +13,7 @@ This is the kind of polish that compounds: every other UI change after this land
 
 - Define an explicit `AssistantTheme` module in `app/lib/shared/theme/` that exports light + dark `ThemeData` built from:
   - A small, named seed palette (primary, secondary, tertiary) rather than a single seed colour, so accents are intentional rather than algorithmically derived.
-  - A typography ramp that pairs Inter (or Geist) for UI with JetBrains Mono for code blocks and trace attributes.
+  - A typography ramp that pairs Inter for UI with JetBrains Mono for code blocks and trace attributes.
   - Centralised spacing / radius / elevation tokens (`AssistantSpacing`, `AssistantRadius`) replacing magic numbers in the screens.
 - Replace inline `Color(0x...)` / hard-coded `EdgeInsets.all(16)` usages in the highest-traffic screens (chat, sidebar, traces, logs) with token references. Other screens stay on the new theme defaults for now.
 - Audit dark-mode contrast on the chat bubble, inline code, sidebar selection state, and trace status pills. Fix the four worst offenders identified in the audit.

--- a/openspec/changes/fix-web-ui-theme-quality/specs/app-theme-tokens/spec.md
+++ b/openspec/changes/fix-web-ui-theme-quality/specs/app-theme-tokens/spec.md
@@ -1,0 +1,133 @@
+## ADDED Requirements
+
+### Requirement: Theme is centralised in `app/lib/shared/theme/`
+
+The Flutter app SHALL expose all design tokens from `app/lib/shared/theme/`, with these public modules:
+
+- `assistant_theme.dart` — exports `assistantLightTheme()` and `assistantDarkTheme()` `ThemeData` builders.
+- `assistant_colors.dart` — colour seed + role tokens (`AssistantColors.brand`, `AssistantColors.accentSecondary`, `AssistantColors.accentTertiary`, `AssistantColors.warning`).
+- `assistant_typography.dart` — `AssistantTypography.material()` returns a `TextTheme`; exposes `AssistantTypography.mono` (`TextStyle`) for code surfaces.
+- `assistant_spacing.dart` — `AssistantSpacing.xs|sm|md|lg|xl|xxl` (constants), `AssistantRadius.sm|md|lg`, `AssistantElevation.low|medium|high`.
+
+`adaptive_app.dart` SHALL call the builders from `assistant_theme.dart` instead of constructing `ThemeData` inline.
+
+#### Scenario: Adaptive app consumes the theme builders
+
+- **WHEN** `AdaptiveApp` builds
+- **THEN** the resolved `MaterialApp.theme` SHALL be the value returned by `assistantLightTheme()` AND `MaterialApp.darkTheme` SHALL be the value returned by `assistantDarkTheme()`
+
+#### Scenario: Tokens are imported from a single module
+
+- **WHEN** any code outside `app/lib/shared/theme/` needs spacing
+- **THEN** it SHALL import `AssistantSpacing` from `assistant_spacing.dart` AND SHALL NOT define new module-local spacing constants
+
+### Requirement: Theme defines named accent roles
+
+`assistant_colors.dart` SHALL export at minimum these named roles:
+
+- `brand` — primary brand colour (matches `AssistantColors.brand`).
+- `accentSecondary` — secondary accent.
+- `accentTertiary` — tertiary accent (success-leaning).
+- `warning` — amber-ish, used for `denied` status pills and similar.
+
+`assistantLightTheme()` and `assistantDarkTheme()` SHALL apply these via `ColorScheme.fromSeed(...).copyWith(secondary: accentSecondary, tertiary: accentTertiary)`. The `warning` token SHALL be available as a const since Material 3 has no built-in warning role.
+
+#### Scenario: Tertiary slot uses accentTertiary
+
+- **GIVEN** the light theme is active
+- **WHEN** a consumer reads `Theme.of(context).colorScheme.tertiary`
+- **THEN** the value SHALL equal `AssistantColors.accentTertiary`
+
+#### Scenario: Warning token is accessible
+
+- **WHEN** a consumer reads `AssistantColors.warning`
+- **THEN** the returned `Color` SHALL be non-null and SHALL be one of the documented amber tokens
+
+### Requirement: Typography uses Inter for UI and JetBrains Mono for code
+
+`assistant_typography.dart` SHALL build a `TextTheme` whose default `fontFamily` is `"Inter"` and whose `bodySmall.copyWith(fontFamily: 'JetBrainsMono')` (exposed as `AssistantTypography.mono`) is used by code surfaces (inline code in chat, attribute keys in trace cards, log lines).
+
+Inter and JetBrains Mono fonts SHALL be vendored under `app/assets/fonts/` and declared in `pubspec.yaml`. The app SHALL NOT load fonts at runtime via network requests.
+
+#### Scenario: Default text theme uses Inter
+
+- **WHEN** the light theme is active
+- **THEN** `Theme.of(context).textTheme.bodyLarge!.fontFamily` SHALL equal `"Inter"`
+
+#### Scenario: Inline code uses JetBrains Mono
+
+- **WHEN** an inline-code text style is needed
+- **THEN** `AssistantTypography.mono.fontFamily` SHALL equal `"JetBrainsMono"`
+
+#### Scenario: No runtime font fetch
+
+- **WHEN** the app boots offline
+- **THEN** all rendered text SHALL use the vendored fonts AND SHALL NOT issue any HTTP request for font assets
+
+### Requirement: Spacing, radius, and elevation tokens replace magic numbers
+
+`AssistantSpacing` SHALL expose `xs=4`, `sm=8`, `md=12`, `lg=16`, `xl=24`, `xxl=32` as `static const double`. The four migrated screens (`chat_screen.dart`, `nav_shell.dart`, `trace_detail_screen.dart`, `logs_screen.dart` and friends) SHALL reference these constants instead of inline numeric literals for `EdgeInsets`, `SizedBox`, `Padding`, and similar widgets.
+
+`AssistantRadius` SHALL expose `sm=8`, `md=12`, `lg=16`. Card / chip / button radii on the migrated screens SHALL reference these.
+
+#### Scenario: Chat bubble uses spacing tokens
+
+- **GIVEN** the chat bubble renders body padding
+- **THEN** its `EdgeInsets` SHALL use one of `AssistantSpacing.xs|sm|md|lg|xl|xxl` (not a raw numeric literal)
+
+#### Scenario: Trace card radius references AssistantRadius
+
+- **GIVEN** the trace span card renders rounded corners
+- **THEN** its `BorderRadius.circular(...)` SHALL receive an `AssistantRadius.*` constant (not `12`)
+
+### Requirement: Migrated screens meet WCAG AA contrast in both themes
+
+On the migrated screens (`chat_screen.dart`, `nav_shell.dart`, `trace_detail_screen.dart`, logs), foreground / background colour pairs SHALL achieve a contrast ratio of at least:
+
+- `4.5:1` for body text and inline code.
+- `3:1` for large text (>= 18 dp regular or 14 dp bold), icons, and chip pills.
+
+Audited pairs:
+
+- Chat bubble background vs. body text — both themes.
+- Inline code background vs. inline code text — both themes.
+- Sidebar selected-state highlight vs. selected label — both themes.
+- Trace status pill text vs. pill background (`ok`, `error`, `denied`, `unknown`) — both themes.
+
+#### Scenario: Light-mode inline code passes AA
+
+- **GIVEN** the light theme is active
+- **WHEN** an inline-code span is rendered
+- **THEN** the foreground / background contrast ratio SHALL be >= 4.5:1
+
+#### Scenario: Dark-mode chat bubble passes AA
+
+- **GIVEN** the dark theme is active
+- **WHEN** an assistant chat bubble renders body text
+- **THEN** the foreground / background contrast ratio SHALL be >= 4.5:1
+
+#### Scenario: Trace status pills pass large-text AA
+
+- **GIVEN** either theme is active
+- **WHEN** a trace status pill (`ok`, `error`, `denied`, `unknown`) renders
+- **THEN** the pill text / pill background contrast ratio SHALL be >= 3:1
+
+### Requirement: Raw colour literals are banned outside the theme module
+
+A CI check SHALL fail when any file under `app/lib/` outside `app/lib/shared/theme/` (and outside test files) matches:
+
+- `Color\(0x` — raw colour literals.
+- `\bColors\.` — Material's named colour palette.
+
+Exceptions SHALL be expressed via an allow-list file (e.g. `analysis_lint_allowlist.txt`) committed to the repo; entries SHALL include a comment explaining the exception.
+
+#### Scenario: New file introducing `Colors.red` fails CI
+
+- **GIVEN** a PR adds `final color = Colors.red;` in `app/lib/features/foo/foo_widget.dart`
+- **WHEN** the lint check runs
+- **THEN** the check SHALL fail AND the error message SHALL reference the offending file/line AND SHALL point to `docs/design/theme.md`
+
+#### Scenario: Theme module is exempt
+
+- **WHEN** the lint scans `app/lib/shared/theme/assistant_colors.dart`
+- **THEN** raw `Color(0x...)` literals SHALL be allowed

--- a/openspec/changes/fix-web-ui-theme-quality/tasks.md
+++ b/openspec/changes/fix-web-ui-theme-quality/tasks.md
@@ -1,0 +1,54 @@
+## Tasks
+
+### Phase 1 — Failing tests + audit baselines
+
+- [ ] Add `app/test/unit/shared/theme/assistant_theme_test.dart` covering: - light/dark `ThemeData` exposes `Inter` as default font family - `colorScheme.tertiary == AssistantColors.accentTertiary` for both brightnesses - `AssistantSpacing.lg == 16` etc. (sanity) - `AssistantTypography.mono.fontFamily == 'JetBrainsMono'`
+- [ ] Add `app/test/unit/shared/theme/contrast_test.dart` that computes WCAG ratios for the audited pairs (chat bubble bg vs body, inline code bg vs text, sidebar selected vs label, trace status pills) in **both** themes. The test SHALL fail today for the dark-mode inline-code pair.
+- [ ] Add `app/test/golden/theme_smoke_test.dart` rendering a tiny widget tree (Card with body text, mono code span, status pill) in both themes for golden comparison.
+- [ ] Add `scripts/check_no_raw_colors.sh` (or equivalent Dart script) that exits non-zero on any `Color(0x` or `Colors.` match outside `app/lib/shared/theme/` and the allow-list. Wire it into `make lint-flutter`.
+- [ ] Run `flutter test`; confirm RED on theme + contrast specs.
+
+### Phase 2 — Theme module + vendored fonts
+
+- [ ] Vendor Inter (`Inter-Regular.ttf`, `Inter-Medium.ttf`, `Inter-SemiBold.ttf`) and JetBrains Mono (`JetBrainsMono-Regular.ttf`, `JetBrainsMono-Medium.ttf`) under `app/assets/fonts/`. Add the OFL licence file alongside each family.
+- [ ] Declare both families in `app/pubspec.yaml` under `fonts:`.
+- [ ] Create `app/lib/shared/theme/assistant_colors.dart` with `brand`, `accentSecondary`, `accentTertiary`, `warning` (light + dark variants where needed).
+- [ ] Create `app/lib/shared/theme/assistant_typography.dart` exposing `material()` and `mono`.
+- [ ] Create `app/lib/shared/theme/assistant_spacing.dart` with `AssistantSpacing`, `AssistantRadius`, `AssistantElevation`.
+- [ ] Create `app/lib/shared/theme/assistant_theme.dart` exposing `assistantLightTheme()` and `assistantDarkTheme()`.
+- [ ] Run `flutter test`; theme unit tests GREEN. Contrast test may still fail until consumers migrate.
+
+### Phase 3 — Wire `adaptive_app.dart` to the new theme
+
+- [ ] Replace inline `ColorScheme.fromSeed` in `adaptive_app.dart` with calls to `assistantLightTheme()` / `assistantDarkTheme()`.
+- [ ] Run `flutter test`; golden smoke test GREEN.
+
+### Phase 4 — Migrate chat screen tokens
+
+- [ ] In `app/lib/features/chat/chat_screen.dart`, replace inline `EdgeInsets`/`SizedBox` numbers with `AssistantSpacing.*`, inline code background with the theme token, and any raw `Color(0x...)` with theme references.
+- [ ] Re-run `flutter test` + the new lint script; confirm green for `chat_screen.dart`.
+- [ ] Update Playwright chat baselines.
+
+### Phase 5 — Migrate sidebar / nav shell tokens
+
+- [ ] Same migration in `app/lib/shared/nav_shell.dart`. Watch for the sidebar widths (`_kSidebarExpandedWidth = 240` etc.) — those stay as is (semantic constants, not spacing), but `EdgeInsets`/`SizedBox` migrate.
+- [ ] Update Playwright nav-shell baselines.
+
+### Phase 6 — Migrate traces + logs tokens
+
+- [ ] Migrate `app/lib/features/traces/trace_detail_screen.dart` (and `tool_call_span_card.dart` if landed from #265).
+- [ ] Migrate `app/lib/features/logs/logs_screen.dart` and `log_entry.dart` (or equivalent).
+- [ ] Update Playwright trace + log baselines.
+
+### Phase 7 — Lint enforcement + contrast pass
+
+- [ ] Confirm `make lint-flutter` runs `scripts/check_no_raw_colors.sh` and fails on a deliberately introduced raw `Color(0x...)` outside the theme module.
+- [ ] Iterate on `AssistantColors` / `assistantDarkTheme` until the contrast test reports all audited pairs at >= 4.5:1 (body) or >= 3:1 (large text / pills).
+- [ ] Re-run `flutter test`; everything GREEN.
+
+### Phase 8 — Docs + wrap-up
+
+- [ ] Add `docs/design/theme.md` covering: token tables (colours, typography, spacing, radius), how to migrate a new screen, allow-list policy, contrast ratios achieved.
+- [ ] Note the theme migration in `docs/operations/web-ui-shortcuts.md` if there are user-visible behavioural shifts (there should be none — visual only).
+- [ ] `make lint && make format && make test && make lint-flutter && make test-flutter`.
+- [ ] PR description: before/after screenshots of the four migrated screens (light + dark), contrast deltas, bundle-size delta from font assets.

--- a/openspec/changes/fix-web-ui-trace-tool-calls/.openspec.yaml
+++ b/openspec/changes/fix-web-ui-trace-tool-calls/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/fix-web-ui-trace-tool-calls/README.md
+++ b/openspec/changes/fix-web-ui-trace-tool-calls/README.md
@@ -1,3 +1,3 @@
 # fix-web-ui-trace-tool-calls
 
-Persist and render tool call detail in trace views
+Render tool call detail in trace views

--- a/openspec/changes/fix-web-ui-trace-tool-calls/README.md
+++ b/openspec/changes/fix-web-ui-trace-tool-calls/README.md
@@ -1,0 +1,3 @@
+# fix-web-ui-trace-tool-calls
+
+Persist and render tool call detail in trace views

--- a/openspec/changes/fix-web-ui-trace-tool-calls/design.md
+++ b/openspec/changes/fix-web-ui-trace-tool-calls/design.md
@@ -1,0 +1,77 @@
+## Context
+
+Tool calls flow through these layers:
+
+1. **Runtime** (`crates/runtime/src/otel_spans.rs::start_tool_span`) — creates an OTel span named `execute_tool <tool_name>` with attributes:
+   - `tool_name`, `tool_params` (JSON string), `iteration`, `turn`, `interface`, `conversation_id`, `gen_ai.conversation.id`, optional `active_skill`.
+2. **Orchestrator** (`crates/runtime/src/orchestrator/dispatch.rs`) — closes the span with:
+   - `duration_ms`, `tool_status` in {`ok`, `error`, `denied`}, plus `tool_observation` on success or `tool_error` on failure / denial.
+3. **Exporter** (`crates/opentelemetry-exporter-sqlite`) — persists spans to SQLite.
+4. **Web-ui API** — returns `TraceDetailResponse.spans` with each `OtelSpanRecord { name, durationMs, attributes }`.
+5. **Flutter trace detail screen** (`app/lib/features/traces/trace_detail_screen.dart`) — sorts spans by `startTime`, renders each through `_SpanCard` with name, duration bar, and an expandable alphabetical attribute dump.
+
+The data is all there. The web UI just renders it generically. This change is **rendering-only on the Flutter side**.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- A tool span is immediately recognisable in the trace list — distinct card style, status icon and color.
+- The two most-asked questions while debugging — _"what did the tool receive?"_ and _"what did it return?"_ — are answerable without expanding a long attribute dump.
+- Status colours match the chat `tool-call-display` chip palette so users build one mental model.
+
+**Non-goals**
+
+- Span-tree visualisation across non-tool spans (separate change).
+- Live streaming trace updates (out of scope).
+
+## Decisions
+
+### D1: Detection — `span.name.startsWith('execute_tool ')`
+
+**Choice:** Treat a span as a tool span when its name starts with the literal `execute_tool ` prefix. Fall back to `attributes['tool_name'] != null` if the prefix is missing (defensive — in case future runtime code drops the prefix).
+
+**Why:** The prefix is set in exactly one place (`otel_spans.rs:181`) and is stable. Attribute-based detection alone would mis-categorise unrelated spans that happen to mention a tool name.
+
+### D2: Status palette mirrors chat tool-call chips
+
+**Choice:** Use the same colours as the chat `tool-call-display` spec:
+
+- `ok` → checkmark icon, `colorScheme.tertiary` (green-ish in seed-based scheme).
+- `error` → cross icon, `colorScheme.error`.
+- `denied` → prohibition icon, amber (`Color(0xFFB45309)` or the closest theme token).
+
+**Why:** Users debugging a turn often look at the chat _and_ the trace. Identical chip semantics across both views makes the link obvious without explicit cross-references.
+
+### D3: Two-pane body — `Params` / `Output`
+
+**Choice:** Each `_ToolCallSpanCard`, when expanded, renders a two-pane scrollable body:
+
+```
+┌──────────────────────────────┐ ┌──────────────────────────────┐
+│ Params                       │ │ Output                       │
+│ {                            │ │ "Wrote 3 files to /tmp/..."  │
+│   "path": "/tmp/foo.txt"     │ │                              │
+│ }                            │ │                              │
+└──────────────────────────────┘ └──────────────────────────────┘
+```
+
+`tool_params` is pretty-printed via `JsonEncoder.withIndent('  ')`. If parsing fails the raw string is shown verbatim. On `error` or `denied`, the Output pane shows `tool_error` styled with `colorScheme.error` text.
+
+**Why:** Aligns with the existing log/JSON viewer aesthetic and keeps everything on one row at desktop widths. On narrow widths (< 600 dp), the two panes stack vertically — handled with `LayoutBuilder`.
+
+### D4: Other attributes stay accessible via a "show all" toggle
+
+**Choice:** The remaining attributes (`iteration`, `turn`, `interface`, `active_skill`, etc.) live behind a small `Show all attributes` toggle in the footer, so the card stays focused on the diagnostically critical fields by default but doesn't hide data.
+
+**Why:** Power users still need iteration / turn info; we just stop making it the front-of-house information.
+
+## Risks / Trade-offs
+
+- **JSON parsing cost:** `tool_params` and `tool_observation` are strings that may be large. Parse lazily on first expand, not on every list render.
+- **Theme drift:** If `colorScheme.tertiary` is reused for unrelated purposes, our success-green could clash. We accept this; revisit when the broader theme audit (#266) lands.
+- **Missing attributes from older traces:** Traces generated before this PR may not have `tool_status` (rare — code path predates this change but the schema is stable). The detector falls back to "unknown" status (neutral grey) so older traces still render.
+
+## Migration Plan
+
+No data migration. Existing trace records already contain the attributes we display. New rendering only.

--- a/openspec/changes/fix-web-ui-trace-tool-calls/proposal.md
+++ b/openspec/changes/fix-web-ui-trace-tool-calls/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+Trace detail views in the web UI render every span identically — name, duration bar, and a flat key/value dump of attributes (`app/lib/features/traces/trace_detail_screen.dart:174`). Tool calls _are_ recorded as OpenTelemetry spans named `execute_tool <tool_name>` with attributes `tool_name`, `tool_params`, `tool_status` (`ok` / `error` / `denied`), `tool_observation` (output) or `tool_error`, and `duration_ms` (`crates/runtime/src/otel_spans.rs:170`, `crates/runtime/src/orchestrator/dispatch.rs:169-215`). But because the UI doesn't single out tool spans:
+
+- A failed tool execution looks identical to a successful one until you expand it.
+- The most diagnostically useful attributes (`tool_status`, `tool_error`, `tool_observation`) are buried in the alphabetical attribute dump.
+- The relationship between an LLM span and its child tool spans is invisible — they're flattened by start-time sort.
+- Tool input parameters are stored as a JSON string inside a single attribute — readable only after expanding and squinting.
+
+The result is that the trace viewer, our primary debugging surface for the ReAct loop, is much less useful than it should be.
+
+## What Changes
+
+- Detect tool spans (`span.name` starts with `execute_tool ` or `tool_name` attribute is present) and render them with a dedicated `_ToolCallSpanCard` instead of the generic `_SpanCard`.
+- Surface status as a colored badge (`ok` green, `error` red, `denied` amber) matching the chat `tool-call-display` chip palette.
+- Show `tool_name` as the card title, `duration_ms` and `tool_status` in the header, and a two-pane "Params / Output" body that pretty-prints the JSON.
+- Add a regression test that builds a synthetic trace with one successful and one failed tool call and asserts the rendered output for each.
+
+## Non-goals
+
+- Changing how spans are stored (`opentelemetry-exporter-sqlite` schema unchanged).
+- Adding span-tree / parent-child visualization for non-tool spans (separate, larger work).
+- Streaming live trace updates (out of scope).
+- Capturing extra attributes — the current `tool_params` / `tool_observation` / `tool_status` set is sufficient for this fix.
+
+## Capabilities
+
+### Added Capabilities
+
+- `trace-tool-call-rendering` (new spec) — how tool spans are surfaced in the web UI trace detail.
+
+## Impact
+
+- `app/lib/features/traces/trace_detail_screen.dart` — add detection helper and new `_ToolCallSpanCard` widget. Wire the list builder to switch on span type.
+- `app/test/widget/traces/trace_detail_tool_call_test.dart` — golden / widget test covering the three statuses (ok, error, denied) and the params + output panes.
+- No backend changes. The required attributes are already emitted; we only render them better.
+
+## Visual / UI change
+
+Yes — the trace detail page gains a distinct card style for tool-call spans. Status colors share the chat tool-call chip palette to keep the trace ↔ chat mental model unified. Playwright trace-detail screenshot baselines will move.
+
+## User-facing documentation
+
+Brief addition to `docs/operations/observability.md` describing the new tool-call card and which attributes it surfaces.

--- a/openspec/changes/fix-web-ui-trace-tool-calls/specs/trace-tool-call-rendering/spec.md
+++ b/openspec/changes/fix-web-ui-trace-tool-calls/specs/trace-tool-call-rendering/spec.md
@@ -1,0 +1,105 @@
+## ADDED Requirements
+
+### Requirement: Tool spans are rendered as dedicated cards in trace detail
+
+The trace detail screen SHALL detect tool-call spans and render them with a `_ToolCallSpanCard` widget distinct from the generic `_SpanCard`. A span SHALL be classified as a tool call when its `name` starts with the literal prefix `"execute_tool "` OR, defensively, when `attributes['tool_name']` is non-null. The tool name SHALL be derived from `attributes['tool_name']` when present, otherwise from the suffix of the span name after `"execute_tool "`.
+
+#### Scenario: Span with `execute_tool` prefix renders as tool card
+
+- **GIVEN** a span with `name == "execute_tool file-read"` and attribute `tool_name == "file-read"`
+- **WHEN** the trace detail screen renders
+- **THEN** the entry for that span SHALL be a `_ToolCallSpanCard` AND the card title SHALL be `"file-read"`
+
+#### Scenario: Generic span is unaffected
+
+- **GIVEN** a span with `name == "chat anthropic/claude-haiku-4-5-20251001"`
+- **WHEN** the trace detail screen renders
+- **THEN** the entry SHALL be a `_SpanCard` (generic), not `_ToolCallSpanCard`
+
+#### Scenario: Span with tool_name attribute but no prefix
+
+- **GIVEN** a span with `name == "tool_invocation"` AND `attributes['tool_name'] == "bash"`
+- **THEN** the entry SHALL be a `_ToolCallSpanCard` with title `"bash"`
+
+### Requirement: Tool-call card surfaces status with an icon and theme-aware colour
+
+The `_ToolCallSpanCard` header SHALL display a status icon and a coloured pill matching `attributes['tool_status']`:
+
+| `tool_status`     | Icon                 | Colour                                                        |
+| ----------------- | -------------------- | ------------------------------------------------------------- |
+| `ok`              | `Icons.check_circle` | `colorScheme.tertiary`                                        |
+| `error`           | `Icons.error`        | `colorScheme.error`                                           |
+| `denied`          | `Icons.block`        | `colorScheme.error.withAlpha(0xCC)` or theme-equivalent amber |
+| missing / unknown | `Icons.help_outline` | `colorScheme.onSurfaceVariant`                                |
+
+The icon and pill SHALL be visible without expanding the card.
+
+#### Scenario: ok status shows check icon and tertiary colour
+
+- **GIVEN** a tool span with `tool_status == "ok"`
+- **THEN** the card header SHALL render `Icons.check_circle` AND a pill labelled `"ok"` in `colorScheme.tertiary`
+
+#### Scenario: error status shows error icon and error colour
+
+- **GIVEN** a tool span with `tool_status == "error"`
+- **THEN** the card header SHALL render `Icons.error` AND a pill labelled `"error"` in `colorScheme.error`
+
+#### Scenario: denied status shows block icon
+
+- **GIVEN** a tool span with `tool_status == "denied"`
+- **THEN** the card header SHALL render `Icons.block` AND a pill labelled `"denied"`
+
+#### Scenario: Missing status falls back to neutral
+
+- **GIVEN** a tool span without a `tool_status` attribute
+- **THEN** the card header SHALL render `Icons.help_outline` AND a pill labelled `"unknown"` in `colorScheme.onSurfaceVariant`
+
+### Requirement: Expanded tool-call card shows params and output side by side
+
+When the card is expanded, it SHALL render a two-pane body labelled `Params` and `Output`.
+
+- `Params` SHALL show `attributes['tool_params']`, pretty-printed via `JsonEncoder.withIndent('  ')` when it parses as JSON, or verbatim when it does not.
+- `Output` SHALL show:
+  - `attributes['tool_observation']` for `tool_status == "ok"` (pretty-printed when JSON-parseable).
+  - `attributes['tool_error']` for `tool_status` in {`error`, `denied`}, styled with `colorScheme.error` text.
+  - The literal string `"(no output)"` when neither attribute is present.
+
+The two panes SHALL lay out side-by-side at viewport widths >= 600 dp and stack vertically below that.
+
+#### Scenario: Success — params + observation visible
+
+- **GIVEN** a tool span with `tool_params == '{"path":"/tmp/foo.txt"}'` and `tool_observation == "ok, 42 bytes"` and `tool_status == "ok"`
+- **WHEN** the card is expanded
+- **THEN** the `Params` pane SHALL show the pretty-printed JSON AND the `Output` pane SHALL show `"ok, 42 bytes"`
+
+#### Scenario: Error — error message styled red
+
+- **GIVEN** a tool span with `tool_status == "error"` and `tool_error == "permission denied"` (no `tool_observation`)
+- **WHEN** the card is expanded
+- **THEN** the `Output` pane SHALL show `"permission denied"` in `colorScheme.error` text
+
+#### Scenario: Narrow viewport stacks panes
+
+- **GIVEN** the viewport is 480 dp wide
+- **WHEN** a tool card is expanded
+- **THEN** the `Params` pane SHALL render above the `Output` pane (vertical stack), not side-by-side
+
+#### Scenario: Non-JSON params shown verbatim
+
+- **GIVEN** a tool span with `tool_params == "not json {{"`
+- **WHEN** the card is expanded
+- **THEN** the `Params` pane SHALL show the literal string `"not json {{"`
+
+### Requirement: "Show all attributes" toggle preserves the full attribute set
+
+Other tool-span attributes (`iteration`, `turn`, `interface`, `active_skill`, `conversation_id`, etc.) SHALL remain accessible behind a `"Show all attributes"` toggle in the card footer, rendered as the existing key/value list when toggled on.
+
+#### Scenario: Default view hides extra attributes
+
+- **WHEN** the card is first expanded
+- **THEN** the `iteration` / `turn` / `interface` attributes SHALL NOT be visible
+
+#### Scenario: Toggle reveals the full attribute dump
+
+- **WHEN** the user taps `"Show all attributes"`
+- **THEN** the card SHALL render all attributes (including the four primary ones already shown) in the existing key/value list format

--- a/openspec/changes/fix-web-ui-trace-tool-calls/specs/trace-tool-call-rendering/spec.md
+++ b/openspec/changes/fix-web-ui-trace-tool-calls/specs/trace-tool-call-rendering/spec.md
@@ -25,12 +25,12 @@ The trace detail screen SHALL detect tool-call spans and render them with a `_To
 
 The `_ToolCallSpanCard` header SHALL display a status icon and a coloured pill matching `attributes['tool_status']`:
 
-| `tool_status`     | Icon                 | Colour                                                        |
-| ----------------- | -------------------- | ------------------------------------------------------------- |
-| `ok`              | `Icons.check_circle` | `colorScheme.tertiary`                                        |
-| `error`           | `Icons.error`        | `colorScheme.error`                                           |
-| `denied`          | `Icons.block`        | `colorScheme.error.withAlpha(0xCC)` or theme-equivalent amber |
-| missing / unknown | `Icons.help_outline` | `colorScheme.onSurfaceVariant`                                |
+| `tool_status`     | Icon                 | Colour                                                    |
+| ----------------- | -------------------- | --------------------------------------------------------- |
+| `ok`              | `Icons.check_circle` | `colorScheme.tertiary`                                    |
+| `error`           | `Icons.error`        | `colorScheme.error`                                       |
+| `denied`          | `Icons.block`        | Amber via `AssistantColors.warning` (`Color(0xFFB45309)`) |
+| missing / unknown | `Icons.help_outline` | `colorScheme.onSurfaceVariant`                            |
 
 The icon and pill SHALL be visible without expanding the card.
 

--- a/openspec/changes/fix-web-ui-trace-tool-calls/tasks.md
+++ b/openspec/changes/fix-web-ui-trace-tool-calls/tasks.md
@@ -1,0 +1,32 @@
+## Tasks
+
+### Phase 1 — Failing tests
+
+- [ ] Add `app/test/widget/traces/trace_detail_tool_call_test.dart` that pumps `_TraceDetailBody` with a synthetic `TraceDetailResponse` containing: - one span `execute_tool file-read` with `tool_status == "ok"`, parseable `tool_params` JSON, and a short `tool_observation` - one span `execute_tool bash` with `tool_status == "error"` and a `tool_error` message - one span `execute_tool web-fetch` with `tool_status == "denied"` and a `tool_error` - one generic `chat anthropic/...` span
+- [ ] Assertions: - finds three `_ToolCallSpanCard` widgets and one `_SpanCard` - each tool card surfaces the correct status icon and pill colour - expanding the `ok` card reveals `Params` / `Output` panes - expanding the `error` card shows the error message styled with `colorScheme.error` - `Show all attributes` toggle reveals `iteration` / `turn` / `interface`
+- [ ] Add a narrow-width variant of the same test (480 dp) asserting vertical stacking.
+- [ ] Run `flutter test` and confirm RED.
+
+### Phase 2 — Detection helper + widget
+
+- [ ] Add `bool isToolSpan(OtelSpanRecord span)` in `app/lib/features/traces/span_classifier.dart`. Cover with a unit test.
+- [ ] Build `_ToolCallSpanCard` in `app/lib/features/traces/tool_call_span_card.dart` with: - Header: tool name, duration, status icon + pill - Expandable body with `LayoutBuilder` switching between row / column at 600 dp - JSON pretty-printer with parse fallback - `Show all attributes` toggle reusing the existing key/value list
+- [ ] Add a widget test for `_ToolCallSpanCard` in isolation covering each status and the parse-fallback branch.
+- [ ] Run `flutter test`; confirm Phase-1 widget-card assertions GREEN.
+
+### Phase 3 — Wire into `_TraceDetailBody`
+
+- [ ] In `trace_detail_screen.dart`, branch the list builder on `isToolSpan` and emit `_ToolCallSpanCard` for matches.
+- [ ] Keep `_SpanCard` for non-tool spans.
+- [ ] Run `flutter test`; confirm the full Phase-1 trace-detail test is GREEN.
+
+### Phase 4 — Playwright + screenshot baselines
+
+- [ ] Add a Playwright spec capturing the trace detail page with at least one tool call (success and failure).
+- [ ] Update existing trace-detail screenshot baselines; document the intentional diff in the PR.
+
+### Phase 5 — Wrap-up
+
+- [ ] `make lint-flutter && make test-flutter && make lint && make format`.
+- [ ] Update `docs/operations/observability.md` with a short section describing the tool-call card and which attributes it surfaces.
+- [ ] Manual smoke: run `assistant webui serve`, trigger a turn with both a successful and a failing tool, open `/traces/{id}` and verify the cards.


### PR DESCRIPTION
## Summary
- Adds change proposals capturing the intended behaviour for four open web-ui bugs before any code lands.
- `fix-web-ui-markdown-links` (#619) — clickable markdown anchors in chat.
- `fix-web-ui-ipad-sidebar-collapse` (#620) — collapsible + persistent sidebar with top-leading toggle and edge-swipe gesture.
- `fix-web-ui-trace-tool-calls` (#265) — dedicated tool-call cards with status / params / output in the trace detail view.
- `fix-web-ui-theme-quality` (#266) — centralised theme module with named tokens, typography ramp, contrast audit, and lint enforcement.

## Stacked PR base for the implementation series
This is the bottom of the stack. Implementation PRs follow:
- #619 implementation → fix/web-ui-markdown-links
- #620 implementation → fix/web-ui-ipad-sidebar-collapse
- #265 implementation → fix/web-ui-trace-tool-calls
- #266 implementation → fix/web-ui-theme-quality (WIP)

## Test plan
- [x] \`openspec validate\` passes for all four changes.
- [ ] No code touched — landing this first sets the spec baseline for review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sidebar collapse now persists on iPad landscapes with visible toggle and left-edge swipe gesture support.
  * Markdown links in chat messages are now clickable and open in external applications.
  * Tool call spans in trace views now display dedicated cards with structured parameter and output sections.

* **Improvements**
  * Enhanced web UI theme consistency with improved contrast, typography, and color token system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cedricziel/assistant/pull/723?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->