### PR TITLE
refactor(runtime): ratchet to deny-level panic-free lints

### DIFF
--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -47,15 +47,16 @@ image = { workspace = true }
 wiremock = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["testing"] }
 
-# TODO(workspace-lint-policy): ratchet by removing the allow overrides below
-# once non-test unwrap/expect/panic calls are gone from this crate. The
-# workspace baseline (root Cargo.toml [workspace.lints]) is `warn`; we cannot
-# combine `workspace = true` with overrides, so this crate manually replays
-# the relevant lints. See openspec/changes/workspace-lint-policy/.
+# Panic-free contract: all non-test code in this crate propagates errors
+# via `Result<_, anyhow::Error>`, falls back via `std::future::pending()`
+# for signal-handler install failures, or compile-time-evaluates its
+# invariants. Cargo forbids combining `workspace = true` with per-crate
+# overrides, so this manually replays the workspace baseline plus the
+# deny ratchet. See openspec/changes/workspace-lint-policy/.
 [lints.clippy]
-unwrap_used = "allow"
-expect_used = "allow"
-panic = "allow"
+unwrap_used = "deny"
+expect_used = "deny"
+panic = "deny"
 unimplemented = "warn"
 todo = "warn"
 

--- a/crates/runtime/src/channel_runner.rs
+++ b/crates/runtime/src/channel_runner.rs
@@ -34,6 +34,13 @@ use uuid::Uuid;
 use crate::command_registry::{CommandContext, CommandRegistry};
 use crate::orchestrator::Orchestrator;
 
+/// LRU capacity for the in-memory `conversation_key → Uuid` map.
+/// Compile-time-evaluated so the non-zero invariant cannot regress.
+const CONVERSATION_CACHE_CAPACITY: NonZeroUsize = match NonZeroUsize::new(10_000) {
+    Some(n) => n,
+    None => unreachable!(),
+};
+
 /// Type alias for the per-conversation serialisation map.
 type ConvLocks = Arc<Mutex<HashMap<Uuid, Arc<Mutex<()>>>>>;
 
@@ -67,9 +74,7 @@ impl ChannelRunner {
         Self {
             adapter,
             orchestrator,
-            conversations: Arc::new(Mutex::new(LruCache::new(
-                NonZeroUsize::new(10_000).unwrap(),
-            ))),
+            conversations: Arc::new(Mutex::new(LruCache::new(CONVERSATION_CACHE_CAPACITY))),
             conv_locks: Arc::new(Mutex::new(HashMap::new())),
             shutdown: None,
             command_registry: Arc::new(CommandRegistry::new()),
@@ -442,19 +447,33 @@ impl ChannelRunner {
     }
 
     /// Default (standalone) shutdown signal: Ctrl-C or SIGTERM.
+    ///
+    /// If either signal handler fails to install (extremely rare; typically
+    /// only happens in restricted sandboxes), that branch falls back to
+    /// `pending()` so the other handler still works. The runner can also be
+    /// stopped via the external `shutdown` token regardless of signal state.
     async fn default_shutdown_signal() {
         let ctrl_c = async {
-            tokio::signal::ctrl_c()
-                .await
-                .expect("failed to install Ctrl+C handler");
+            match tokio::signal::ctrl_c().await {
+                Ok(()) => {}
+                Err(e) => {
+                    error!(error = %e, "failed to install Ctrl+C handler; falling back to pending");
+                    std::future::pending::<()>().await
+                }
+            }
         };
 
         #[cfg(unix)]
         let terminate = async {
-            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
-                .expect("failed to install SIGTERM handler")
-                .recv()
-                .await;
+            match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+                Ok(mut sig) => {
+                    sig.recv().await;
+                }
+                Err(e) => {
+                    error!(error = %e, "failed to install SIGTERM handler; falling back to pending");
+                    std::future::pending::<()>().await
+                }
+            }
         };
 
         #[cfg(not(unix))]

--- a/crates/runtime/src/webhook_dispatch.rs
+++ b/crates/runtime/src/webhook_dispatch.rs
@@ -54,7 +54,7 @@ pub async fn dispatch_event(
         delivery_span.set_attribute(KeyValue::new("webhook.id", webhook.id.clone()));
         delivery_span.set_attribute(KeyValue::new("webhook.url", webhook.url.clone()));
 
-        let signature = compute_signature(&webhook.secret, &body);
+        let signature = compute_signature(&webhook.secret, &body)?;
         let result = client
             .post(&webhook.url)
             .header("Content-Type", "application/json")
@@ -117,10 +117,11 @@ pub async fn dispatch_event(
     Ok(delivered)
 }
 
-fn compute_signature(secret: &str, body: &str) -> String {
-    let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).expect("HMAC accepts any key size");
+fn compute_signature(secret: &str, body: &str) -> Result<String> {
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes())
+        .map_err(|e| anyhow::anyhow!("invalid HMAC key length: {e}"))?;
     mac.update(body.as_bytes());
-    hex::encode(mac.finalize().into_bytes())
+    Ok(hex::encode(mac.finalize().into_bytes()))
 }
 
 fn payload_count_hint(payload: &Value) -> usize {


### PR DESCRIPTION
## Summary

Fourth ratchet step under the workspace-lint-policy contract. Cleans the 4 unwrap/expect call sites in `crates/runtime/` and flips its `[lints.clippy]` overrides from `allow` to `deny`.

## Changes

- `channel_runner.rs`: hoist `NonZeroUsize::new(10_000)` into a `const CONVERSATION_CACHE_CAPACITY` evaluated at compile time.
- `channel_runner.rs::default_shutdown_signal`: replace two `.expect("failed to install ... handler")` calls with explicit `match`. On install failure (rare; restricted sandboxes only), log error and fall back to `std::future::pending()` so the other handler or the external shutdown token still works. Previously this would panic the entire channel runner.
- `webhook_dispatch.rs::compute_signature`: return `Result<String>` and propagate HMAC key construction errors. Caller in `dispatch_event` propagates via `?`.
- `crates/runtime/Cargo.toml`: flip `unwrap_used`/`expect_used`/`panic` from `"allow"` to `"deny"`.

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` green
- [x] `cargo test -p assistant-runtime --lib` — 220 tests pass
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo machete` clean
- [ ] CI green

Independent of #738, #739, #740.