### PR TITLE
refactor(core): split transcription/TTS types into types::transcription

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 # Tool-specific project metadata (not part of the project)
 .claude/settings.local.json
 .claude/worktrees/
+.claude/scheduled_tasks.lock
 .serena/
 
 # Environment / secrets

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -70,6 +70,11 @@ pub use memory::{
 pub use subagent::SubagentRunner;
 pub use text::{preview, sanitize_llm_output, strip_cite_tags, strip_think_tags};
 pub use tool::{Attachment, ToolHandler, ToolOutput};
+// Note: types previously flat-re-exported are being migrated out of the root
+// namespace into per-domain submodules under `types::*`. Consumers should
+// import from the canonical submodule path (e.g.
+// `assistant_core::types::transcription::TranscriptionConfig`) rather than
+// from the crate root.
 pub use types::{
     AgentConfig, AssistantConfig, BusConfig, BusKind, ChannelType, CompactionConfig,
     DEFAULT_MAX_AGENT_DEPTH, EmbeddingConfig, EmbeddingProviderKind, ExecutionContext,
@@ -78,7 +83,6 @@ pub use types::{
     Message, MessageRole, MirrorConfig, MoonshotOptions, MoonshotWebSearchOptions, NextcloudConfig,
     NotificationsConfig, ObservabilityConfig, OpenAIAuthMode, OpenAIOptions, OpenAIUserLocation,
     OpenAIWebSearchOptions, OpenRouterOptions, OtelExporter, PartitionGranularity, SignalConfig,
-    SkillsConfig, SlackConfig, SlackListenMode, StorageConfig, TitlingConfig, TranscriptionConfig,
-    TranscriptionProviderKind, TtsConfig, TtsProviderKind, TurnIdentity,
+    SkillsConfig, SlackConfig, SlackListenMode, StorageConfig, TitlingConfig, TurnIdentity,
 };
 pub use upload::resolve_upload_bytes;

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -4,6 +4,8 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use self::transcription::{TranscriptionConfig, TtsConfig};
+
 /// Role of a message in the conversation
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -408,92 +410,11 @@ fn default_nextcloud_listen_addr() -> String {
     "0.0.0.0:8080".to_string()
 }
 
-// ── Transcription configuration ───────────────────────────────────────────────
-
-/// Which transcription backend to use.
-///
-/// Set via `[transcription] provider = "whisper"` in `config.toml`.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum TranscriptionProviderKind {
-    /// OpenAI Whisper API (or any compatible endpoint).
-    Whisper,
-    /// Local Ollama server running a whisper-compatible model.
-    Ollama,
-    /// Deepgram hosted speech-to-text API.
-    Deepgram,
-}
-
-/// Configuration for audio transcription.
-///
-/// When present, interfaces that receive audio attachments (Slack voice
-/// messages, Signal voice notes, …) will automatically transcribe them
-/// and inject the transcript into the conversation as text.
-///
-/// ```toml
-/// [transcription]
-/// provider = "whisper"
-/// # model = "whisper-1"
-/// # api_key = "sk-..."  # or set OPENAI_API_KEY env var
-/// ```
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TranscriptionConfig {
-    /// Which transcription backend to use.
-    pub provider: TranscriptionProviderKind,
-    /// Model name (uses provider-specific default if omitted).
-    pub model: Option<String>,
-    /// Base URL override (uses provider-specific default if omitted).
-    pub base_url: Option<String>,
-    /// API key (also checked via provider-specific env vars:
-    /// `OPENAI_API_KEY` for Whisper, `DEEPGRAM_API_KEY` for Deepgram).
-    pub api_key: Option<String>,
-    /// Optional BCP-47 language hint (e.g. `"en"`, `"de"`).
-    pub language: Option<String>,
-}
-
-/// Which TTS backend to use.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum TtsProviderKind {
-    /// OpenAI TTS API (`POST /v1/audio/speech`).
-    OpenAI,
-    /// Deepgram TTS API (`POST /v1/speak`).
-    Deepgram,
-}
-
-/// Configuration for text-to-speech synthesis.
-///
-/// When present, the web UI will offer voice playback on assistant messages.
-///
-/// ```toml
-/// [tts]
-/// provider = "openai"
-/// voice = "nova"
-/// # api_key = "sk-..."  # or set OPENAI_API_KEY env var
-/// ```
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TtsConfig {
-    /// Which TTS backend to use.
-    pub provider: TtsProviderKind,
-    /// Model name (provider-specific default if omitted; e.g. `"tts-1"` for OpenAI).
-    pub model: Option<String>,
-    /// Voice name (provider-specific; e.g. `"nova"`, `"alloy"` for OpenAI).
-    pub voice: Option<String>,
-    /// Base URL override (uses provider-specific default if omitted).
-    pub base_url: Option<String>,
-    /// API key (also checked via provider-specific env vars: `OPENAI_API_KEY` for OpenAI,
-    /// `DEEPGRAM_API_KEY` for Deepgram).
-    pub api_key: Option<String>,
-    /// Per-language voice overrides (Deepgram only).
-    ///
-    /// ```toml
-    /// [tts.voices]
-    /// en = "aura-2-zeus-en"
-    /// de = "aura-2-aurelia-de"
-    /// ```
-    #[serde(default)]
-    pub voices: std::collections::HashMap<String, String>,
-}
+// ── Transcription / TTS configuration ─────────────────────────────────────────
+//
+// Moved to the `transcription` submodule. Import via
+// `use assistant_core::types::transcription::{TranscriptionConfig, TtsConfig, ...};`
+pub mod transcription;
 
 fn default_llm_model() -> String {
     "qwen2.5:7b".to_string()

--- a/crates/core/src/types/transcription.rs
+++ b/crates/core/src/types/transcription.rs
@@ -1,0 +1,95 @@
+//! Configuration for speech-to-text (`Transcription*`) and text-to-speech
+//! (`Tts*`) providers.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+// ── Speech-to-text ────────────────────────────────────────────────────────────
+
+/// Which transcription backend to use.
+///
+/// Set via `[transcription] provider = "whisper"` in `config.toml`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TranscriptionProviderKind {
+    /// OpenAI Whisper API (or any compatible endpoint).
+    Whisper,
+    /// Local Ollama server running a whisper-compatible model.
+    Ollama,
+    /// Deepgram hosted speech-to-text API.
+    Deepgram,
+}
+
+/// Configuration for audio transcription.
+///
+/// When present, interfaces that receive audio attachments (Slack voice
+/// messages, Signal voice notes, …) will automatically transcribe them
+/// and inject the transcript into the conversation as text.
+///
+/// ```toml
+/// [transcription]
+/// provider = "whisper"
+/// # model = "whisper-1"
+/// # api_key = "sk-..."  # or set OPENAI_API_KEY env var
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TranscriptionConfig {
+    /// Which transcription backend to use.
+    pub provider: TranscriptionProviderKind,
+    /// Model name (uses provider-specific default if omitted).
+    pub model: Option<String>,
+    /// Base URL override (uses provider-specific default if omitted).
+    pub base_url: Option<String>,
+    /// API key (also checked via provider-specific env vars:
+    /// `OPENAI_API_KEY` for Whisper, `DEEPGRAM_API_KEY` for Deepgram).
+    pub api_key: Option<String>,
+    /// Optional BCP-47 language hint (e.g. `"en"`, `"de"`).
+    pub language: Option<String>,
+}
+
+// ── Text-to-speech ────────────────────────────────────────────────────────────
+
+/// Which TTS backend to use.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TtsProviderKind {
+    /// OpenAI TTS API (`POST /v1/audio/speech`).
+    OpenAI,
+    /// Deepgram TTS API (`POST /v1/speak`).
+    Deepgram,
+}
+
+/// Configuration for text-to-speech synthesis.
+///
+/// When present, the web UI will offer voice playback on assistant messages.
+///
+/// ```toml
+/// [tts]
+/// provider = "openai"
+/// voice = "nova"
+/// # api_key = "sk-..."  # or set OPENAI_API_KEY env var
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TtsConfig {
+    /// Which TTS backend to use.
+    pub provider: TtsProviderKind,
+    /// Model name (provider-specific default if omitted; e.g. `"tts-1"` for OpenAI).
+    pub model: Option<String>,
+    /// Voice name (provider-specific; e.g. `"nova"`, `"alloy"` for OpenAI).
+    pub voice: Option<String>,
+    /// Base URL override (uses provider-specific default if omitted).
+    pub base_url: Option<String>,
+    /// API key (also checked via provider-specific env vars: `OPENAI_API_KEY` for OpenAI,
+    /// `DEEPGRAM_API_KEY` for Deepgram).
+    pub api_key: Option<String>,
+    /// Per-language voice overrides (Deepgram only).
+    ///
+    /// ```toml
+    /// [tts.voices]
+    /// en = "aura-2-zeus-en"
+    /// de = "aura-2-aurelia-de"
+    /// ```
+    #[serde(default)]
+    pub voices: HashMap<String, String>,
+}

--- a/crates/transcription/src/lib.rs
+++ b/crates/transcription/src/lib.rs
@@ -22,7 +22,9 @@ mod whisper;
 
 use std::sync::Arc;
 
-use assistant_core::{TranscriptionConfig, TranscriptionProviderKind, TtsConfig, TtsProviderKind};
+use assistant_core::types::transcription::{
+    TranscriptionConfig, TranscriptionProviderKind, TtsConfig, TtsProviderKind,
+};
 
 pub use audio_store::AudioStore;
 pub use converter::{AudioConverter, AudioFormat, ConversionResult};


### PR DESCRIPTION
## Summary

First step of the `core/src/types.rs` kitchen-sink split (1675 lines → per-domain submodules). Moves the 4 transcription/TTS types into `types::transcription` and drops their entries from the `lib.rs` flat re-export.

## Changes

- New: `crates/core/src/types/transcription.rs` containing `TranscriptionProviderKind`, `TranscriptionConfig`, `TtsProviderKind`, `TtsConfig`.
- `crates/core/src/types.rs`: declare `pub mod transcription;`, remove the 4 type bodies, import them locally for the `AssistantConfig` field.
- `crates/core/src/lib.rs`: drop the 4 types from the `pub use types::{...}` block. Add a header comment noting the migration to per-domain submodules.
- `crates/transcription/src/lib.rs`: 1 use statement updated to `assistant_core::types::transcription::{...}`.

No flat re-export from the crate root for the migrated types — consumers import from the canonical submodule path. This is the deliberate part: the flat re-export is what makes `types.rs` a kitchen sink.

## Test plan

- [x] `cargo check --workspace` — green
- [x] `cargo clippy --workspace -- -D warnings` — green
- [x] `cargo test -p assistant-core --lib` — 183 pass
- [x] `cargo test -p assistant-transcription --lib` — 36 pass
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo machete` — clean
- [ ] CI green

## Roadmap

This is the proof-of-concept PR. Subsequent PRs will migrate the remaining domains one at a time:
- `types::channels` (Slack/Mattermost/Matrix/Nextcloud/Signal configs)
- `types::llm` (LlmConfig + provider opts: Anthropic/OpenAI/Moonshot/OpenRouter)
- `types::storage` (StorageConfig, Bus*)
- `types::mcp` (Mcp*, MirrorConfig, SkillsConfig)
- `types::observability` (Otel*, ObservabilityConfig, Iceberg*, PartitionGranularity)
- `types::features` (Memory/Compaction/Learning/Titling/Notifications configs)
- `types::conversation` (Message, ExecutionContext, TurnIdentity, Interface, ChannelType, MessageRole)
- `types::agent` (AssistantConfig, AgentConfig)