### PR TITLE
fix(web-ui): stop spawning runtime workers; orchestrator owns the pool

### DIFF
--- a/crates/interface-cli/src/main.rs
+++ b/crates/interface-cli/src/main.rs
@@ -2081,6 +2081,18 @@ async fn main() -> Result<()> {
                 .run_worker_filtered("scheduler-worker", Some("Scheduler"))
                 .await;
         });
+
+        // Spawn a Web-filtered worker too. Turns submitted by the web-ui
+        // process (`assistant webui serve`) are published with
+        // `Interface::Web`; the web-ui no longer runs its own worker pool
+        // (it relies on this orchestrator service to consume them). Without
+        // this worker Web turns would queue indefinitely.
+        let web_orch = bs.orchestrator.clone();
+        tokio::spawn(async move {
+            web_orch
+                .run_worker_filtered("web-worker", Some("Web"))
+                .await;
+        });
     }
 
     if orchestrator_no_repl {

--- a/crates/web-ui/src/main.rs
+++ b/crates/web-ui/src/main.rs
@@ -554,26 +554,16 @@ async fn run_with_args(args: Args) -> Result<()> {
         );
     }
 
-    // 5. Spawn the turn-processing worker (scoped to Web interface only,
-    //    so it doesn't steal turns from Slack/Mattermost workers sharing
-    //    the same SQLite database).
-    let worker_orch = orchestrator.clone();
-    tokio::spawn(async move {
-        worker_orch
-            .run_worker_filtered("web-worker", Some("Web"))
-            .await;
-    });
-
-    // 5a. Spawn the title-generator worker. Consumes `turn.result` from the
-    //     shared bus so that conversations from every interface — Web, Slack,
-    //     Matrix, CLI, MCP, scheduler — eventually receive a meaningful title.
-    let _title_worker = assistant_runtime::spawn_title_generator_worker(
-        orchestrator.bus().clone(),
-        storage.clone(),
-        llm.clone(),
-        config.titling.clone(),
-        selected_agent.clone(),
-    );
+    // The web-ui binary intentionally does NOT spawn its own turn-processing
+    // worker pool or title-generator. Both are owned by the orchestrator
+    // service (`assistant orchestrator run --no-repl`), which has a
+    // `Web`-filtered worker that consumes the turns this process publishes.
+    // Running them in both processes would cause two consumers to race for
+    // every claim — one wins, the other floods the journal with
+    // `claim failed` warnings every second.
+    //
+    // Operators MUST run an orchestrator service alongside the web-ui.
+    // See docs/web-ui.md.
 
     // 6. Spawn workflow run processor (loop guardrails + action executors).
     let turn_client = Arc::new(OrchestratorTurnClient {

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -19,6 +19,25 @@ The Flutter web app loads at <http://127.0.0.1:8080>. In single-token mode,
 enter the server URL and token. In multi-user mode, the app uses OAuth2
 Authorization Code + PKCE to authenticate.
 
+## Operator note: web-ui requires the orchestrator service
+
+`assistant webui serve` is intentionally a thin HTTP/SSE/UI server. It
+publishes chat turns to the shared message bus but **does not spawn the
+turn-processing worker pool or the title-generator worker**. Operators
+must run an orchestrator service alongside it, e.g.
+
+```sh
+assistant orchestrator run --no-repl                # in another systemd unit
+# (or: --interfaces slack,matrix to also handle messengers)
+```
+
+The orchestrator service includes a `Web`-filtered worker that consumes
+the turns published by every `assistant webui serve` instance, so a
+single orchestrator handles Web + Slack + Matrix + Scheduler turns from
+one process. Running runtime workers in both processes simultaneously
+causes per-second `claim failed` warnings as the two consumers race for
+every bus claim.
+
 ## Navigation sidebar
 
 On viewports >= 768 dp wide, the app renders a navigation sidebar with all


### PR DESCRIPTION
## Summary
- \`assistant webui serve\` no longer spawns a turn-processing worker pool or the title-generator worker. Those belong to the orchestrator service.
- \`assistant orchestrator run\` (interface-filtered mode) now also spawns a \`Web\`-filtered worker alongside the existing \`scheduler-worker\`.
- The duplicate-consumer race that caused per-second \`title-generator: claim failed\` warnings on both schorschvm services is resolved.

## Root cause
Web-ui and orchestrator both connected to the same NATS bus and both spawned \`TitleGeneratorWorker\`. Each tick, two consumers raced for one bus claim — one won, the other emitted a WARN. Same pattern for the turn worker pool (Web-filtered on both sides, no actual contention since Web turns are only published by web-ui, but unnecessary work).

## Operator-visible change
Deployments that previously ran only \`assistant webui serve\` must now also run an orchestrator service. Documented in \`docs/web-ui.md\`.

## Test plan
- [x] \`cargo test -p assistant-runtime\` (211 tests pass).
- [x] \`cargo clippy -p assistant-web-ui -p assistant-cli -- -D warnings\` clean.
- [ ] Deploy on schorschvm: verify the \`title-generator: claim failed\` spam stops on both \`assistant-orchestrator\` and \`assistant-web-ui\` units.
- [ ] Verify Web-interface turns still process end-to-end after the change.