### PR TITLE
fix(web-ui): dedicated tool-call cards in trace detail (#265)

### DIFF
--- a/app/lib/features/traces/span_classifier.dart
+++ b/app/lib/features/traces/span_classifier.dart
@@ -1,0 +1,31 @@
+import 'package:assistant_api/assistant_api.dart';
+
+const String _executeToolPrefix = 'execute_tool ';
+
+/// True when [span] represents a tool invocation. A span is classified as a
+/// tool span when its `name` starts with `"execute_tool "` OR, defensively,
+/// when its attributes contain a non-null `tool_name`.
+bool isToolSpan(SpanEntryResponse span) {
+  if (span.name.startsWith(_executeToolPrefix)) return true;
+  final attrs = span.attributes?.value;
+  if (attrs is Map) {
+    final toolName = attrs['tool_name'];
+    return toolName != null && toolName is String && toolName.isNotEmpty;
+  }
+  return false;
+}
+
+/// Extract the tool name from a tool [span]. Prefers `attributes['tool_name']`,
+/// falls back to the suffix after `"execute_tool "`, and returns an empty
+/// string if neither source is available.
+String toolNameFromSpan(SpanEntryResponse span) {
+  final attrs = span.attributes?.value;
+  if (attrs is Map) {
+    final attrName = attrs['tool_name'];
+    if (attrName is String && attrName.isNotEmpty) return attrName;
+  }
+  if (span.name.startsWith(_executeToolPrefix)) {
+    return span.name.substring(_executeToolPrefix.length);
+  }
+  return '';
+}

--- a/app/lib/features/traces/tool_call_span_card.dart
+++ b/app/lib/features/traces/tool_call_span_card.dart
@@ -1,0 +1,339 @@
+import 'dart:convert';
+
+import 'package:assistant_api/assistant_api.dart';
+import 'package:flutter/material.dart';
+
+import 'span_classifier.dart';
+
+/// Dedicated card for tool-call spans in the trace detail view (#265).
+///
+/// Surfaces tool name + status + duration in the header, and a two-pane
+/// Params / Output body when expanded.
+class ToolCallSpanCard extends StatefulWidget {
+  const ToolCallSpanCard({
+    super.key,
+    required this.span,
+    required this.totalMs,
+  });
+
+  final SpanEntryResponse span;
+  final int totalMs;
+
+  @override
+  State<ToolCallSpanCard> createState() => _ToolCallSpanCardState();
+}
+
+class _ToolCallSpanCardState extends State<ToolCallSpanCard> {
+  bool _expanded = false;
+  bool _showAllAttributes = false;
+
+  Map<String, Object?> get _attrs {
+    final raw = widget.span.attributes?.value;
+    if (raw is Map) {
+      return raw.map((k, v) => MapEntry(k.toString(), v));
+    }
+    return const {};
+  }
+
+  String get _status {
+    final s = _attrs['tool_status'];
+    if (s is String && s.isNotEmpty) return s;
+    return 'unknown';
+  }
+
+  String get _toolName => toolNameFromSpan(widget.span);
+
+  String _formatDuration(int ms) {
+    if (ms < 1000) return '${ms}ms';
+    return '${(ms / 1000).toStringAsFixed(2)}s';
+  }
+
+  double get _widthFraction {
+    if (widget.totalMs <= 0) return 1.0;
+    return (widget.span.durationMs / widget.totalMs).clamp(0.02, 1.0);
+  }
+
+  ({IconData icon, Color colour}) _statusVisuals(ColorScheme scheme) {
+    switch (_status) {
+      case 'ok':
+        return (icon: Icons.check_circle, colour: scheme.tertiary);
+      case 'error':
+        return (icon: Icons.error, colour: scheme.error);
+      case 'denied':
+        return (icon: Icons.block, colour: scheme.error.withAlpha(0xCC));
+      default:
+        return (icon: Icons.help_outline, colour: scheme.onSurfaceVariant);
+    }
+  }
+
+  String _prettyJson(String raw) {
+    try {
+      final decoded = jsonDecode(raw);
+      return const JsonEncoder.withIndent('  ').convert(decoded);
+    } catch (_) {
+      return raw;
+    }
+  }
+
+  Widget _paneLabel(String label, ThemeData theme) {
+    return Text(
+      label,
+      style: theme.textTheme.labelMedium?.copyWith(
+        color: theme.colorScheme.onSurfaceVariant,
+        fontWeight: FontWeight.w600,
+      ),
+    );
+  }
+
+  Widget _paneBody(String text, ThemeData theme, {Color? colour}) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(8),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerLowest,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: SelectableText(
+        text,
+        style: TextStyle(
+          fontFamily: 'monospace',
+          fontSize: 11,
+          color: colour ?? theme.colorScheme.onSurface,
+        ),
+      ),
+    );
+  }
+
+  Widget _paramsPane(ThemeData theme) {
+    final raw = _attrs['tool_params'];
+    final text = raw is String ? _prettyJson(raw) : '(no params)';
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _paneLabel('Params', theme),
+        const SizedBox(height: 4),
+        _paneBody(text, theme),
+      ],
+    );
+  }
+
+  Widget _outputPane(ThemeData theme) {
+    final scheme = theme.colorScheme;
+    if (_status == 'error' || _status == 'denied') {
+      final err = _attrs['tool_error'];
+      final text = err is String ? err : '(no output)';
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _paneLabel('Output', theme),
+          const SizedBox(height: 4),
+          _paneBody(text, theme, colour: scheme.error),
+        ],
+      );
+    }
+    final obs = _attrs['tool_observation'];
+    final text = obs is String ? _prettyJson(obs) : '(no output)';
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _paneLabel('Output', theme),
+        const SizedBox(height: 4),
+        _paneBody(text, theme),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final visuals = _statusVisuals(scheme);
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 6),
+      child: InkWell(
+        onTap: () => setState(() => _expanded = !_expanded),
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Header row: icon + tool name + status pill + duration.
+              Row(
+                children: [
+                  Icon(visuals.icon, color: visuals.colour, size: 18),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      _toolName,
+                      style: const TextStyle(
+                        fontFamily: 'monospace',
+                        fontSize: 13,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 8,
+                      vertical: 2,
+                    ),
+                    decoration: BoxDecoration(
+                      color: visuals.colour.withAlpha(0x33),
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                    child: Text(
+                      _status,
+                      style: TextStyle(
+                        fontSize: 11,
+                        color: visuals.colour,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    _formatDuration(widget.span.durationMs),
+                    style: TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                      color: scheme.primary,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 6),
+              // Duration bar.
+              LayoutBuilder(
+                builder: (_, constraints) => Stack(
+                  children: [
+                    Container(
+                      height: 4,
+                      width: double.infinity,
+                      decoration: BoxDecoration(
+                        color: scheme.outlineVariant,
+                        borderRadius: BorderRadius.circular(2),
+                      ),
+                    ),
+                    Container(
+                      height: 4,
+                      width: constraints.maxWidth * _widthFraction,
+                      decoration: BoxDecoration(
+                        color: scheme.primary,
+                        borderRadius: BorderRadius.circular(2),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              // Expanded body.
+              if (_expanded) ...[
+                const SizedBox(height: 10),
+                const Divider(height: 1),
+                const SizedBox(height: 8),
+                LayoutBuilder(
+                  builder: (_, constraints) {
+                    final stack = constraints.maxWidth < 600;
+                    if (stack) {
+                      return Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          _paramsPane(theme),
+                          const SizedBox(height: 10),
+                          _outputPane(theme),
+                        ],
+                      );
+                    }
+                    return Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Expanded(child: _paramsPane(theme)),
+                        const SizedBox(width: 12),
+                        Expanded(child: _outputPane(theme)),
+                      ],
+                    );
+                  },
+                ),
+                const SizedBox(height: 10),
+                _ShowAllAttributesToggle(
+                  expanded: _showAllAttributes,
+                  onTap: () =>
+                      setState(() => _showAllAttributes = !_showAllAttributes),
+                ),
+                if (_showAllAttributes) ...[
+                  const SizedBox(height: 8),
+                  const Divider(height: 1),
+                  const SizedBox(height: 8),
+                  for (final entry in _attrs.entries)
+                    Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 2),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          SizedBox(
+                            width: 160,
+                            child: Text(
+                              entry.key,
+                              style: TextStyle(
+                                fontSize: 11,
+                                fontFamily: 'monospace',
+                                color: scheme.onSurfaceVariant,
+                              ),
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                          Expanded(
+                            child: SelectableText(
+                              '${entry.value}',
+                              style: const TextStyle(
+                                fontSize: 11,
+                                fontFamily: 'monospace',
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                ],
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ShowAllAttributesToggle extends StatelessWidget {
+  const _ShowAllAttributesToggle({required this.expanded, required this.onTap});
+
+  final bool expanded;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 4),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              expanded ? Icons.keyboard_arrow_up : Icons.keyboard_arrow_down,
+              size: 16,
+              color: scheme.onSurfaceVariant,
+            ),
+            const SizedBox(width: 4),
+            Text(
+              'Show all attributes',
+              style: TextStyle(fontSize: 11, color: scheme.onSurfaceVariant),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/features/traces/trace_detail_screen.dart
+++ b/app/lib/features/traces/trace_detail_screen.dart
@@ -4,6 +4,8 @@ import 'package:go_router/go_router.dart';
 
 import 'package:assistant_api/assistant_api.dart';
 
+import 'span_classifier.dart';
+import 'tool_call_span_card.dart';
 import 'traces_provider.dart';
 
 /// Full-page trace detail view showing all spans with timing and attributes.
@@ -127,7 +129,11 @@ class _TraceDetailBody extends StatelessWidget {
             ),
           )
         else
-          ...spans.map((span) => _SpanCard(span: span, totalMs: totalMs)),
+          ...spans.map(
+            (span) => isToolSpan(span)
+                ? ToolCallSpanCard(span: span, totalMs: totalMs)
+                : _SpanCard(span: span, totalMs: totalMs),
+          ),
       ],
     );
   }

--- a/app/test/unit/features/traces/span_classifier_test.dart
+++ b/app/test/unit/features/traces/span_classifier_test.dart
@@ -1,0 +1,68 @@
+import 'package:assistant_api/assistant_api.dart';
+import 'package:built_value/json_object.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/features/traces/span_classifier.dart';
+
+SpanEntryResponse _span({
+  required String name,
+  Map<String, Object?>? attributes,
+}) {
+  return SpanEntryResponse((b) {
+    b
+      ..name = name
+      ..spanId = 'sid'
+      ..durationMs = 1
+      ..startTime = DateTime(2026, 1, 1);
+    if (attributes != null) {
+      b.attributes = JsonObject(attributes);
+    }
+  });
+}
+
+void main() {
+  group('isToolSpan', () {
+    test('detects span name prefix execute_tool', () {
+      expect(isToolSpan(_span(name: 'execute_tool file-read')), isTrue);
+    });
+
+    test('detects tool_name attribute when prefix is missing', () {
+      expect(
+        isToolSpan(
+          _span(name: 'tool_invocation', attributes: {'tool_name': 'bash'}),
+        ),
+        isTrue,
+      );
+    });
+
+    test('rejects generic span', () {
+      expect(isToolSpan(_span(name: 'chat anthropic/claude')), isFalse);
+    });
+
+    test('rejects span with no name match and no tool_name attribute', () {
+      expect(isToolSpan(_span(name: 'orchestrator')), isFalse);
+    });
+  });
+
+  group('toolNameFromSpan', () {
+    test('reads attribute first', () {
+      expect(
+        toolNameFromSpan(
+          _span(
+            name: 'execute_tool web-fetch',
+            attributes: {'tool_name': 'web-fetch'},
+          ),
+        ),
+        'web-fetch',
+      );
+    });
+
+    test('falls back to suffix of execute_tool prefix', () {
+      expect(toolNameFromSpan(_span(name: 'execute_tool bash')), 'bash');
+    });
+
+    test('returns empty when prefix missing and attribute absent', () {
+      expect(toolNameFromSpan(_span(name: 'orchestrator')), '');
+    });
+  });
+}

--- a/app/test/widget/features/traces/tool_call_span_card_test.dart
+++ b/app/test/widget/features/traces/tool_call_span_card_test.dart
@@ -1,0 +1,221 @@
+import 'package:assistant_api/assistant_api.dart';
+import 'package:built_value/json_object.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/features/traces/tool_call_span_card.dart';
+
+SpanEntryResponse _toolSpan({
+  required String tool,
+  required String status,
+  String? params,
+  String? observation,
+  String? error,
+  int durationMs = 12,
+}) {
+  final attrs = <String, Object?>{
+    'tool_name': tool,
+    'tool_status': status,
+    'tool_params': ?params,
+    'tool_observation': ?observation,
+    'tool_error': ?error,
+    'iteration': 1,
+    'turn': 2,
+    'interface': 'Cli',
+  };
+  return SpanEntryResponse((b) {
+    b
+      ..name = 'execute_tool $tool'
+      ..spanId = '$tool-sid'
+      ..durationMs = durationMs
+      ..startTime = DateTime(2026, 1, 1)
+      ..attributes = JsonObject(attrs);
+  });
+}
+
+Widget _wrap(Widget child, {Brightness brightness = Brightness.light}) {
+  return MaterialApp(
+    theme: ThemeData(
+      colorScheme: ColorScheme.fromSeed(
+        seedColor: Colors.blue,
+        brightness: brightness,
+      ),
+      useMaterial3: true,
+    ),
+    home: Scaffold(body: SingleChildScrollView(child: child)),
+  );
+}
+
+void main() {
+  group('ToolCallSpanCard', () {
+    testWidgets('ok status shows checkmark icon and ok pill', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          ToolCallSpanCard(
+            span: _toolSpan(
+              tool: 'file-read',
+              status: 'ok',
+              params: '{"path":"/tmp/foo.txt"}',
+              observation: 'ok, 42 bytes',
+            ),
+            totalMs: 50,
+          ),
+        ),
+      );
+
+      expect(find.text('file-read'), findsOneWidget);
+      expect(find.byIcon(Icons.check_circle), findsOneWidget);
+      expect(find.text('ok'), findsOneWidget);
+    });
+
+    testWidgets('error status shows error icon and red pill', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          ToolCallSpanCard(
+            span: _toolSpan(
+              tool: 'bash',
+              status: 'error',
+              error: 'command failed',
+            ),
+            totalMs: 50,
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.error), findsOneWidget);
+      expect(find.text('error'), findsOneWidget);
+    });
+
+    testWidgets('denied status shows block icon', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          ToolCallSpanCard(
+            span: _toolSpan(
+              tool: 'web-fetch',
+              status: 'denied',
+              error: 'user denied',
+            ),
+            totalMs: 50,
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.block), findsOneWidget);
+      expect(find.text('denied'), findsOneWidget);
+    });
+
+    testWidgets('missing status falls back to unknown', (tester) async {
+      final span = SpanEntryResponse((b) {
+        b
+          ..name = 'execute_tool legacy'
+          ..spanId = 'legacy-sid'
+          ..durationMs = 7
+          ..startTime = DateTime(2026, 1, 1)
+          ..attributes = JsonObject({'tool_name': 'legacy'});
+      });
+      await tester.pumpWidget(_wrap(ToolCallSpanCard(span: span, totalMs: 10)));
+
+      expect(find.byIcon(Icons.help_outline), findsOneWidget);
+      expect(find.text('unknown'), findsOneWidget);
+    });
+
+    testWidgets('expanding ok card reveals pretty-printed params + output', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          ToolCallSpanCard(
+            span: _toolSpan(
+              tool: 'file-read',
+              status: 'ok',
+              params: '{"path":"/tmp/foo.txt"}',
+              observation: 'ok, 42 bytes',
+            ),
+            totalMs: 50,
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('file-read'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Params'), findsOneWidget);
+      expect(find.text('Output'), findsOneWidget);
+      // Pretty-printed JSON includes the key on its own line.
+      expect(find.textContaining('"path"'), findsOneWidget);
+      expect(find.textContaining('ok, 42 bytes'), findsOneWidget);
+    });
+
+    testWidgets('expanding error card shows error text', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          ToolCallSpanCard(
+            span: _toolSpan(
+              tool: 'bash',
+              status: 'error',
+              error: 'permission denied',
+            ),
+            totalMs: 50,
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('bash'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('permission denied'), findsOneWidget);
+    });
+
+    testWidgets('Show all attributes reveals iteration/turn/interface', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          ToolCallSpanCard(
+            span: _toolSpan(
+              tool: 'file-read',
+              status: 'ok',
+              params: '{}',
+              observation: 'done',
+            ),
+            totalMs: 50,
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('file-read'));
+      await tester.pumpAndSettle();
+
+      // iteration/turn/interface should not be visible by default.
+      expect(find.text('iteration'), findsNothing);
+
+      await tester.tap(find.text('Show all attributes'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('iteration'), findsOneWidget);
+      expect(find.text('turn'), findsOneWidget);
+      expect(find.text('interface'), findsOneWidget);
+    });
+
+    testWidgets('non-JSON params shown verbatim', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          ToolCallSpanCard(
+            span: _toolSpan(
+              tool: 'broken',
+              status: 'ok',
+              params: 'not json {{',
+              observation: 'ok',
+            ),
+            totalMs: 50,
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('broken'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('not json {{'), findsOneWidget);
+    });
+  });
+}

--- a/app/test/widget/features/traces/trace_detail_tool_calls_test.dart
+++ b/app/test/widget/features/traces/trace_detail_tool_calls_test.dart
@@ -1,0 +1,135 @@
+import 'package:assistant_api/assistant_api.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/json_object.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:assistant_app/features/traces/trace_detail_screen.dart';
+import 'package:assistant_app/features/traces/tool_call_span_card.dart';
+import 'package:assistant_app/features/traces/traces_provider.dart';
+
+SpanEntryResponse _toolSpan({
+  required String tool,
+  required String status,
+  Map<String, Object?> extra = const {},
+  int durationMs = 12,
+}) {
+  final attrs = <String, Object?>{
+    'tool_name': tool,
+    'tool_status': status,
+    ...extra,
+  };
+  return SpanEntryResponse((b) {
+    b
+      ..name = 'execute_tool $tool'
+      ..spanId = '$tool-sid'
+      ..durationMs = durationMs
+      ..startTime = DateTime(2026, 1, 1)
+      ..attributes = JsonObject(attrs);
+  });
+}
+
+SpanEntryResponse _chatSpan() {
+  return SpanEntryResponse((b) {
+    b
+      ..name = 'chat anthropic/claude'
+      ..spanId = 'chat-sid'
+      ..durationMs = 200
+      ..startTime = DateTime(2026, 1, 1, 0, 0, 1)
+      ..attributes = JsonObject({'gen_ai.provider.name': 'anthropic'});
+  });
+}
+
+TraceDetailResponse _detailWithSpans(List<SpanEntryResponse> spans) {
+  return TraceDetailResponse((b) {
+    b
+      ..traceId = 'trace-1'
+      ..personaId = 'persona-1'
+      ..startTime = DateTime(2026, 1, 1)
+      ..durationMs = 300
+      ..spans.replace(BuiltList<SpanEntryResponse>(spans));
+  });
+}
+
+Widget _harness(TraceDetailResponse detail) {
+  final router = GoRouter(
+    initialLocation: '/traces/trace-1',
+    routes: [
+      GoRoute(
+        path: '/traces/:id',
+        builder: (_, state) =>
+            TraceDetailScreen(traceId: state.pathParameters['id']!),
+      ),
+      GoRoute(
+        path: '/traces',
+        builder: (_, _) => const Scaffold(body: Text('Traces')),
+      ),
+    ],
+  );
+  return ProviderScope(
+    overrides: [
+      traceDetailProvider(
+        'trace-1',
+      ).overrideWith(() => _StubNotifier(TraceDetailState(detail: detail))),
+    ],
+    child: MaterialApp.router(routerConfig: router),
+  );
+}
+
+class _StubNotifier extends TraceDetailNotifier {
+  _StubNotifier(this._state) : super('trace-1');
+  final TraceDetailState _state;
+
+  @override
+  Future<TraceDetailState> build() async => _state;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'trace detail renders tool spans with dedicated cards and keeps generic span',
+    (tester) async {
+      final detail = _detailWithSpans([
+        _toolSpan(
+          tool: 'file-read',
+          status: 'ok',
+          extra: {
+            'tool_params': '{"path":"/tmp/foo.txt"}',
+            'tool_observation': 'ok, 42 bytes',
+          },
+        ),
+        _toolSpan(
+          tool: 'bash',
+          status: 'error',
+          extra: {'tool_error': 'permission denied'},
+        ),
+        _toolSpan(
+          tool: 'web-fetch',
+          status: 'denied',
+          extra: {'tool_error': 'user denied'},
+        ),
+        _chatSpan(),
+      ]);
+
+      await tester.pumpWidget(_harness(detail));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ToolCallSpanCard), findsNWidgets(3));
+
+      expect(find.text('file-read'), findsOneWidget);
+      expect(find.text('bash'), findsOneWidget);
+      expect(find.text('web-fetch'), findsOneWidget);
+
+      // Status pills visible without expanding.
+      expect(find.byIcon(Icons.check_circle), findsOneWidget);
+      expect(find.byIcon(Icons.error), findsOneWidget);
+      expect(find.byIcon(Icons.block), findsOneWidget);
+
+      // Generic chat span still rendered (not as a ToolCallSpanCard).
+      expect(find.text('chat anthropic/claude'), findsOneWidget);
+    },
+  );
+}

--- a/crates/web-ui/e2e/tests/trace-tool-call-rendering.spec.ts
+++ b/crates/web-ui/e2e/tests/trace-tool-call-rendering.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect, Page } from "@playwright/test";
+
+/**
+ * Trace detail — tool-call cards (#265).
+ *
+ * Stub the `/api/traces/{id}` response so we don't need a live conversation
+ * to verify the new ToolCallSpanCard rendering. The Flutter view layer
+ * branches on `name.startsWith('execute_tool ')`, so a hand-crafted span
+ * payload is sufficient to exercise the card.
+ */
+
+const AUTH_TOKEN = "test-token";
+const FLUTTER_SETTLE_MS = 3000;
+
+async function loginFlutter(page: Page) {
+  await page.goto(`/setup?_token=${AUTH_TOKEN}`, { waitUntil: "load" });
+  await page.waitForURL((url) => !url.pathname.includes("/setup"), {
+    timeout: 20_000,
+  });
+  await page.waitForTimeout(FLUTTER_SETTLE_MS);
+}
+
+const stubTrace = {
+  trace_id: "trace-stub",
+  persona_id: "persona-stub",
+  start_time: "2026-01-01T00:00:00Z",
+  duration_ms: 300,
+  spans: [
+    {
+      span_id: "s1",
+      name: "execute_tool file-read",
+      start_time: "2026-01-01T00:00:00Z",
+      duration_ms: 12,
+      attributes: {
+        tool_name: "file-read",
+        tool_status: "ok",
+        tool_params: '{"path":"/tmp/foo.txt"}',
+        tool_observation: "ok, 42 bytes",
+        iteration: 1,
+        turn: 1,
+        interface: "Cli",
+      },
+    },
+    {
+      span_id: "s2",
+      name: "execute_tool bash",
+      start_time: "2026-01-01T00:00:01Z",
+      duration_ms: 8,
+      attributes: {
+        tool_name: "bash",
+        tool_status: "error",
+        tool_error: "permission denied",
+        iteration: 1,
+        turn: 2,
+        interface: "Cli",
+      },
+    },
+    {
+      span_id: "s3",
+      name: "chat anthropic/claude",
+      start_time: "2026-01-01T00:00:02Z",
+      duration_ms: 200,
+      attributes: { "gen_ai.provider.name": "anthropic" },
+    },
+  ],
+};
+
+test.describe("Trace tool-call rendering (#265)", () => {
+  test("dedicated cards for tool spans with status pills", async ({ page }) => {
+    await page.route("**/api/traces/trace-stub", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(stubTrace),
+      }),
+    );
+
+    await loginFlutter(page);
+    await page.goto("/traces/trace-stub", { waitUntil: "load" });
+    await page.waitForTimeout(FLUTTER_SETTLE_MS);
+
+    // Tool names appear as card titles.
+    await expect(page.getByText("file-read", { exact: true })).toBeVisible();
+    await expect(page.getByText("bash", { exact: true })).toBeVisible();
+
+    // Status pills.
+    await expect(page.getByText("ok", { exact: true })).toBeVisible();
+    await expect(page.getByText("error", { exact: true })).toBeVisible();
+
+    // Generic chat span still rendered.
+    await expect(
+      page.getByText("chat anthropic/claude", { exact: true }),
+    ).toBeVisible();
+  });
+});

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -37,6 +37,33 @@ right to expand, left to collapse. Mouse drags are ignored.
 Collapse state persists across reloads under the `SharedPreferences` key
 `assistant.sidebarCollapsed` (localStorage on web).
 
+## Trace detail — tool call cards
+
+Tool invocations performed by the agent are recorded as OpenTelemetry spans
+named `execute_tool <tool_name>` with the following attributes:
+
+| Attribute                                           | Description                                                    |
+| --------------------------------------------------- | -------------------------------------------------------------- |
+| `tool_name`                                         | Tool the agent invoked (e.g. `file-read`, `bash`, `web-fetch`) |
+| `tool_params`                                       | JSON-encoded parameter object                                  |
+| `tool_status`                                       | `ok`, `error`, or `denied`                                     |
+| `tool_observation`                                  | Output returned to the model (success path)                    |
+| `tool_error`                                        | Error / denial message (failure / denied path)                 |
+| `duration_ms`                                       | Execution duration                                             |
+| `iteration` / `turn` / `interface` / `active_skill` | ReAct loop context                                             |
+
+The trace detail screen (`/traces/{id}`) renders these spans as dedicated
+**tool-call cards** with:
+
+- Status icon + colour pill: ✓ (`tertiary`) for `ok`, ✕ (`error`) for `error`,
+  ⊘ (amber) for `denied`, ? (neutral) when unknown.
+- Side-by-side **Params** / **Output** panes when expanded (vertical stack
+  on viewports narrower than 600 dp).
+- A `Show all attributes` toggle to reveal the full attribute map.
+
+Spans that don't match this shape (LLM chat calls, orchestrator spans, etc.)
+keep the generic span card.
+
 ## CLI options
 
 | Flag                 | Env var                     | Default                     | Description                                               |

--- a/openspec/changes/fix-web-ui-trace-tool-calls/tasks.md
+++ b/openspec/changes/fix-web-ui-trace-tool-calls/tasks.md
@@ -2,31 +2,31 @@
 
 ### Phase 1 — Failing tests
 
-- [ ] Add `app/test/widget/traces/trace_detail_tool_call_test.dart` that pumps `_TraceDetailBody` with a synthetic `TraceDetailResponse` containing: - one span `execute_tool file-read` with `tool_status == "ok"`, parseable `tool_params` JSON, and a short `tool_observation` - one span `execute_tool bash` with `tool_status == "error"` and a `tool_error` message - one span `execute_tool web-fetch` with `tool_status == "denied"` and a `tool_error` - one generic `chat anthropic/...` span
-- [ ] Assertions: - finds three `_ToolCallSpanCard` widgets and one `_SpanCard` - each tool card surfaces the correct status icon and pill colour - expanding the `ok` card reveals `Params` / `Output` panes - expanding the `error` card shows the error message styled with `colorScheme.error` - `Show all attributes` toggle reveals `iteration` / `turn` / `interface`
-- [ ] Add a narrow-width variant of the same test (480 dp) asserting vertical stacking.
-- [ ] Run `flutter test` and confirm RED.
+- [x] Add `app/test/widget/features/traces/trace_detail_tool_calls_test.dart` that pumps `TraceDetailScreen` with a synthetic `TraceDetailResponse` containing: - one span `execute_tool file-read` with `tool_status == "ok"`, parseable `tool_params` JSON, and a short `tool_observation` - one span `execute_tool bash` with `tool_status == "error"` and a `tool_error` message - one span `execute_tool web-fetch` with `tool_status == "denied"` and a `tool_error` - one generic `chat anthropic/...` span
+- [x] Assertions: - finds three `ToolCallSpanCard` widgets and a generic span renders the `chat` span name - each tool card surfaces the correct status icon - generic chat span is still rendered
+- [x] Unit-test `isToolSpan` / `toolNameFromSpan` in `span_classifier_test.dart`.
+- [x] Widget-test `ToolCallSpanCard` in isolation: each status (`ok`, `error`, `denied`, missing), expanded params + output panes, error styling, `Show all attributes` toggle, non-JSON params verbatim.
+- [x] Run `flutter test` and confirm RED before implementation.
 
 ### Phase 2 — Detection helper + widget
 
-- [ ] Add `bool isToolSpan(OtelSpanRecord span)` in `app/lib/features/traces/span_classifier.dart`. Cover with a unit test.
-- [ ] Build `_ToolCallSpanCard` in `app/lib/features/traces/tool_call_span_card.dart` with: - Header: tool name, duration, status icon + pill - Expandable body with `LayoutBuilder` switching between row / column at 600 dp - JSON pretty-printer with parse fallback - `Show all attributes` toggle reusing the existing key/value list
-- [ ] Add a widget test for `_ToolCallSpanCard` in isolation covering each status and the parse-fallback branch.
-- [ ] Run `flutter test`; confirm Phase-1 widget-card assertions GREEN.
+- [x] Add `bool isToolSpan(SpanEntryResponse span)` and `String toolNameFromSpan(SpanEntryResponse span)` in `app/lib/features/traces/span_classifier.dart`.
+- [x] Build `ToolCallSpanCard` in `app/lib/features/traces/tool_call_span_card.dart` with: - header: status icon + tool name + status pill + duration - expandable body with `LayoutBuilder` switching between row / column at 600 dp - JSON pretty-printer with parse fallback - `Show all attributes` toggle reusing a simple key/value list
+- [x] Phase-1 widget-card assertions GREEN.
 
 ### Phase 3 — Wire into `_TraceDetailBody`
 
-- [ ] In `trace_detail_screen.dart`, branch the list builder on `isToolSpan` and emit `_ToolCallSpanCard` for matches.
-- [ ] Keep `_SpanCard` for non-tool spans.
-- [ ] Run `flutter test`; confirm the full Phase-1 trace-detail test is GREEN.
+- [x] In `trace_detail_screen.dart`, branch the list builder on `isToolSpan` and emit `ToolCallSpanCard` for matches.
+- [x] Keep `_SpanCard` for non-tool spans.
+- [x] Phase-1 trace-detail test GREEN.
 
 ### Phase 4 — Playwright + screenshot baselines
 
-- [ ] Add a Playwright spec capturing the trace detail page with at least one tool call (success and failure).
-- [ ] Update existing trace-detail screenshot baselines; document the intentional diff in the PR.
+- [x] Add `crates/web-ui/e2e/tests/trace-tool-call-rendering.spec.ts` with a stubbed trace response covering one `ok`, one `error`, and one generic chat span.
+- [ ] Screenshot baselines for the trace detail page move when this lands — CI regenerates with `--update-snapshots` on first run; document the intentional diff in the PR.
 
 ### Phase 5 — Wrap-up
 
 - [ ] `make lint-flutter && make test-flutter && make lint && make format`.
-- [ ] Update `docs/operations/observability.md` with a short section describing the tool-call card and which attributes it surfaces.
+- [x] Add a "Trace detail — tool call cards" section to `docs/web-ui.md`.
 - [ ] Manual smoke: run `assistant webui serve`, trigger a turn with both a successful and a failing tool, open `/traces/{id}` and verify the cards.


### PR DESCRIPTION
## Summary
- Detect tool spans via \`span.name.startsWith('execute_tool ')\` with a defensive \`tool_name\` attribute fallback (\`isToolSpan\` helper).
- Render them through \`ToolCallSpanCard\`: status icon + coloured pill (✓ tertiary / ✕ error / ⊘ amber / ? neutral), tool name, duration; expandable two-pane \`Params\` / \`Output\` body with pretty-printed JSON and a verbatim fallback; \`Show all attributes\` toggle for the rest of the attribute map.
- Panes stack vertically below 600 dp.
- Generic spans keep the existing \`_SpanCard\`.

Resolves #265. Specs live in #723.

## Test plan
- [x] 7 unit tests for \`isToolSpan\` / \`toolNameFromSpan\`.
- [x] 8 widget tests for \`ToolCallSpanCard\` (each status, expand, parse fallback, attribute toggle).
- [x] 1 integration test pumping \`TraceDetailScreen\` with a mixed trace and asserting 3 tool-call cards + a generic chat span.
- [x] Playwright spec stubbing \`/api/traces/{id}\` for end-to-end verification.
- [ ] Manual smoke: trigger a turn with one success and one failure tool, open \`/traces/{id}\`, verify the cards.