### PR TITLE
refactor(llm-provider): ratchet to deny-level panic-free lints

### DIFF
--- a/crates/llm-provider/Cargo.toml
+++ b/crates/llm-provider/Cargo.toml
@@ -30,15 +30,14 @@ getrandom            = { workspace = true }
 [dev-dependencies]
 wiremock             = { workspace = true }
 
-# TODO(workspace-lint-policy): ratchet by removing the allow overrides below
-# once non-test unwrap/expect/panic calls are gone from this crate. The
-# workspace baseline (root Cargo.toml [workspace.lints]) is `warn`; we cannot
-# combine `workspace = true` with overrides, so this crate manually replays
-# the relevant lints. See openspec/changes/workspace-lint-policy/.
+# Panic-free contract: all non-test code in this crate propagates errors
+# via `Result<_, anyhow::Error>`. Cargo forbids combining `workspace = true`
+# with per-crate overrides, so this manually replays the workspace baseline
+# plus the deny ratchet. See openspec/changes/workspace-lint-policy/.
 [lints.clippy]
-unwrap_used = "allow"
-expect_used = "allow"
-panic = "allow"
+unwrap_used = "deny"
+expect_used = "deny"
+panic = "deny"
 unimplemented = "warn"
 todo = "warn"
 

--- a/crates/llm-provider/src/chat_completions/mod.rs
+++ b/crates/llm-provider/src/chat_completions/mod.rs
@@ -105,8 +105,8 @@ impl ChatCompletionsProvider {
         let (messages, _pending) = build_chat_messages(system_prompt, history);
         let openai_tools: Vec<ChatCompletionTools> = tools
             .iter()
-            .map(|t| ChatCompletionTools::Function(tool_spec_to_chat(t)))
-            .collect();
+            .map(|t| tool_spec_to_chat(t).map(ChatCompletionTools::Function))
+            .collect::<anyhow::Result<_>>()?;
 
         let mut builder = CreateChatCompletionRequestArgs::default();
         builder
@@ -178,8 +178,8 @@ impl ChatCompletionsProvider {
         let (messages, _pending) = build_chat_messages(system_prompt, history);
         let openai_tools: Vec<ChatCompletionTools> = tools
             .iter()
-            .map(|t| ChatCompletionTools::Function(tool_spec_to_chat(t)))
-            .collect();
+            .map(|t| tool_spec_to_chat(t).map(ChatCompletionTools::Function))
+            .collect::<anyhow::Result<_>>()?;
 
         let mut builder = CreateChatCompletionRequestArgs::default();
         builder

--- a/crates/llm-provider/src/chat_completions/tools.rs
+++ b/crates/llm-provider/src/chat_completions/tools.rs
@@ -11,15 +11,19 @@ use serde_json::Value;
 use assistant_core::{LlmResponseMeta, ToolCallItem, ToolSpec};
 
 /// Convert a [`ToolSpec`] to an `async-openai` `ChatCompletionTool`.
-pub fn tool_spec_to_chat(tool: &ToolSpec) -> ChatCompletionTool {
+///
+/// Returns an error if the `FunctionObject` builder fails (in practice this
+/// only happens when a required field is missing, which our deterministic
+/// construction below cannot trigger — but we propagate rather than panic).
+pub fn tool_spec_to_chat(tool: &ToolSpec) -> anyhow::Result<ChatCompletionTool> {
     let function = FunctionObjectArgs::default()
         .name(&tool.name)
         .description(&tool.description)
         .parameters(tool.normalized_params_schema())
         .build()
-        .expect("FunctionObject build should not fail");
+        .map_err(|e| anyhow::anyhow!("Failed to build OpenAI FunctionObject: {e}"))?;
 
-    ChatCompletionTool { function }
+    Ok(ChatCompletionTool { function })
 }
 
 /// Extract response metadata from a Chat Completions response.

--- a/crates/llm-provider/src/openai/oauth.rs
+++ b/crates/llm-provider/src/openai/oauth.rs
@@ -148,9 +148,9 @@ impl OAuthManager {
 
     async fn perform_pkce_login(&self) -> anyhow::Result<OAuthTokens> {
         // 1. Generate PKCE verifier + challenge.
-        let verifier = generate_code_verifier();
+        let verifier = generate_code_verifier()?;
         let challenge = compute_code_challenge(&verifier);
-        let state = generate_random_string(32);
+        let state = generate_random_string(32)?;
 
         // 2. Build authorization URL.
         let auth_url = format!(
@@ -294,7 +294,7 @@ impl OAuthManager {
 // ── PKCE helpers ──────────────────────────────────────────────────────────────
 
 /// Generate a random code verifier (43–128 characters, base64url-safe).
-fn generate_code_verifier() -> String {
+fn generate_code_verifier() -> anyhow::Result<String> {
     generate_random_string(64)
 }
 
@@ -305,10 +305,10 @@ fn compute_code_challenge(verifier: &str) -> String {
 }
 
 /// Generate a random base64url-encoded string of the given byte length.
-fn generate_random_string(byte_len: usize) -> String {
+fn generate_random_string(byte_len: usize) -> anyhow::Result<String> {
     let mut buf = vec![0u8; byte_len];
-    getrandom::fill(&mut buf).expect("getrandom should not fail");
-    URL_SAFE_NO_PAD.encode(&buf)
+    getrandom::fill(&mut buf).map_err(|e| anyhow::anyhow!("getrandom failed: {e}"))?;
+    Ok(URL_SAFE_NO_PAD.encode(&buf))
 }
 
 /// Percent-encode a value for use in a URL query string.
@@ -425,8 +425,8 @@ mod tests {
 
     #[test]
     fn random_strings_are_unique() {
-        let a = generate_random_string(32);
-        let b = generate_random_string(32);
+        let a = generate_random_string(32).unwrap();
+        let b = generate_random_string(32).unwrap();
         assert_ne!(a, b);
     }
 


### PR DESCRIPTION
## Summary

Second ratchet step under the workspace-lint-policy contract. Cleans the 2 `.expect()` call sites in `crates/llm-provider/` and flips its `[lints.clippy]` overrides from `allow` to `deny`.

## Changes

- `openai/oauth.rs`: `generate_random_string` and `generate_code_verifier` return `anyhow::Result<String>`, propagating `getrandom::fill` failures.
- `chat_completions/tools.rs`: `tool_spec_to_chat` returns `anyhow::Result<ChatCompletionTool>`; callers in `chat_completions/mod.rs` collect into `anyhow::Result<Vec<_>>` via `?`.
- `crates/llm-provider/Cargo.toml`: flip `unwrap_used`/`expect_used`/`panic` from `"allow"` to `"deny"`.

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` green
- [x] `cargo test -p assistant-llm-provider --lib` — 101 tests pass
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo machete` clean
- [ ] CI green

Independent of #738 (different crate); either can merge first.