### PR TITLE
refactor(core): split observability types into types::observability

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -70,15 +70,15 @@ pub use memory::{
 pub use subagent::SubagentRunner;
 pub use text::{preview, sanitize_llm_output, strip_cite_tags, strip_think_tags};
 pub use tool::{Attachment, ToolHandler, ToolOutput};
-// `assistant_core::types::storage::BusConfig`) rather than from the crate root.
+// `assistant_core::types::observability::OtelExporter`) rather than from the
+// crate root.
 pub use types::{
     AgentConfig, AssistantConfig, ChannelType, CompactionConfig, DEFAULT_MAX_AGENT_DEPTH,
-    EmbeddingConfig, EmbeddingProviderKind, ExecutionContext, IcebergConfig, Interface,
-    LearningConfig, LlmConfig, LlmProviderKind, MatrixConfig, MattermostConfig, McpConfig,
-    McpServerEntry, McpTransportConfig, McpTrustLevel, MemoryConfig, Message, MessageRole,
-    MirrorConfig, MoonshotOptions, MoonshotWebSearchOptions, NextcloudConfig, NotificationsConfig,
-    ObservabilityConfig, OpenAIAuthMode, OpenAIOptions, OpenAIUserLocation, OpenAIWebSearchOptions,
-    OpenRouterOptions, OtelExporter, PartitionGranularity, SignalConfig, SkillsConfig, SlackConfig,
-    SlackListenMode, TitlingConfig, TurnIdentity,
+    EmbeddingConfig, EmbeddingProviderKind, ExecutionContext, Interface, LearningConfig, LlmConfig,
+    LlmProviderKind, MatrixConfig, MattermostConfig, McpConfig, McpServerEntry, McpTransportConfig,
+    McpTrustLevel, MemoryConfig, Message, MessageRole, MirrorConfig, MoonshotOptions,
+    MoonshotWebSearchOptions, NextcloudConfig, NotificationsConfig, OpenAIAuthMode, OpenAIOptions,
+    OpenAIUserLocation, OpenAIWebSearchOptions, OpenRouterOptions, SignalConfig, SkillsConfig,
+    SlackConfig, SlackListenMode, TitlingConfig, TurnIdentity,
 };
 pub use upload::resolve_upload_bytes;

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -4,6 +4,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use self::observability::ObservabilityConfig;
 use self::storage::{BusConfig, StorageConfig};
 use self::transcription::{TranscriptionConfig, TtsConfig};
 
@@ -877,109 +878,11 @@ impl Default for MirrorConfig {
     }
 }
 
-/// Which local OTel exporter backend(s) to use for spans, logs, and metrics.
-///
-/// OTLP export is always additive and is controlled separately via
-/// `OTEL_EXPORTER_OTLP_*` environment variables.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum OtelExporter {
-    /// Write to the local SQLite database (default — backwards-compatible).
-    #[default]
-    Sqlite,
-    /// Write to Apache Iceberg tables in Parquet format.
-    Iceberg,
-    /// Write to both SQLite and Iceberg simultaneously.
-    Both,
-    /// Disable all local exporters (OTLP only, or no local storage).
-    None,
-}
-
-/// Top-level observability configuration.
-///
-/// Configured via `[observability]` in `config.toml`.
-/// The legacy `[self_improvement]` / `[mirror]` section is still accepted for
-/// backwards compatibility; an explicit `[observability]` block always takes
-/// precedence.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ObservabilityConfig {
-    /// Which local exporter backend(s) to activate. Default: `sqlite`.
-    #[serde(default)]
-    pub exporter: OtelExporter,
-    /// When `true`, LLM span events include full message content
-    /// (`gen_ai.input.messages`, `gen_ai.output.messages`, etc.).
-    /// Off by default because content may contain PII.
-    #[serde(default)]
-    pub trace_content: bool,
-    /// Iceberg-specific settings.  Used when `exporter` is `"iceberg"` or `"both"`.
-    #[serde(default)]
-    pub iceberg: IcebergConfig,
-}
-
-impl Default for ObservabilityConfig {
-    fn default() -> Self {
-        Self {
-            exporter: OtelExporter::Sqlite,
-            trace_content: false,
-            iceberg: IcebergConfig::default(),
-        }
-    }
-}
-
-/// Iceberg exporter configuration.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct IcebergConfig {
-    /// Warehouse root path where Parquet data files are written.
-    /// Default: `~/.assistant/iceberg`
-    pub warehouse: Option<String>,
-    /// Iceberg namespace for the three tables (`assistant_spans`,
-    /// `assistant_logs`, `assistant_metric_points`).
-    /// Default: `"assistant"`
-    #[serde(default = "IcebergConfig::default_namespace")]
-    pub namespace: String,
-    /// Time-based partition granularity applied to all three tables.
-    /// Default: `day`.
-    #[serde(default)]
-    pub partition: PartitionGranularity,
-    /// REST catalog URI (e.g. `http://localhost:8181` for a local Nessie or
-    /// Polaris instance).  When absent, an in-memory catalog backed by the
-    /// filesystem `FileIO` is used instead.
-    pub catalog_uri: Option<String>,
-}
-
-impl IcebergConfig {
-    fn default_namespace() -> String {
-        "assistant".to_string()
-    }
-}
-
-impl Default for IcebergConfig {
-    fn default() -> Self {
-        Self {
-            warehouse: None,
-            namespace: Self::default_namespace(),
-            partition: PartitionGranularity::default(),
-            catalog_uri: None,
-        }
-    }
-}
-
-/// Time-based partition granularity for Iceberg tables.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum PartitionGranularity {
-    /// No partitioning.
-    None,
-    /// Partition by year.
-    Year,
-    /// Partition by month.
-    Month,
-    /// Partition by day (default).
-    #[default]
-    Day,
-    /// Partition by hour.
-    Hour,
-}
+// ── Observability / telemetry configuration ──────────────────────────────────
+//
+// Moved to the `observability` submodule. Import via
+// `use assistant_core::types::observability::{OtelExporter, ObservabilityConfig, ...};`
+pub mod observability;
 
 fn default_true() -> bool {
     true

--- a/crates/core/src/types/observability.rs
+++ b/crates/core/src/types/observability.rs
@@ -1,0 +1,108 @@
+//! Observability / telemetry configuration: OTel exporter selection and
+//! Iceberg-specific settings.
+
+use serde::{Deserialize, Serialize};
+
+/// Which local OTel exporter backend(s) to use for spans, logs, and metrics.
+///
+/// OTLP export is always additive and is controlled separately via
+/// `OTEL_EXPORTER_OTLP_*` environment variables.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OtelExporter {
+    /// Write to the local SQLite database (default — backwards-compatible).
+    #[default]
+    Sqlite,
+    /// Write to Apache Iceberg tables in Parquet format.
+    Iceberg,
+    /// Write to both SQLite and Iceberg simultaneously.
+    Both,
+    /// Disable all local exporters (OTLP only, or no local storage).
+    None,
+}
+
+/// Top-level observability configuration.
+///
+/// Configured via `[observability]` in `config.toml`.
+/// The legacy `[self_improvement]` / `[mirror]` section is still accepted for
+/// backwards compatibility; an explicit `[observability]` block always takes
+/// precedence.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ObservabilityConfig {
+    /// Which local exporter backend(s) to activate. Default: `sqlite`.
+    #[serde(default)]
+    pub exporter: OtelExporter,
+    /// When `true`, LLM span events include full message content
+    /// (`gen_ai.input.messages`, `gen_ai.output.messages`, etc.).
+    /// Off by default because content may contain PII.
+    #[serde(default)]
+    pub trace_content: bool,
+    /// Iceberg-specific settings.  Used when `exporter` is `"iceberg"` or `"both"`.
+    #[serde(default)]
+    pub iceberg: IcebergConfig,
+}
+
+impl Default for ObservabilityConfig {
+    fn default() -> Self {
+        Self {
+            exporter: OtelExporter::Sqlite,
+            trace_content: false,
+            iceberg: IcebergConfig::default(),
+        }
+    }
+}
+
+/// Iceberg exporter configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IcebergConfig {
+    /// Warehouse root path where Parquet data files are written.
+    /// Default: `~/.assistant/iceberg`
+    pub warehouse: Option<String>,
+    /// Iceberg namespace for the three tables (`assistant_spans`,
+    /// `assistant_logs`, `assistant_metric_points`).
+    /// Default: `"assistant"`
+    #[serde(default = "IcebergConfig::default_namespace")]
+    pub namespace: String,
+    /// Time-based partition granularity applied to all three tables.
+    /// Default: `day`.
+    #[serde(default)]
+    pub partition: PartitionGranularity,
+    /// REST catalog URI (e.g. `http://localhost:8181` for a local Nessie or
+    /// Polaris instance).  When absent, an in-memory catalog backed by the
+    /// filesystem `FileIO` is used instead.
+    pub catalog_uri: Option<String>,
+}
+
+impl IcebergConfig {
+    fn default_namespace() -> String {
+        "assistant".to_string()
+    }
+}
+
+impl Default for IcebergConfig {
+    fn default() -> Self {
+        Self {
+            warehouse: None,
+            namespace: Self::default_namespace(),
+            partition: PartitionGranularity::default(),
+            catalog_uri: None,
+        }
+    }
+}
+
+/// Time-based partition granularity for Iceberg tables.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PartitionGranularity {
+    /// No partitioning.
+    None,
+    /// Partition by year.
+    Year,
+    /// Partition by month.
+    Month,
+    /// Partition by day (default).
+    #[default]
+    Day,
+    /// Partition by hour.
+    Hour,
+}

--- a/crates/opentelemetry-exporter-iceberg/src/catalog.rs
+++ b/crates/opentelemetry-exporter-iceberg/src/catalog.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use assistant_core::IcebergConfig;
+use assistant_core::types::observability::IcebergConfig;
 use iceberg::io::FileIO;
 use iceberg::memory::{MEMORY_CATALOG_WAREHOUSE, MemoryCatalogBuilder};
 use iceberg::{Catalog, CatalogBuilder, NamespaceIdent};

--- a/crates/opentelemetry-exporter-iceberg/src/lib.rs
+++ b/crates/opentelemetry-exporter-iceberg/src/lib.rs
@@ -32,7 +32,7 @@
 //! metadata.
 
 use anyhow::Result;
-use assistant_core::IcebergConfig;
+use assistant_core::types::observability::IcebergConfig;
 
 pub mod catalog;
 mod log;

--- a/crates/opentelemetry-exporter-iceberg/src/log.rs
+++ b/crates/opentelemetry-exporter-iceberg/src/log.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, RwLock};
 use anyhow::Result;
 use arrow_array::{ArrayRef, Int32Array, RecordBatch, StringArray, TimestampMicrosecondArray};
 use arrow_schema::Schema as ArrowSchema;
-use assistant_core::IcebergConfig;
+use assistant_core::types::observability::IcebergConfig;
 use iceberg::spec::DataFileFormat;
 use iceberg::transaction::{ApplyTransactionAction, Transaction};
 use iceberg::writer::IcebergWriter;

--- a/crates/opentelemetry-exporter-iceberg/src/metric.rs
+++ b/crates/opentelemetry-exporter-iceberg/src/metric.rs
@@ -8,7 +8,7 @@ use arrow_array::{
     ArrayRef, Float64Array, Int64Array, RecordBatch, StringArray, TimestampMicrosecondArray,
 };
 use arrow_schema::Schema as ArrowSchema;
-use assistant_core::IcebergConfig;
+use assistant_core::types::observability::IcebergConfig;
 use iceberg::spec::DataFileFormat;
 use iceberg::transaction::{ApplyTransactionAction, Transaction};
 use iceberg::writer::IcebergWriter;

--- a/crates/opentelemetry-exporter-iceberg/src/partition.rs
+++ b/crates/opentelemetry-exporter-iceberg/src/partition.rs
@@ -6,7 +6,7 @@ use chrono::{Datelike, TimeZone, Utc};
 use iceberg::spec::{Literal, PartitionKey, SchemaRef, Struct, Transform, UnboundPartitionSpec};
 use iceberg::table::Table;
 
-use assistant_core::PartitionGranularity;
+use assistant_core::types::observability::PartitionGranularity;
 
 /// Build an [`UnboundPartitionSpec`] that partitions a table by the given time
 /// column field ID, using the requested granularity.

--- a/crates/opentelemetry-exporter-iceberg/src/span.rs
+++ b/crates/opentelemetry-exporter-iceberg/src/span.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, RwLock};
 use anyhow::Result;
 use arrow_array::{ArrayRef, Int64Array, RecordBatch, StringArray, TimestampMicrosecondArray};
 use arrow_schema::Schema as ArrowSchema;
-use assistant_core::IcebergConfig;
+use assistant_core::types::observability::IcebergConfig;
 use iceberg::spec::DataFileFormat;
 use iceberg::transaction::ApplyTransactionAction;
 use iceberg::transaction::Transaction;

--- a/crates/opentelemetry-exporter-iceberg/tests/e2e_write_read.rs
+++ b/crates/opentelemetry-exporter-iceberg/tests/e2e_write_read.rs
@@ -6,7 +6,7 @@ use std::borrow::Cow;
 use std::time::SystemTime;
 
 use arrow_array::Array;
-use assistant_core::{IcebergConfig, PartitionGranularity};
+use assistant_core::types::observability::{IcebergConfig, PartitionGranularity};
 use opentelemetry::InstrumentationScope;
 use opentelemetry::trace::{
     SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId, TraceState,

--- a/crates/runtime/src/telemetry.rs
+++ b/crates/runtime/src/telemetry.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use anyhow::Result;
-use assistant_core::{ObservabilityConfig, OtelExporter};
+use assistant_core::types::observability::{ObservabilityConfig, OtelExporter};
 use opentelemetry::{KeyValue, global};
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
 use opentelemetry_exporter_iceberg::build_exporters;

--- a/crates/web-ui/src/backends/iceberg.rs
+++ b/crates/web-ui/src/backends/iceberg.rs
@@ -21,7 +21,7 @@ use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use serde_json::Value;
 use uuid::Uuid;
 
-use assistant_core::IcebergConfig;
+use assistant_core::types::observability::IcebergConfig;
 use assistant_storage::{
     LogStats, MetricsSummary, ModelTokenUsage, RecordedLog, RecordedSpan, SkillStatsProvider,
     TimeSeriesPoint, ToolUsageStats, TraceFilter, TraceStats, TraceSummary,

--- a/crates/web-ui/src/lib.rs
+++ b/crates/web-ui/src/lib.rs
@@ -20,10 +20,11 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use assistant_core::LlmProvider;
+use assistant_core::types::observability::OtelExporter;
 use assistant_core::types::storage::BusKind;
 use assistant_core::{
-    Interface, LlmProviderKind, MessageBus, OtelExporter, apply_agent_context,
-    default_workspace_dir, set_runtime_agent_root, set_runtime_workspace_dir, validate_agent_id,
+    Interface, LlmProviderKind, MessageBus, apply_agent_context, default_workspace_dir,
+    set_runtime_agent_root, set_runtime_workspace_dir, validate_agent_id,
 };
 use assistant_runtime::bootstrap::AutoDenyConfirmation;
 use assistant_runtime::{Orchestrator, init_tracing};


### PR DESCRIPTION
## Summary

Third step of the `core/src/types.rs` kitchen-sink split. Moves `OtelExporter`, `ObservabilityConfig`, `IcebergConfig`, `PartitionGranularity` into `types::observability` and drops their entries from the `lib.rs` flat re-export.

## Changes

- New: `crates/core/src/types/observability.rs` containing the 4 types.
- `crates/core/src/types.rs`: declare `pub mod observability;`, remove the 4 type bodies, import `ObservabilityConfig` locally.
- `crates/core/src/lib.rs`: drop the 4 types from the `pub use types::{...}` block.
- 10 use sites updated to import from `assistant_core::types::observability::{...}`:
  - `crates/runtime/src/telemetry.rs`
  - `crates/web-ui/src/lib.rs` (split `OtelExporter` out of a combined `use`)
  - `crates/web-ui/src/backends/iceberg.rs`
  - `crates/opentelemetry-exporter-iceberg/src/{lib,catalog,log,metric,partition,span}.rs`
  - `crates/opentelemetry-exporter-iceberg/tests/e2e_write_read.rs`

## Test plan

- [x] `cargo check --workspace` — green
- [x] `cargo clippy --workspace -- -D warnings` — green
- [x] `cargo test -p assistant-core --lib` — 183 pass
- [x] `cargo test -p assistant-runtime telemetry` — 7 pass
- [x] `cargo test -p opentelemetry-exporter-iceberg --lib` — 5 pass
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo machete` — clean
- [ ] CI green

Independent of #749 (merged) and #750.