### PR TITLE
fix(bus-nats): sanitize consumer names; fix title-generator claim spam

### DIFF
--- a/crates/bus-nats/src/lib.rs
+++ b/crates/bus-nats/src/lib.rs
@@ -192,7 +192,16 @@ impl NatsMessageBus {
     /// [`MAX_DELIVER`], we delete the stale consumer and re-create it with
     /// the current config. At most one reconciliation pass per call.
     async fn consumer_for(&self, worker_id: &str, topic: &str) -> Result<Consumer<pull::Config>> {
-        let name = format!("{}-{}", worker_id, topic.replace('.', "-"));
+        // NATS JetStream consumer names accept only `[A-Za-z0-9_-]`. Any other
+        // character (e.g. `.` or `/`) makes `get_or_create_consumer` fail
+        // every call, silently flooding the journal — see the title-generator
+        // `claim failed` spam regression. Sanitize both inputs defensively so
+        // a future caller can't reintroduce the bug.
+        let name = format!(
+            "{}-{}",
+            sanitize_consumer_segment(worker_id),
+            sanitize_consumer_segment(topic),
+        );
         let cfg = pull::Config {
             durable_name: Some(name.clone()),
             filter_subject: format!("bus.{topic}"),
@@ -229,6 +238,23 @@ impl NatsMessageBus {
             .await
             .map_err(|e| anyhow::anyhow!("failed to recreate NATS consumer {name}: {e}"))
     }
+}
+
+/// Replace every character outside `[A-Za-z0-9_-]` with `-`. JetStream
+/// rejects consumer names containing any other character; passing an
+/// unsanitized `worker_id` or `topic` (e.g. `title-generator/<agent>` or
+/// `turn.result`) makes `get_or_create_consumer` fail every call.
+fn sanitize_consumer_segment(input: &str) -> String {
+    input
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect()
 }
 
 fn resolve_nats_url_with<F>(config: &BusConfig, get_env: F) -> String
@@ -623,6 +649,58 @@ mod tests {
     use super::*;
 
     // -- Unit tests (no Docker) ---------------------------------------------
+
+    #[test]
+    fn sanitize_consumer_segment_passes_safe_characters_through() {
+        assert_eq!(sanitize_consumer_segment("main-worker"), "main-worker");
+        assert_eq!(sanitize_consumer_segment("slack_worker"), "slack_worker");
+        assert_eq!(
+            sanitize_consumer_segment("title-generator-default"),
+            "title-generator-default"
+        );
+        assert_eq!(sanitize_consumer_segment("abc123"), "abc123");
+    }
+
+    #[test]
+    fn sanitize_consumer_segment_replaces_slashes() {
+        // Regression: the title-generator's original worker_id was
+        // `title-generator/<agent>`, which JetStream rejected every call.
+        assert_eq!(
+            sanitize_consumer_segment("title-generator/default"),
+            "title-generator-default"
+        );
+    }
+
+    #[test]
+    fn sanitize_consumer_segment_replaces_dots() {
+        // `topic.replace('.', "-")` used to be inline; sanitization now
+        // covers dots too (and anything else NATS would reject).
+        assert_eq!(sanitize_consumer_segment("turn.result"), "turn-result");
+        assert_eq!(sanitize_consumer_segment("a.b.c.d"), "a-b-c-d");
+    }
+
+    #[test]
+    fn sanitize_consumer_segment_replaces_arbitrary_specials() {
+        assert_eq!(
+            sanitize_consumer_segment("foo bar baz"),
+            "foo-bar-baz",
+            "spaces must become dashes"
+        );
+        assert_eq!(
+            sanitize_consumer_segment("hello@world"),
+            "hello-world",
+            "@ is not allowed"
+        );
+        // Non-ASCII characters get replaced; consumer names are ASCII only.
+        assert_eq!(sanitize_consumer_segment("team-α"), "team--");
+    }
+
+    #[test]
+    fn sanitize_consumer_segment_idempotent() {
+        let s = "title-generator-team-1";
+        assert_eq!(sanitize_consumer_segment(s), s);
+        assert_eq!(sanitize_consumer_segment(&sanitize_consumer_segment(s)), s);
+    }
 
     #[test]
     fn test_matches_filter_empty() {

--- a/crates/runtime/src/title_generator.rs
+++ b/crates/runtime/src/title_generator.rs
@@ -235,8 +235,16 @@ impl TitleGeneratorWorker {
     }
 
     /// Stable worker identity used for bus claim attribution.
+    ///
+    /// The id is embedded in the NATS JetStream consumer name (via
+    /// `bus-nats::consumer_for`, which does
+    /// `format!("{worker_id}-{topic}")`). NATS consumer names only accept
+    /// `[A-Za-z0-9_-]`, so this method MUST avoid slashes and other special
+    /// characters — historically `title-generator/<agent_id>` produced an
+    /// invalid consumer name that `get_or_create_consumer` rejected every
+    /// poll, surfacing as a per-second `claim failed` WARN in production.
     fn worker_id(&self) -> String {
-        format!("title-generator/{}", self.agent_id)
+        format!("title-generator-{}", self.agent_id)
     }
 
     /// Run a single claim → process → ack/nack iteration.
@@ -349,7 +357,14 @@ impl TitleGeneratorWorker {
         info!(worker_id = %self.worker_id(), "Title-generator worker started");
         loop {
             if let Err(e) = self.run_one().await {
-                warn!(error = %e, "title-generator: run_one returned an error");
+                // `{:#}` walks the full anyhow context chain — without this,
+                // operators only see the outermost context ("claim failed")
+                // and can't tell what the underlying bus / provider failure
+                // actually was.
+                warn!(
+                    error = format!("{e:#}"),
+                    "title-generator: run_one returned an error"
+                );
                 sleep(Duration::from_secs(1)).await;
                 continue;
             }
@@ -450,6 +465,51 @@ mod tests {
 
         fn chat_calls(&self) -> usize {
             self.chat_calls.load(Ordering::SeqCst)
+        }
+    }
+
+    /// Regression test: the title-generator's `worker_id()` is embedded in
+    /// the NATS JetStream consumer name via
+    /// `bus-nats::consumer_for` (`format!("{worker_id}-{topic}")`). NATS
+    /// rejects any consumer name containing characters outside
+    /// `[A-Za-z0-9_-]`. The original implementation used a slash separator
+    /// (`title-generator/<agent_id>`) which silently failed every poll,
+    /// producing the per-second `claim failed` WARN spam observed on
+    /// schorschvm. Lock the invariant in.
+    #[tokio::test]
+    async fn worker_id_is_nats_safe() {
+        let (bus, storage) = make_bus_and_storage().await;
+        let llm: Arc<dyn LlmProvider> = Arc::new(MockLlm::new_ok("ignored"));
+
+        // Realistic agent_ids the system actually generates. Non-ASCII
+        // edge cases (e.g. user-supplied `team-α`) are covered by
+        // `bus-nats::sanitize_consumer_segment` instead — title-gen's own
+        // output just needs to be safe for the ASCII-only agent_ids the
+        // runtime currently mints.
+        for agent_id in &["default", "work", "ops-team", "agent_42"] {
+            let worker = TitleGeneratorWorker::new(
+                bus.clone(),
+                storage.clone(),
+                llm.clone(),
+                default_cfg(),
+                (*agent_id).to_string(),
+            );
+            let id = worker.worker_id();
+
+            // Whole id, plus the joined `<id>-<topic>` consumer name, must
+            // match `[A-Za-z0-9_-]+`.
+            let joined = format!("{id}-turn-result");
+            assert!(
+                joined
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'),
+                "worker_id-derived consumer name {joined:?} contains characters \
+                 NATS rejects; only [A-Za-z0-9_-] is allowed"
+            );
+            assert!(
+                !id.contains('/'),
+                "worker_id {id:?} contains a slash — NATS consumer names cannot include `/`"
+            );
         }
     }
 


### PR DESCRIPTION
## Root cause
The title-generator's \`worker_id()\` returned \`title-generator/<agent_id>\`. NATS consumer names accept only \`[A-Za-z0-9_-]\`, so \`get_or_create_consumer\` failed every poll — once a second — producing the
\`title-generator: run_one returned an error error=title-generator: claim failed\` spam observed on schorschvm.

Confirmed by listing consumers on the live ASSISTANT_BUS stream:

\`\`\`
main-worker-turn-request
matrix-worker-turn-request
scheduler-worker-turn-request
slack-worker-turn-request
submit_turn-turn-result
web-worker-turn-request
\`\`\`

— no \`title-generator-*\` entry, because creation kept rejecting the malformed name.

## Fix (two-pronged)

1. \`title_generator.rs::worker_id()\` now returns \`title-generator-<agent_id>\` (dash separator). Docstring locks in the NATS character constraint.
2. \`bus-nats::consumer_for\` defensively sanitizes both worker_id and topic via a new \`sanitize_consumer_segment\` helper that replaces anything outside \`[A-Za-z0-9_-]\` with \`-\`. Future callers can't reintroduce the bug.

The \`error = format!("{e:#}")\` change walks the full anyhow context chain so future regressions are diagnosable (the original WARN swallowed the underlying NATS error).

## Test plan
- [x] New \`worker_id_is_nats_safe\` regression test in \`title_generator.rs\` asserts the consumer name (for realistic ASCII agent_ids) is composed only of \`[A-Za-z0-9_-]\`.
- [x] 5 unit tests for \`sanitize_consumer_segment\` covering pass-through / slash / dot / arbitrary specials / idempotency.
- [x] All 219 runtime tests + 22 bus-nats tests pass.
- [ ] After deploy: confirm the \`claim failed\` log line stops on schorschvm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed consumer naming format to ensure compatibility with NATS JetStream requirements by sanitizing special characters in identifiers.

* **Chores**
  * Improved error logging with complete context information for better diagnostics during troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cedricziel/assistant/pull/737?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->