### PR TITLE
refactor(backup): ratchet to deny-level panic-free lints

### DIFF
--- a/crates/backup/Cargo.toml
+++ b/crates/backup/Cargo.toml
@@ -24,15 +24,15 @@ sqlx = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }
 
-# TODO(workspace-lint-policy): ratchet by removing the allow overrides below
-# once non-test unwrap/expect/panic calls are gone from this crate. The
-# workspace baseline (root Cargo.toml [workspace.lints]) is `warn`; we cannot
-# combine `workspace = true` with overrides, so this crate manually replays
-# the relevant lints. See openspec/changes/workspace-lint-policy/.
+# Panic-free contract: all non-test code in this crate propagates errors
+# via `Result<_, anyhow::Error>` or recovers from `std::sync::RwLock` poison
+# explicitly. Cargo forbids combining `workspace = true` with per-crate
+# overrides, so this manually replays the workspace baseline plus the deny
+# ratchet. See openspec/changes/workspace-lint-policy/.
 [lints.clippy]
-unwrap_used = "allow"
-expect_used = "allow"
-panic = "allow"
+unwrap_used = "deny"
+expect_used = "deny"
+panic = "deny"
 unimplemented = "warn"
 todo = "warn"
 

--- a/crates/backup/src/lib.rs
+++ b/crates/backup/src/lib.rs
@@ -111,7 +111,13 @@ impl FakeFs {
 
     /// Seed a file into the fake filesystem.
     pub fn seed(&self, path: impl Into<PathBuf>, data: impl Into<Vec<u8>>) {
-        self.files.write().unwrap().insert(path.into(), data.into());
+        // Recover from a poisoned lock: this is an in-memory test fixture
+        // with no invariants beyond the HashMap itself, so a previous panic
+        // while holding the lock does not invalidate the data.
+        self.files
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(path.into(), data.into());
     }
 }
 
@@ -120,7 +126,7 @@ impl BackupFs for FakeFs {
     async fn read_file(&self, path: &Path) -> Result<Vec<u8>> {
         self.files
             .read()
-            .unwrap()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .get(path)
             .cloned()
             .with_context(|| format!("FakeFs: file not found: {:?}", path))
@@ -129,13 +135,16 @@ impl BackupFs for FakeFs {
     async fn write_file(&self, path: &Path, data: &[u8]) -> Result<()> {
         self.files
             .write()
-            .unwrap()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .insert(path.to_path_buf(), data.to_vec());
         Ok(())
     }
 
     async fn list_dir(&self, path: &Path) -> Result<Vec<PathBuf>> {
-        let guard = self.files.read().unwrap();
+        let guard = self
+            .files
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let entries: Vec<PathBuf> = guard
             .keys()
             .filter(|k| k.parent() == Some(path))
@@ -145,13 +154,16 @@ impl BackupFs for FakeFs {
     }
 
     async fn file_exists(&self, path: &Path) -> bool {
-        self.files.read().unwrap().contains_key(path)
+        self.files
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .contains_key(path)
     }
 
     async fn file_size(&self, path: &Path) -> Result<u64> {
         self.files
             .read()
-            .unwrap()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .get(path)
             .map(|d| d.len() as u64)
             .with_context(|| format!("FakeFs: file not found: {:?}", path))


### PR DESCRIPTION
## Summary

Fifth ratchet step under the workspace-lint-policy contract. Cleans the 6 `std::sync::RwLock::*().unwrap()` call sites in `crates/backup/src/lib.rs` (`FakeFs`) and flips its `[lints.clippy]` overrides from `allow` to `deny`.

## Changes

- `lib.rs`: replace `.read()/write().unwrap()` with `.read()/write().unwrap_or_else(std::sync::PoisonError::into_inner)` on the `FakeFs` `BackupFs` impl. In-memory test fixture, no invariants beyond the `HashMap` itself.
- `crates/backup/Cargo.toml`: flip `unwrap_used`/`expect_used`/`panic` from `"allow"` to `"deny"`.

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` green
- [x] `cargo test -p assistant-backup --lib` — 18 tests pass
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo machete` clean
- [ ] CI green

Independent of #738, #739, #740, #741.