### PR TITLE
refactor(core): split messenger interface configs into types::channels

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -74,9 +74,8 @@ pub use tool::{Attachment, ToolHandler, ToolOutput};
 // crate root.
 pub use types::{
     AgentConfig, AssistantConfig, ChannelType, DEFAULT_MAX_AGENT_DEPTH, EmbeddingConfig,
-    EmbeddingProviderKind, ExecutionContext, Interface, LlmConfig, LlmProviderKind, MatrixConfig,
-    MattermostConfig, Message, MessageRole, MoonshotOptions, MoonshotWebSearchOptions,
-    NextcloudConfig, OpenAIAuthMode, OpenAIOptions, OpenAIUserLocation, OpenAIWebSearchOptions,
-    OpenRouterOptions, SignalConfig, SlackConfig, SlackListenMode, TurnIdentity,
+    EmbeddingProviderKind, ExecutionContext, Interface, LlmConfig, LlmProviderKind, Message,
+    MessageRole, MoonshotOptions, MoonshotWebSearchOptions, OpenAIAuthMode, OpenAIOptions,
+    OpenAIUserLocation, OpenAIWebSearchOptions, OpenRouterOptions, TurnIdentity,
 };
 pub use upload::resolve_upload_bytes;

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -2,6 +2,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use self::channels::{MatrixConfig, MattermostConfig, NextcloudConfig, SignalConfig, SlackConfig};
 use self::features::{
     CompactionConfig, LearningConfig, MemoryConfig, NotificationsConfig, TitlingConfig,
 };
@@ -275,149 +276,11 @@ fn default_agent_id() -> String {
     "default".to_string()
 }
 
-/// Configuration for the Signal messenger interface.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct SignalConfig {
-    /// The phone number registered with Signal (e.g. `"+14155550123"`).
-    pub phone_number: Option<String>,
-
-    /// If non-empty, only messages from these sender identifiers are
-    /// dispatched to the orchestrator.  An empty list accepts all contacts.
-    #[serde(default)]
-    pub allowed_senders: Vec<String>,
-
-    /// Base URL of the signal-cli-rest-api daemon.
-    /// Defaults to `http://localhost:8080` if not set.
-    pub api_url: Option<String>,
-
-    /// HTTP Basic Auth username for signal-cli-rest-api (optional).
-    pub api_user: Option<String>,
-
-    /// HTTP Basic Auth password for signal-cli-rest-api (optional).
-    pub api_password: Option<String>,
-}
-
-/// Controls which messages the Slack bot reacts to.
-///
-/// - `Mention` (default) — respond only when `@`-mentioned, in DMs, or in
-///   threads the bot is already participating in.
-/// - `All` — respond to every message in allowed channels (previous default).
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
-pub enum SlackListenMode {
-    /// Respond only to `@`-mentions, DMs, and thread replies.
-    #[default]
-    Mention,
-    /// Respond to every message in allowed channels.
-    All,
-}
-
-/// Configuration for the Slack interface.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct SlackConfig {
-    /// Bot OAuth token (`xoxb-…`) for sending messages via the Web API.
-    pub bot_token: Option<String>,
-    /// App-level token (`xapp-…`) for Socket Mode connections.
-    pub app_token: Option<String>,
-    /// If non-empty, only dispatch messages from these channel IDs.
-    #[serde(default)]
-    pub allowed_channels: Vec<String>,
-    /// If non-empty, only dispatch messages from these Slack user IDs.
-    #[serde(default)]
-    pub allowed_users: Vec<String>,
-    /// Which messages the bot should react to.
-    #[serde(default)]
-    pub mode: SlackListenMode,
-}
-
-/// Configuration for the Mattermost interface.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct MattermostConfig {
-    /// Base URL of the Mattermost server (e.g. `"https://mattermost.example.com"`).
-    pub server_url: Option<String>,
-    /// Personal access token or bot token for authentication.
-    pub token: Option<String>,
-    /// If non-empty, only dispatch messages from these channel IDs.
-    #[serde(default)]
-    pub allowed_channels: Vec<String>,
-    /// If non-empty, only dispatch messages from these Mattermost user IDs.
-    #[serde(default)]
-    pub allowed_users: Vec<String>,
-}
-
-/// Configuration for the Matrix interface.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct MatrixConfig {
-    /// Base URL of the Matrix homeserver (e.g. `"https://matrix.example.com"`).
-    pub homeserver_url: Option<String>,
-    /// Full Matrix user ID of the bot account (e.g. `"@assistant:example.com"`).
-    pub username: Option<String>,
-    /// Bot account password (used for initial login; session persisted to disk).
-    /// Prefer `access_token` for production deployments.
-    pub password: Option<String>,
-    /// Pre-issued Matrix access token (skips password login on every start).
-    pub access_token: Option<String>,
-    /// Device ID for session restoration. Auto-generated on first login if omitted.
-    pub device_id: Option<String>,
-    /// Path for the matrix-sdk SQLite state store.
-    /// Defaults to `~/.assistant/matrix-state/` at runtime.
-    pub state_store_path: Option<String>,
-    /// If non-empty, only dispatch messages from these Matrix room IDs.
-    /// An empty list accepts all rooms.
-    #[serde(default)]
-    pub allowed_rooms: Vec<String>,
-    /// If non-empty, only dispatch messages from these Matrix user IDs.
-    /// An empty list accepts all users.
-    #[serde(default)]
-    pub allowed_users: Vec<String>,
-}
-
-/// Configuration for the Nextcloud Talk interface.
-///
-/// The bot is installed on the Nextcloud server via
-/// `occ talk:bot:install` which sets up the webhook URL and a shared secret.
-/// The assistant runs an HTTP server that receives incoming webhook callbacks
-/// and replies via the Nextcloud Talk Bot REST API.
-///
-/// ```toml
-/// [nextcloud]
-/// server_url = "https://nextcloud.example.com"
-/// secret = "shared-secret-from-occ-install"
-/// listen_addr = "0.0.0.0:8080"
-/// ```
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct NextcloudConfig {
-    /// Base URL of the Nextcloud server (e.g. `"https://nextcloud.example.com"`).
-    pub server_url: Option<String>,
-    /// Shared secret configured when registering the bot via `occ talk:bot:install`.
-    /// Also checked via `NEXTCLOUD_TALK_SECRET` env var.
-    pub secret: Option<String>,
-    /// Socket address the webhook HTTP server listens on (default: `"0.0.0.0:8080"`).
-    #[serde(default = "default_nextcloud_listen_addr")]
-    pub listen_addr: String,
-    /// If non-empty, only dispatch messages from these conversation tokens.
-    #[serde(default)]
-    pub allowed_channels: Vec<String>,
-    /// If non-empty, only dispatch messages from these Nextcloud user IDs.
-    #[serde(default)]
-    pub allowed_users: Vec<String>,
-}
-
-impl Default for NextcloudConfig {
-    fn default() -> Self {
-        Self {
-            server_url: None,
-            secret: None,
-            listen_addr: default_nextcloud_listen_addr(),
-            allowed_channels: Vec::new(),
-            allowed_users: Vec::new(),
-        }
-    }
-}
-
-fn default_nextcloud_listen_addr() -> String {
-    "0.0.0.0:8080".to_string()
-}
+// ── Channel adapter configuration ─────────────────────────────────────────────
+//
+// Moved to the `channels` submodule. Import via
+// `use assistant_core::types::channels::{SlackConfig, MatrixConfig, ...};`
+pub mod channels;
 
 // ── Transcription / TTS configuration ─────────────────────────────────────────
 //

--- a/crates/core/src/types/channels.rs
+++ b/crates/core/src/types/channels.rs
@@ -1,0 +1,158 @@
+//! Configuration for the messenger interface adapters: Signal, Slack,
+//! Mattermost, Matrix, and Nextcloud Talk.
+
+use serde::{Deserialize, Serialize};
+
+// ── Signal ────────────────────────────────────────────────────────────────────
+
+/// Configuration for the Signal messenger interface.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SignalConfig {
+    /// The phone number registered with Signal (e.g. `"+14155550123"`).
+    pub phone_number: Option<String>,
+
+    /// If non-empty, only messages from these sender identifiers are
+    /// dispatched to the orchestrator.  An empty list accepts all contacts.
+    #[serde(default)]
+    pub allowed_senders: Vec<String>,
+
+    /// Base URL of the signal-cli-rest-api daemon.
+    /// Defaults to `http://localhost:8080` if not set.
+    pub api_url: Option<String>,
+
+    /// HTTP Basic Auth username for signal-cli-rest-api (optional).
+    pub api_user: Option<String>,
+
+    /// HTTP Basic Auth password for signal-cli-rest-api (optional).
+    pub api_password: Option<String>,
+}
+
+// ── Slack ─────────────────────────────────────────────────────────────────────
+
+/// Controls which messages the Slack bot reacts to.
+///
+/// - `Mention` (default) — respond only when `@`-mentioned, in DMs, or in
+///   threads the bot is already participating in.
+/// - `All` — respond to every message in allowed channels (previous default).
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SlackListenMode {
+    /// Respond only to `@`-mentions, DMs, and thread replies.
+    #[default]
+    Mention,
+    /// Respond to every message in allowed channels.
+    All,
+}
+
+/// Configuration for the Slack interface.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SlackConfig {
+    /// Bot OAuth token (`xoxb-…`) for sending messages via the Web API.
+    pub bot_token: Option<String>,
+    /// App-level token (`xapp-…`) for Socket Mode connections.
+    pub app_token: Option<String>,
+    /// If non-empty, only dispatch messages from these channel IDs.
+    #[serde(default)]
+    pub allowed_channels: Vec<String>,
+    /// If non-empty, only dispatch messages from these Slack user IDs.
+    #[serde(default)]
+    pub allowed_users: Vec<String>,
+    /// Which messages the bot should react to.
+    #[serde(default)]
+    pub mode: SlackListenMode,
+}
+
+// ── Mattermost ────────────────────────────────────────────────────────────────
+
+/// Configuration for the Mattermost interface.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct MattermostConfig {
+    /// Base URL of the Mattermost server (e.g. `"https://mattermost.example.com"`).
+    pub server_url: Option<String>,
+    /// Personal access token or bot token for authentication.
+    pub token: Option<String>,
+    /// If non-empty, only dispatch messages from these channel IDs.
+    #[serde(default)]
+    pub allowed_channels: Vec<String>,
+    /// If non-empty, only dispatch messages from these Mattermost user IDs.
+    #[serde(default)]
+    pub allowed_users: Vec<String>,
+}
+
+// ── Matrix ────────────────────────────────────────────────────────────────────
+
+/// Configuration for the Matrix interface.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct MatrixConfig {
+    /// Base URL of the Matrix homeserver (e.g. `"https://matrix.example.com"`).
+    pub homeserver_url: Option<String>,
+    /// Full Matrix user ID of the bot account (e.g. `"@assistant:example.com"`).
+    pub username: Option<String>,
+    /// Bot account password (used for initial login; session persisted to disk).
+    /// Prefer `access_token` for production deployments.
+    pub password: Option<String>,
+    /// Pre-issued Matrix access token (skips password login on every start).
+    pub access_token: Option<String>,
+    /// Device ID for session restoration. Auto-generated on first login if omitted.
+    pub device_id: Option<String>,
+    /// Path for the matrix-sdk SQLite state store.
+    /// Defaults to `~/.assistant/matrix-state/` at runtime.
+    pub state_store_path: Option<String>,
+    /// If non-empty, only dispatch messages from these Matrix room IDs.
+    /// An empty list accepts all rooms.
+    #[serde(default)]
+    pub allowed_rooms: Vec<String>,
+    /// If non-empty, only dispatch messages from these Matrix user IDs.
+    /// An empty list accepts all users.
+    #[serde(default)]
+    pub allowed_users: Vec<String>,
+}
+
+// ── Nextcloud Talk ────────────────────────────────────────────────────────────
+
+/// Configuration for the Nextcloud Talk interface.
+///
+/// The bot is installed on the Nextcloud server via
+/// `occ talk:bot:install` which sets up the webhook URL and a shared secret.
+/// The assistant runs an HTTP server that receives incoming webhook callbacks
+/// and replies via the Nextcloud Talk Bot REST API.
+///
+/// ```toml
+/// [nextcloud]
+/// server_url = "https://nextcloud.example.com"
+/// secret = "shared-secret-from-occ-install"
+/// listen_addr = "0.0.0.0:8080"
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NextcloudConfig {
+    /// Base URL of the Nextcloud server (e.g. `"https://nextcloud.example.com"`).
+    pub server_url: Option<String>,
+    /// Shared secret configured when registering the bot via `occ talk:bot:install`.
+    /// Also checked via `NEXTCLOUD_TALK_SECRET` env var.
+    pub secret: Option<String>,
+    /// Socket address the webhook HTTP server listens on (default: `"0.0.0.0:8080"`).
+    #[serde(default = "default_nextcloud_listen_addr")]
+    pub listen_addr: String,
+    /// If non-empty, only dispatch messages from these conversation tokens.
+    #[serde(default)]
+    pub allowed_channels: Vec<String>,
+    /// If non-empty, only dispatch messages from these Nextcloud user IDs.
+    #[serde(default)]
+    pub allowed_users: Vec<String>,
+}
+
+impl Default for NextcloudConfig {
+    fn default() -> Self {
+        Self {
+            server_url: None,
+            secret: None,
+            listen_addr: default_nextcloud_listen_addr(),
+            allowed_channels: Vec::new(),
+            allowed_users: Vec::new(),
+        }
+    }
+}
+
+fn default_nextcloud_listen_addr() -> String {
+    "0.0.0.0:8080".to_string()
+}

--- a/crates/interfaces/src/matrix/config.rs
+++ b/crates/interfaces/src/matrix/config.rs
@@ -4,7 +4,7 @@
 //! in [`AssistantConfig`][assistant_core::AssistantConfig].  This module
 //! re-exports it and adds runtime helpers that depend on env vars.
 
-pub use assistant_core::MatrixConfig;
+pub use assistant_core::types::channels::MatrixConfig;
 
 /// Extension methods for [`MatrixConfig`] that resolve values from env vars.
 #[allow(dead_code)]

--- a/crates/interfaces/src/matrix/runner.rs
+++ b/crates/interfaces/src/matrix/runner.rs
@@ -12,7 +12,7 @@ use super::adapter::MatrixAdapter;
 use super::client::MatrixClient;
 use super::config::MatrixConfigExt;
 
-pub use assistant_core::MatrixConfig;
+pub use assistant_core::types::channels::MatrixConfig;
 
 /// Matrix interface runner.
 pub struct MatrixInterface {
@@ -102,7 +102,7 @@ impl InterfaceRunner for MatrixInterface {
 
 #[cfg(test)]
 mod tests {
-    use assistant_core::MatrixConfig;
+    use assistant_core::types::channels::MatrixConfig;
 
     #[test]
     fn allowlist_room_empty_accepts_all() {

--- a/crates/interfaces/src/mattermost/config.rs
+++ b/crates/interfaces/src/mattermost/config.rs
@@ -5,7 +5,7 @@
 //! re-exports it and adds runtime helpers that depend on the `dirs` crate,
 //! which is not a dependency of `assistant-core`.
 
-pub use assistant_core::MattermostConfig;
+pub use assistant_core::types::channels::MattermostConfig;
 
 /// Extension methods for [`MattermostConfig`] that require the `dirs` crate.
 pub trait MattermostConfigExt {

--- a/crates/interfaces/src/mattermost/runner.rs
+++ b/crates/interfaces/src/mattermost/runner.rs
@@ -12,7 +12,7 @@ use super::adapter::MattermostAdapter;
 use super::client::MattermostClient;
 use super::config::MattermostConfigExt;
 
-pub use assistant_core::MattermostConfig;
+pub use assistant_core::types::channels::MattermostConfig;
 
 /// Mattermost interface runner. Connects via WebSocket and dispatches messages.
 pub struct MattermostInterface {
@@ -83,7 +83,7 @@ impl InterfaceRunner for MattermostInterface {
 
 #[cfg(test)]
 mod tests {
-    use assistant_core::MattermostConfig;
+    use assistant_core::types::channels::MattermostConfig;
 
     #[test]
     fn allowlist_channel_empty_accepts_all() {

--- a/crates/interfaces/src/nextcloud/adapter.rs
+++ b/crates/interfaces/src/nextcloud/adapter.rs
@@ -12,9 +12,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
+use assistant_core::types::channels::NextcloudConfig;
 use assistant_core::{
     Attachment, ChannelAdapter, ChannelContent, ChannelMessage, ChannelType, ChannelUser,
-    NextcloudConfig, ToolHandler,
+    ToolHandler,
 };
 use assistant_transcription::{TranscriptionProvider, TranscriptionRequest, is_audio_mime};
 use async_trait::async_trait;

--- a/crates/interfaces/src/nextcloud/config.rs
+++ b/crates/interfaces/src/nextcloud/config.rs
@@ -4,7 +4,7 @@
 //! it can be embedded in `AssistantConfig`.  This module adds an extension
 //! trait with runtime helpers (env-var fallbacks).
 
-pub use assistant_core::NextcloudConfig;
+pub use assistant_core::types::channels::NextcloudConfig;
 
 /// Extension methods for [`NextcloudConfig`] that provide env-var fallbacks.
 pub trait NextcloudConfigExt {

--- a/crates/interfaces/src/nextcloud/runner.rs
+++ b/crates/interfaces/src/nextcloud/runner.rs
@@ -18,7 +18,7 @@ use tracing::info;
 use super::adapter::NextcloudAdapter;
 use super::config::NextcloudConfigExt;
 
-pub use assistant_core::NextcloudConfig;
+pub use assistant_core::types::channels::NextcloudConfig;
 
 /// The Nextcloud Talk bot interface.
 ///

--- a/crates/interfaces/src/signal/config.rs
+++ b/crates/interfaces/src/signal/config.rs
@@ -5,7 +5,7 @@
 //! re-exports it and adds runtime helpers (e.g. `resolved_api_url`) that
 //! resolve defaults and environment-variable overrides.
 
-pub use assistant_core::SignalConfig;
+pub use assistant_core::types::channels::SignalConfig;
 
 /// Extension methods for [`SignalConfig`].
 pub trait SignalConfigExt {

--- a/crates/interfaces/src/signal/runner.rs
+++ b/crates/interfaces/src/signal/runner.rs
@@ -6,7 +6,7 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use assistant_core::SignalConfig;
+use assistant_core::types::channels::SignalConfig;
 use assistant_runtime::{ChannelRunner, InterfaceRunner, Orchestrator};
 use assistant_transcription::TranscriptionProvider;
 use async_trait::async_trait;
@@ -65,7 +65,7 @@ impl InterfaceRunner for SignalInterface {
 
 #[cfg(test)]
 mod tests {
-    use assistant_core::SignalConfig;
+    use assistant_core::types::channels::SignalConfig;
 
     #[test]
     fn allowlist_logic_empty_accepts_all() {

--- a/crates/interfaces/src/slack/adapter.rs
+++ b/crates/interfaces/src/slack/adapter.rs
@@ -11,9 +11,10 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use anyhow::Result;
+use assistant_core::types::channels::{SlackConfig, SlackListenMode};
 use assistant_core::{
     ChannelAdapter, ChannelContent, ChannelMessage, ChannelType, ChannelUser, Message, MessageRole,
-    SlackConfig, SlackListenMode, ToolHandler,
+    ToolHandler,
 };
 use assistant_storage::StorageLayer;
 use assistant_transcription::{TranscriptionProvider, TranscriptionRequest, is_audio_mime};
@@ -1221,7 +1222,7 @@ mod tests {
     #[test]
     fn mention_mode_accepts_dm() {
         let result = should_process(
-            &assistant_core::SlackListenMode::Mention,
+            &SlackListenMode::Mention,
             "U_BOT",
             "D123ABC", // DM channel
             "hello",
@@ -1239,7 +1240,7 @@ mod tests {
     #[test]
     fn mention_mode_accepts_at_mention() {
         let result = should_process(
-            &assistant_core::SlackListenMode::Mention,
+            &SlackListenMode::Mention,
             "U_BOT",
             "C123",
             "hey <@U_BOT> help me",
@@ -1257,7 +1258,7 @@ mod tests {
     #[test]
     fn mention_mode_accepts_tracked_thread_reply() {
         let result = should_process(
-            &assistant_core::SlackListenMode::Mention,
+            &SlackListenMode::Mention,
             "U_BOT",
             "C123",
             "thanks!",
@@ -1275,7 +1276,7 @@ mod tests {
     #[test]
     fn mention_mode_rejects_unmentioned_channel_message() {
         let result = should_process(
-            &assistant_core::SlackListenMode::Mention,
+            &SlackListenMode::Mention,
             "U_BOT",
             "C123",
             "just chatting",
@@ -1293,7 +1294,7 @@ mod tests {
     #[test]
     fn mention_mode_rejects_untracked_thread_reply() {
         let result = should_process(
-            &assistant_core::SlackListenMode::Mention,
+            &SlackListenMode::Mention,
             "U_BOT",
             "C123",
             "reply without prior mention",
@@ -1311,7 +1312,7 @@ mod tests {
     #[test]
     fn all_mode_accepts_everything() {
         let result = should_process(
-            &assistant_core::SlackListenMode::All,
+            &SlackListenMode::All,
             "U_BOT",
             "C123",
             "random message",

--- a/crates/interfaces/src/slack/config.rs
+++ b/crates/interfaces/src/slack/config.rs
@@ -5,7 +5,7 @@
 //! re-exports it and adds runtime helpers that resolve tokens from
 //! environment variables when not explicitly configured.
 
-pub use assistant_core::SlackConfig;
+pub use assistant_core::types::channels::SlackConfig;
 
 /// Extension methods for [`SlackConfig`] that resolve tokens from the environment.
 pub trait SlackConfigExt {

--- a/crates/interfaces/src/slack/runner.rs
+++ b/crates/interfaces/src/slack/runner.rs
@@ -5,7 +5,7 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use assistant_core::SlackConfig;
+use assistant_core::types::channels::SlackConfig;
 use assistant_runtime::{ChannelRunner, InterfaceRunner, Orchestrator};
 use assistant_storage::StorageLayer;
 use assistant_transcription::TranscriptionProvider;


### PR DESCRIPTION
## Summary

Sixth step of the `core/src/types.rs` kitchen-sink split. Moves the 6 channel-adapter configs (`SignalConfig`, `SlackListenMode`, `SlackConfig`, `MattermostConfig`, `MatrixConfig`, `NextcloudConfig`) into `types::channels` and drops their entries from the `lib.rs` flat re-export.

## Changes

- New: `crates/core/src/types/channels.rs` with all 6 types.
- `crates/core/src/types.rs`: declare `pub mod channels;`, add `use self::channels::{...}` for `AssistantConfig` fields, remove the 6 type bodies.
- `crates/core/src/lib.rs`: drop the 6 names from the `pub use types::{...}` block.
- 12 use sites updated across `crates/interfaces/` (Slack/Mattermost/Matrix/Nextcloud/Signal config + runner + adapter files).

## Test plan

- [x] `cargo check --workspace` — green
- [x] `cargo clippy --workspace -- -D warnings` — green
- [x] `cargo test -p assistant-core --lib` — 183 pass
- [x] `cargo test -p assistant-interfaces --lib` — 128 pass
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo machete` — clean
- [ ] CI green

Will need rebase after #753 (mcp) lands.