### PR TITLE
docs(agents): fix Edition drift — workspace is 2024

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,7 @@ GitHub Actions runs `flutter analyze --fatal-infos` and `flutter test` on every 
 
 ## Workspace Structure
 
-Multiple crates under `crates/`, one root crate. Edition 2021, resolver 2.
+Multiple crates under `crates/`, one root crate. Edition 2024, resolver 2.
 
 | Crate (package name)             | Path                                    | Purpose                                                                                                                                         |
 | -------------------------------- | --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Summary

One-line doc fix: `AGENTS.md` claimed the workspace was on Edition 2021 in its "Workspace Structure" section, but `Cargo.toml`'s `[workspace.package]` has `edition = "2024"`.

## Test plan

- [x] `grep "Edition" AGENTS.md` reflects 2024
- [ ] CI green (docs-only change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workspace documentation to reflect Rust Edition 2024.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cedricziel/assistant/pull/746?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->