### PR TITLE
refactor(core): split skills/MCP/mirror configs into types::skills_mcp

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -75,9 +75,8 @@ pub use tool::{Attachment, ToolHandler, ToolOutput};
 pub use types::{
     AgentConfig, AssistantConfig, ChannelType, DEFAULT_MAX_AGENT_DEPTH, EmbeddingConfig,
     EmbeddingProviderKind, ExecutionContext, Interface, LlmConfig, LlmProviderKind, MatrixConfig,
-    MattermostConfig, McpConfig, McpServerEntry, McpTransportConfig, McpTrustLevel, Message,
-    MessageRole, MirrorConfig, MoonshotOptions, MoonshotWebSearchOptions, NextcloudConfig,
-    OpenAIAuthMode, OpenAIOptions, OpenAIUserLocation, OpenAIWebSearchOptions, OpenRouterOptions,
-    SignalConfig, SkillsConfig, SlackConfig, SlackListenMode, TurnIdentity,
+    MattermostConfig, Message, MessageRole, MoonshotOptions, MoonshotWebSearchOptions,
+    NextcloudConfig, OpenAIAuthMode, OpenAIOptions, OpenAIUserLocation, OpenAIWebSearchOptions,
+    OpenRouterOptions, SignalConfig, SlackConfig, SlackListenMode, TurnIdentity,
 };
 pub use upload::resolve_upload_bytes;

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -8,6 +6,7 @@ use self::features::{
     CompactionConfig, LearningConfig, MemoryConfig, NotificationsConfig, TitlingConfig,
 };
 use self::observability::ObservabilityConfig;
+use self::skills_mcp::{McpConfig, MirrorConfig, SkillsConfig};
 use self::storage::{BusConfig, StorageConfig};
 use self::transcription::{TranscriptionConfig, TtsConfig};
 
@@ -767,124 +766,11 @@ pub struct OpenRouterOptions {
 // `use assistant_core::types::storage::{StorageConfig, BusConfig, BusKind};`
 pub mod storage;
 
-/// Skills configuration
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SkillsConfig {
-    /// Extra directories to scan for Agent Skills.
-    /// Defaults cover Claude Code / NanoClaw shared skill folders.
-    #[serde(default = "default_skill_extra_dirs")]
-    pub extra_dirs: Vec<String>,
-}
-
-impl Default for SkillsConfig {
-    fn default() -> Self {
-        Self {
-            extra_dirs: default_skill_extra_dirs(),
-        }
-    }
-}
-
-fn default_skill_extra_dirs() -> Vec<String> {
-    vec![
-        "~/.claude/skills".to_string(),
-        "./.claude/skills".to_string(),
-    ]
-}
-
-/// MCP configuration — covers external MCP client connections.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct McpConfig {
-    /// External MCP servers to connect to as a client.
-    /// Each entry spawns a connection at startup and bridges the server's tools
-    /// into the assistant's tool registry.
-    #[serde(default)]
-    pub servers: Vec<McpServerEntry>,
-}
-
-/// An external MCP server the assistant connects to as a client.
-///
-/// Tools discovered from the server are registered with the prefix
-/// `mcp__{name}__{tool_name}` to avoid collisions with builtin tools.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct McpServerEntry {
-    /// Unique name for this server (used in tool prefix).
-    /// Must be a valid identifier: lowercase alphanumeric + hyphens.
-    pub name: String,
-    /// Transport configuration — determines how we connect to the server.
-    #[serde(flatten)]
-    pub transport: McpTransportConfig,
-    /// Extra environment variables passed to stdio-spawned servers.
-    /// Values may reference environment variables with `${VAR}` syntax.
-    #[serde(default)]
-    pub env: HashMap<String, String>,
-    /// Whether this server is enabled (default: true).
-    #[serde(default = "default_true")]
-    pub enabled: bool,
-    /// Trust level controlling safety-gate behaviour for this server's tools.
-    #[serde(default)]
-    pub trust: McpTrustLevel,
-}
-
-/// How to connect to an external MCP server.
-///
-/// Uses `#[serde(untagged)]` for compatibility with the standard MCP
-/// configuration format (Claude Desktop, VS Code, etc.).  Serde tries
-/// variants in order: if `command` is present the entry is treated as
-/// `Stdio`; otherwise `url` selects `Http`.  If a config entry contains
-/// *both* `command` and `url`, `Stdio` wins and `url` is silently
-/// ignored.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum McpTransportConfig {
-    /// Spawn a local subprocess; communicate via JSON-RPC over stdin/stdout.
-    Stdio {
-        /// Command and its arguments (e.g. `["npx", "-y", "@mcp/server-github"]`).
-        command: Vec<String>,
-    },
-    /// Connect to a remote HTTP endpoint (SSE or Streamable HTTP).
-    Http {
-        /// Server URL (e.g. `"https://example.com/mcp/sse"`).
-        url: String,
-        /// Extra HTTP headers sent with every request.
-        /// Values may reference environment variables with `${VAR}` syntax.
-        #[serde(default)]
-        headers: HashMap<String, String>,
-    },
-}
-
-/// Trust level for tools from an external MCP server.
-///
-/// Controls whether the safety gate requires user confirmation before executing
-/// a tool call from this server.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "kebab-case")]
-pub enum McpTrustLevel {
-    /// Every tool call requires explicit user confirmation (default).
-    #[default]
-    Confirm,
-    /// Tools may run without confirmation (use for trusted, read-only servers).
-    Trust,
-}
-
-/// Self-improvement / tracing config
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MirrorConfig {
-    pub trace_enabled: bool,
-    /// When `true`, LLM span events include full message content
-    /// (`gen_ai.input.messages`, `gen_ai.output.messages`, etc.).
-    /// Off by default because content may contain PII.
-    #[serde(default)]
-    pub trace_content: bool,
-}
-
-impl Default for MirrorConfig {
-    fn default() -> Self {
-        Self {
-            trace_enabled: true,
-            trace_content: false,
-        }
-    }
-}
+// ── Skills / MCP / mirror configuration ───────────────────────────────────────
+//
+// Moved to the `skills_mcp` submodule. Import via
+// `use assistant_core::types::skills_mcp::{SkillsConfig, McpConfig, ...};`
+pub mod skills_mcp;
 
 // ── Observability / telemetry configuration ──────────────────────────────────
 //
@@ -901,6 +787,7 @@ pub mod features;
 // ── Tests ────────────────────────────────────────────────────────────────────
 #[cfg(test)]
 mod tests {
+    use super::skills_mcp::{McpTransportConfig, McpTrustLevel};
     use super::*;
 
     // -- TitlingConfig defaults / overrides ----------------------------------

--- a/crates/core/src/types/skills_mcp.rs
+++ b/crates/core/src/types/skills_mcp.rs
@@ -1,0 +1,133 @@
+//! Configuration for skill discovery, external MCP server connections, and
+//! the legacy mirror/trace section.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::default_true;
+
+// ── Skills ────────────────────────────────────────────────────────────────────
+
+/// Skills configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillsConfig {
+    /// Extra directories to scan for Agent Skills.
+    /// Defaults cover Claude Code / NanoClaw shared skill folders.
+    #[serde(default = "default_skill_extra_dirs")]
+    pub extra_dirs: Vec<String>,
+}
+
+impl Default for SkillsConfig {
+    fn default() -> Self {
+        Self {
+            extra_dirs: default_skill_extra_dirs(),
+        }
+    }
+}
+
+fn default_skill_extra_dirs() -> Vec<String> {
+    vec![
+        "~/.claude/skills".to_string(),
+        "./.claude/skills".to_string(),
+    ]
+}
+
+// ── MCP ───────────────────────────────────────────────────────────────────────
+
+/// MCP configuration — covers external MCP client connections.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct McpConfig {
+    /// External MCP servers to connect to as a client.
+    /// Each entry spawns a connection at startup and bridges the server's tools
+    /// into the assistant's tool registry.
+    #[serde(default)]
+    pub servers: Vec<McpServerEntry>,
+}
+
+/// An external MCP server the assistant connects to as a client.
+///
+/// Tools discovered from the server are registered with the prefix
+/// `mcp__{name}__{tool_name}` to avoid collisions with builtin tools.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpServerEntry {
+    /// Unique name for this server (used in tool prefix).
+    /// Must be a valid identifier: lowercase alphanumeric + hyphens.
+    pub name: String,
+    /// Transport configuration — determines how we connect to the server.
+    #[serde(flatten)]
+    pub transport: McpTransportConfig,
+    /// Extra environment variables passed to stdio-spawned servers.
+    /// Values may reference environment variables with `${VAR}` syntax.
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+    /// Whether this server is enabled (default: true).
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// Trust level controlling safety-gate behaviour for this server's tools.
+    #[serde(default)]
+    pub trust: McpTrustLevel,
+}
+
+/// How to connect to an external MCP server.
+///
+/// Uses `#[serde(untagged)]` for compatibility with the standard MCP
+/// configuration format (Claude Desktop, VS Code, etc.).  Serde tries
+/// variants in order: if `command` is present the entry is treated as
+/// `Stdio`; otherwise `url` selects `Http`.  If a config entry contains
+/// *both* `command` and `url`, `Stdio` wins and `url` is silently
+/// ignored.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum McpTransportConfig {
+    /// Spawn a local subprocess; communicate via JSON-RPC over stdin/stdout.
+    Stdio {
+        /// Command and its arguments (e.g. `["npx", "-y", "@mcp/server-github"]`).
+        command: Vec<String>,
+    },
+    /// Connect to a remote HTTP endpoint (SSE or Streamable HTTP).
+    Http {
+        /// Server URL (e.g. `"https://example.com/mcp/sse"`).
+        url: String,
+        /// Extra HTTP headers sent with every request.
+        /// Values may reference environment variables with `${VAR}` syntax.
+        #[serde(default)]
+        headers: HashMap<String, String>,
+    },
+}
+
+/// Trust level for tools from an external MCP server.
+///
+/// Controls whether the safety gate requires user confirmation before executing
+/// a tool call from this server.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum McpTrustLevel {
+    /// Every tool call requires explicit user confirmation (default).
+    #[default]
+    Confirm,
+    /// Tools may run without confirmation (use for trusted, read-only servers).
+    Trust,
+}
+
+// ── Mirror (legacy trace config) ──────────────────────────────────────────────
+
+/// Self-improvement / tracing config
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MirrorConfig {
+    pub trace_enabled: bool,
+    /// When `true`, LLM span events include full message content
+    /// (`gen_ai.input.messages`, `gen_ai.output.messages`, etc.).
+    /// Off by default because content may contain PII.
+    #[serde(default)]
+    pub trace_content: bool,
+}
+
+impl Default for MirrorConfig {
+    fn default() -> Self {
+        Self {
+            trace_enabled: true,
+            trace_content: false,
+        }
+    }
+}

--- a/crates/interface-cli/src/cmd_doctor.rs
+++ b/crates/interface-cli/src/cmd_doctor.rs
@@ -8,8 +8,9 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 
+use assistant_core::types::skills_mcp::McpTransportConfig;
 use assistant_core::types::storage::BusKind;
-use assistant_core::{AssistantConfig, LlmProviderKind, McpTransportConfig};
+use assistant_core::{AssistantConfig, LlmProviderKind};
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/crates/mcp-client/src/manager.rs
+++ b/crates/mcp-client/src/manager.rs
@@ -17,7 +17,8 @@ use rmcp::model::Tool;
 use tokio::sync::RwLock;
 use tracing::{debug, error, info, warn};
 
-use assistant_core::{McpServerEntry, McpTransportConfig, McpTrustLevel, ToolHandler};
+use assistant_core::ToolHandler;
+use assistant_core::types::skills_mcp::{McpServerEntry, McpTransportConfig, McpTrustLevel};
 
 use crate::bridge::{self, McpToolHandler};
 use crate::client::McpClient;


### PR DESCRIPTION
## Summary

Fifth step of the `core/src/types.rs` kitchen-sink split. Moves `SkillsConfig`, `McpConfig`, `McpServerEntry`, `McpTransportConfig`, `McpTrustLevel`, and the legacy `MirrorConfig` into `types::skills_mcp` and drops their entries from the `lib.rs` flat re-export.

## Changes

- New: `crates/core/src/types/skills_mcp.rs`.
- `crates/core/src/types.rs`: `pub mod skills_mcp;`, local `use self::skills_mcp::{...}`, drop the moved types, drop unused `HashMap` import.
- `crates/core/src/lib.rs`: 6 names removed from the `pub use types::{...}` block.
- 2 use sites updated:
  - `crates/mcp-client/src/manager.rs` — split into `assistant_core::ToolHandler` + `assistant_core::types::skills_mcp::{...}`.
  - `crates/interface-cli/src/cmd_doctor.rs` — `McpTransportConfig` moved to `types::skills_mcp`.

## Test plan

- [x] `cargo check --workspace` — green
- [x] `cargo clippy --workspace -- -D warnings` — green
- [x] `cargo test -p assistant-core --lib` — 183 pass
- [x] `cargo test -p assistant-mcp-client --lib` — 11 pass
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo machete` — clean
- [ ] CI green

Conflicts with #750, #751, #752 on `types.rs` import lines and the `lib.rs` re-export block; will rebase when prior PRs land.