### PR TITLE
refactor(core): split storage/bus types into types::storage

### DIFF
--- a/crates/bus-nats/src/lib.rs
+++ b/crates/bus-nats/src/lib.rs
@@ -39,9 +39,9 @@ use tokio::sync::RwLock;
 use tracing::{debug, warn};
 use uuid::Uuid;
 
+use assistant_core::types::storage::BusConfig;
 use assistant_core::{
-    BusConfig, BusMessage, ClaimFilter, MAX_TURN_REDELIVERIES, MessageBus, MessageStatus,
-    PublishRequest,
+    BusMessage, ClaimFilter, MAX_TURN_REDELIVERIES, MessageBus, MessageStatus, PublishRequest,
 };
 
 // -- Header keys ------------------------------------------------------------

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -70,19 +70,15 @@ pub use memory::{
 pub use subagent::SubagentRunner;
 pub use text::{preview, sanitize_llm_output, strip_cite_tags, strip_think_tags};
 pub use tool::{Attachment, ToolHandler, ToolOutput};
-// Note: types previously flat-re-exported are being migrated out of the root
-// namespace into per-domain submodules under `types::*`. Consumers should
-// import from the canonical submodule path (e.g.
-// `assistant_core::types::transcription::TranscriptionConfig`) rather than
-// from the crate root.
+// `assistant_core::types::storage::BusConfig`) rather than from the crate root.
 pub use types::{
-    AgentConfig, AssistantConfig, BusConfig, BusKind, ChannelType, CompactionConfig,
-    DEFAULT_MAX_AGENT_DEPTH, EmbeddingConfig, EmbeddingProviderKind, ExecutionContext,
-    IcebergConfig, Interface, LearningConfig, LlmConfig, LlmProviderKind, MatrixConfig,
-    MattermostConfig, McpConfig, McpServerEntry, McpTransportConfig, McpTrustLevel, MemoryConfig,
-    Message, MessageRole, MirrorConfig, MoonshotOptions, MoonshotWebSearchOptions, NextcloudConfig,
-    NotificationsConfig, ObservabilityConfig, OpenAIAuthMode, OpenAIOptions, OpenAIUserLocation,
-    OpenAIWebSearchOptions, OpenRouterOptions, OtelExporter, PartitionGranularity, SignalConfig,
-    SkillsConfig, SlackConfig, SlackListenMode, StorageConfig, TitlingConfig, TurnIdentity,
+    AgentConfig, AssistantConfig, ChannelType, CompactionConfig, DEFAULT_MAX_AGENT_DEPTH,
+    EmbeddingConfig, EmbeddingProviderKind, ExecutionContext, IcebergConfig, Interface,
+    LearningConfig, LlmConfig, LlmProviderKind, MatrixConfig, MattermostConfig, McpConfig,
+    McpServerEntry, McpTransportConfig, McpTrustLevel, MemoryConfig, Message, MessageRole,
+    MirrorConfig, MoonshotOptions, MoonshotWebSearchOptions, NextcloudConfig, NotificationsConfig,
+    ObservabilityConfig, OpenAIAuthMode, OpenAIOptions, OpenAIUserLocation, OpenAIWebSearchOptions,
+    OpenRouterOptions, OtelExporter, PartitionGranularity, SignalConfig, SkillsConfig, SlackConfig,
+    SlackListenMode, TitlingConfig, TurnIdentity,
 };
 pub use upload::resolve_upload_bytes;

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -4,6 +4,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use self::storage::{BusConfig, StorageConfig};
 use self::transcription::{TranscriptionConfig, TtsConfig};
 
 /// Role of a message in the conversation
@@ -751,66 +752,11 @@ pub struct OpenRouterOptions {
     pub max_tokens: Option<u32>,
 }
 
-/// Storage configuration
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct StorageConfig {
-    pub db_path: Option<String>,
-}
-
-/// Message bus backend kind.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
-pub enum BusKind {
-    /// SQLite-backed bus (default) — uses the same pool as storage.
-    #[default]
-    Sqlite,
-    /// NATS JetStream-backed bus — eliminates SQLite write-lock contention.
-    Nats,
-}
-
-/// Message bus configuration.
-///
-/// Controls which bus backend is used. Add a `[bus]` section to
-/// `config.toml`:
-///
-/// ```toml
-/// [bus]
-/// kind = "nats"
-/// nats_url = "nats://localhost:4222"
-/// ```
-///
-/// The `nats_url` field falls back to the `NATS_URL` environment variable.
-///
-/// ## Authentication
-///
-/// Multiple auth methods are supported (in priority order):
-///
-/// 1. **Credentials file** (`credentials_file`) — `.creds` file with JWT + NKey
-/// 2. **Token** (`token` or `NATS_TOKEN` env var)
-/// 3. **Username/password** (`username`/`password` or `NATS_USER`/`NATS_PASSWORD` env vars)
-///
-/// If none are set, the connection is unauthenticated.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct BusConfig {
-    /// Which bus backend to use: `"sqlite"` (default) or `"nats"`.
-    #[serde(default)]
-    pub kind: BusKind,
-    /// NATS server URL (e.g. `nats://localhost:4222`).
-    /// Falls back to the `NATS_URL` environment variable when not set.
-    pub nats_url: Option<String>,
-    /// Username for NATS authentication.
-    /// Falls back to the `NATS_USER` environment variable.
-    pub username: Option<String>,
-    /// Password for NATS authentication.
-    /// Falls back to the `NATS_PASSWORD` environment variable.
-    pub password: Option<String>,
-    /// Authentication token for NATS.
-    /// Falls back to the `NATS_TOKEN` environment variable.
-    pub token: Option<String>,
-    /// Path to a `.creds` file for NATS JWT + NKey authentication.
-    /// Falls back to the `NATS_CREDENTIALS_FILE` environment variable.
-    pub credentials_file: Option<String>,
-}
+// ── Storage / message-bus configuration ───────────────────────────────────────
+//
+// Moved to the `storage` submodule. Import via
+// `use assistant_core::types::storage::{StorageConfig, BusConfig, BusKind};`
+pub mod storage;
 
 /// Skills configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/core/src/types/storage.rs
+++ b/crates/core/src/types/storage.rs
@@ -1,0 +1,64 @@
+//! Storage and message-bus configuration.
+
+use serde::{Deserialize, Serialize};
+
+/// Storage configuration
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct StorageConfig {
+    pub db_path: Option<String>,
+}
+
+/// Message bus backend kind.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum BusKind {
+    /// SQLite-backed bus (default) — uses the same pool as storage.
+    #[default]
+    Sqlite,
+    /// NATS JetStream-backed bus — eliminates SQLite write-lock contention.
+    Nats,
+}
+
+/// Message bus configuration.
+///
+/// Controls which bus backend is used. Add a `[bus]` section to
+/// `config.toml`:
+///
+/// ```toml
+/// [bus]
+/// kind = "nats"
+/// nats_url = "nats://localhost:4222"
+/// ```
+///
+/// The `nats_url` field falls back to the `NATS_URL` environment variable.
+///
+/// ## Authentication
+///
+/// Multiple auth methods are supported (in priority order):
+///
+/// 1. **Credentials file** (`credentials_file`) — `.creds` file with JWT + NKey
+/// 2. **Token** (`token` or `NATS_TOKEN` env var)
+/// 3. **Username/password** (`username`/`password` or `NATS_USER`/`NATS_PASSWORD` env vars)
+///
+/// If none are set, the connection is unauthenticated.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct BusConfig {
+    /// Which bus backend to use: `"sqlite"` (default) or `"nats"`.
+    #[serde(default)]
+    pub kind: BusKind,
+    /// NATS server URL (e.g. `nats://localhost:4222`).
+    /// Falls back to the `NATS_URL` environment variable when not set.
+    pub nats_url: Option<String>,
+    /// Username for NATS authentication.
+    /// Falls back to the `NATS_USER` environment variable.
+    pub username: Option<String>,
+    /// Password for NATS authentication.
+    /// Falls back to the `NATS_PASSWORD` environment variable.
+    pub password: Option<String>,
+    /// Authentication token for NATS.
+    /// Falls back to the `NATS_TOKEN` environment variable.
+    pub token: Option<String>,
+    /// Path to a `.creds` file for NATS JWT + NKey authentication.
+    /// Falls back to the `NATS_CREDENTIALS_FILE` environment variable.
+    pub credentials_file: Option<String>,
+}

--- a/crates/interface-cli/src/cmd_doctor.rs
+++ b/crates/interface-cli/src/cmd_doctor.rs
@@ -8,7 +8,8 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 
-use assistant_core::{AssistantConfig, BusKind, LlmProviderKind, McpTransportConfig};
+use assistant_core::types::storage::BusKind;
+use assistant_core::{AssistantConfig, LlmProviderKind, McpTransportConfig};
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/crates/interface-cli/src/main.rs
+++ b/crates/interface-cli/src/main.rs
@@ -20,6 +20,7 @@ use tokio::sync::mpsc;
 use tracing::{info, warn};
 use uuid::Uuid;
 
+use assistant_core::types::storage::BusKind;
 use assistant_core::{
     AssistantConfig, ConversationConfig, EmbeddingConfig, EmbeddingProviderKind, Interface,
     MemoryLoader, MessageBus, apply_agent_context, default_workspace_dir, set_runtime_agent_root,
@@ -1338,7 +1339,6 @@ async fn bootstrap(
     let bus: Arc<dyn MessageBus> = {
         #[cfg(feature = "nats")]
         {
-            use assistant_core::BusKind;
             if config.bus.kind == BusKind::Nats {
                 info!("Using NATS message bus");
                 Arc::new(
@@ -1352,7 +1352,6 @@ async fn bootstrap(
         }
         #[cfg(not(feature = "nats"))]
         {
-            use assistant_core::BusKind;
             if config.bus.kind == BusKind::Nats {
                 anyhow::bail!(
                     "[bus] kind = \"nats\" configured but this binary was built without the `nats` feature"

--- a/crates/web-ui/src/lib.rs
+++ b/crates/web-ui/src/lib.rs
@@ -20,8 +20,9 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use assistant_core::LlmProvider;
+use assistant_core::types::storage::BusKind;
 use assistant_core::{
-    BusKind, Interface, LlmProviderKind, MessageBus, OtelExporter, apply_agent_context,
+    Interface, LlmProviderKind, MessageBus, OtelExporter, apply_agent_context,
     default_workspace_dir, set_runtime_agent_root, set_runtime_workspace_dir, validate_agent_id,
 };
 use assistant_runtime::bootstrap::AutoDenyConfirmation;
@@ -481,7 +482,6 @@ async fn run_with_args(args: Args) -> Result<()> {
     let bus: Arc<dyn MessageBus> = {
         #[cfg(feature = "nats")]
         {
-            use assistant_core::BusKind;
             if config.bus.kind == BusKind::Nats {
                 tracing::info!("Using NATS message bus");
                 Arc::new(
@@ -495,7 +495,6 @@ async fn run_with_args(args: Args) -> Result<()> {
         }
         #[cfg(not(feature = "nats"))]
         {
-            use assistant_core::BusKind;
             if config.bus.kind == BusKind::Nats {
                 anyhow::bail!(
                     "[bus] kind = \"nats\" configured but this binary was built without the `nats` feature"


### PR DESCRIPTION
## Summary

Second step of the `core/src/types.rs` kitchen-sink split. Moves `StorageConfig`, `BusKind`, and `BusConfig` into `types::storage` and drops their entries from the `lib.rs` flat re-export.

## Changes

- New: `crates/core/src/types/storage.rs` containing the 3 types.
- `crates/core/src/types.rs`: declare `pub mod storage;`, remove the 3 type bodies, import them locally for the `AssistantConfig` struct fields.
- `crates/core/src/lib.rs`: drop the 3 types from the `pub use types::{...}` block.
- `crates/bus-nats/src/lib.rs`: `BusConfig` now from `assistant_core::types::storage`.
- `crates/web-ui/src/lib.rs`: hoist `BusKind` to a single top-level `use`; drop two inline `use assistant_core::BusKind` blocks inside `#[cfg(feature = "nats")]` arms.
- `crates/interface-cli/src/main.rs`: same shape.
- `crates/interface-cli/src/cmd_doctor.rs`: split the combined import.

## Test plan

- [x] `cargo check --workspace` — green
- [x] `cargo clippy --workspace -- -D warnings` — green
- [x] `cargo test -p assistant-core --lib` — 183 pass
- [x] `cargo test -p assistant-bus-nats --lib` — 15 pass
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo machete` — clean
- [ ] CI green

Independent of #749 (different types).