### PR TITLE
refactor(core): split AssistantConfig/AgentConfig into types::agent

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 
 use tracing::{info, warn};
 
-use crate::AssistantConfig;
+use crate::types::agent::AssistantConfig;
 
 /// Return the default path to the assistant config file
 /// (`~/.assistant/config.toml`).

--- a/crates/core/src/context.rs
+++ b/crates/core/src/context.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::sync::{OnceLock, RwLock};
 
-use crate::AssistantConfig;
+use crate::types::agent::AssistantConfig;
 
 pub fn default_agent_id() -> &'static str {
     "default"

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -72,5 +72,4 @@ pub use text::{preview, sanitize_llm_output, strip_cite_tags, strip_think_tags};
 pub use tool::{Attachment, ToolHandler, ToolOutput};
 // `assistant_core::types::observability::OtelExporter`) rather than from the
 // crate root.
-pub use types::{AgentConfig, AssistantConfig};
 pub use upload::resolve_upload_bytes;

--- a/crates/core/src/memory.rs
+++ b/crates/core/src/memory.rs
@@ -17,7 +17,7 @@ use chrono::Local;
 use tracing::{debug, warn};
 
 use crate::context::runtime_agent_root;
-use crate::types::AssistantConfig;
+use crate::types::agent::AssistantConfig;
 use crate::types::features::MemoryConfig;
 
 /// Maximum characters per individual memory file included in the system prompt.

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -1,15 +1,6 @@
-use serde::{Deserialize, Serialize};
-
-use self::channels::{MatrixConfig, MattermostConfig, NextcloudConfig, SignalConfig, SlackConfig};
-use self::features::{
-    CompactionConfig, LearningConfig, MemoryConfig, NotificationsConfig, TitlingConfig,
-};
-use self::llm::LlmConfig;
-use self::observability::ObservabilityConfig;
-use self::skills_mcp::{McpConfig, MirrorConfig, SkillsConfig};
-use self::storage::{BusConfig, StorageConfig};
-use self::transcription::{TranscriptionConfig, TtsConfig};
-
+/// Crate-internal `serde` default helper used by submodule structs that
+/// have `enabled: bool` fields defaulting to true. Kept here so submodules
+/// can share it via `super::default_true`.
 #[doc(hidden)]
 pub(crate) fn default_true() -> bool {
     true
@@ -21,83 +12,11 @@ pub(crate) fn default_true() -> bool {
 // `use assistant_core::types::conversation::{Message, MessageRole, ...};`
 pub mod conversation;
 
-/// Top-level assistant configuration
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct AssistantConfig {
-    #[serde(default)]
-    pub llm: LlmConfig,
-    #[serde(default)]
-    pub storage: StorageConfig,
-    #[serde(default)]
-    pub bus: BusConfig,
-    #[serde(default)]
-    pub skills: SkillsConfig,
-    #[serde(default)]
-    pub mcp: McpConfig,
-    /// Deprecated — use `[observability]` instead. Kept for backwards compatibility.
-    #[serde(default, alias = "self_improvement", skip_serializing)]
-    pub mirror: MirrorConfig,
-    /// Observability / telemetry configuration (`[observability]` section).
-    #[serde(default)]
-    pub observability: ObservabilityConfig,
-    #[serde(default)]
-    pub memory: MemoryConfig,
-    #[serde(default)]
-    pub compaction: CompactionConfig,
-    /// Autonomous learning configuration (`[learning]` section).
-    #[serde(default)]
-    pub learning: LearningConfig,
-    /// Conversation title-generator configuration (`[titling]` section).
-    #[serde(default)]
-    pub titling: TitlingConfig,
-    #[serde(default)]
-    pub agent: AgentConfig,
-    /// Signal messenger interface configuration (optional).
-    /// Populated from the `[signal]` section of `config.toml`.
-    pub signal: Option<SignalConfig>,
-    /// Slack interface configuration (optional).
-    /// Populated from the `[slack]` section of `config.toml`.
-    pub slack: Option<SlackConfig>,
-    /// Mattermost interface configuration (optional).
-    /// Populated from the `[mattermost]` section of `config.toml`.
-    pub mattermost: Option<MattermostConfig>,
-    /// Nextcloud Talk interface configuration (optional).
-    /// Populated from the `[nextcloud]` section of `config.toml`.
-    pub nextcloud: Option<NextcloudConfig>,
-    /// Matrix interface configuration (optional).
-    /// Populated from the `[matrix]` section of `config.toml`.
-    pub matrix: Option<MatrixConfig>,
-    /// Audio transcription configuration (optional).
-    /// Populated from the `[transcription]` section of `config.toml`.
-    #[serde(default)]
-    pub transcription: Option<TranscriptionConfig>,
-    /// Text-to-speech configuration (optional).
-    /// Populated from the `[tts]` section of `config.toml`.
-    #[serde(default)]
-    pub tts: Option<TtsConfig>,
-    /// Push notification / VAPID configuration (`[notifications]` section).
-    #[serde(default)]
-    pub notifications: NotificationsConfig,
-}
-
-/// Active assistant agent configuration.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AgentConfig {
-    #[serde(default = "default_agent_id")]
-    pub id: String,
-}
-
-impl Default for AgentConfig {
-    fn default() -> Self {
-        Self {
-            id: default_agent_id(),
-        }
-    }
-}
-
-fn default_agent_id() -> String {
-    "default".to_string()
-}
+// ── Top-level assistant config + agent context ────────────────────────────────
+//
+// Moved to the `agent` submodule. Import via
+// `use assistant_core::types::agent::{AssistantConfig, AgentConfig};`
+pub mod agent;
 
 // ── Channel adapter configuration ─────────────────────────────────────────────
 //
@@ -144,9 +63,10 @@ pub mod features;
 // ── Tests ────────────────────────────────────────────────────────────────────
 #[cfg(test)]
 mod tests {
-    use super::llm::{EmbeddingConfig, EmbeddingProviderKind, LlmProviderKind};
-    use super::skills_mcp::{McpTransportConfig, McpTrustLevel};
-    use super::*;
+    use super::agent::AssistantConfig;
+    use super::features::MemoryConfig;
+    use super::llm::{EmbeddingConfig, EmbeddingProviderKind, LlmConfig, LlmProviderKind};
+    use super::skills_mcp::{McpConfig, McpTransportConfig, McpTrustLevel};
 
     // -- TitlingConfig defaults / overrides ----------------------------------
 

--- a/crates/core/src/types/agent.rs
+++ b/crates/core/src/types/agent.rs
@@ -1,0 +1,92 @@
+//! Top-level assistant configuration (`AssistantConfig`) and the active
+//! agent context (`AgentConfig`).
+
+use serde::{Deserialize, Serialize};
+
+use super::channels::{MatrixConfig, MattermostConfig, NextcloudConfig, SignalConfig, SlackConfig};
+use super::features::{
+    CompactionConfig, LearningConfig, MemoryConfig, NotificationsConfig, TitlingConfig,
+};
+use super::llm::LlmConfig;
+use super::observability::ObservabilityConfig;
+use super::skills_mcp::{McpConfig, MirrorConfig, SkillsConfig};
+use super::storage::{BusConfig, StorageConfig};
+use super::transcription::{TranscriptionConfig, TtsConfig};
+
+/// Top-level assistant configuration
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AssistantConfig {
+    #[serde(default)]
+    pub llm: LlmConfig,
+    #[serde(default)]
+    pub storage: StorageConfig,
+    #[serde(default)]
+    pub bus: BusConfig,
+    #[serde(default)]
+    pub skills: SkillsConfig,
+    #[serde(default)]
+    pub mcp: McpConfig,
+    /// Deprecated — use `[observability]` instead. Kept for backwards compatibility.
+    #[serde(default, alias = "self_improvement", skip_serializing)]
+    pub mirror: MirrorConfig,
+    /// Observability / telemetry configuration (`[observability]` section).
+    #[serde(default)]
+    pub observability: ObservabilityConfig,
+    #[serde(default)]
+    pub memory: MemoryConfig,
+    #[serde(default)]
+    pub compaction: CompactionConfig,
+    /// Autonomous learning configuration (`[learning]` section).
+    #[serde(default)]
+    pub learning: LearningConfig,
+    /// Conversation title-generator configuration (`[titling]` section).
+    #[serde(default)]
+    pub titling: TitlingConfig,
+    #[serde(default)]
+    pub agent: AgentConfig,
+    /// Signal messenger interface configuration (optional).
+    /// Populated from the `[signal]` section of `config.toml`.
+    pub signal: Option<SignalConfig>,
+    /// Slack interface configuration (optional).
+    /// Populated from the `[slack]` section of `config.toml`.
+    pub slack: Option<SlackConfig>,
+    /// Mattermost interface configuration (optional).
+    /// Populated from the `[mattermost]` section of `config.toml`.
+    pub mattermost: Option<MattermostConfig>,
+    /// Nextcloud Talk interface configuration (optional).
+    /// Populated from the `[nextcloud]` section of `config.toml`.
+    pub nextcloud: Option<NextcloudConfig>,
+    /// Matrix interface configuration (optional).
+    /// Populated from the `[matrix]` section of `config.toml`.
+    pub matrix: Option<MatrixConfig>,
+    /// Audio transcription configuration (optional).
+    /// Populated from the `[transcription]` section of `config.toml`.
+    #[serde(default)]
+    pub transcription: Option<TranscriptionConfig>,
+    /// Text-to-speech configuration (optional).
+    /// Populated from the `[tts]` section of `config.toml`.
+    #[serde(default)]
+    pub tts: Option<TtsConfig>,
+    /// Push notification / VAPID configuration (`[notifications]` section).
+    #[serde(default)]
+    pub notifications: NotificationsConfig,
+}
+
+/// Active assistant agent configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentConfig {
+    #[serde(default = "default_agent_id")]
+    pub id: String,
+}
+
+impl Default for AgentConfig {
+    fn default() -> Self {
+        Self {
+            id: default_agent_id(),
+        }
+    }
+}
+
+fn default_agent_id() -> String {
+    "default".to_string()
+}

--- a/crates/integration-tests/tests/smoke.rs
+++ b/crates/integration-tests/tests/smoke.rs
@@ -14,7 +14,8 @@ use std::{env, time::Duration};
 
 use anyhow::Result;
 use assistant_core::{
-    AssistantConfig, MessageBus,
+    MessageBus,
+    types::agent::AssistantConfig,
     types::conversation::{ExecutionContext, Interface, TurnIdentity},
 };
 use assistant_llm_provider::ollama::client::{LlmClient, LlmClientConfig};

--- a/crates/interface-cli/src/cmd_doctor.rs
+++ b/crates/interface-cli/src/cmd_doctor.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 
-use assistant_core::AssistantConfig;
+use assistant_core::types::agent::AssistantConfig;
 use assistant_core::types::llm::LlmProviderKind;
 use assistant_core::types::skills_mcp::McpTransportConfig;
 use assistant_core::types::storage::BusKind;

--- a/crates/interface-cli/src/main.rs
+++ b/crates/interface-cli/src/main.rs
@@ -20,12 +20,13 @@ use tokio::sync::mpsc;
 use tracing::{info, warn};
 use uuid::Uuid;
 
+use assistant_core::types::agent::AssistantConfig;
+use assistant_core::types::conversation::Interface;
 use assistant_core::types::llm::{EmbeddingConfig, EmbeddingProviderKind};
 use assistant_core::types::storage::BusKind;
 use assistant_core::{
-    AssistantConfig, ConversationConfig, MemoryLoader, MessageBus, apply_agent_context,
-    default_workspace_dir, set_runtime_agent_root, set_runtime_workspace_dir,
-    types::conversation::Interface, validate_agent_id,
+    ConversationConfig, MemoryLoader, MessageBus, apply_agent_context, default_workspace_dir,
+    set_runtime_agent_root, set_runtime_workspace_dir, validate_agent_id,
 };
 use assistant_core::{EmbeddingProvider, LlmEmbedder, LlmProvider, WithEmbeddingOverride};
 use assistant_llm_provider::{OllamaConfig, OllamaProvider, OpenAIProvider, OpenAIProviderConfig};

--- a/crates/interfaces/src/matrix/config.rs
+++ b/crates/interfaces/src/matrix/config.rs
@@ -1,7 +1,7 @@
 //! Matrix interface configuration.
 //!
 //! [`MatrixConfig`] is defined in `assistant-core` so it can be embedded
-//! in [`AssistantConfig`][assistant_core::AssistantConfig].  This module
+//! in [`AssistantConfig`][assistant_core::types::agent::AssistantConfig].  This module
 //! re-exports it and adds runtime helpers that depend on env vars.
 
 pub use assistant_core::types::channels::MatrixConfig;
@@ -147,7 +147,8 @@ mod tests {
             homeserver_url = "https://matrix.example.com"
             access_token = "tok-abc"
         "#;
-        let cfg: assistant_core::AssistantConfig = toml::from_str(toml_str).expect("parse");
+        let cfg: assistant_core::types::agent::AssistantConfig =
+            toml::from_str(toml_str).expect("parse");
         let mx = cfg.matrix.expect("matrix section present");
         assert_eq!(
             mx.homeserver_url.as_deref(),
@@ -163,7 +164,7 @@ mod tests {
 
     #[test]
     fn assistant_config_without_matrix_section_is_none() {
-        let cfg: assistant_core::AssistantConfig = toml::from_str("").expect("parse");
+        let cfg: assistant_core::types::agent::AssistantConfig = toml::from_str("").expect("parse");
         assert!(cfg.matrix.is_none(), "matrix should be None when absent");
     }
 }

--- a/crates/interfaces/src/mattermost/config.rs
+++ b/crates/interfaces/src/mattermost/config.rs
@@ -1,7 +1,7 @@
 //! Mattermost interface configuration.
 //!
 //! [`MattermostConfig`] is defined in `assistant-core` so it can be embedded
-//! in [`AssistantConfig`][assistant_core::AssistantConfig].  This module
+//! in [`AssistantConfig`][assistant_core::types::agent::AssistantConfig].  This module
 //! re-exports it and adds runtime helpers that depend on the `dirs` crate,
 //! which is not a dependency of `assistant-core`.
 
@@ -84,7 +84,8 @@ mod tests {
             server_url = "https://mm.example.com"
             token = "tok-abc"
         "#;
-        let cfg: assistant_core::AssistantConfig = toml::from_str(toml_str).expect("parse");
+        let cfg: assistant_core::types::agent::AssistantConfig =
+            toml::from_str(toml_str).expect("parse");
         let mm = cfg.mattermost.expect("mattermost section present");
         assert_eq!(mm.server_url.as_deref(), Some("https://mm.example.com"));
         assert_eq!(mm.token.as_deref(), Some("tok-abc"));
@@ -92,7 +93,7 @@ mod tests {
 
     #[test]
     fn assistant_config_without_mattermost_section_is_none() {
-        let cfg: assistant_core::AssistantConfig = toml::from_str("").expect("parse");
+        let cfg: assistant_core::types::agent::AssistantConfig = toml::from_str("").expect("parse");
         assert!(cfg.mattermost.is_none());
     }
 }

--- a/crates/interfaces/src/signal/config.rs
+++ b/crates/interfaces/src/signal/config.rs
@@ -1,7 +1,7 @@
 //! Signal interface configuration.
 //!
 //! [`SignalConfig`] is defined in `assistant-core` so it can be embedded in
-//! [`AssistantConfig`][assistant_core::AssistantConfig].  This module
+//! [`AssistantConfig`][assistant_core::types::agent::AssistantConfig].  This module
 //! re-exports it and adds runtime helpers (e.g. `resolved_api_url`) that
 //! resolve defaults and environment-variable overrides.
 
@@ -90,7 +90,8 @@ mod tests {
             phone_number = "+14155550123"
             allowed_senders = ["uuid-x"]
         "#;
-        let cfg: assistant_core::AssistantConfig = toml::from_str(toml_str).expect("parse");
+        let cfg: assistant_core::types::agent::AssistantConfig =
+            toml::from_str(toml_str).expect("parse");
         let sig = cfg.signal.expect("signal section present");
         assert_eq!(sig.phone_number.as_deref(), Some("+14155550123"));
         assert_eq!(sig.allowed_senders, ["uuid-x"]);
@@ -98,7 +99,7 @@ mod tests {
 
     #[test]
     fn assistant_config_without_signal_section_is_none() {
-        let cfg: assistant_core::AssistantConfig = toml::from_str("").expect("parse");
+        let cfg: assistant_core::types::agent::AssistantConfig = toml::from_str("").expect("parse");
         assert!(cfg.signal.is_none());
     }
 }

--- a/crates/interfaces/src/slack/config.rs
+++ b/crates/interfaces/src/slack/config.rs
@@ -1,7 +1,7 @@
 //! Slack interface configuration.
 //!
 //! [`SlackConfig`] is defined in `assistant-core` so it can be embedded in
-//! [`AssistantConfig`][assistant_core::AssistantConfig].  This module
+//! [`AssistantConfig`][assistant_core::types::agent::AssistantConfig].  This module
 //! re-exports it and adds runtime helpers that resolve tokens from
 //! environment variables when not explicitly configured.
 
@@ -81,7 +81,8 @@ mod tests {
             bot_token = "xoxb-abc"
             allowed_channels = ["CGENERAL"]
         "#;
-        let cfg: assistant_core::AssistantConfig = toml::from_str(toml_str).expect("parse");
+        let cfg: assistant_core::types::agent::AssistantConfig =
+            toml::from_str(toml_str).expect("parse");
         let slack = cfg.slack.expect("slack section present");
         assert_eq!(slack.bot_token.as_deref(), Some("xoxb-abc"));
         assert_eq!(slack.allowed_channels, ["CGENERAL"]);
@@ -89,7 +90,7 @@ mod tests {
 
     #[test]
     fn assistant_config_without_slack_section_is_none() {
-        let cfg: assistant_core::AssistantConfig = toml::from_str("").expect("parse");
+        let cfg: assistant_core::types::agent::AssistantConfig = toml::from_str("").expect("parse");
         assert!(cfg.slack.is_none());
     }
 }

--- a/crates/runtime/src/bootstrap.rs
+++ b/crates/runtime/src/bootstrap.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use assistant_core::types::features::MemoryConfig;
-use assistant_core::{AssistantConfig, LlmProvider, expand_tilde};
+use assistant_core::{LlmProvider, expand_tilde, types::agent::AssistantConfig};
 use assistant_skills::SkillSource;
 use assistant_storage::StorageLayer;
 use tracing::info;

--- a/crates/runtime/src/memory_indexer/mod.rs
+++ b/crates/runtime/src/memory_indexer/mod.rs
@@ -10,7 +10,9 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::Result;
-use assistant_core::{AssistantConfig, LlmProvider, base_dir, resolve_dir, resolve_path};
+use assistant_core::{
+    LlmProvider, base_dir, resolve_dir, resolve_path, types::agent::AssistantConfig,
+};
 use assistant_storage::{MemoryChunkStore, StorageLayer};
 use sha2::{Digest, Sha256};
 use tracing::{debug, info, warn};

--- a/crates/runtime/src/orchestrator/mod.rs
+++ b/crates/runtime/src/orchestrator/mod.rs
@@ -234,7 +234,7 @@ impl Orchestrator {
         executor: Arc<ToolExecutor>,
         registry: Arc<SkillRegistry>,
         bus: Arc<dyn MessageBus>,
-        config: &assistant_core::AssistantConfig,
+        config: &assistant_core::types::agent::AssistantConfig,
     ) -> Self {
         let memory_loader = MemoryLoader::new(config);
         memory_loader.ensure_defaults();

--- a/crates/runtime/src/orchestrator/tests.rs
+++ b/crates/runtime/src/orchestrator/tests.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 
 use assistant_core::types::conversation::{Interface, TurnIdentity};
 use assistant_core::{
-    AssistantConfig, ChatHistoryMessage, ChatRole, ContentBlock, LlmProvider, MessageBus, OrgId,
-    PublishRequest, SpaceId, ToolCallItem, UserId, bus_messages, topic,
+    ChatHistoryMessage, ChatRole, ContentBlock, LlmProvider, MessageBus, OrgId, PublishRequest,
+    SpaceId, ToolCallItem, UserId, bus_messages, topic, types::agent::AssistantConfig,
 };
 use assistant_llm_provider::ollama::client::{LlmClient, LlmClientConfig};
 use assistant_storage::{StorageLayer, registry::SkillRegistry};

--- a/crates/runtime/src/scheduler.rs
+++ b/crates/runtime/src/scheduler.rs
@@ -548,7 +548,7 @@ async fn has_active_bus_message(pool: &SqlitePool, conversation_id: &str) -> Res
 mod tests {
     use std::sync::Arc;
 
-    use assistant_core::{AssistantConfig, LlmProvider, MessageBus, topic};
+    use assistant_core::{LlmProvider, MessageBus, topic, types::agent::AssistantConfig};
     use assistant_llm_provider::ollama::client::{LlmClient, LlmClientConfig};
     use assistant_storage::StorageLayer;
     use assistant_storage::registry::SkillRegistry;

--- a/crates/tool-executor/src/builtins/memory_append.rs
+++ b/crates/tool-executor/src/builtins/memory_append.rs
@@ -16,7 +16,7 @@ use tokio::io::AsyncWriteExt;
 
 use assistant_core::types::conversation::ExecutionContext;
 use assistant_core::{
-    AssistantConfig, ToolHandler, ToolOutput, base_dir, resolve_dir, resolve_path,
+    ToolHandler, ToolOutput, base_dir, resolve_dir, resolve_path, types::agent::AssistantConfig,
 };
 
 /// Canonicalize as much of `p` as exists, then re-append non-existent tail

--- a/crates/tool-executor/src/builtins/memory_get.rs
+++ b/crates/tool-executor/src/builtins/memory_get.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use assistant_core::{
-    AssistantConfig, ToolHandler, ToolOutput, base_dir, resolve_dir, resolve_path,
+    ToolHandler, ToolOutput, base_dir, resolve_dir, resolve_path, types::agent::AssistantConfig,
     types::conversation::ExecutionContext,
 };
 use async_trait::async_trait;

--- a/crates/tool-executor/src/executor.rs
+++ b/crates/tool-executor/src/executor.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, RwLock};
 use anyhow::Result;
 use assistant_core::types::conversation::ExecutionContext;
 use assistant_core::{
-    AssistantConfig, LlmProvider, SubagentRunner, ToolHandler, ToolOutput, ToolSpec,
+    LlmProvider, SubagentRunner, ToolHandler, ToolOutput, ToolSpec, types::agent::AssistantConfig,
 };
 use assistant_storage::{SkillRegistry, SkillStatsProvider, StorageLayer};
 use tracing::warn;

--- a/crates/web-ui/src/api/mod.rs
+++ b/crates/web-ui/src/api/mod.rs
@@ -2384,7 +2384,7 @@ mod tests {
 
     use std::collections::HashMap;
 
-    use assistant_core::AssistantConfig;
+    use assistant_core::types::agent::AssistantConfig;
     use assistant_llm_provider::ollama::client::{LlmClient, LlmClientConfig};
     use assistant_llm_provider::retry::RetryConfig;
     use assistant_runtime::{CommandRegistry, Orchestrator};
@@ -2507,7 +2507,7 @@ mod tests {
     /// No worker task is spawned, so the single in-memory connection is not
     /// contended. Use this for tests that only exercise the event log endpoints.
     async fn event_log_state() -> (ApiState, Arc<StorageLayer>) {
-        use assistant_core::AssistantConfig;
+        use assistant_core::types::agent::AssistantConfig;
         use assistant_llm_provider::ollama::client::{LlmClient, LlmClientConfig};
         use assistant_llm_provider::retry::RetryConfig;
         use assistant_runtime::Orchestrator;
@@ -3612,7 +3612,7 @@ mod tests {
         short_ttl_store.prune_expired().await.unwrap();
 
         // Build a state that uses the same pool (events are now gone).
-        use assistant_core::AssistantConfig;
+        use assistant_core::types::agent::AssistantConfig;
         use assistant_llm_provider::ollama::client::{LlmClient, LlmClientConfig};
         use assistant_llm_provider::retry::RetryConfig;
         use assistant_runtime::Orchestrator;

--- a/crates/web-ui/src/lib.rs
+++ b/crates/web-ui/src/lib.rs
@@ -286,7 +286,7 @@ async fn run_with_args(args: Args) -> Result<()> {
         Some(p) => assistant_core::load_config(&p),
         None => {
             warn!("Cannot determine home directory; using default LLM config");
-            assistant_core::AssistantConfig::default()
+            assistant_core::types::agent::AssistantConfig::default()
         }
     };
 


### PR DESCRIPTION
Final step of the `core/src/types.rs` split. Moves the top-level `AssistantConfig` + `AgentConfig` into `types::agent`. After this lands (alongside #756 conversation), `types.rs` is purely a namespace module declaring submodules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal reorganization of configuration type imports and exports. No changes to user-facing functionality or features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cedricziel/assistant/pull/757?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->