### PR TITLE
refactor(interfaces): ratchet to deny-level panic-free lints

### DIFF
--- a/crates/interfaces/Cargo.toml
+++ b/crates/interfaces/Cargo.toml
@@ -68,15 +68,15 @@ toml = { workspace = true }
 wiremock = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros"] }
 
-# TODO(workspace-lint-policy): ratchet by removing the allow overrides below
-# once non-test unwrap/expect/panic calls are gone from this crate. The
-# workspace baseline (root Cargo.toml [workspace.lints]) is `warn`; we cannot
-# combine `workspace = true` with overrides, so this crate manually replays
-# the relevant lints. See openspec/changes/workspace-lint-policy/.
+# Panic-free contract: all non-test code in this crate propagates errors
+# via `Result<_, anyhow::Error>` or constant-evaluates its invariants.
+# Cargo forbids combining `[lints] workspace = true` with per-crate overrides,
+# so this manually replays the workspace baseline plus the deny ratchet.
+# See openspec/changes/workspace-lint-policy/.
 [lints.clippy]
-unwrap_used = "allow"
-expect_used = "allow"
-panic = "allow"
+unwrap_used = "deny"
+expect_used = "deny"
+panic = "deny"
 unimplemented = "warn"
 todo = "warn"
 

--- a/crates/interfaces/src/nextcloud/signing.rs
+++ b/crates/interfaces/src/nextcloud/signing.rs
@@ -30,17 +30,18 @@ pub fn verify_signature(secret: &str, random: &str, body: &[u8], signature: &str
 /// and `signature` is the HMAC-SHA256 of `random + body` using the secret.
 pub fn sign_request(secret: &str, body: &str) -> Result<(String, String)> {
     let random = generate_random().context("failed to generate random bytes for HMAC signing")?;
-    let signature = compute_signature(secret, &random, body.as_bytes());
+    let signature = compute_signature(secret, &random, body.as_bytes())
+        .context("failed to compute HMAC signature")?;
     Ok((random, signature))
 }
 
 /// Compute the HMAC-SHA256 signature of `random + body` with the given secret.
-fn compute_signature(secret: &str, random: &str, body: &[u8]) -> String {
-    let mut mac =
-        HmacSha256::new_from_slice(secret.as_bytes()).expect("HMAC can take key of any size");
+fn compute_signature(secret: &str, random: &str, body: &[u8]) -> Result<String> {
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes())
+        .map_err(|e| anyhow::anyhow!("invalid HMAC key length: {e}"))?;
     mac.update(random.as_bytes());
     mac.update(body);
-    hex::encode(mac.finalize().into_bytes())
+    Ok(hex::encode(mac.finalize().into_bytes()))
 }
 
 /// Generate a 64-character hex random string.

--- a/crates/interfaces/src/slack/adapter.rs
+++ b/crates/interfaces/src/slack/adapter.rs
@@ -6,6 +6,7 @@
 //! `futures::Stream`.
 
 use std::collections::HashSet;
+use std::num::NonZeroUsize;
 use std::pin::Pin;
 use std::sync::Arc;
 
@@ -33,6 +34,14 @@ use super::config::SlackConfigExt;
 use crate::common::{BACKOFF_MIN, sleep_backoff};
 
 /// Maximum audio file size downloaded for transcription (25 MB — Whisper API limit).
+/// LRU capacity for the in-process cache of Slack thread roots that the bot
+/// has been @-mentioned in. Compile-time-evaluated so the non-zero invariant
+/// cannot regress.
+const ACTIVE_THREAD_CACHE_CAPACITY: NonZeroUsize = match NonZeroUsize::new(1024) {
+    Some(n) => n,
+    None => unreachable!(),
+};
+
 const MAX_AUDIO_ATTACHMENT_BYTES: usize = 25 * 1024 * 1024;
 /// Maximum image file size downloaded for vision (10 MB).
 const MAX_IMAGE_ATTACHMENT_BYTES: usize = 10 * 1024 * 1024;
@@ -141,7 +150,7 @@ impl ChannelAdapter for SlackAdapter {
             // Survives reconnects within the same process; DB provides
             // persistence across restarts.
             let mut active_threads: LruCache<String, ()> =
-                LruCache::new(std::num::NonZeroUsize::new(1024).unwrap());
+                LruCache::new(ACTIVE_THREAD_CACHE_CAPACITY);
 
             let mut backoff = BACKOFF_MIN;
             loop {


### PR DESCRIPTION
## Summary

- First ratchet step under the workspace-lint-policy contract (#TBD merged via eeaafe9a)
- Cleans the 2 unwrap/expect call sites in `crates/interfaces/` and flips its `[lints.clippy]` overrides from `allow` to `deny`

## Changes

- `nextcloud/signing.rs`: `compute_signature` now returns `Result<String>` and propagates HMAC key construction errors instead of `.expect()`-ing. Infallible-in-practice but the structural panic vector is gone.
- `slack/adapter.rs`: replace `NonZeroUsize::new(1024).unwrap()` with a `const ACTIVE_THREAD_CACHE_CAPACITY: NonZeroUsize` whose non-zero invariant is compile-time-checked via exhaustive match.
- `crates/interfaces/Cargo.toml`: flip `unwrap_used`, `expect_used`, `panic` from `"allow"` to `"deny"`.

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` green
- [x] `cargo test -p assistant-interfaces --lib` — 128 tests pass
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo machete` clean
- [ ] CI green

## Rollback impact

Reverting flips the lint back to `allow` — no behavioral change beyond losing the gate.