### PR TITLE
refactor(web-ui): ratchet to deny-level panic-free lints

### DIFF
--- a/crates/web-ui/Cargo.toml
+++ b/crates/web-ui/Cargo.toml
@@ -71,15 +71,17 @@ uuid = { workspace = true }
 jsonwebtoken = { workspace = true }
 serde_json = { workspace = true }
 
-# TODO(workspace-lint-policy): ratchet by removing the allow overrides below
-# once non-test unwrap/expect/panic calls are gone from this crate. The
-# workspace baseline (root Cargo.toml [workspace.lints]) is `warn`; we cannot
-# combine `workspace = true` with overrides, so this crate manually replays
-# the relevant lints. See openspec/changes/workspace-lint-policy/.
+# Panic-free contract: all non-test code in this crate (and its sub-modules)
+# propagates errors via `Result<_, anyhow::Error>` or returns an HTTP error
+# response. The build script (`build.rs`) is exempt via its own per-file
+# `#![allow(...)]` block since panicking is the correct error signal for a
+# failed compile-time prerequisite. Cargo forbids combining `workspace = true`
+# with per-crate overrides, so this manually replays the workspace baseline
+# plus the deny ratchet. See openspec/changes/workspace-lint-policy/.
 [lints.clippy]
-unwrap_used = "allow"
-expect_used = "allow"
-panic = "allow"
+unwrap_used = "deny"
+expect_used = "deny"
+panic = "deny"
 unimplemented = "warn"
 todo = "warn"
 

--- a/crates/web-ui/build.rs
+++ b/crates/web-ui/build.rs
@@ -1,3 +1,9 @@
+// Build scripts are a special context: failures here mean the package cannot
+// be built, so `unwrap`/`expect`/`panic!` are the *correct* error signaling
+// mechanism (cargo surfaces them to the operator with full context). The
+// workspace-lint-policy deny doesn't apply to build scripts.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
 //! Build script for `assistant-web-ui`.
 //!
 //! Runs `flutter build web --release` inside the `app/` directory at the repo

--- a/crates/web-ui/src/a2a/agent_store.rs
+++ b/crates/web-ui/src/a2a/agent_store.rs
@@ -8,11 +8,6 @@
 //! File naming convention: `<slugified-name>.md` (e.g., `my-cool-profile.md`).
 //! The slug also serves as the profile ID.
 
-#![cfg_attr(
-    not(test),
-    deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)
-)]
-
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 

--- a/crates/web-ui/src/a2a/handlers.rs
+++ b/crates/web-ui/src/a2a/handlers.rs
@@ -170,7 +170,17 @@ pub async fn send_message(
         .update_status(&task.id, TaskState::TaskStateCompleted, Some(agent_msg))
         .await;
 
-    let final_task = state.task_store.get_task(&task.id).await.unwrap();
+    let Some(final_task) = state.task_store.get_task(&task.id).await else {
+        // We just created and updated the task on the previous lines; the
+        // store dropping it between the update and the get would only happen
+        // under a concurrent eviction race that the in-memory store does not
+        // perform. Treat as a 500 rather than panicking the worker.
+        return (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": "task disappeared after creation"})),
+        )
+            .into_response();
+    };
 
     let resp = SendMessageResponse {
         task: Some(final_task),

--- a/crates/web-ui/src/api/mod.rs
+++ b/crates/web-ui/src/api/mod.rs
@@ -7,11 +7,6 @@
 //! - `logs.rs`: log entry retrieval
 //! - `skills.rs`: skill discovery per persona
 
-#![cfg_attr(
-    not(test),
-    deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)
-)]
-
 pub mod account;
 pub mod agents;
 pub mod analytics;

--- a/crates/web-ui/src/auth.rs
+++ b/crates/web-ui/src/auth.rs
@@ -14,11 +14,6 @@
 //! it maps to a default org-admin context so existing single-user deployments
 //! continue to work without reconfiguration.
 
-#![cfg_attr(
-    not(test),
-    deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)
-)]
-
 use std::sync::Arc;
 
 use axum::Form;

--- a/crates/web-ui/src/oauth/mod.rs
+++ b/crates/web-ui/src/oauth/mod.rs
@@ -3,11 +3,6 @@
 //! Wires the `assistant-auth` crate's OAuth2 server, device code flow,
 //! and client registration into Axum HTTP handlers.
 
-#![cfg_attr(
-    not(test),
-    deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)
-)]
-
 pub mod authorize;
 pub mod callback;
 pub mod complete;

--- a/tests/workspace_lint_policy.rs
+++ b/tests/workspace_lint_policy.rs
@@ -43,12 +43,8 @@ const REQUIRED_WORKSPACE_LINTS: &[&str] = &[
 ];
 
 /// Crates that have completed the ratchet from `warn` to `deny` for the
-/// panic-free lint set. Crates that still contain non-test panics elsewhere
-/// in their source tree (e.g. `crates/web-ui`, which retains per-file
-/// `#![cfg_attr(not(test), deny(...))]` on hot paths but is not fully clean
-/// at the crate level) are not listed here and will be ratcheted in
-/// follow-up changes.
-const DENY_LEVEL_CRATES: &[&str] = &["crates/storage"];
+/// panic-free lint set.
+const DENY_LEVEL_CRATES: &[&str] = &["crates/storage", "crates/web-ui"];
 
 #[test]
 fn root_cargo_toml_declares_workspace_lint_table() {
@@ -151,11 +147,17 @@ fn deny_level_crates_enforce_panic_free_contract() {
 
 #[test]
 fn deny_level_source_files_do_not_duplicate_panic_free_attribute() {
-    // Only check source files for crates that enforce the contract at the
-    // crate (Cargo.toml) level. Crates still using per-file `cfg_attr` blocks
-    // (e.g. web-ui's hot paths) are not in scope until they ratchet to
-    // crate-level deny.
-    let suspects = ["crates/storage/src/lib.rs"];
+    // For deny-level crates, the contract lives in their Cargo.toml
+    // `[lints.clippy]` block. Source files MUST NOT redeclare the same
+    // policy via a `#![cfg_attr(not(test), deny(...))]` attribute — that
+    // would create two sources of truth.
+    let suspects = [
+        "crates/storage/src/lib.rs",
+        "crates/web-ui/src/auth.rs",
+        "crates/web-ui/src/oauth/mod.rs",
+        "crates/web-ui/src/a2a/agent_store.rs",
+        "crates/web-ui/src/api/mod.rs",
+    ];
 
     for suspect in suspects {
         let path = workspace_root().join(suspect);


### PR DESCRIPTION
## Summary

Seventh ratchet step under the workspace-lint-policy contract. Cleans the one production `.unwrap()` in `crates/web-ui/src/a2a/handlers.rs`, allows `build.rs` to keep its diagnostic panics, and migrates the four per-file `cfg_attr` denies into a single crate-level `[lints.clippy]` override.

## Changes

- `src/a2a/handlers.rs::send_message`: `get_task(...).await.unwrap()` → `let Some(...) else { 500 + error envelope }`.
- `build.rs`: add per-file `#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]`. Build scripts use panic as their correct error signal.
- Remove `#![cfg_attr(not(test), deny(...))]` from `auth.rs`, `oauth/mod.rs`, `a2a/agent_store.rs`, `api/mod.rs` — replaced by the crate-level deny.
- `crates/web-ui/Cargo.toml`: flip `unwrap_used`/`expect_used`/`panic` from `"allow"` to `"deny"`.
- `tests/workspace_lint_policy.rs`: add web-ui to `DENY_LEVEL_CRATES`; add the 4 source files to the duplicate-attribute suspect list.

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` green
- [x] `cargo test -p assistant-web-ui --lib` — 241 tests pass
- [x] `cargo test -p assistant --test workspace_lint_policy` — 4/4 pass (including the deny-level + cfg_attr-absence checks)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo machete` clean
- [ ] CI green

Independent of #738–#743.