### PR TITLE
refactor(auth): ratchet to deny-level panic-free lints

### DIFF
--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -57,15 +57,15 @@ tempfile = { workspace = true }
 wiremock = { workspace = true }
 tokio = { workspace = true }
 
-# TODO(workspace-lint-policy): ratchet by removing the allow overrides below
-# once non-test unwrap/expect/panic calls are gone from this crate. The
-# workspace baseline (root Cargo.toml [workspace.lints]) is `warn`; we cannot
-# combine `workspace = true` with overrides, so this crate manually replays
-# the relevant lints. See openspec/changes/workspace-lint-policy/.
+# Panic-free contract: all non-test code in this crate propagates errors
+# via `Result<_, anyhow::Error>` or recovers from `std::sync::Mutex` poison
+# explicitly. Cargo forbids combining `workspace = true` with per-crate
+# overrides, so this manually replays the workspace baseline plus the deny
+# ratchet. See openspec/changes/workspace-lint-policy/.
 [lints.clippy]
-unwrap_used = "allow"
-expect_used = "allow"
-panic = "allow"
+unwrap_used = "deny"
+expect_used = "deny"
+panic = "deny"
 unimplemented = "warn"
 todo = "warn"
 

--- a/crates/auth/src/api_keys.rs
+++ b/crates/auth/src/api_keys.rs
@@ -141,17 +141,29 @@ impl Default for InMemoryApiKeyStore {
 #[async_trait::async_trait]
 impl ApiKeyStore for InMemoryApiKeyStore {
     async fn store_key(&self, record: ApiKeyRecord) -> Result<()> {
-        self.records.lock().unwrap().push(record);
+        // Recover from a poisoned mutex: this is an in-memory store with no
+        // critical invariants beyond the Vec itself, so a previous panic
+        // while holding the lock does not invalidate the data.
+        self.records
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(record);
         Ok(())
     }
 
     async fn get_by_hash(&self, key_hash: &str) -> Result<Option<ApiKeyRecord>> {
-        let records = self.records.lock().unwrap();
+        let records = self
+            .records
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         Ok(records.iter().find(|r| r.key_hash == key_hash).cloned())
     }
 
     async fn list_for_user(&self, user_id: &UserId) -> Result<Vec<ApiKeyRecord>> {
-        let records = self.records.lock().unwrap();
+        let records = self
+            .records
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         Ok(records
             .iter()
             .filter(|r| r.user_id == *user_id)
@@ -160,7 +172,10 @@ impl ApiKeyStore for InMemoryApiKeyStore {
     }
 
     async fn revoke(&self, key_id: &str, user_id: &UserId) -> Result<bool> {
-        let mut records = self.records.lock().unwrap();
+        let mut records = self
+            .records
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let len_before = records.len();
         records.retain(|r| !(r.id == key_id && r.user_id == *user_id));
         Ok(records.len() < len_before)


### PR DESCRIPTION
## Summary

Third ratchet step under the workspace-lint-policy contract. Cleans the 4 `.unwrap()` call sites in `crates/auth/src/api_keys.rs` (the `InMemoryApiKeyStore` impl) and flips its `[lints.clippy]` overrides from `allow` to `deny`.

## Changes

- `api_keys.rs`: replace `self.records.lock().unwrap()` with `self.records.lock().unwrap_or_else(std::sync::PoisonError::into_inner)` — the idiomatic poison-recovery pattern for an in-memory store with no critical invariants beyond the `Vec` itself.
- `crates/auth/Cargo.toml`: flip `unwrap_used`/`expect_used`/`panic` from `"allow"` to `"deny"`.

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` green
- [x] `cargo test -p assistant-auth --lib` — 106 tests pass
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo machete` clean
- [ ] CI green

Independent of #738 and #739.