### PR TITLE
feat(llm): batched embed_batch() on LlmProvider; Ollama native batching (#30)

### DIFF
--- a/crates/core/src/llm/embedding.rs
+++ b/crates/core/src/llm/embedding.rs
@@ -25,6 +25,18 @@ use super::types::{ChatHistoryMessage, LlmResponse};
 pub trait EmbeddingProvider: Send + Sync {
     /// Compute a dense vector embedding for `text`.
     async fn embed(&self, text: &str) -> anyhow::Result<Vec<f32>>;
+
+    /// Compute dense vector embeddings for a batch of texts. The default
+    /// implementation falls back to sequential [`embed`] calls — implementors
+    /// that support batched APIs (Ollama `/api/embed`, OpenAI, Voyage) SHOULD
+    /// override this for fewer round-trips (#30).
+    async fn embed_batch(&self, texts: &[&str]) -> anyhow::Result<Vec<Vec<f32>>> {
+        let mut out = Vec::with_capacity(texts.len());
+        for text in texts {
+            out.push(self.embed(text).await?);
+        }
+        Ok(out)
+    }
 }
 
 // ── LlmEmbedder adapter ─────────────────────────────────────────────────────
@@ -40,6 +52,10 @@ pub struct LlmEmbedder(pub Arc<dyn LlmProvider>);
 impl EmbeddingProvider for LlmEmbedder {
     async fn embed(&self, text: &str) -> anyhow::Result<Vec<f32>> {
         self.0.embed(text).await
+    }
+
+    async fn embed_batch(&self, texts: &[&str]) -> anyhow::Result<Vec<Vec<f32>>> {
+        self.0.embed_batch(texts).await
     }
 }
 
@@ -95,6 +111,10 @@ impl LlmProvider for WithEmbeddingOverride {
 
     async fn embed(&self, text: &str) -> anyhow::Result<Vec<f32>> {
         self.embedder.embed(text).await
+    }
+
+    async fn embed_batch(&self, texts: &[&str]) -> anyhow::Result<Vec<Vec<f32>>> {
+        self.embedder.embed_batch(texts).await
     }
 
     fn provider_name(&self) -> &str {

--- a/crates/core/src/llm/provider.rs
+++ b/crates/core/src/llm/provider.rs
@@ -101,6 +101,21 @@ pub trait LlmProvider: Send + Sync {
         Err(anyhow::anyhow!("Embedding not supported by this provider"))
     }
 
+    /// Compute dense vector embeddings for a batch of texts in a single
+    /// request. The default implementation falls back to calling [`embed`]
+    /// once per text — providers that natively batch (Ollama, OpenAI, Voyage)
+    /// SHOULD override this for a meaningful speed-up (#30).
+    ///
+    /// The returned vector MUST have the same length and order as the input
+    /// slice. If any single text fails, the whole batch returns the error.
+    async fn embed_batch(&self, texts: &[&str]) -> anyhow::Result<Vec<Vec<f32>>> {
+        let mut out = Vec::with_capacity(texts.len());
+        for text in texts {
+            out.push(self.embed(text).await?);
+        }
+        Ok(out)
+    }
+
     // ── Provider identity (for OTel GenAI semantic conventions) ───────────
 
     /// Short, stable identifier for the provider system (e.g. `"ollama"`,

--- a/crates/llm-provider/src/ollama/mod.rs
+++ b/crates/llm-provider/src/ollama/mod.rs
@@ -130,10 +130,25 @@ impl LlmProvider for OllamaProvider {
     }
 
     async fn embed(&self, text: &str) -> anyhow::Result<Vec<f32>> {
+        let vectors = self.embed_batch(&[text]).await?;
+        vectors
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("Empty embeddings array in response"))
+    }
+
+    async fn embed_batch(&self, texts: &[&str]) -> anyhow::Result<Vec<Vec<f32>>> {
+        if texts.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Ollama's `/api/embed` accepts a string OR an array of strings under
+        // `"input"` and returns `{"embeddings": [[…], [...]]}`. Sending the
+        // whole batch in one call avoids `texts.len()` round-trips (#30).
         let url = format!("{}/api/embed", self.base_url);
         let body = serde_json::json!({
             "model": self.embedding_model,
-            "input": text,
+            "input": texts,
         });
         let resp = self
             .http
@@ -154,11 +169,14 @@ impl LlmProvider for OllamaProvider {
             .await
             .map_err(|e| anyhow::anyhow!("Failed to parse embed response: {e}"))?;
 
-        embed_resp
-            .embeddings
-            .into_iter()
-            .next()
-            .ok_or_else(|| anyhow::anyhow!("Empty embeddings array in response"))
+        if embed_resp.embeddings.len() != texts.len() {
+            anyhow::bail!(
+                "Ollama returned {} embeddings for {} inputs",
+                embed_resp.embeddings.len(),
+                texts.len()
+            );
+        }
+        Ok(embed_resp.embeddings)
     }
 
     fn provider_name(&self) -> &str {
@@ -171,5 +189,109 @@ impl LlmProvider for OllamaProvider {
 
     fn server_address(&self) -> &str {
         &self.base_url
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assistant_core::LlmProvider;
+    use wiremock::matchers::{body_json, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn provider_pointed_at(base_url: &str) -> OllamaProvider {
+        OllamaProvider::new(OllamaConfig {
+            model: "qwen2.5:7b".to_string(),
+            base_url: base_url.to_string(),
+            timeout_secs: 5,
+            embedding_model: "nomic-embed-text".to_string(),
+        })
+        .unwrap()
+    }
+
+    /// `embed_batch` SHALL send a single request with `"input": [...]` and
+    /// return all vectors in input order (#30).
+    #[tokio::test]
+    async fn embed_batch_sends_array_input_in_one_request() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/embed"))
+            .and(body_json(serde_json::json!({
+                "model": "nomic-embed-text",
+                "input": ["foo", "bar", "baz"],
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "embeddings": [
+                    [1.0, 2.0],
+                    [3.0, 4.0],
+                    [5.0, 6.0],
+                ],
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let provider = provider_pointed_at(&server.uri());
+        let vectors = provider.embed_batch(&["foo", "bar", "baz"]).await.unwrap();
+
+        assert_eq!(
+            vectors,
+            vec![vec![1.0, 2.0], vec![3.0, 4.0], vec![5.0, 6.0]],
+            "vectors must be returned in input order"
+        );
+    }
+
+    /// Single-input `embed()` continues to work and routes through the same
+    /// batched endpoint.
+    #[tokio::test]
+    async fn embed_single_still_works() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/embed"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "embeddings": [[0.1, 0.2, 0.3]],
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let provider = provider_pointed_at(&server.uri());
+        let vec = provider.embed("hello").await.unwrap();
+        assert_eq!(vec, vec![0.1, 0.2, 0.3]);
+    }
+
+    /// Empty batch SHALL short-circuit without an HTTP request.
+    #[tokio::test]
+    async fn embed_batch_empty_skips_request() {
+        let server = MockServer::start().await;
+        // No mock mounted — any request hits a 404 from wiremock and fails
+        // the test. The call must return [] without touching the server.
+
+        let provider = provider_pointed_at(&server.uri());
+        let vectors: Vec<_> = vec![];
+        let texts: Vec<&str> = vectors.iter().copied().collect();
+        let result = provider.embed_batch(&texts).await.unwrap();
+        assert!(result.is_empty());
+    }
+
+    /// Mismatched response length SHALL surface as an error rather than
+    /// silently corrupting downstream embeddings.
+    #[tokio::test]
+    async fn embed_batch_rejects_mismatched_response_length() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/embed"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "embeddings": [[1.0]],  // only one — but we asked for two
+            })))
+            .mount(&server)
+            .await;
+
+        let provider = provider_pointed_at(&server.uri());
+        let err = provider.embed_batch(&["a", "b"]).await.unwrap_err();
+        assert!(
+            err.to_string().contains("mismatch") || err.to_string().contains("1 embeddings for 2"),
+            "expected length-mismatch error, got: {err}"
+        );
     }
 }

--- a/crates/runtime/src/memory_indexer/mod.rs
+++ b/crates/runtime/src/memory_indexer/mod.rs
@@ -118,24 +118,44 @@ impl MemoryIndexer {
         Ok(())
     }
 
-    /// Embed all unembedded chunks up to `EMBED_BATCH_SIZE`.
+    /// Embed all unembedded chunks up to `EMBED_BATCH_SIZE`. Uses
+    /// `LlmProvider::embed_batch` (#30) so providers that support batched
+    /// embeddings (Ollama / OpenAI / Voyage) issue a single HTTP request for
+    /// the whole batch. Providers without batching fall back to the trait's
+    /// sequential default — same behaviour as before but with one fewer
+    /// abstraction layer.
     async fn embed_pending(&self, store: &MemoryChunkStore) -> Result<()> {
         let unembedded = store.get_unembedded(EMBED_BATCH_SIZE).await?;
-        for chunk in unembedded {
-            match self.llm.embed(&chunk.content).await {
-                Ok(vec) => {
-                    if let Err(e) = store.update_embedding(chunk.id, &vec).await {
-                        warn!(chunk_id = chunk.id, error = %e, "Failed to store embedding");
-                    }
+        if unembedded.is_empty() {
+            return Ok(());
+        }
+
+        let texts: Vec<&str> = unembedded.iter().map(|c| c.content.as_str()).collect();
+        let vectors = match self.llm.embed_batch(&texts).await {
+            Ok(v) => v,
+            Err(e) => {
+                let msg = e.to_string();
+                if msg.contains("not supported") || msg.contains("Not supported") {
+                    debug!("Embedding unsupported by provider; skipping batch");
+                } else {
+                    debug!(error = %e, "Embedding batch failed; skipping");
                 }
-                Err(e) => {
-                    let msg = e.to_string();
-                    if msg.contains("not supported") || msg.contains("Not supported") {
-                        debug!("Embedding unsupported by provider; skipping batch");
-                        break;
-                    }
-                    debug!(chunk_id = chunk.id, error = %e, "Embedding skipped");
-                }
+                return Ok(());
+            }
+        };
+
+        if vectors.len() != unembedded.len() {
+            warn!(
+                got = vectors.len(),
+                expected = unembedded.len(),
+                "embed_batch returned mismatched vector count; skipping persistence"
+            );
+            return Ok(());
+        }
+
+        for (chunk, vec) in unembedded.iter().zip(vectors.iter()) {
+            if let Err(e) = store.update_embedding(chunk.id, vec).await {
+                warn!(chunk_id = chunk.id, error = %e, "Failed to store embedding");
             }
         }
         Ok(())


### PR DESCRIPTION
## Summary
- New default trait method \`embed_batch(&[&str]) -> Vec<Vec<f32>>\` on \`LlmProvider\` and \`EmbeddingProvider\`. Default impl is a sequential fallback so unchanged providers stay green.
- \`OllamaProvider::embed_batch\` posts \`{"input": [...]}\` to \`/api/embed\` in one request and asserts the response length matches input.
- \`OllamaProvider::embed\` is now a thin wrapper around \`embed_batch(&[t])\`.
- \`MemoryIndexer::embed_pending\` collects all unembedded chunk texts and calls \`embed_batch\` once per tick — was doing up to 100 sequential round-trips before.

Closes #30

## Test plan
- [x] 4 new Ollama wiremock tests cover the array request body, the single-embed round-trip, the empty-batch short-circuit, and the length-mismatch error.
- [x] 183 core tests + 219 runtime tests pass.