### PR TITLE
refactor(tool-executor): ratchet to deny-level panic-free lints

### DIFF
--- a/crates/tool-executor/Cargo.toml
+++ b/crates/tool-executor/Cargo.toml
@@ -32,15 +32,17 @@ stop-words = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
-# TODO(workspace-lint-policy): ratchet by removing the allow overrides below
-# once non-test unwrap/expect/panic calls are gone from this crate. The
-# workspace baseline (root Cargo.toml [workspace.lints]) is `warn`; we cannot
-# combine `workspace = true` with overrides, so this crate manually replays
-# the relevant lints. See openspec/changes/workspace-lint-policy/.
+# Panic-free contract: all non-test code in this crate either propagates
+# errors via `Result<_, anyhow::Error>` / `ToolOutput::error(...)`, or
+# recovers from `std::sync::RwLock` poison explicitly, or gracefully
+# degrades when a static `scraper::Selector` somehow fails to parse.
+# Cargo forbids combining `workspace = true` with per-crate overrides,
+# so this manually replays the workspace baseline plus the deny ratchet.
+# See openspec/changes/workspace-lint-policy/.
 [lints.clippy]
-unwrap_used = "allow"
-expect_used = "allow"
-panic = "allow"
+unwrap_used = "deny"
+expect_used = "deny"
+panic = "deny"
 unimplemented = "warn"
 todo = "warn"
 

--- a/crates/tool-executor/src/builtins/process.rs
+++ b/crates/tool-executor/src/builtins/process.rs
@@ -176,8 +176,20 @@ impl ProcessHandler {
 
         let pid = child.id().unwrap_or(0);
         let stdin = child.stdin.take();
-        let stdout = child.stdout.take().expect("stdout was piped");
-        let stderr = child.stderr.take().expect("stderr was piped");
+        // stdout/stderr are guaranteed by the `Stdio::piped()` configuration
+        // above. If either is missing, the spawn invariants were violated by
+        // an OS-level error after spawn — surface it as a tool error rather
+        // than panicking the worker.
+        let Some(stdout) = child.stdout.take() else {
+            return Ok(ToolOutput::error(
+                "spawned process did not provide a piped stdout handle",
+            ));
+        };
+        let Some(stderr) = child.stderr.take() else {
+            return Ok(ToolOutput::error(
+                "spawned process did not provide a piped stderr handle",
+            ));
+        };
 
         let stdout_buf: Arc<Mutex<VecDeque<String>>> = Arc::new(Mutex::new(VecDeque::new()));
         let stderr_buf: Arc<Mutex<VecDeque<String>>> = Arc::new(Mutex::new(VecDeque::new()));

--- a/crates/tool-executor/src/builtins/schedule_task.rs
+++ b/crates/tool-executor/src/builtins/schedule_task.rs
@@ -140,7 +140,15 @@ impl ToolHandler for ScheduleTaskHandler {
         }
 
         // -- Cron-based (recurring or once) ---------------------------------------
-        let cron_raw = cron_expr.unwrap();
+        // The two earlier branches (`cron_expr.is_none() && run_at.is_none()` and
+        // the `if let Some(raw) = run_at { ... return ... }` block) cover every
+        // case where `cron_expr` could be absent. Treat any leftover `None` as
+        // a tool-error rather than panicking the worker.
+        let Some(cron_raw) = cron_expr else {
+            return Ok(ToolOutput::error(
+                "internal: schedule-task reached cron branch without a cron_expr",
+            ));
+        };
         let (schedule, effective_expr) = match Schedule::from_str(cron_raw) {
             Ok(s) => (s, cron_raw.to_string()),
             Err(e) => {

--- a/crates/tool-executor/src/builtins/web_fetch.rs
+++ b/crates/tool-executor/src/builtins/web_fetch.rs
@@ -158,21 +158,29 @@ fn extract_title(document: &Html) -> Option<String> {
 fn extract_text(document: &Html) -> String {
     use scraper::Selector;
 
-    let body_selector = Selector::parse("body").expect("valid static selector");
-    let skip_selector =
-        Selector::parse("script, style, noscript, head").expect("valid static selector");
-
-    let root = if let Some(body) = document.select(&body_selector).next() {
-        body
-    } else {
-        return document
+    // Static, known-valid selectors. If parsing somehow fails we degrade
+    // gracefully to a root-only text extraction rather than panicking.
+    let root_text_fallback = || {
+        document
             .root_element()
             .text()
             .collect::<Vec<_>>()
             .join(" ")
             .split_whitespace()
             .collect::<Vec<_>>()
-            .join(" ");
+            .join(" ")
+    };
+    let Ok(body_selector) = Selector::parse("body") else {
+        return root_text_fallback();
+    };
+    let Ok(skip_selector) = Selector::parse("script, style, noscript, head") else {
+        return root_text_fallback();
+    };
+
+    let root = if let Some(body) = document.select(&body_selector).next() {
+        body
+    } else {
+        return root_text_fallback();
     };
 
     let skip_ids: std::collections::HashSet<_> =

--- a/crates/tool-executor/src/builtins/web_search.rs
+++ b/crates/tool-executor/src/builtins/web_search.rs
@@ -161,9 +161,18 @@ impl ToolHandler for WebSearchHandler {
 fn parse_ddg_results(html: &str, limit: usize) -> Vec<(String, String, Option<String>)> {
     let document = Html::parse_document(html);
 
-    let result_sel = Selector::parse(".result, .web-result").unwrap();
-    let title_sel = Selector::parse("a.result__a").unwrap();
-    let snippet_sel = Selector::parse(".result__snippet").unwrap();
+    // Static, known-valid selectors. If parsing fails (a scraper upgrade
+    // tightens validation, etc.) we degrade to "no results" rather than
+    // panicking the worker.
+    let Ok(result_sel) = Selector::parse(".result, .web-result") else {
+        return Vec::new();
+    };
+    let Ok(title_sel) = Selector::parse("a.result__a") else {
+        return Vec::new();
+    };
+    let Ok(snippet_sel) = Selector::parse(".result__snippet") else {
+        return Vec::new();
+    };
 
     let mut results = Vec::new();
 

--- a/crates/tool-executor/src/executor.rs
+++ b/crates/tool-executor/src/executor.rs
@@ -91,7 +91,10 @@ impl ToolExecutor {
             Arc::new(AgentStatusHandler::new(storage.clone())),
         ];
 
-        let mut tool_handlers = self.tool_handlers.write().unwrap();
+        let mut tool_handlers = self
+            .tool_handlers
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         for t in tools {
             tool_handlers.insert(t.name().to_string(), t);
         }
@@ -101,7 +104,7 @@ impl ToolExecutor {
     pub fn register_ambient_tool(&self, handler: Arc<dyn ToolHandler>) {
         self.tool_handlers
             .write()
-            .unwrap()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .insert(handler.name().to_string(), handler);
     }
 
@@ -118,7 +121,7 @@ impl ToolExecutor {
         let handler = Arc::new(VoiceResponseHandler::new(tts, store));
         self.tool_handlers
             .write()
-            .unwrap()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .insert(handler.name().to_string(), handler);
     }
 
@@ -142,7 +145,7 @@ impl ToolExecutor {
     pub fn unregister_tools_by_prefix(&self, prefix: &str) {
         self.tool_handlers
             .write()
-            .unwrap()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .retain(|name, _| !name.starts_with(prefix));
     }
 
@@ -150,7 +153,7 @@ impl ToolExecutor {
     pub fn list_tools(&self) -> Vec<Arc<dyn ToolHandler>> {
         self.tool_handlers
             .read()
-            .unwrap()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .values()
             .cloned()
             .collect()
@@ -161,7 +164,7 @@ impl ToolExecutor {
         let mut specs: Vec<ToolSpec> = self
             .tool_handlers
             .read()
-            .unwrap()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .values()
             .map(|t| ToolSpec {
                 name: t.name().to_string(),
@@ -182,7 +185,7 @@ impl ToolExecutor {
         let mut specs: Vec<ToolSpec> = self
             .tool_handlers
             .read()
-            .unwrap()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .values()
             .filter(|t| match allowed {
                 Some(list) => list.iter().any(|a| a == t.name()),
@@ -221,7 +224,12 @@ impl ToolExecutor {
         }
 
         // Clone Arc before releasing the read lock to avoid holding it across an await.
-        let handler = self.tool_handlers.read().unwrap().get(name).cloned();
+        let handler = self
+            .tool_handlers
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(name)
+            .cloned();
 
         if let Some(handler) = handler {
             // Validate params against the declared JSON Schema before dispatch.


### PR DESCRIPTION
## Summary

Sixth ratchet step under the workspace-lint-policy contract. Cleans the 16 unwrap/expect call sites in `crates/tool-executor/` and flips its `[lints.clippy]` overrides from `allow` to `deny`.

## Changes

- `executor.rs` (8 hits): `tool_handlers.read()/write().unwrap()` → `.unwrap_or_else(std::sync::PoisonError::into_inner)`.
- `builtins/process.rs` (2 hits): `child.stdout/stderr.take().expect("…piped")` → `let Some(...) else { ToolOutput::error(...) }`.
- `builtins/schedule_task.rs` (1 hit): `cron_expr.unwrap()` → defensive `let Some(...) else { ToolOutput::error(...) }`.
- `builtins/web_fetch.rs` (2 hits): static `Selector::parse(...).expect(...)` → `.ok()` guard with root-only text fallback.
- `builtins/web_search.rs` (3 hits): three DuckDuckGo selectors → `.ok()` guards with empty-result fallback.
- `crates/tool-executor/Cargo.toml`: flip `unwrap_used`/`expect_used`/`panic` from `"allow"` to `"deny"`.

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` green
- [x] `cargo test -p assistant-tool-executor --lib` — 73 tests pass
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo machete` clean
- [ ] CI green

Independent of #738–#742.