### PR TITLE
feat(cli): unified diff view in /review command (#7)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,6 +475,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "similar",
  "sqlx",
  "sysinfo",
  "tempfile",
@@ -5705,6 +5706,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "simple_asn1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,6 +184,9 @@ storage = { path = "crates/storage" }
 runtime = { path = "crates/runtime" }
 tool-executor = { path = "crates/tool-executor" }
 
+# Text diffing for `/review` skill refinement display.
+similar = "2.6"
+
 [profile.dev]
 # macOS: avoid dsymutil bottleneck at link time
 split-debuginfo = "unpacked"

--- a/crates/interface-cli/Cargo.toml
+++ b/crates/interface-cli/Cargo.toml
@@ -59,6 +59,8 @@ rustls = { workspace = true }
 sqlx = { workspace = true }
 # Process detection for `assistant migrate finalize`
 sysinfo = { workspace = true }
+# Unified diff rendering for `/review` skill refinement display.
+similar = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/interface-cli/src/main.rs
+++ b/crates/interface-cli/src/main.rs
@@ -4,6 +4,7 @@ mod cmd_doctor;
 mod cmd_login;
 mod cmd_migrate;
 mod credentials;
+mod skill_diff;
 
 use std::collections::{HashMap, HashSet};
 use std::io::{self, Write as IoWrite};
@@ -664,12 +665,30 @@ async fn cmd_review(storage: &StorageLayer, registry: &SkillRegistry) -> Result<
         return Ok(());
     }
 
+    let use_colour = std::io::IsTerminal::is_terminal(&std::io::stdout());
+
     println!("\nPending skill refinement proposals:\n");
     for r in &pending {
         println!(
-            "  id:     {}\n  skill:  {}\n  reason: {}\n",
+            "  id:     {}\n  skill:  {}\n  reason: {}",
             r.id, r.target_skill, r.rationale
         );
+
+        // Read current SKILL.md from disk so the reviewer can see exactly
+        // what the acceptance would change (#7).
+        let skill_def = registry.get(&r.target_skill).await;
+        let current_skill_md = match &skill_def {
+            Some(def) => std::fs::read_to_string(def.dir.join("SKILL.md")).unwrap_or_default(),
+            None => String::new(),
+        };
+
+        println!("  diff:");
+        let diff =
+            skill_diff::render_unified_diff(&current_skill_md, &r.proposed_skill_md, use_colour);
+        for line in diff.lines() {
+            println!("    {line}");
+        }
+        println!();
     }
 
     println!("Commands: accept <id>  |  reject <id> [note]  |  done");

--- a/crates/interface-cli/src/skill_diff.rs
+++ b/crates/interface-cli/src/skill_diff.rs
@@ -1,0 +1,152 @@
+//! Unified-diff rendering for `/review` skill refinement display (#7).
+//!
+//! The orchestrator emits skill refinement proposals (`SKILL.md` replacements)
+//! that the user reviews via the `/review` CLI command. Until #7 was fixed,
+//! the command only showed the proposal's id / target / rationale — to see
+//! what would actually change the user had to manually `diff` the file
+//! against the proposal. Now we render a unified diff inline with ANSI
+//! colour so the change is visible at a glance.
+
+use std::fmt::Write;
+
+use similar::{ChangeTag, TextDiff};
+
+/// ANSI escape codes. Kept tiny so we don't pull in a colour crate just for
+/// three sequences.
+const ANSI_GREEN: &str = "\x1b[32m";
+const ANSI_RED: &str = "\x1b[31m";
+const ANSI_DIM: &str = "\x1b[2m";
+const ANSI_RESET: &str = "\x1b[0m";
+
+/// Render a unified diff between `current` and `proposed` SKILL.md content as
+/// a coloured, terminal-printable string. The output is line-oriented:
+///
+/// - `+ ...` (green) for additions.
+/// - `- ...` (red) for deletions.
+/// - `  ...` (dim) for surrounding context, capped at three lines on either
+///   side of each hunk.
+///
+/// `colour` controls whether ANSI escapes are emitted. Tests pass `false` to
+/// keep snapshot output stable.
+pub fn render_unified_diff(current: &str, proposed: &str, colour: bool) -> String {
+    let diff = TextDiff::from_lines(current, proposed);
+
+    let mut out = String::new();
+    for group in diff.grouped_ops(3) {
+        for op in group {
+            for change in diff.iter_changes(&op) {
+                let (sign, ansi) = match change.tag() {
+                    ChangeTag::Insert => ("+", ANSI_GREEN),
+                    ChangeTag::Delete => ("-", ANSI_RED),
+                    ChangeTag::Equal => (" ", ANSI_DIM),
+                };
+                let line = change.value();
+                // `change.value()` already includes the trailing newline when
+                // the source did; preserve it verbatim.
+                if colour {
+                    let _ = write!(out, "{ansi}{sign} {line}{ANSI_RESET}");
+                } else {
+                    let _ = write!(out, "{sign} {line}");
+                }
+                if !line.ends_with('\n') {
+                    out.push('\n');
+                }
+            }
+        }
+    }
+
+    if out.is_empty() {
+        out.push_str("(no changes)\n");
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_unified_diff_marks_inserts_and_deletes() {
+        let current = "alpha\nbeta\ngamma\n";
+        let proposed = "alpha\nBETA\ngamma\n";
+        let diff = render_unified_diff(current, proposed, false);
+
+        assert!(
+            diff.contains("- beta"),
+            "expected '- beta' marker, got:\n{diff}"
+        );
+        assert!(
+            diff.contains("+ BETA"),
+            "expected '+ BETA' marker, got:\n{diff}"
+        );
+        // Surrounding context should appear.
+        assert!(
+            diff.contains("  alpha"),
+            "expected surrounding context, got:\n{diff}"
+        );
+        assert!(
+            diff.contains("  gamma"),
+            "expected surrounding context, got:\n{diff}"
+        );
+    }
+
+    #[test]
+    fn render_unified_diff_no_changes_returns_sentinel() {
+        let same = "alpha\nbeta\n";
+        let diff = render_unified_diff(same, same, false);
+        assert_eq!(diff.trim(), "(no changes)");
+    }
+
+    #[test]
+    fn render_unified_diff_pure_addition() {
+        let current = "";
+        let proposed = "new line\n";
+        let diff = render_unified_diff(current, proposed, false);
+        assert!(
+            diff.contains("+ new line"),
+            "expected '+ new line', got:\n{diff}"
+        );
+    }
+
+    #[test]
+    fn render_unified_diff_pure_deletion() {
+        let current = "old line\n";
+        let proposed = "";
+        let diff = render_unified_diff(current, proposed, false);
+        assert!(
+            diff.contains("- old line"),
+            "expected '- old line', got:\n{diff}"
+        );
+    }
+
+    #[test]
+    fn render_unified_diff_emits_ansi_when_requested() {
+        let current = "a\n";
+        let proposed = "b\n";
+        let diff = render_unified_diff(current, proposed, true);
+        assert!(
+            diff.contains(ANSI_GREEN),
+            "expected ANSI green escape, got:\n{diff:?}"
+        );
+        assert!(
+            diff.contains(ANSI_RED),
+            "expected ANSI red escape, got:\n{diff:?}"
+        );
+        assert!(
+            diff.contains(ANSI_RESET),
+            "expected ANSI reset escape, got:\n{diff:?}"
+        );
+    }
+
+    #[test]
+    fn render_unified_diff_omits_ansi_when_disabled() {
+        let current = "a\n";
+        let proposed = "b\n";
+        let diff = render_unified_diff(current, proposed, false);
+        assert!(
+            !diff.contains('\x1b'),
+            "expected no ANSI escapes, got:\n{diff:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- New \`crates/interface-cli/src/skill_diff.rs\` exposing \`render_unified_diff(current, proposed, colour)\` built on the \`similar\` crate.
- Three-line context grouping; ANSI colour gated on a TTY check (\`std::io::IsTerminal::is_terminal(&stdout)\`).
- \`cmd_review\` reads the live SKILL.md from disk for each pending proposal and renders the diff inline before the interactive accept/reject loop.

Closes #7

## Test plan
- [x] 6 new unit tests cover insert / delete / pure-addition / pure-deletion / no-changes / ANSI on/off.