### PR TITLE
fix(chat): make markdown hyperlinks clickable (#619)

### DIFF
--- a/app/lib/features/chat/chat_screen.dart
+++ b/app/lib/features/chat/chat_screen.dart
@@ -34,6 +34,7 @@ import 'command_event_tile.dart';
 import 'commands_provider.dart';
 import 'conversation_list.dart';
 import 'image_utils.dart';
+import 'markdown_link_handler.dart';
 import 'streaming_timeline_entry.dart';
 import 'theme_aware_mermaid.dart';
 import 'voice_recorder_button.dart';
@@ -758,6 +759,8 @@ class _MessageBubble extends StatelessWidget {
                                 ),
                               ),
                           useEnhancedComponents: true,
+                          onTapLink: (url) =>
+                              MarkdownLinkHandler(context: context).onTap(url),
                           plugins: ParserPluginRegistry()
                             ..registerBlock(MermaidPlugin())
                             ..registerBlock(const SvgPlugin()),
@@ -788,6 +791,8 @@ class _MessageBubble extends StatelessWidget {
                               ),
                           selectable: true,
                           useEnhancedComponents: true,
+                          onTapLink: (url) =>
+                              MarkdownLinkHandler(context: context).onTap(url),
                           plugins: ParserPluginRegistry()
                             ..registerBlock(MermaidPlugin())
                             ..registerBlock(const SvgPlugin()),

--- a/app/lib/features/chat/markdown_link_handler.dart
+++ b/app/lib/features/chat/markdown_link_handler.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+typedef UrlLauncher = Future<bool> Function(Uri uri, {LaunchMode mode});
+
+Future<bool> _defaultLauncher(
+  Uri uri, {
+  LaunchMode mode = LaunchMode.platformDefault,
+}) {
+  return launchUrl(uri, mode: mode);
+}
+
+const Set<String> _allowedSchemes = {'http', 'https', 'mailto'};
+
+class MarkdownLinkHandler {
+  MarkdownLinkHandler({
+    required this.context,
+    UrlLauncher launcher = _defaultLauncher,
+  }) : _launcher = launcher;
+
+  final BuildContext context;
+  final UrlLauncher _launcher;
+
+  Future<void> onTap(String url) async {
+    final uri = Uri.tryParse(url);
+    if (uri == null ||
+        uri.scheme.isEmpty ||
+        !_allowedSchemes.contains(uri.scheme)) {
+      _showSnackBar('Cannot open link: $url');
+      return;
+    }
+
+    try {
+      final ok = await _launcher(uri, mode: LaunchMode.externalApplication);
+      if (!ok) {
+        _showSnackBar('Could not open link: $url');
+      }
+    } catch (e, st) {
+      debugPrint('MarkdownLinkHandler launch failed: $e\n$st');
+      _showSnackBar('Could not open link');
+    }
+  }
+
+  void _showSnackBar(String message) {
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    if (messenger == null) return;
+    messenger.showSnackBar(SnackBar(content: Text(message)));
+  }
+}

--- a/app/lib/features/chat/streaming_timeline_entry.dart
+++ b/app/lib/features/chat/streaming_timeline_entry.dart
@@ -6,6 +6,7 @@ import 'package:flutter_smooth_markdown/flutter_smooth_markdown.dart'
     hide ToolCallStatus;
 
 import 'chat_provider.dart';
+import 'markdown_link_handler.dart';
 
 /// Display density for timeline entries, derived from viewport width.
 enum TimelineDensity {
@@ -186,6 +187,7 @@ class _StreamingTimelineEntryState extends State<StreamingTimelineEntry> {
               fontStyle: FontStyle.italic,
             ),
           ),
+          onTapLink: (url) => MarkdownLinkHandler(context: context).onTap(url),
         ),
       );
     } else if (hasContent) {

--- a/app/test/unit/features/chat/markdown_link_handler_test.dart
+++ b/app/test/unit/features/chat/markdown_link_handler_test.dart
@@ -1,0 +1,201 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import 'package:assistant_app/features/chat/markdown_link_handler.dart';
+
+class _RecordingLauncher {
+  final List<({Uri uri, LaunchMode mode})> calls = [];
+  bool result = true;
+  Object? throws;
+
+  Future<bool> call(Uri uri, {LaunchMode mode = LaunchMode.platformDefault}) {
+    calls.add((uri: uri, mode: mode));
+    if (throws != null) {
+      return Future.error(throws!);
+    }
+    return Future.value(result);
+  }
+}
+
+Future<void> _pump(WidgetTester tester, void Function(BuildContext) onBuild) {
+  return tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (context) {
+            onBuild(context);
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('MarkdownLinkHandler', () {
+    testWidgets('launches allowed https scheme', (tester) async {
+      final launcher = _RecordingLauncher();
+      late MarkdownLinkHandler handler;
+      await _pump(tester, (context) {
+        handler = MarkdownLinkHandler(
+          context: context,
+          launcher: launcher.call,
+        );
+      });
+
+      await handler.onTap('https://example.com');
+
+      expect(launcher.calls, hasLength(1));
+      expect(launcher.calls.single.uri, Uri.parse('https://example.com'));
+      expect(launcher.calls.single.mode, LaunchMode.externalApplication);
+    });
+
+    testWidgets('launches allowed http scheme', (tester) async {
+      final launcher = _RecordingLauncher();
+      late MarkdownLinkHandler handler;
+      await _pump(tester, (context) {
+        handler = MarkdownLinkHandler(
+          context: context,
+          launcher: launcher.call,
+        );
+      });
+
+      await handler.onTap('http://example.com');
+      expect(launcher.calls, hasLength(1));
+    });
+
+    testWidgets('launches mailto scheme', (tester) async {
+      final launcher = _RecordingLauncher();
+      late MarkdownLinkHandler handler;
+      await _pump(tester, (context) {
+        handler = MarkdownLinkHandler(
+          context: context,
+          launcher: launcher.call,
+        );
+      });
+
+      await handler.onTap('mailto:hi@example.com');
+
+      expect(launcher.calls, hasLength(1));
+      expect(launcher.calls.single.uri, Uri.parse('mailto:hi@example.com'));
+    });
+
+    testWidgets('rejects javascript scheme without launching', (tester) async {
+      final launcher = _RecordingLauncher();
+      late MarkdownLinkHandler handler;
+      await _pump(tester, (context) {
+        handler = MarkdownLinkHandler(
+          context: context,
+          launcher: launcher.call,
+        );
+      });
+
+      await handler.onTap('javascript:alert(1)');
+      await tester.pump();
+
+      expect(launcher.calls, isEmpty);
+      expect(find.textContaining('Cannot open link'), findsOneWidget);
+    });
+
+    testWidgets('rejects file scheme without launching', (tester) async {
+      final launcher = _RecordingLauncher();
+      late MarkdownLinkHandler handler;
+      await _pump(tester, (context) {
+        handler = MarkdownLinkHandler(
+          context: context,
+          launcher: launcher.call,
+        );
+      });
+
+      await handler.onTap('file:///etc/passwd');
+      await tester.pump();
+
+      expect(launcher.calls, isEmpty);
+    });
+
+    testWidgets('rejects data scheme without launching', (tester) async {
+      final launcher = _RecordingLauncher();
+      late MarkdownLinkHandler handler;
+      await _pump(tester, (context) {
+        handler = MarkdownLinkHandler(
+          context: context,
+          launcher: launcher.call,
+        );
+      });
+
+      await handler.onTap('data:text/html,<script>alert(1)</script>');
+      await tester.pump();
+
+      expect(launcher.calls, isEmpty);
+    });
+
+    testWidgets('rejects custom scheme without launching', (tester) async {
+      final launcher = _RecordingLauncher();
+      late MarkdownLinkHandler handler;
+      await _pump(tester, (context) {
+        handler = MarkdownLinkHandler(
+          context: context,
+          launcher: launcher.call,
+        );
+      });
+
+      await handler.onTap('assistant://chat/123');
+      await tester.pump();
+
+      expect(launcher.calls, isEmpty);
+    });
+
+    testWidgets('shows snackbar when launcher returns false', (tester) async {
+      final launcher = _RecordingLauncher()..result = false;
+      late MarkdownLinkHandler handler;
+      await _pump(tester, (context) {
+        handler = MarkdownLinkHandler(
+          context: context,
+          launcher: launcher.call,
+        );
+      });
+
+      await handler.onTap('https://example.com');
+      await tester.pump();
+
+      expect(find.textContaining('Could not open link'), findsOneWidget);
+    });
+
+    testWidgets('catches launcher exceptions and shows snackbar', (
+      tester,
+    ) async {
+      final launcher = _RecordingLauncher()..throws = Exception('boom');
+      late MarkdownLinkHandler handler;
+      await _pump(tester, (context) {
+        handler = MarkdownLinkHandler(
+          context: context,
+          launcher: launcher.call,
+        );
+      });
+
+      await handler.onTap('https://example.com');
+      await tester.pump();
+
+      expect(find.textContaining('Could not open link'), findsOneWidget);
+    });
+
+    testWidgets('rejects malformed url with snackbar', (tester) async {
+      final launcher = _RecordingLauncher();
+      late MarkdownLinkHandler handler;
+      await _pump(tester, (context) {
+        handler = MarkdownLinkHandler(
+          context: context,
+          launcher: launcher.call,
+        );
+      });
+
+      await handler.onTap('not a url at all');
+      await tester.pump();
+
+      expect(launcher.calls, isEmpty);
+      expect(find.textContaining('Cannot open link'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Wire \`onTapLink\` on both \`SmoothMarkdown\` / \`StreamMarkdown\` blocks in the chat surface so anchor taps actually open the URL.
- New \`MarkdownLinkHandler\` opens \`http\` / \`https\` / \`mailto\` via \`url_launcher\` and rejects every other scheme with a snackbar (closes the \`javascript:\` / \`data:\` / \`file:\` prompt-injection foot-guns).
- Launcher failure / exception surfaces a snackbar instead of silently dropping the click.

Resolves #619. Specs live in #723.

## Test plan
- [x] 10 unit tests covering allowed schemes, blocked schemes, launcher failure, and exception paths.
- [ ] Manual smoke: send \`[example](https://example.com)\` from a chat, tap the link, confirm new tab / browser opens.