### PR TITLE
chore(workspace): drop unused internal-crate aliases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,15 +191,6 @@ argon2 = { version = "0.5", features = ["std"] }
 rand = "0.10"
 # Constant-time comparison (API key verification)
 subtle = "2"
-# Internal crates
-opentelemetry-exporter-sqlite = { path = "crates/opentelemetry-exporter-sqlite" }
-opentelemetry-exporter-iceberg = { path = "crates/opentelemetry-exporter-iceberg" }
-core = { path = "crates/core", package = "assistant-core" }
-auth = { path = "crates/auth", package = "assistant-auth" }
-skills = { path = "crates/skills" }
-storage = { path = "crates/storage" }
-runtime = { path = "crates/runtime" }
-tool-executor = { path = "crates/tool-executor" }
 
 # Text diffing for `/review` skill refinement display.
 similar = "2.6"


### PR DESCRIPTION
## Summary

Removes eight dead entries from the root `Cargo.toml [workspace.dependencies]` table:

\`\`\`toml
# Internal crates
opentelemetry-exporter-sqlite = { path = "crates/opentelemetry-exporter-sqlite" }
opentelemetry-exporter-iceberg = { path = "crates/opentelemetry-exporter-iceberg" }
core = { path = "crates/core", package = "assistant-core" }
auth = { path = "crates/auth", package = "assistant-auth" }
skills = { path = "crates/skills" }
storage = { path = "crates/storage" }
runtime = { path = "crates/runtime" }
tool-executor = { path = "crates/tool-executor" }
\`\`\`

Audit (`grep -lE "^X = { workspace = true" crates/*/Cargo.toml`): **0 member crates** inherit any of these. All internal dependencies use direct `path = "../X"` declarations. Four of the aliases (`skills`, `storage`, `runtime`, `tool-executor`) were also subtly broken — missing `package = "assistant-X"`, so they would have failed to resolve if used.

Net effect: removes confusion about which style to use, drops 9 lines of dead manifest, no behavior change.

## Test plan

- [x] `cargo check --workspace` — green
- [x] `cargo machete --with-metadata` — clean
- [x] `cargo clippy --workspace -- -D warnings` — green (via pre-commit hook)
- [ ] CI green

Independent of #746, #747.