### PR TITLE
test(runtime): extract core worker plan with unit-test coverage

### DIFF
--- a/crates/interface-cli/src/main.rs
+++ b/crates/interface-cli/src/main.rs
@@ -1604,6 +1604,34 @@ async fn main() -> Result<()> {
 
     let is_signal_only = matches!(cli.command, Some(Command::Signal));
 
+    let is_matrix_only = matches!(cli.command, Some(Command::Matrix));
+
+    let is_worker_only = matches!(cli.command, Some(Command::Worker { .. }));
+
+    // Derive the binary role and infrastructure-worker plan. The plan is the
+    // single source of truth for which `main-worker` / `scheduler-worker` /
+    // `web-worker` / `TitleGeneratorWorker` / `memory_indexer` to spawn.
+    // See `assistant_runtime::worker_plan` for the rules and their unit tests.
+    let binary_role = if is_mcp {
+        assistant_runtime::BinaryRole::Mcp
+    } else if is_worker_only {
+        assistant_runtime::BinaryRole::WorkerOnly
+    } else if is_slack_only
+        || is_mattermost_only
+        || is_nextcloud_only
+        || is_signal_only
+        || is_matrix_only
+    {
+        assistant_runtime::BinaryRole::InterfaceOnly
+    } else if orchestrator_interface_filtered {
+        assistant_runtime::BinaryRole::OrchestratorFiltered
+    } else if matches!(cli.command, Some(Command::Orchestrator { .. })) {
+        assistant_runtime::BinaryRole::OrchestratorUnfiltered
+    } else {
+        assistant_runtime::BinaryRole::Repl
+    };
+    let worker_plan = assistant_runtime::core_worker_plan(binary_role.clone());
+
     let confirmation_cb: Arc<dyn ConfirmationCallback> = if is_mcp
         || is_slack_only
         || is_mattermost_only
@@ -1689,21 +1717,22 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
-    // 5b. Spawn the main turn worker (processes generic bus messages).
-    // In interface-only modes we run a dedicated, interface-filtered worker
-    // below to avoid duplicate consumption of the same turn requests.
-    let _worker = if !is_slack_only
-        && !is_mattermost_only
-        && !is_nextcloud_only
-        && !orchestrator_interface_filtered
+    // 5b. Spawn the unfiltered main turn worker if the plan asks for it.
+    // The plan rules live in `assistant_runtime::worker_plan` and are unit
+    // tested there. Interface-filtered workers (scheduler-worker, web-worker)
+    // are spawned later in this function for the orchestrator-filtered role.
+    let mut _spawned_workers = Vec::new();
+    if let Some(spec) = worker_plan
+        .workers
+        .iter()
+        .find(|w| w.interface_filter.is_none())
     {
         let worker_orch = bs.orchestrator.clone();
-        Some(tokio::spawn(async move {
-            worker_orch.run_worker("main-worker").await;
-        }))
-    } else {
-        None
-    };
+        let id = spec.worker_id;
+        _spawned_workers.push(tokio::spawn(async move {
+            worker_orch.run_worker(id).await;
+        }));
+    }
 
     // 6. MCP mode — run the stdio JSON-RPC server and exit.
     #[cfg(feature = "mcp")]
@@ -1740,20 +1769,24 @@ async fn main() -> Result<()> {
         warn!(error = %e, "Failed to register skill improvement task");
     }
 
-    // 7b. Start the memory indexer background task.
-    let _memory_indexer =
-        spawn_memory_indexer(&bs.config.memory, bs.storage.clone(), bs.llm.clone());
+    // 7b. Start the memory indexer background task (gated by the worker plan).
+    let _memory_indexer = worker_plan
+        .spawn_memory_indexer
+        .then(|| spawn_memory_indexer(&bs.config.memory, bs.storage.clone(), bs.llm.clone()));
 
-    // 7b'. Start the title-generator worker (consumes turn.result and auto-titles
-    //      conversations). Runs for every interface because every turn flows
-    //      through the same bus.
-    let _title_worker = assistant_runtime::spawn_title_generator_worker(
-        bs.orchestrator.bus().clone(),
-        bs.storage.clone(),
-        bs.llm.clone(),
-        bs.config.titling.clone(),
-        selected_persona.clone(),
-    );
+    // 7b'. Start the title-generator worker (gated by the worker plan). Consumes
+    //      `turn.result` and auto-titles conversations across every interface.
+    //      The web-ui binary intentionally skips this to avoid duplicate
+    //      consumers racing on the same bus claim (#730).
+    let _title_worker = worker_plan.spawn_title_generator.then(|| {
+        assistant_runtime::spawn_title_generator_worker(
+            bs.orchestrator.bus().clone(),
+            bs.storage.clone(),
+            bs.llm.clone(),
+            bs.config.titling.clone(),
+            selected_persona.clone(),
+        )
+    });
 
     // 7c. Build transcription provider (shared across interfaces).
     let transcription_language = bs
@@ -2070,28 +2103,21 @@ async fn main() -> Result<()> {
         });
     }
 
-    // Spawn a scheduler worker when running in interface-filtered orchestrator
-    // mode. The main unfiltered worker is suppressed in this mode (to avoid
-    // double-consuming Slack/Mattermost/etc. turns), so scheduled tasks would
-    // never be consumed without a dedicated Scheduler worker.
-    if orchestrator_interface_filtered {
-        let sched_orch = bs.orchestrator.clone();
+    // Spawn the interface-filtered workers (scheduler-worker, web-worker)
+    // requested by the worker plan. The plan returns these for
+    // `OrchestratorFiltered` so scheduled tasks and Web-interface turns get
+    // consumed by this process — the main unfiltered worker is suppressed in
+    // that mode to avoid double-consuming Slack/Mattermost/etc. turns.
+    for spec in worker_plan
+        .workers
+        .iter()
+        .filter(|w| w.interface_filter.is_some())
+    {
+        let orch = bs.orchestrator.clone();
+        let id = spec.worker_id;
+        let filter = spec.interface_filter;
         tokio::spawn(async move {
-            sched_orch
-                .run_worker_filtered("scheduler-worker", Some("Scheduler"))
-                .await;
-        });
-
-        // Spawn a Web-filtered worker too. Turns submitted by the web-ui
-        // process (`assistant webui serve`) are published with
-        // `Interface::Web`; the web-ui no longer runs its own worker pool
-        // (it relies on this orchestrator service to consume them). Without
-        // this worker Web turns would queue indefinitely.
-        let web_orch = bs.orchestrator.clone();
-        tokio::spawn(async move {
-            web_orch
-                .run_worker_filtered("web-worker", Some("Web"))
-                .await;
+            orch.run_worker_filtered(id, filter).await;
         });
     }
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -17,6 +17,7 @@ pub(crate) mod skill_learner;
 pub mod telemetry;
 pub mod title_generator;
 pub mod webhook_dispatch;
+pub mod worker_plan;
 
 pub use adapter_registry::AdapterRegistry;
 pub use bootstrap::spawn_memory_indexer;
@@ -30,3 +31,4 @@ pub use otel_spans::start_conversation_context;
 pub use scheduler::spawn_scheduler;
 pub use telemetry::{OtelGuard, init_tracing};
 pub use title_generator::{TitleGeneratorWorker, spawn_title_generator_worker};
+pub use worker_plan::{BinaryRole, CoreWorkerPlan, CoreWorkerSpec, core_worker_plan};

--- a/crates/runtime/src/worker_plan.rs
+++ b/crates/runtime/src/worker_plan.rs
@@ -1,0 +1,209 @@
+//! Worker-spawning plan for each binary role.
+//!
+//! The unified `assistant` binary boots into several different modes (REPL,
+//! orchestrator daemon, single-interface daemon, MCP server, dedicated worker,
+//! web-UI). Each mode decides which **infrastructure** workers to spawn at
+//! startup:
+//!
+//! - `main-worker` — unfiltered turn consumer (REPL / orchestrator-unfiltered).
+//! - `scheduler-worker` — claims `Scheduler`-interface turns.
+//! - `web-worker` — claims `Web`-interface turns.
+//! - `TitleGeneratorWorker` — consumes `turn.result` and auto-titles
+//!   conversations.
+//! - `memory_indexer` — periodic memory embedding pipeline.
+//!
+//! Interface-specific workers (`slack-worker`, `matrix-worker`, etc.) are
+//! co-located with their adapter init code and aren't covered here — they
+//! exist iff the adapter runs in this process.
+//!
+//! This helper exists so the binary-level wiring can be verified by unit
+//! tests instead of subprocess smoke tests. Call sites in
+//! `crates/interface-cli/src/main.rs` and `crates/web-ui/src/main.rs`
+//! consume the plan and spawn exactly what it returns.
+
+/// One infrastructure worker spawn.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CoreWorkerSpec {
+    /// Worker identifier passed to `Orchestrator::run_worker_filtered`.
+    pub worker_id: &'static str,
+    /// Optional interface filter for `ClaimFilter::with_interface`. `None`
+    /// means an unfiltered worker that claims every interface.
+    pub interface_filter: Option<&'static str>,
+}
+
+/// The full set of infrastructure workers + companion services a binary
+/// should spawn at startup.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CoreWorkerPlan {
+    pub workers: Vec<CoreWorkerSpec>,
+    pub spawn_title_generator: bool,
+    pub spawn_memory_indexer: bool,
+}
+
+impl CoreWorkerPlan {
+    /// Returns `true` if the plan asks for any worker / companion service.
+    pub fn is_empty(&self) -> bool {
+        self.workers.is_empty() && !self.spawn_title_generator && !self.spawn_memory_indexer
+    }
+
+    /// Convenience: does the plan include a worker with the given filter?
+    pub fn includes_filter(&self, interface_filter: Option<&str>) -> bool {
+        self.workers
+            .iter()
+            .any(|w| w.interface_filter == interface_filter)
+    }
+}
+
+/// Which `assistant`-binary role is starting up.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BinaryRole {
+    /// `assistant` interactive REPL (no subcommand).
+    Repl,
+    /// `assistant orchestrator run` without `--interfaces`.
+    OrchestratorUnfiltered,
+    /// `assistant orchestrator run --interfaces a,b,c`.
+    OrchestratorFiltered,
+    /// `assistant slack | mattermost | nextcloud | signal | matrix` —
+    /// single-interface daemon. The interface-specific worker is spawned
+    /// alongside the adapter init code, not by this plan.
+    InterfaceOnly,
+    /// `assistant mcp` — stdio JSON-RPC server. No turn workers.
+    Mcp,
+    /// `assistant worker --interface X` — single dedicated worker. No
+    /// companion services.
+    WorkerOnly,
+    /// `assistant webui serve` — HTTP/SSE/UI server only; the orchestrator
+    /// service owns the worker pool (see #730).
+    WebUi,
+}
+
+/// Build the worker plan for a given binary role.
+pub fn core_worker_plan(role: BinaryRole) -> CoreWorkerPlan {
+    match role {
+        BinaryRole::WebUi | BinaryRole::Mcp | BinaryRole::WorkerOnly => CoreWorkerPlan {
+            workers: vec![],
+            spawn_title_generator: false,
+            spawn_memory_indexer: false,
+        },
+        BinaryRole::Repl | BinaryRole::OrchestratorUnfiltered => CoreWorkerPlan {
+            workers: vec![CoreWorkerSpec {
+                worker_id: "main-worker",
+                interface_filter: None,
+            }],
+            spawn_title_generator: true,
+            spawn_memory_indexer: true,
+        },
+        BinaryRole::OrchestratorFiltered => CoreWorkerPlan {
+            workers: vec![
+                CoreWorkerSpec {
+                    worker_id: "scheduler-worker",
+                    interface_filter: Some("Scheduler"),
+                },
+                CoreWorkerSpec {
+                    worker_id: "web-worker",
+                    interface_filter: Some("Web"),
+                },
+            ],
+            spawn_title_generator: true,
+            spawn_memory_indexer: true,
+        },
+        BinaryRole::InterfaceOnly => CoreWorkerPlan {
+            // Interface-specific worker (slack-worker / matrix-worker / …)
+            // plus a Scheduler-filtered worker are spawned alongside the
+            // adapter init code, not here. The plan still asks for the
+            // shared companions.
+            workers: vec![],
+            spawn_title_generator: true,
+            spawn_memory_indexer: true,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn webui_plan_is_empty() {
+        let plan = core_worker_plan(BinaryRole::WebUi);
+        assert!(
+            plan.is_empty(),
+            "web-ui must not spawn any infrastructure workers (#730)"
+        );
+        assert!(plan.workers.is_empty());
+        assert!(!plan.spawn_title_generator);
+        assert!(!plan.spawn_memory_indexer);
+    }
+
+    #[test]
+    fn webui_plan_omits_web_filtered_worker() {
+        let plan = core_worker_plan(BinaryRole::WebUi);
+        assert!(
+            !plan.includes_filter(Some("Web")),
+            "web-ui must NOT spawn a Web-filtered worker — the orchestrator owns it"
+        );
+    }
+
+    #[test]
+    fn mcp_plan_is_empty() {
+        let plan = core_worker_plan(BinaryRole::Mcp);
+        assert!(plan.is_empty(), "mcp mode runs no turn workers");
+    }
+
+    #[test]
+    fn worker_only_plan_is_empty() {
+        let plan = core_worker_plan(BinaryRole::WorkerOnly);
+        assert!(
+            plan.is_empty(),
+            "worker-only mode is a single dedicated worker"
+        );
+    }
+
+    #[test]
+    fn repl_plan_spawns_main_worker() {
+        let plan = core_worker_plan(BinaryRole::Repl);
+        assert!(plan.includes_filter(None));
+        assert_eq!(plan.workers.len(), 1);
+        assert_eq!(plan.workers[0].worker_id, "main-worker");
+        assert!(plan.spawn_title_generator);
+        assert!(plan.spawn_memory_indexer);
+    }
+
+    #[test]
+    fn orchestrator_unfiltered_plan_matches_repl() {
+        assert_eq!(
+            core_worker_plan(BinaryRole::OrchestratorUnfiltered),
+            core_worker_plan(BinaryRole::Repl),
+        );
+    }
+
+    #[test]
+    fn orchestrator_filtered_plan_includes_scheduler_and_web() {
+        let plan = core_worker_plan(BinaryRole::OrchestratorFiltered);
+        assert!(
+            plan.includes_filter(Some("Scheduler")),
+            "filtered orchestrator must include scheduler-worker"
+        );
+        assert!(
+            plan.includes_filter(Some("Web")),
+            "filtered orchestrator must include web-worker (#730)"
+        );
+        assert!(
+            !plan.includes_filter(None),
+            "filtered orchestrator must NOT spawn an unfiltered worker (would double-consume)"
+        );
+        assert!(plan.spawn_title_generator);
+        assert!(plan.spawn_memory_indexer);
+    }
+
+    #[test]
+    fn interface_only_plan_has_companions_no_main_worker() {
+        let plan = core_worker_plan(BinaryRole::InterfaceOnly);
+        assert!(
+            plan.workers.is_empty(),
+            "interface-specific worker is spawned by adapter init, not by the plan"
+        );
+        assert!(plan.spawn_title_generator);
+        assert!(plan.spawn_memory_indexer);
+    }
+}

--- a/crates/web-ui/src/main.rs
+++ b/crates/web-ui/src/main.rs
@@ -564,6 +564,20 @@ async fn run_with_args(args: Args) -> Result<()> {
     //
     // Operators MUST run an orchestrator service alongside the web-ui.
     // See docs/web-ui.md.
+    //
+    // The plan is computed (and asserted empty) so the binary is wired to
+    // the same source of truth as the orchestrator's spawn logic. If a
+    // future change adds a worker to `BinaryRole::WebUi` in
+    // `assistant_runtime::worker_plan`, the assertion fires loudly here
+    // instead of silently re-introducing the duplicate-consumer race.
+    let webui_worker_plan =
+        assistant_runtime::core_worker_plan(assistant_runtime::BinaryRole::WebUi);
+    assert!(
+        webui_worker_plan.is_empty(),
+        "BinaryRole::WebUi must not request any infrastructure workers; got {:?}",
+        webui_worker_plan
+    );
+    let _ = webui_worker_plan;
 
     // 6. Spawn workflow run processor (loop guardrails + action executors).
     let turn_client = Arc::new(OrchestratorTurnClient {


### PR DESCRIPTION
## Summary
- Extract the rules for "which infrastructure workers does each \`assistant\`-binary mode spawn" into \`assistant_runtime::worker_plan::core_worker_plan(BinaryRole)\`.
- Both call sites consume the plan as their single source of truth:
  - \`crates/interface-cli/src/main.rs\` derives the role from CLI + \`--interfaces\` and spawns workers / title-gen / memory-indexer from the plan.
  - \`crates/web-ui/src/main.rs\` calls the plan and asserts it is empty for \`BinaryRole::WebUi\` — a defensive \`assert!\` so a future change re-introducing workers panics at boot instead of silently re-creating #730's duplicate-consumer race.

Follow-up to #730 which closed the duplicate-consumer race without test coverage.

## Test plan
- [x] 8 new unit tests cover every \`BinaryRole\` variant + cross-variant assertions (\`OrchestratorUnfiltered == Repl\`, \`!OrchestratorFiltered.includes_filter(None)\`).
- [x] All 219 runtime tests pass.
- [x] \`cargo clippy -p assistant-runtime -p assistant-web-ui -p assistant-cli -- -D warnings\` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved runtime initialization to intelligently load worker components based on the active mode (REPL, orchestrator, interface, MCP, or worker-only), ensuring only necessary services are spawned for each mode.
  * Background services (memory indexer and title generator) now conditionally start based on operational context, optimizing startup efficiency across different execution modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cedricziel/assistant/pull/732?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->