### PR TITLE
refactor(web-ui): split api/mod.rs — capabilities, audio, attachments

### DIFF
--- a/crates/web-ui/src/api/attachments.rs
+++ b/crates/web-ui/src/api/attachments.rs
@@ -1,0 +1,535 @@
+//! Image attachment endpoints: upload (`POST /api/conversations/{id}/attachments`)
+//! and serve (`GET /api/attachments/{id}`) with on-demand resizing.
+
+use axum::Json;
+use axum::body::Body;
+use axum::extract::{Multipart, Path, State};
+use axum::http::{StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+use uuid::Uuid;
+
+use assistant_storage::ConversationStore;
+
+use super::ApiState;
+
+/// Multipart form for image attachment upload.
+#[derive(utoipa::ToSchema)]
+#[allow(dead_code)]
+struct AttachmentUploadForm {
+    /// The image file.
+    #[schema(format = Binary)]
+    file: String,
+}
+
+/// Metadata returned after a successful upload.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct AttachmentMetaResponse {
+    pub id: Uuid,
+    pub filename: String,
+    pub mime_type: String,
+    pub size_bytes: u64,
+    pub created_at: DateTime<Utc>,
+    /// URL to fetch the attachment content.
+    pub url: String,
+}
+
+impl AttachmentMetaResponse {
+    pub(crate) fn from_meta(meta: &assistant_core::AttachmentMeta) -> Self {
+        Self {
+            id: meta.id,
+            filename: meta.filename.clone(),
+            mime_type: meta.mime_type.clone(),
+            size_bytes: meta.size_bytes,
+            created_at: meta.created_at,
+            url: format!("/api/attachments/{}", meta.id),
+        }
+    }
+}
+
+/// `POST /api/conversations/{id}/attachments` — upload an image attachment.
+///
+/// Accepts a `multipart/form-data` body with a single `file` field.
+/// Returns `201 Created` with the attachment metadata on success.
+#[utoipa::path(
+    post,
+    path = "/api/conversations/{id}/attachments",
+    tag = "attachments",
+    params(("id" = Uuid, Path, description = "Conversation ID")),
+    request_body(
+        content_type = "multipart/form-data",
+        content = inline(AttachmentUploadForm),
+    ),
+    responses(
+        (status = 201, description = "Attachment uploaded", body = AttachmentMetaResponse),
+        (status = 400, description = "Bad request (invalid MIME type, too large, etc.)"),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Conversation not found"),
+    ),
+    security(("bearer_token" = []))
+)]
+pub async fn upload_attachment(
+    State(state): State<ApiState>,
+    Path(id): Path<String>,
+    mut multipart: Multipart,
+) -> Response {
+    let conv_id = match Uuid::parse_str(&id) {
+        Ok(u) => u,
+        Err(_) => return (StatusCode::BAD_REQUEST, "Invalid conversation ID").into_response(),
+    };
+
+    let agent_id = state.agent_id.read().await.clone();
+    let store = ConversationStore::for_agent(state.pool.clone(), &agent_id);
+    match store.get_conversation(conv_id).await {
+        Ok(None) => return (StatusCode::NOT_FOUND, "Conversation not found").into_response(),
+        Err(e) => {
+            warn!("Failed to check conversation {conv_id}: {e}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "Database error").into_response();
+        }
+        _ => {}
+    }
+
+    // Parse multipart — expect a single "file" field.
+    let mut file_bytes: Option<Vec<u8>> = None;
+    let mut mime_type = String::new();
+    let mut filename = String::from("attachment");
+
+    while let Ok(Some(field)) = multipart.next_field().await {
+        if field.name() == Some("file") {
+            if let Some(ct) = field.content_type() {
+                mime_type = ct.to_string();
+            }
+            if let Some(name) = field.file_name() {
+                filename = name.to_string();
+            }
+            match field.bytes().await {
+                Ok(b) => {
+                    if b.len() as u64 > assistant_core::MAX_ATTACHMENT_SIZE {
+                        return (
+                            StatusCode::BAD_REQUEST,
+                            format!(
+                                "File too large (max {} MB)",
+                                assistant_core::MAX_ATTACHMENT_SIZE / (1024 * 1024)
+                            ),
+                        )
+                            .into_response();
+                    }
+                    file_bytes = Some(b.to_vec());
+                }
+                Err(e) => {
+                    warn!("Failed to read file field: {e}");
+                    return (StatusCode::BAD_REQUEST, "Failed to read file data").into_response();
+                }
+            }
+        }
+    }
+
+    let file_bytes = match file_bytes {
+        Some(b) if !b.is_empty() => b,
+        _ => return (StatusCode::BAD_REQUEST, "Missing file field").into_response(),
+    };
+
+    // Validate MIME type.
+    if !assistant_core::is_supported_mime_type(&mime_type) {
+        warn!(
+            mime_type = %mime_type,
+            filename = %filename,
+            "Attachment upload rejected: unsupported MIME type"
+        );
+        return (
+            StatusCode::BAD_REQUEST,
+            format!(
+                "Unsupported MIME type '{mime_type}'. Supported: {}",
+                assistant_core::SUPPORTED_MIME_TYPES.join(", ")
+            ),
+        )
+            .into_response();
+    }
+
+    let meta = assistant_core::AttachmentMeta {
+        id: Uuid::new_v4(),
+        message_id: None,
+        conversation_id: conv_id,
+        agent_id,
+        filename,
+        mime_type,
+        size_bytes: file_bytes.len() as u64,
+        created_at: Utc::now(),
+    };
+
+    if let Err(e) = state.attachment_store.store(&meta, &file_bytes).await {
+        warn!("Failed to store attachment: {e}");
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to store attachment",
+        )
+            .into_response();
+    }
+
+    (
+        StatusCode::CREATED,
+        Json(AttachmentMetaResponse::from_meta(&meta)),
+    )
+        .into_response()
+}
+
+/// Optional query parameters for the attachment serve endpoint.
+#[derive(Debug, Deserialize, utoipa::IntoParams)]
+pub struct AttachmentServeParams {
+    /// Desired width in pixels (preserves aspect ratio).
+    pub w: Option<u32>,
+    /// Desired height in pixels (preserves aspect ratio).
+    pub h: Option<u32>,
+}
+
+/// `GET /api/attachments/{id}` — serve an attachment, optionally resized.
+///
+/// Supports `w` and `h` query params for on-demand image resizing. Resized
+/// variants are cached on disk. Responds with `ETag` and `Cache-Control`
+/// headers; returns `304 Not Modified` when `If-None-Match` matches.
+#[utoipa::path(
+    get,
+    path = "/api/attachments/{id}",
+    tag = "attachments",
+    params(
+        ("id" = Uuid, Path, description = "Attachment ID"),
+        AttachmentServeParams,
+    ),
+    responses(
+        (status = 200, description = "Attachment bytes", content_type = "application/octet-stream"),
+        (status = 304, description = "Not modified"),
+        (status = 400, description = "Invalid ID"),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Attachment not found"),
+    ),
+    security(("bearer_token" = []))
+)]
+pub async fn serve_attachment(
+    State(state): State<ApiState>,
+    Path(id): Path<String>,
+    headers: axum::http::HeaderMap,
+    axum::extract::Query(params): axum::extract::Query<AttachmentServeParams>,
+) -> Response {
+    let att_id = match Uuid::parse_str(&id) {
+        Ok(u) => u,
+        Err(_) => return (StatusCode::BAD_REQUEST, "Invalid attachment ID").into_response(),
+    };
+
+    let meta = match state.attachment_store.get_meta(att_id).await {
+        Ok(m) => m,
+        Err(_) => return (StatusCode::NOT_FOUND, "Attachment not found").into_response(),
+    };
+
+    // Determine target size (default: original).
+    let want_w = params.w.unwrap_or(0);
+    let want_h = params.h.unwrap_or(0);
+    let needs_resize =
+        (want_w > 0 || want_h > 0) && assistant_core::is_resizable_mime_type(&meta.mime_type);
+
+    // Build ETag from attachment ID + resize dimensions.
+    let etag = if needs_resize {
+        format!("\"{}-{}x{}\"", meta.id, want_w, want_h)
+    } else {
+        format!("\"{}\"", meta.id)
+    };
+
+    // Conditional request: check If-None-Match.
+    if let Some(inm) = headers.get(header::IF_NONE_MATCH)
+        && let Ok(inm_str) = inm.to_str()
+        && inm_str == etag
+    {
+        return StatusCode::NOT_MODIFIED.into_response();
+    }
+
+    // Load original bytes.
+    let original = match state.attachment_store.load_bytes(att_id).await {
+        Ok(b) => b,
+        Err(e) => {
+            warn!("Failed to load attachment bytes for {att_id}: {e}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to read attachment",
+            )
+                .into_response();
+        }
+    };
+
+    let (bytes, content_type) = if needs_resize {
+        match resize_image(&original, &meta.mime_type, want_w, want_h) {
+            Ok(resized) => (resized, meta.mime_type.clone()),
+            Err(e) => {
+                warn!("Failed to resize attachment {att_id}: {e}");
+                // Fall back to original.
+                (original, meta.mime_type.clone())
+            }
+        }
+    } else {
+        (original, meta.mime_type.clone())
+    };
+
+    (
+        [
+            (header::CONTENT_TYPE, content_type),
+            (
+                header::CACHE_CONTROL,
+                "private, immutable, max-age=31536000".to_string(),
+            ),
+            (header::ETAG, etag),
+        ],
+        Body::from(bytes),
+    )
+        .into_response()
+}
+
+/// Resize an image to fit within a bounding box, preserving aspect ratio.
+fn resize_image(data: &[u8], mime_type: &str, max_w: u32, max_h: u32) -> anyhow::Result<Vec<u8>> {
+    use image::ImageFormat;
+
+    let format = match mime_type {
+        "image/png" => ImageFormat::Png,
+        "image/jpeg" => ImageFormat::Jpeg,
+        "image/gif" => ImageFormat::Gif,
+        "image/webp" => ImageFormat::WebP,
+        _ => anyhow::bail!("unsupported mime type for resize: {mime_type}"),
+    };
+
+    let img = image::load_from_memory_with_format(data, format)?;
+    let (orig_w, orig_h) = (img.width(), img.height());
+
+    // Compute target dimensions preserving aspect ratio.
+    let target_w = if max_w > 0 { max_w } else { orig_w };
+    let target_h = if max_h > 0 { max_h } else { orig_h };
+
+    // Only downscale, never upscale.
+    if orig_w <= target_w && orig_h <= target_h {
+        return Ok(data.to_vec());
+    }
+
+    let resized = img.resize(target_w, target_h, image::imageops::FilterType::Lanczos3);
+
+    let mut buf = std::io::Cursor::new(Vec::new());
+    resized.write_to(&mut buf, format)?;
+    Ok(buf.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use chrono::Utc;
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+    use uuid::Uuid;
+
+    use assistant_storage::ConversationStore;
+
+    use super::super::test_helpers::*;
+
+    #[tokio::test]
+    async fn upload_attachment_rejects_unsupported_mime() {
+        let (state, storage) = event_log_state().await;
+        let conv_store = ConversationStore::for_agent(storage.pool.clone(), "default");
+        let conv = conv_store.create_conversation(None).await.unwrap();
+
+        let (content_type, body) =
+            multipart_body("file", "test.exe", "application/x-msdownload", b"MZ");
+
+        let app = app(state);
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!("/conversations/{}/attachments", conv.id))
+            .header("Authorization", "Bearer test-token")
+            .header("Content-Type", content_type)
+            .body(Body::from(body))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn upload_attachment_succeeds_with_png() {
+        let (state, storage) = event_log_state().await;
+        let conv_store = ConversationStore::for_agent(storage.pool.clone(), "default");
+        let conv = conv_store.create_conversation(None).await.unwrap();
+
+        let png_data = tiny_png();
+        let (content_type, body) = multipart_body("file", "test.png", "image/png", &png_data);
+
+        let app = app(state);
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!("/conversations/{}/attachments", conv.id))
+            .header("Authorization", "Bearer test-token")
+            .header("Content-Type", content_type)
+            .body(Body::from(body))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        let body_bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let meta: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+        assert_eq!(meta["mime_type"], "image/png");
+        assert_eq!(meta["filename"], "test.png");
+        assert!(meta["id"].as_str().is_some());
+        assert!(
+            meta["url"]
+                .as_str()
+                .unwrap()
+                .starts_with("/api/attachments/")
+        );
+    }
+
+    #[tokio::test]
+    async fn upload_attachment_404_for_missing_conversation() {
+        let (state, _storage) = event_log_state().await;
+        let fake_id = Uuid::new_v4();
+
+        let png_data = tiny_png();
+        let (content_type, body) = multipart_body("file", "test.png", "image/png", &png_data);
+
+        let app = app(state);
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!("/conversations/{fake_id}/attachments"))
+            .header("Authorization", "Bearer test-token")
+            .header("Content-Type", content_type)
+            .body(Body::from(body))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn serve_attachment_returns_bytes_and_cache_headers() {
+        let (state, _storage) = event_log_state().await;
+        let conv_id = Uuid::new_v4();
+
+        // Store an attachment directly.
+        let png_data = tiny_png();
+        let meta = assistant_core::AttachmentMeta {
+            id: Uuid::new_v4(),
+            message_id: None,
+            conversation_id: conv_id,
+            agent_id: "default".to_string(),
+            filename: "test.png".to_string(),
+            mime_type: "image/png".to_string(),
+            size_bytes: png_data.len() as u64,
+            created_at: Utc::now(),
+        };
+        state
+            .attachment_store
+            .store(&meta, &png_data)
+            .await
+            .unwrap();
+
+        let app = app(state);
+        let req = Request::builder()
+            .uri(format!("/attachments/{}", meta.id))
+            .header("Authorization", "Bearer test-token")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(resp.headers().get("content-type").unwrap(), "image/png");
+        assert!(
+            resp.headers()
+                .get("cache-control")
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .contains("immutable")
+        );
+        assert!(resp.headers().get("etag").is_some());
+
+        let body_bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(body_bytes.as_ref(), png_data.as_slice());
+    }
+
+    #[tokio::test]
+    async fn serve_attachment_304_on_matching_etag() {
+        let (state, _storage) = event_log_state().await;
+        let conv_id = Uuid::new_v4();
+
+        let png_data = tiny_png();
+        let meta = assistant_core::AttachmentMeta {
+            id: Uuid::new_v4(),
+            message_id: None,
+            conversation_id: conv_id,
+            agent_id: "default".to_string(),
+            filename: "test.png".to_string(),
+            mime_type: "image/png".to_string(),
+            size_bytes: png_data.len() as u64,
+            created_at: Utc::now(),
+        };
+        state
+            .attachment_store
+            .store(&meta, &png_data)
+            .await
+            .unwrap();
+
+        let etag = format!("\"{}\"", meta.id);
+
+        let app = app(state);
+        let req = Request::builder()
+            .uri(format!("/attachments/{}", meta.id))
+            .header("Authorization", "Bearer test-token")
+            .header("If-None-Match", &etag)
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_MODIFIED);
+    }
+
+    #[tokio::test]
+    async fn serve_attachment_with_resize_params() {
+        let (state, _storage) = event_log_state().await;
+        let conv_id = Uuid::new_v4();
+
+        // Create a slightly larger image so resize actually does something.
+        let img: image::ImageBuffer<image::Rgba<u8>, Vec<u8>> =
+            image::ImageBuffer::from_pixel(100, 100, image::Rgba([0, 128, 255, 255]));
+        let mut buf = std::io::Cursor::new(Vec::new());
+        img.write_to(&mut buf, image::ImageFormat::Png).unwrap();
+        let png_data = buf.into_inner();
+
+        let meta = assistant_core::AttachmentMeta {
+            id: Uuid::new_v4(),
+            message_id: None,
+            conversation_id: conv_id,
+            agent_id: "default".to_string(),
+            filename: "big.png".to_string(),
+            mime_type: "image/png".to_string(),
+            size_bytes: png_data.len() as u64,
+            created_at: Utc::now(),
+        };
+        state
+            .attachment_store
+            .store(&meta, &png_data)
+            .await
+            .unwrap();
+
+        let app = app(state);
+        let req = Request::builder()
+            .uri(format!("/attachments/{}?w=50&h=50", meta.id))
+            .header("Authorization", "Bearer test-token")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body_bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        // Resized image should be smaller than original.
+        assert!(
+            body_bytes.len() < png_data.len(),
+            "resized should be smaller"
+        );
+    }
+}

--- a/crates/web-ui/src/api/audio.rs
+++ b/crates/web-ui/src/api/audio.rs
@@ -1,0 +1,187 @@
+//! Audio handlers: synthesize-on-demand for assistant messages
+//! (`GET /api/messages/{id}/audio`) and serve tool-synthesized blobs
+//! (`GET /api/audio/{id}`).
+
+use axum::body::Body;
+use axum::extract::{Path, State};
+use axum::http::{StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use tracing::warn;
+use uuid::Uuid;
+
+use assistant_core::types::conversation::MessageRole;
+use assistant_storage::ConversationStore;
+use assistant_transcription::TtsRequest;
+
+use super::ApiState;
+
+/// `GET /api/messages/{id}/audio` — synthesize TTS audio for an assistant
+/// message and return it as `audio/mpeg`.
+#[utoipa::path(
+    get,
+    path = "/api/messages/{id}/audio",
+    tag = "conversations",
+    params(("id" = Uuid, Path, description = "Message ID")),
+    responses(
+        (status = 200, description = "MP3 audio bytes", content_type = "audio/mpeg"),
+        (status = 400, description = "Invalid ID or non-assistant message"),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Message not found"),
+        (status = 503, description = "TTS not configured"),
+    ),
+    security(("bearer_token" = []))
+)]
+pub async fn get_message_audio(State(state): State<ApiState>, Path(id): Path<String>) -> Response {
+    let tts_provider = match &state.tts_provider {
+        Some(p) => p.clone(),
+        None => {
+            return (StatusCode::SERVICE_UNAVAILABLE, "TTS not configured").into_response();
+        }
+    };
+
+    let msg_id = match Uuid::parse_str(&id) {
+        Ok(u) => u,
+        Err(_) => return (StatusCode::BAD_REQUEST, "Invalid message ID").into_response(),
+    };
+
+    let agent_id = state.agent_id.read().await.clone();
+    let store = ConversationStore::for_agent(state.pool.clone(), &agent_id);
+
+    let msg = match store.get_message(msg_id).await {
+        Ok(Some(m)) => m,
+        Ok(None) => return (StatusCode::NOT_FOUND, "Message not found").into_response(),
+        Err(e) => {
+            warn!("Failed to fetch message {msg_id}: {e}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "Database error").into_response();
+        }
+    };
+
+    if !matches!(msg.role, MessageRole::Assistant) {
+        return (
+            StatusCode::BAD_REQUEST,
+            "Only assistant messages can be synthesized",
+        )
+            .into_response();
+    }
+
+    match tts_provider
+        .synthesize(TtsRequest {
+            text: msg.content,
+            voice: None,
+            format: None,
+            speed: None,
+        })
+        .await
+    {
+        Ok(result) => (
+            [(header::CONTENT_TYPE, result.mime_type)],
+            Body::from(result.audio_data),
+        )
+            .into_response(),
+        Err(e) => {
+            warn!("TTS synthesis failed for message {msg_id}: {e}");
+            (StatusCode::INTERNAL_SERVER_ERROR, "TTS synthesis failed").into_response()
+        }
+    }
+}
+
+/// `GET /api/audio/{id}` — serve a synthesized audio blob from the in-memory store.
+#[utoipa::path(
+    get,
+    path = "/api/audio/{id}",
+    tag = "conversations",
+    params(("id" = Uuid, Path, description = "Audio blob ID")),
+    responses(
+        (status = 200, description = "MP3 audio bytes", content_type = "audio/mpeg"),
+        (status = 400, description = "Invalid ID"),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Audio not found or expired"),
+    ),
+    security(("bearer_token" = []))
+)]
+pub async fn get_audio(State(state): State<ApiState>, Path(id): Path<String>) -> Response {
+    let audio_id = match Uuid::parse_str(&id) {
+        Ok(u) => u,
+        Err(_) => return (StatusCode::BAD_REQUEST, "Invalid audio ID").into_response(),
+    };
+
+    match state.audio_store.get(audio_id).await {
+        Some((bytes, mime)) => ([(header::CONTENT_TYPE, mime)], Body::from(bytes)).into_response(),
+        None => (StatusCode::NOT_FOUND, "Audio not found or expired").into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+    use uuid::Uuid;
+    use wiremock::MockServer;
+
+    use super::super::test_helpers::*;
+
+    #[tokio::test]
+    async fn get_audio_unknown_id_returns_404() {
+        let server = MockServer::start().await;
+        let (state, _) = test_state(&server.uri()).await;
+        let resp = app(state)
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/audio/{}", Uuid::new_v4()))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn get_audio_invalid_id_returns_400() {
+        let server = MockServer::start().await;
+        let (state, _) = test_state(&server.uri()).await;
+        let resp = app(state)
+            .oneshot(
+                Request::builder()
+                    .uri("/audio/not-a-uuid")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn get_audio_returns_stored_bytes() {
+        let server = MockServer::start().await;
+        let (state, _) = test_state(&server.uri()).await;
+
+        let fake_audio = b"mp3-bytes".to_vec();
+        let audio_id = state
+            .audio_store
+            .insert(fake_audio.clone(), "audio/mpeg".to_string())
+            .await;
+
+        let resp = app(state)
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/audio/{audio_id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers()
+                .get("content-type")
+                .and_then(|v| v.to_str().ok()),
+            Some("audio/mpeg")
+        );
+        let bytes = body_bytes(resp.into_body()).await;
+        assert_eq!(bytes, fake_audio);
+    }
+}

--- a/crates/web-ui/src/api/capabilities.rs
+++ b/crates/web-ui/src/api/capabilities.rs
@@ -1,0 +1,67 @@
+//! `GET /api/capabilities` — report server capability flags.
+
+use axum::Json;
+use axum::extract::State;
+use axum::response::{IntoResponse, Response};
+use serde::Serialize;
+
+use super::ApiState;
+
+/// Server capability flags.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct ServerCapabilities {
+    /// Whether the server can accept voice messages (STT configured).
+    pub voice_send: bool,
+    /// Whether the server can serve TTS audio for messages (TTS configured).
+    pub voice_receive: bool,
+}
+
+/// `GET /api/capabilities` — return server capability flags.
+#[utoipa::path(
+    get,
+    path = "/api/capabilities",
+    tag = "capabilities",
+    responses(
+        (status = 200, description = "Server capabilities", body = ServerCapabilities),
+        (status = 401, description = "Unauthorized"),
+    ),
+    security(("bearer_token" = []))
+)]
+pub async fn get_capabilities(State(state): State<ApiState>) -> Response {
+    Json(ServerCapabilities {
+        voice_send: state.transcription_provider.is_some(),
+        voice_receive: state.tts_provider.is_some(),
+    })
+    .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+    use wiremock::MockServer;
+
+    use super::super::test_helpers::*;
+
+    #[tokio::test]
+    async fn capabilities_no_providers_returns_false() {
+        let server = MockServer::start().await;
+        let (state, _) = test_state(&server.uri()).await;
+        // Both providers absent — both flags must be false.
+        let resp = app(state)
+            .oneshot(
+                Request::builder()
+                    .uri("/capabilities")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json = body_json(resp.into_body()).await;
+        assert_eq!(json["voice_send"], false);
+        assert_eq!(json["voice_receive"], false);
+    }
+}

--- a/crates/web-ui/src/api/mod.rs
+++ b/crates/web-ui/src/api/mod.rs
@@ -11,7 +11,10 @@ pub mod account;
 pub mod agents;
 pub mod analytics;
 pub mod api_keys;
+pub mod attachments;
+pub mod audio;
 pub mod bindings;
+pub mod capabilities;
 pub mod catalog;
 pub mod commands;
 pub mod interfaces;
@@ -27,6 +30,11 @@ pub mod traces;
 pub mod users;
 pub mod webhooks;
 pub mod workflows;
+
+#[cfg(test)]
+mod test_helpers;
+
+use attachments::AttachmentMetaResponse;
 
 // -- Shared helpers ----------------------------------------------------------
 
@@ -99,9 +107,7 @@ fn sse_response(rx: mpsc::Receiver<Result<Event, Infallible>>) -> Response {
 use std::convert::Infallible;
 use std::sync::Arc;
 
-use assistant_transcription::{
-    TranscriptionProvider, TranscriptionRequest, TtsProvider, TtsRequest,
-};
+use assistant_transcription::{TranscriptionProvider, TranscriptionRequest, TtsProvider};
 
 use std::collections::HashMap;
 
@@ -115,7 +121,6 @@ use assistant_storage::{
 };
 use axum::{
     Json, Router,
-    body::Body,
     extract::{DefaultBodyLimit, Multipart, Path, State},
     http::{StatusCode, header},
     response::{
@@ -342,7 +347,7 @@ pub struct QuickMessageResponse {
 /// Build the conversations API sub-router.  Mounted under `/api`.
 pub fn api_router() -> Router<ApiState> {
     Router::new()
-        .route("/capabilities", get(get_capabilities))
+        .route("/capabilities", get(capabilities::get_capabilities))
         .route("/conversations", get(list_conversations))
         .route("/conversations/stream", get(stream_conversations))
         .route("/conversations", post(create_conversation))
@@ -354,15 +359,15 @@ pub fn api_router() -> Router<ApiState> {
         .route("/quick-message", post(quick_message))
         .route(
             "/conversations/{id}/attachments",
-            post(upload_attachment).layer(DefaultBodyLimit::max(27 * 1024 * 1024)), // 27 MB
+            post(attachments::upload_attachment).layer(DefaultBodyLimit::max(27 * 1024 * 1024)), // 27 MB
         )
-        .route("/attachments/{id}", get(serve_attachment))
+        .route("/attachments/{id}", get(attachments::serve_attachment))
         .route(
             "/conversations/{id}/runs/{run_id}/events/stream",
             get(stream_run_events),
         )
-        .route("/messages/{id}/audio", get(get_message_audio))
-        .route("/audio/{id}", get(get_audio))
+        .route("/messages/{id}/audio", get(audio::get_message_audio))
+        .route("/audio/{id}", get(audio::get_audio))
         .route("/commands", get(commands::list_commands))
         .route(
             "/conversations/{id}/command",
@@ -1620,16 +1625,7 @@ pub async fn quick_message(
     }
 }
 
-// -- Voice / capabilities handlers ------------------------------------------
-
-/// Server capability flags.
-#[derive(Debug, Serialize, utoipa::ToSchema)]
-pub struct ServerCapabilities {
-    /// Whether the server can accept voice messages (STT configured).
-    pub voice_send: bool,
-    /// Whether the server can serve TTS audio for messages (TTS configured).
-    pub voice_receive: bool,
-}
+// -- Voice handler ----------------------------------------------------------
 
 /// Multipart form body for `POST /api/conversations/{id}/voice`.
 #[derive(utoipa::ToSchema)]
@@ -1638,25 +1634,6 @@ struct VoiceUploadForm {
     /// Raw audio bytes (opus/aac/webm/wav …).
     #[schema(format = Binary, content_encoding = "binary")]
     audio: Vec<u8>,
-}
-
-/// `GET /api/capabilities` — return server capability flags.
-#[utoipa::path(
-    get,
-    path = "/api/capabilities",
-    tag = "capabilities",
-    responses(
-        (status = 200, description = "Server capabilities", body = ServerCapabilities),
-        (status = 401, description = "Unauthorized"),
-    ),
-    security(("bearer_token" = []))
-)]
-pub async fn get_capabilities(State(state): State<ApiState>) -> Response {
-    Json(ServerCapabilities {
-        voice_send: state.transcription_provider.is_some(),
-        voice_receive: state.tts_provider.is_some(),
-    })
-    .into_response()
 }
 
 /// `POST /api/conversations/{id}/voice` — upload audio, transcribe it, run
@@ -1969,403 +1946,6 @@ pub async fn send_voice_message(
     sse_response(sse_rx)
 }
 
-/// `GET /api/messages/{id}/audio` — synthesize TTS audio for an assistant
-/// message and return it as `audio/mpeg`.
-#[utoipa::path(
-    get,
-    path = "/api/messages/{id}/audio",
-    tag = "conversations",
-    params(("id" = Uuid, Path, description = "Message ID")),
-    responses(
-        (status = 200, description = "MP3 audio bytes", content_type = "audio/mpeg"),
-        (status = 400, description = "Invalid ID or non-assistant message"),
-        (status = 401, description = "Unauthorized"),
-        (status = 404, description = "Message not found"),
-        (status = 503, description = "TTS not configured"),
-    ),
-    security(("bearer_token" = []))
-)]
-pub async fn get_message_audio(State(state): State<ApiState>, Path(id): Path<String>) -> Response {
-    let tts_provider = match &state.tts_provider {
-        Some(p) => p.clone(),
-        None => {
-            return (StatusCode::SERVICE_UNAVAILABLE, "TTS not configured").into_response();
-        }
-    };
-
-    let msg_id = match Uuid::parse_str(&id) {
-        Ok(u) => u,
-        Err(_) => return (StatusCode::BAD_REQUEST, "Invalid message ID").into_response(),
-    };
-
-    let agent_id = state.agent_id.read().await.clone();
-    let store = ConversationStore::for_agent(state.pool.clone(), &agent_id);
-
-    let msg = match store.get_message(msg_id).await {
-        Ok(Some(m)) => m,
-        Ok(None) => return (StatusCode::NOT_FOUND, "Message not found").into_response(),
-        Err(e) => {
-            warn!("Failed to fetch message {msg_id}: {e}");
-            return (StatusCode::INTERNAL_SERVER_ERROR, "Database error").into_response();
-        }
-    };
-
-    if !matches!(msg.role, MessageRole::Assistant) {
-        return (
-            StatusCode::BAD_REQUEST,
-            "Only assistant messages can be synthesized",
-        )
-            .into_response();
-    }
-
-    match tts_provider
-        .synthesize(TtsRequest {
-            text: msg.content,
-            voice: None,
-            format: None,
-            speed: None,
-        })
-        .await
-    {
-        Ok(result) => (
-            [(header::CONTENT_TYPE, result.mime_type)],
-            Body::from(result.audio_data),
-        )
-            .into_response(),
-        Err(e) => {
-            warn!("TTS synthesis failed for message {msg_id}: {e}");
-            (StatusCode::INTERNAL_SERVER_ERROR, "TTS synthesis failed").into_response()
-        }
-    }
-}
-
-/// `GET /api/audio/{id}` — serve a synthesized audio blob from the in-memory store.
-#[utoipa::path(
-    get,
-    path = "/api/audio/{id}",
-    tag = "conversations",
-    params(("id" = Uuid, Path, description = "Audio blob ID")),
-    responses(
-        (status = 200, description = "MP3 audio bytes", content_type = "audio/mpeg"),
-        (status = 400, description = "Invalid ID"),
-        (status = 401, description = "Unauthorized"),
-        (status = 404, description = "Audio not found or expired"),
-    ),
-    security(("bearer_token" = []))
-)]
-pub async fn get_audio(State(state): State<ApiState>, Path(id): Path<String>) -> Response {
-    let audio_id = match Uuid::parse_str(&id) {
-        Ok(u) => u,
-        Err(_) => return (StatusCode::BAD_REQUEST, "Invalid audio ID").into_response(),
-    };
-
-    match state.audio_store.get(audio_id).await {
-        Some((bytes, mime)) => ([(header::CONTENT_TYPE, mime)], Body::from(bytes)).into_response(),
-        None => (StatusCode::NOT_FOUND, "Audio not found or expired").into_response(),
-    }
-}
-
-// -- Attachment endpoints ----------------------------------------------------
-
-/// Multipart form for image attachment upload.
-#[derive(utoipa::ToSchema)]
-#[allow(dead_code)]
-struct AttachmentUploadForm {
-    /// The image file.
-    #[schema(format = Binary)]
-    file: String,
-}
-
-/// Metadata returned after a successful upload.
-#[derive(Debug, Serialize, utoipa::ToSchema)]
-pub struct AttachmentMetaResponse {
-    pub id: Uuid,
-    pub filename: String,
-    pub mime_type: String,
-    pub size_bytes: u64,
-    pub created_at: DateTime<Utc>,
-    /// URL to fetch the attachment content.
-    pub url: String,
-}
-
-impl AttachmentMetaResponse {
-    fn from_meta(meta: &assistant_core::AttachmentMeta) -> Self {
-        Self {
-            id: meta.id,
-            filename: meta.filename.clone(),
-            mime_type: meta.mime_type.clone(),
-            size_bytes: meta.size_bytes,
-            created_at: meta.created_at,
-            url: format!("/api/attachments/{}", meta.id),
-        }
-    }
-}
-
-/// `POST /api/conversations/{id}/attachments` — upload an image attachment.
-///
-/// Accepts a `multipart/form-data` body with a single `file` field.
-/// Returns `201 Created` with the attachment metadata on success.
-#[utoipa::path(
-    post,
-    path = "/api/conversations/{id}/attachments",
-    tag = "attachments",
-    params(("id" = Uuid, Path, description = "Conversation ID")),
-    request_body(
-        content_type = "multipart/form-data",
-        content = inline(AttachmentUploadForm),
-    ),
-    responses(
-        (status = 201, description = "Attachment uploaded", body = AttachmentMetaResponse),
-        (status = 400, description = "Bad request (invalid MIME type, too large, etc.)"),
-        (status = 401, description = "Unauthorized"),
-        (status = 404, description = "Conversation not found"),
-    ),
-    security(("bearer_token" = []))
-)]
-pub async fn upload_attachment(
-    State(state): State<ApiState>,
-    Path(id): Path<String>,
-    mut multipart: Multipart,
-) -> Response {
-    let conv_id = match Uuid::parse_str(&id) {
-        Ok(u) => u,
-        Err(_) => return (StatusCode::BAD_REQUEST, "Invalid conversation ID").into_response(),
-    };
-
-    let agent_id = state.agent_id.read().await.clone();
-    let store = ConversationStore::for_agent(state.pool.clone(), &agent_id);
-    match store.get_conversation(conv_id).await {
-        Ok(None) => return (StatusCode::NOT_FOUND, "Conversation not found").into_response(),
-        Err(e) => {
-            warn!("Failed to check conversation {conv_id}: {e}");
-            return (StatusCode::INTERNAL_SERVER_ERROR, "Database error").into_response();
-        }
-        _ => {}
-    }
-
-    // Parse multipart — expect a single "file" field.
-    let mut file_bytes: Option<Vec<u8>> = None;
-    let mut mime_type = String::new();
-    let mut filename = String::from("attachment");
-
-    while let Ok(Some(field)) = multipart.next_field().await {
-        if field.name() == Some("file") {
-            if let Some(ct) = field.content_type() {
-                mime_type = ct.to_string();
-            }
-            if let Some(name) = field.file_name() {
-                filename = name.to_string();
-            }
-            match field.bytes().await {
-                Ok(b) => {
-                    if b.len() as u64 > assistant_core::MAX_ATTACHMENT_SIZE {
-                        return (
-                            StatusCode::BAD_REQUEST,
-                            format!(
-                                "File too large (max {} MB)",
-                                assistant_core::MAX_ATTACHMENT_SIZE / (1024 * 1024)
-                            ),
-                        )
-                            .into_response();
-                    }
-                    file_bytes = Some(b.to_vec());
-                }
-                Err(e) => {
-                    warn!("Failed to read file field: {e}");
-                    return (StatusCode::BAD_REQUEST, "Failed to read file data").into_response();
-                }
-            }
-        }
-    }
-
-    let file_bytes = match file_bytes {
-        Some(b) if !b.is_empty() => b,
-        _ => return (StatusCode::BAD_REQUEST, "Missing file field").into_response(),
-    };
-
-    // Validate MIME type.
-    if !assistant_core::is_supported_mime_type(&mime_type) {
-        warn!(
-            mime_type = %mime_type,
-            filename = %filename,
-            "Attachment upload rejected: unsupported MIME type"
-        );
-        return (
-            StatusCode::BAD_REQUEST,
-            format!(
-                "Unsupported MIME type '{mime_type}'. Supported: {}",
-                assistant_core::SUPPORTED_MIME_TYPES.join(", ")
-            ),
-        )
-            .into_response();
-    }
-
-    let meta = assistant_core::AttachmentMeta {
-        id: Uuid::new_v4(),
-        message_id: None,
-        conversation_id: conv_id,
-        agent_id,
-        filename,
-        mime_type,
-        size_bytes: file_bytes.len() as u64,
-        created_at: Utc::now(),
-    };
-
-    if let Err(e) = state.attachment_store.store(&meta, &file_bytes).await {
-        warn!("Failed to store attachment: {e}");
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "Failed to store attachment",
-        )
-            .into_response();
-    }
-
-    (
-        StatusCode::CREATED,
-        Json(AttachmentMetaResponse::from_meta(&meta)),
-    )
-        .into_response()
-}
-
-/// Optional query parameters for the attachment serve endpoint.
-#[derive(Debug, Deserialize, utoipa::IntoParams)]
-pub struct AttachmentServeParams {
-    /// Desired width in pixels (preserves aspect ratio).
-    pub w: Option<u32>,
-    /// Desired height in pixels (preserves aspect ratio).
-    pub h: Option<u32>,
-}
-
-/// `GET /api/attachments/{id}` — serve an attachment, optionally resized.
-///
-/// Supports `w` and `h` query params for on-demand image resizing. Resized
-/// variants are cached on disk. Responds with `ETag` and `Cache-Control`
-/// headers; returns `304 Not Modified` when `If-None-Match` matches.
-#[utoipa::path(
-    get,
-    path = "/api/attachments/{id}",
-    tag = "attachments",
-    params(
-        ("id" = Uuid, Path, description = "Attachment ID"),
-        AttachmentServeParams,
-    ),
-    responses(
-        (status = 200, description = "Attachment bytes", content_type = "application/octet-stream"),
-        (status = 304, description = "Not modified"),
-        (status = 400, description = "Invalid ID"),
-        (status = 401, description = "Unauthorized"),
-        (status = 404, description = "Attachment not found"),
-    ),
-    security(("bearer_token" = []))
-)]
-pub async fn serve_attachment(
-    State(state): State<ApiState>,
-    Path(id): Path<String>,
-    headers: axum::http::HeaderMap,
-    axum::extract::Query(params): axum::extract::Query<AttachmentServeParams>,
-) -> Response {
-    let att_id = match Uuid::parse_str(&id) {
-        Ok(u) => u,
-        Err(_) => return (StatusCode::BAD_REQUEST, "Invalid attachment ID").into_response(),
-    };
-
-    let meta = match state.attachment_store.get_meta(att_id).await {
-        Ok(m) => m,
-        Err(_) => return (StatusCode::NOT_FOUND, "Attachment not found").into_response(),
-    };
-
-    // Determine target size (default: original).
-    let want_w = params.w.unwrap_or(0);
-    let want_h = params.h.unwrap_or(0);
-    let needs_resize =
-        (want_w > 0 || want_h > 0) && assistant_core::is_resizable_mime_type(&meta.mime_type);
-
-    // Build ETag from attachment ID + resize dimensions.
-    let etag = if needs_resize {
-        format!("\"{}-{}x{}\"", meta.id, want_w, want_h)
-    } else {
-        format!("\"{}\"", meta.id)
-    };
-
-    // Conditional request: check If-None-Match.
-    if let Some(inm) = headers.get(header::IF_NONE_MATCH)
-        && let Ok(inm_str) = inm.to_str()
-        && inm_str == etag
-    {
-        return StatusCode::NOT_MODIFIED.into_response();
-    }
-
-    // Load original bytes.
-    let original = match state.attachment_store.load_bytes(att_id).await {
-        Ok(b) => b,
-        Err(e) => {
-            warn!("Failed to load attachment bytes for {att_id}: {e}");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Failed to read attachment",
-            )
-                .into_response();
-        }
-    };
-
-    let (bytes, content_type) = if needs_resize {
-        match resize_image(&original, &meta.mime_type, want_w, want_h) {
-            Ok(resized) => (resized, meta.mime_type.clone()),
-            Err(e) => {
-                warn!("Failed to resize attachment {att_id}: {e}");
-                // Fall back to original.
-                (original, meta.mime_type.clone())
-            }
-        }
-    } else {
-        (original, meta.mime_type.clone())
-    };
-
-    (
-        [
-            (header::CONTENT_TYPE, content_type),
-            (
-                header::CACHE_CONTROL,
-                "private, immutable, max-age=31536000".to_string(),
-            ),
-            (header::ETAG, etag),
-        ],
-        Body::from(bytes),
-    )
-        .into_response()
-}
-
-/// Resize an image to fit within a bounding box, preserving aspect ratio.
-fn resize_image(data: &[u8], mime_type: &str, max_w: u32, max_h: u32) -> anyhow::Result<Vec<u8>> {
-    use image::ImageFormat;
-
-    let format = match mime_type {
-        "image/png" => ImageFormat::Png,
-        "image/jpeg" => ImageFormat::Jpeg,
-        "image/gif" => ImageFormat::Gif,
-        "image/webp" => ImageFormat::WebP,
-        _ => anyhow::bail!("unsupported mime type for resize: {mime_type}"),
-    };
-
-    let img = image::load_from_memory_with_format(data, format)?;
-    let (orig_w, orig_h) = (img.width(), img.height());
-
-    // Compute target dimensions preserving aspect ratio.
-    let target_w = if max_w > 0 { max_w } else { orig_w };
-    let target_h = if max_h > 0 { max_h } else { orig_h };
-
-    // Only downscale, never upscale.
-    if orig_w <= target_w && orig_h <= target_h {
-        return Ok(data.to_vec());
-    }
-
-    let resized = img.resize(target_w, target_h, image::imageops::FilterType::Lanczos3);
-
-    let mut buf = std::io::Cursor::new(Vec::new());
-    resized.write_to(&mut buf, format)?;
-    Ok(buf.into_inner())
-}
-
 // -- Tests -------------------------------------------------------------------
 
 #[cfg(test)]
@@ -2375,210 +1955,14 @@ mod tests {
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
     use chrono::Utc;
-    use http_body_util::BodyExt;
-    use tokio::sync::RwLock;
     use tower::ServiceExt;
     use uuid::Uuid;
-    use wiremock::matchers::{method, path};
-    use wiremock::{Mock, MockServer, ResponseTemplate};
+    use wiremock::MockServer;
 
-    use std::collections::HashMap;
+    use assistant_storage::{ConversationStore, SkillRegistry, StorageLayer};
 
-    use assistant_core::types::agent::AssistantConfig;
-    use assistant_llm_provider::ollama::client::{LlmClient, LlmClientConfig};
-    use assistant_llm_provider::retry::RetryConfig;
-    use assistant_runtime::{CommandRegistry, Orchestrator};
-    use assistant_storage::{
-        AttachmentStore, CommandEventStore, ConversationEventStore, ConversationStore,
-        InMemoryConversationBroadcaster, RunBroadcaster, SkillRegistry, StorageLayer,
-    };
-    use assistant_tool_executor::ToolExecutor;
-    use assistant_transcription::{
-        TranscriptionProvider, TranscriptionRequest, TranscriptionResult,
-    };
-    use async_trait::async_trait;
-
-    use super::{ApiState, api_router};
-
-    // -- Stubs -----------------------------------------------------------------
-
-    /// Stub transcription provider that returns a fixed transcript.
-    struct StubTranscriptionProvider {
-        transcript: String,
-    }
-
-    #[async_trait]
-    impl TranscriptionProvider for StubTranscriptionProvider {
-        fn name(&self) -> &str {
-            "stub"
-        }
-
-        async fn transcribe(
-            &self,
-            _request: TranscriptionRequest,
-        ) -> anyhow::Result<TranscriptionResult> {
-            Ok(TranscriptionResult {
-                text: self.transcript.clone(),
-                language: None,
-                duration_secs: None,
-            })
-        }
-    }
-
-    // -- Helpers ---------------------------------------------------------------
-
-    /// Minimal LLM mock: returns a static assistant reply.
-    async fn mount_llm_reply(server: &MockServer, reply: &str) {
-        let body = serde_json::json!({
-            "model": "test",
-            "message": { "role": "assistant", "content": reply },
-            "done": true
-        });
-        Mock::given(method("POST"))
-            .and(path("/api/chat"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(body))
-            .mount(server)
-            .await;
-    }
-
-    /// Build an `ApiState` wired to an in-memory DB and a mock LLM server.
-    async fn test_state(llm_url: &str) -> (ApiState, Arc<StorageLayer>) {
-        let mut config = AssistantConfig::default();
-        config.memory.enabled = false;
-
-        let storage = Arc::new(StorageLayer::new_in_memory().await.unwrap());
-        let registry = Arc::new(SkillRegistry::new(storage.pool.clone()).await.unwrap());
-        let llm = Arc::new(
-            LlmClient::new(LlmClientConfig {
-                model: "test".to_string(),
-                base_url: llm_url.to_string(),
-                timeout_secs: 5,
-                retry_config: RetryConfig::disabled(),
-            })
-            .unwrap(),
-        );
-        let executor = Arc::new(ToolExecutor::new(
-            storage.clone(),
-            llm.clone(),
-            registry.clone(),
-            Arc::new(config.clone()),
-        ));
-        let bus = Arc::new(storage.message_bus());
-        let orchestrator = Arc::new(Orchestrator::new(
-            llm,
-            storage.clone(),
-            executor,
-            registry,
-            bus,
-            &config,
-        ));
-
-        // Spawn the turn-processing worker so submit_turn requests are handled.
-        let worker_orch = orchestrator.clone();
-        tokio::spawn(async move {
-            worker_orch.run_worker("test-worker").await;
-        });
-
-        let orchestrator_ref = orchestrator.clone();
-        let default_model = orchestrator_ref.llm.model_name().to_string();
-        let state = ApiState {
-            pool: storage.pool.clone(),
-            agent_id: Arc::new(RwLock::new("default".to_string())),
-            orchestrator,
-            push_dispatcher: None,
-            transcription_provider: None,
-            tts_provider: None,
-            audio_store: Arc::new(crate::audio_store::AudioStore::new()),
-            event_store: ConversationEventStore::new(storage.pool.clone()),
-            run_broadcaster: RunBroadcaster::new(),
-            attachment_store: AttachmentStore::new(storage.pool.clone()),
-            command_registry: Arc::new(CommandRegistry::new()),
-            command_event_store: CommandEventStore::new(storage.pool.clone()),
-            conversation_broadcaster: Arc::new(InMemoryConversationBroadcaster::new()),
-            conversation_configs: Arc::new(RwLock::new(HashMap::new())),
-            orchestrator_ref,
-            active_turns: Arc::new(RwLock::new(HashMap::new())),
-            default_model,
-        };
-        (state, storage)
-    }
-
-    /// Create a minimal state with a real event store but a stub orchestrator.
-    /// No worker task is spawned, so the single in-memory connection is not
-    /// contended. Use this for tests that only exercise the event log endpoints.
-    async fn event_log_state() -> (ApiState, Arc<StorageLayer>) {
-        use assistant_core::types::agent::AssistantConfig;
-        use assistant_llm_provider::ollama::client::{LlmClient, LlmClientConfig};
-        use assistant_llm_provider::retry::RetryConfig;
-        use assistant_runtime::Orchestrator;
-        use assistant_tool_executor::ToolExecutor;
-
-        let mut config = AssistantConfig::default();
-        config.memory.enabled = false;
-
-        let storage = Arc::new(StorageLayer::new_in_memory().await.unwrap());
-        let registry = Arc::new(SkillRegistry::new(storage.pool.clone()).await.unwrap());
-        let llm = Arc::new(
-            LlmClient::new(LlmClientConfig {
-                model: "test".to_string(),
-                base_url: "http://127.0.0.1:1".to_string(),
-                timeout_secs: 1,
-                retry_config: RetryConfig::disabled(),
-            })
-            .unwrap(),
-        );
-        let executor = Arc::new(ToolExecutor::new(
-            storage.clone(),
-            llm.clone(),
-            registry.clone(),
-            Arc::new(config.clone()),
-        ));
-        let bus = Arc::new(storage.message_bus());
-        let orchestrator = Arc::new(Orchestrator::new(
-            llm,
-            storage.clone(),
-            executor,
-            registry,
-            bus,
-            &config,
-        ));
-        // NOTE: No worker task spawned — avoids contention on the single in-memory connection.
-        let orchestrator_ref = orchestrator.clone();
-        let default_model = orchestrator_ref.llm.model_name().to_string();
-        let state = ApiState {
-            pool: storage.pool.clone(),
-            agent_id: Arc::new(RwLock::new("default".to_string())),
-            orchestrator,
-            push_dispatcher: None,
-            transcription_provider: None,
-            tts_provider: None,
-            audio_store: Arc::new(crate::audio_store::AudioStore::new()),
-            event_store: ConversationEventStore::new(storage.pool.clone()),
-            run_broadcaster: RunBroadcaster::new(),
-            attachment_store: AttachmentStore::new(storage.pool.clone()),
-            command_registry: Arc::new(CommandRegistry::new()),
-            command_event_store: CommandEventStore::new(storage.pool.clone()),
-            conversation_broadcaster: Arc::new(InMemoryConversationBroadcaster::new()),
-            conversation_configs: Arc::new(RwLock::new(HashMap::new())),
-            orchestrator_ref,
-            active_turns: Arc::new(RwLock::new(HashMap::new())),
-            default_model,
-        };
-        (state, storage)
-    }
-
-    fn app(state: ApiState) -> axum::Router {
-        api_router().with_state(state)
-    }
-
-    async fn body_bytes(body: Body) -> Vec<u8> {
-        body.collect().await.unwrap().to_bytes().to_vec()
-    }
-
-    async fn body_json(body: Body) -> serde_json::Value {
-        let b = body_bytes(body).await;
-        serde_json::from_slice(&b).unwrap()
-    }
+    use super::test_helpers::*;
+    use super::*;
 
     // -- GET /conversations ----------------------------------------------------
 
@@ -3135,27 +2519,6 @@ mod tests {
 
     // -- GET /capabilities -----------------------------------------------------
 
-    #[tokio::test]
-    async fn capabilities_no_providers_returns_false() {
-        let server = MockServer::start().await;
-        let (state, _) = test_state(&server.uri()).await;
-        // Both providers absent — both flags must be false.
-        let resp = app(state)
-            .oneshot(
-                Request::builder()
-                    .uri("/capabilities")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(resp.status(), StatusCode::OK);
-        let json = body_json(resp.into_body()).await;
-        assert_eq!(json["voice_send"], false);
-        assert_eq!(json["voice_receive"], false);
-    }
-
     // -- POST /conversations/{id}/voice — MIME validation & size limit ---------
 
     #[tokio::test]
@@ -3220,74 +2583,6 @@ mod tests {
     }
 
     // -- GET /audio/{id} -------------------------------------------------------
-
-    #[tokio::test]
-    async fn get_audio_unknown_id_returns_404() {
-        let server = MockServer::start().await;
-        let (state, _) = test_state(&server.uri()).await;
-
-        let resp = app(state)
-            .oneshot(
-                Request::builder()
-                    .uri(format!("/audio/{}", uuid::Uuid::new_v4()))
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
-    }
-
-    #[tokio::test]
-    async fn get_audio_invalid_id_returns_400() {
-        let server = MockServer::start().await;
-        let (state, _) = test_state(&server.uri()).await;
-
-        let resp = app(state)
-            .oneshot(
-                Request::builder()
-                    .uri("/audio/not-a-uuid")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-    }
-
-    #[tokio::test]
-    async fn get_audio_returns_stored_bytes() {
-        let server = MockServer::start().await;
-        let (state, _) = test_state(&server.uri()).await;
-
-        let fake_audio = b"mp3-bytes".to_vec();
-        let audio_id = state
-            .audio_store
-            .insert(fake_audio.clone(), "audio/mpeg".to_string())
-            .await;
-
-        let resp = app(state)
-            .oneshot(
-                Request::builder()
-                    .uri(format!("/audio/{audio_id}"))
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(resp.status(), StatusCode::OK);
-        assert_eq!(
-            resp.headers()
-                .get("content-type")
-                .and_then(|v| v.to_str().ok()),
-            Some("audio/mpeg")
-        );
-        let bytes = body_bytes(resp.into_body()).await;
-        assert_eq!(bytes, fake_audio);
-    }
 
     // -- stream_run_events tests -----------------------------------------------
 
@@ -3677,246 +2972,6 @@ mod tests {
         let resp = app.oneshot(req).await.unwrap();
         // The run existed but events were pruned → currently 404.
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
-    }
-
-    // -- Attachment endpoint tests -----------------------------------------------
-
-    /// Helper: create a minimal 1×1 red PNG in memory.
-    fn tiny_png() -> Vec<u8> {
-        use image::{ImageBuffer, Rgba};
-        let img: ImageBuffer<Rgba<u8>, Vec<u8>> =
-            ImageBuffer::from_pixel(1, 1, Rgba([255, 0, 0, 255]));
-        let mut buf = std::io::Cursor::new(Vec::new());
-        img.write_to(&mut buf, image::ImageFormat::Png).unwrap();
-        buf.into_inner()
-    }
-
-    /// Build a multipart body with a single `file` field.
-    fn multipart_body(
-        field_name: &str,
-        filename: &str,
-        mime: &str,
-        data: &[u8],
-    ) -> (String, Vec<u8>) {
-        let boundary = "----TestBoundary123";
-        let mut body = Vec::new();
-        body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
-        body.extend_from_slice(
-            format!(
-                "Content-Disposition: form-data; name=\"{field_name}\"; filename=\"{filename}\"\r\n"
-            )
-            .as_bytes(),
-        );
-        body.extend_from_slice(format!("Content-Type: {mime}\r\n\r\n").as_bytes());
-        body.extend_from_slice(data);
-        body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
-        (format!("multipart/form-data; boundary={boundary}"), body)
-    }
-
-    #[tokio::test]
-    async fn upload_attachment_rejects_unsupported_mime() {
-        let (state, storage) = event_log_state().await;
-        let conv_store = ConversationStore::for_agent(storage.pool.clone(), "default");
-        let conv = conv_store.create_conversation(None).await.unwrap();
-
-        let (content_type, body) =
-            multipart_body("file", "test.exe", "application/x-msdownload", b"MZ");
-
-        let app = app(state);
-        let req = Request::builder()
-            .method("POST")
-            .uri(format!("/conversations/{}/attachments", conv.id))
-            .header("Authorization", "Bearer test-token")
-            .header("Content-Type", content_type)
-            .body(Body::from(body))
-            .unwrap();
-
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-    }
-
-    #[tokio::test]
-    async fn upload_attachment_succeeds_with_png() {
-        let (state, storage) = event_log_state().await;
-        let conv_store = ConversationStore::for_agent(storage.pool.clone(), "default");
-        let conv = conv_store.create_conversation(None).await.unwrap();
-
-        let png_data = tiny_png();
-        let (content_type, body) = multipart_body("file", "test.png", "image/png", &png_data);
-
-        let app = app(state);
-        let req = Request::builder()
-            .method("POST")
-            .uri(format!("/conversations/{}/attachments", conv.id))
-            .header("Authorization", "Bearer test-token")
-            .header("Content-Type", content_type)
-            .body(Body::from(body))
-            .unwrap();
-
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::CREATED);
-
-        let body_bytes = resp.into_body().collect().await.unwrap().to_bytes();
-        let meta: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
-        assert_eq!(meta["mime_type"], "image/png");
-        assert_eq!(meta["filename"], "test.png");
-        assert!(meta["id"].as_str().is_some());
-        assert!(
-            meta["url"]
-                .as_str()
-                .unwrap()
-                .starts_with("/api/attachments/")
-        );
-    }
-
-    #[tokio::test]
-    async fn upload_attachment_404_for_missing_conversation() {
-        let (state, _storage) = event_log_state().await;
-        let fake_id = Uuid::new_v4();
-
-        let png_data = tiny_png();
-        let (content_type, body) = multipart_body("file", "test.png", "image/png", &png_data);
-
-        let app = app(state);
-        let req = Request::builder()
-            .method("POST")
-            .uri(format!("/conversations/{fake_id}/attachments"))
-            .header("Authorization", "Bearer test-token")
-            .header("Content-Type", content_type)
-            .body(Body::from(body))
-            .unwrap();
-
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
-    }
-
-    #[tokio::test]
-    async fn serve_attachment_returns_bytes_and_cache_headers() {
-        let (state, _storage) = event_log_state().await;
-        let conv_id = Uuid::new_v4();
-
-        // Store an attachment directly.
-        let png_data = tiny_png();
-        let meta = assistant_core::AttachmentMeta {
-            id: Uuid::new_v4(),
-            message_id: None,
-            conversation_id: conv_id,
-            agent_id: "default".to_string(),
-            filename: "test.png".to_string(),
-            mime_type: "image/png".to_string(),
-            size_bytes: png_data.len() as u64,
-            created_at: Utc::now(),
-        };
-        state
-            .attachment_store
-            .store(&meta, &png_data)
-            .await
-            .unwrap();
-
-        let app = app(state);
-        let req = Request::builder()
-            .uri(format!("/attachments/{}", meta.id))
-            .header("Authorization", "Bearer test-token")
-            .body(Body::empty())
-            .unwrap();
-
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::OK);
-        assert_eq!(resp.headers().get("content-type").unwrap(), "image/png");
-        assert!(
-            resp.headers()
-                .get("cache-control")
-                .unwrap()
-                .to_str()
-                .unwrap()
-                .contains("immutable")
-        );
-        assert!(resp.headers().get("etag").is_some());
-
-        let body_bytes = resp.into_body().collect().await.unwrap().to_bytes();
-        assert_eq!(body_bytes.as_ref(), png_data.as_slice());
-    }
-
-    #[tokio::test]
-    async fn serve_attachment_304_on_matching_etag() {
-        let (state, _storage) = event_log_state().await;
-        let conv_id = Uuid::new_v4();
-
-        let png_data = tiny_png();
-        let meta = assistant_core::AttachmentMeta {
-            id: Uuid::new_v4(),
-            message_id: None,
-            conversation_id: conv_id,
-            agent_id: "default".to_string(),
-            filename: "test.png".to_string(),
-            mime_type: "image/png".to_string(),
-            size_bytes: png_data.len() as u64,
-            created_at: Utc::now(),
-        };
-        state
-            .attachment_store
-            .store(&meta, &png_data)
-            .await
-            .unwrap();
-
-        let etag = format!("\"{}\"", meta.id);
-
-        let app = app(state);
-        let req = Request::builder()
-            .uri(format!("/attachments/{}", meta.id))
-            .header("Authorization", "Bearer test-token")
-            .header("If-None-Match", &etag)
-            .body(Body::empty())
-            .unwrap();
-
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::NOT_MODIFIED);
-    }
-
-    #[tokio::test]
-    async fn serve_attachment_with_resize_params() {
-        let (state, _storage) = event_log_state().await;
-        let conv_id = Uuid::new_v4();
-
-        // Create a slightly larger image so resize actually does something.
-        let img: image::ImageBuffer<image::Rgba<u8>, Vec<u8>> =
-            image::ImageBuffer::from_pixel(100, 100, image::Rgba([0, 128, 255, 255]));
-        let mut buf = std::io::Cursor::new(Vec::new());
-        img.write_to(&mut buf, image::ImageFormat::Png).unwrap();
-        let png_data = buf.into_inner();
-
-        let meta = assistant_core::AttachmentMeta {
-            id: Uuid::new_v4(),
-            message_id: None,
-            conversation_id: conv_id,
-            agent_id: "default".to_string(),
-            filename: "big.png".to_string(),
-            mime_type: "image/png".to_string(),
-            size_bytes: png_data.len() as u64,
-            created_at: Utc::now(),
-        };
-        state
-            .attachment_store
-            .store(&meta, &png_data)
-            .await
-            .unwrap();
-
-        let app = app(state);
-        let req = Request::builder()
-            .uri(format!("/attachments/{}?w=50&h=50", meta.id))
-            .header("Authorization", "Bearer test-token")
-            .body(Body::empty())
-            .unwrap();
-
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::OK);
-
-        let body_bytes = resp.into_body().collect().await.unwrap().to_bytes();
-        // Resized image should be smaller than original.
-        assert!(
-            body_bytes.len() < png_data.len(),
-            "resized should be smaller"
-        );
     }
 
     // -- POST /quick-message ---------------------------------------------------

--- a/crates/web-ui/src/api/test_helpers.rs
+++ b/crates/web-ui/src/api/test_helpers.rs
@@ -1,0 +1,236 @@
+//! Shared test fixtures for `api::*` handler tests.
+//!
+//! Each sibling handler module declares its own `#[cfg(test)] mod tests`;
+//! all of them pull fixtures from here via
+//! `use super::super::test_helpers::*;`.
+
+#![cfg(test)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use axum::body::Body;
+use http_body_util::BodyExt;
+use tokio::sync::RwLock;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use assistant_core::types::agent::AssistantConfig;
+use assistant_llm_provider::ollama::client::{LlmClient, LlmClientConfig};
+use assistant_llm_provider::retry::RetryConfig;
+use assistant_runtime::{CommandRegistry, Orchestrator};
+use assistant_storage::{
+    AttachmentStore, CommandEventStore, ConversationEventStore, InMemoryConversationBroadcaster,
+    RunBroadcaster, SkillRegistry, StorageLayer,
+};
+use assistant_tool_executor::ToolExecutor;
+use assistant_transcription::{TranscriptionProvider, TranscriptionRequest, TranscriptionResult};
+
+use super::{ApiState, api_router};
+
+// -- Stubs ---------------------------------------------------------------------
+
+/// Stub transcription provider that returns a fixed transcript.
+pub(crate) struct StubTranscriptionProvider {
+    pub(crate) transcript: String,
+}
+
+#[async_trait]
+impl TranscriptionProvider for StubTranscriptionProvider {
+    fn name(&self) -> &str {
+        "stub"
+    }
+
+    async fn transcribe(
+        &self,
+        _request: TranscriptionRequest,
+    ) -> anyhow::Result<TranscriptionResult> {
+        Ok(TranscriptionResult {
+            text: self.transcript.clone(),
+            language: None,
+            duration_secs: None,
+        })
+    }
+}
+
+// -- HTTP / LLM fixtures -------------------------------------------------------
+
+/// Minimal LLM mock: returns a static assistant reply.
+pub(crate) async fn mount_llm_reply(server: &MockServer, reply: &str) {
+    let body = serde_json::json!({
+        "model": "test",
+        "message": { "role": "assistant", "content": reply },
+        "done": true
+    });
+    Mock::given(method("POST"))
+        .and(path("/api/chat"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(server)
+        .await;
+}
+
+/// Build an `ApiState` wired to an in-memory DB and a mock LLM server.
+pub(crate) async fn test_state(llm_url: &str) -> (ApiState, Arc<StorageLayer>) {
+    let mut config = AssistantConfig::default();
+    config.memory.enabled = false;
+
+    let storage = Arc::new(StorageLayer::new_in_memory().await.unwrap());
+    let registry = Arc::new(SkillRegistry::new(storage.pool.clone()).await.unwrap());
+    let llm = Arc::new(
+        LlmClient::new(LlmClientConfig {
+            model: "test".to_string(),
+            base_url: llm_url.to_string(),
+            timeout_secs: 5,
+            retry_config: RetryConfig::disabled(),
+        })
+        .unwrap(),
+    );
+    let executor = Arc::new(ToolExecutor::new(
+        storage.clone(),
+        llm.clone(),
+        registry.clone(),
+        Arc::new(config.clone()),
+    ));
+    let bus = Arc::new(storage.message_bus());
+    let orchestrator = Arc::new(Orchestrator::new(
+        llm,
+        storage.clone(),
+        executor,
+        registry,
+        bus,
+        &config,
+    ));
+
+    // Spawn the turn-processing worker so submit_turn requests are handled.
+    let worker_orch = orchestrator.clone();
+    tokio::spawn(async move {
+        worker_orch.run_worker("test-worker").await;
+    });
+
+    let orchestrator_ref = orchestrator.clone();
+    let default_model = orchestrator_ref.llm.model_name().to_string();
+    let state = ApiState {
+        pool: storage.pool.clone(),
+        agent_id: Arc::new(RwLock::new("default".to_string())),
+        orchestrator,
+        push_dispatcher: None,
+        transcription_provider: None,
+        tts_provider: None,
+        audio_store: Arc::new(crate::audio_store::AudioStore::new()),
+        event_store: ConversationEventStore::new(storage.pool.clone()),
+        run_broadcaster: RunBroadcaster::new(),
+        attachment_store: AttachmentStore::new(storage.pool.clone()),
+        command_registry: Arc::new(CommandRegistry::new()),
+        command_event_store: CommandEventStore::new(storage.pool.clone()),
+        conversation_broadcaster: Arc::new(InMemoryConversationBroadcaster::new()),
+        conversation_configs: Arc::new(RwLock::new(HashMap::new())),
+        orchestrator_ref,
+        active_turns: Arc::new(RwLock::new(HashMap::new())),
+        default_model,
+    };
+    (state, storage)
+}
+
+/// Create a minimal state with a real event store but a stub orchestrator.
+/// No worker task is spawned, so the single in-memory connection is not
+/// contended. Use this for tests that only exercise the event log endpoints.
+pub(crate) async fn event_log_state() -> (ApiState, Arc<StorageLayer>) {
+    let mut config = AssistantConfig::default();
+    config.memory.enabled = false;
+
+    let storage = Arc::new(StorageLayer::new_in_memory().await.unwrap());
+    let registry = Arc::new(SkillRegistry::new(storage.pool.clone()).await.unwrap());
+    let llm = Arc::new(
+        LlmClient::new(LlmClientConfig {
+            model: "test".to_string(),
+            base_url: "http://127.0.0.1:1".to_string(),
+            timeout_secs: 1,
+            retry_config: RetryConfig::disabled(),
+        })
+        .unwrap(),
+    );
+    let executor = Arc::new(ToolExecutor::new(
+        storage.clone(),
+        llm.clone(),
+        registry.clone(),
+        Arc::new(config.clone()),
+    ));
+    let bus = Arc::new(storage.message_bus());
+    let orchestrator = Arc::new(Orchestrator::new(
+        llm,
+        storage.clone(),
+        executor,
+        registry,
+        bus,
+        &config,
+    ));
+    // NOTE: No worker task spawned — avoids contention on the single in-memory connection.
+    let orchestrator_ref = orchestrator.clone();
+    let default_model = orchestrator_ref.llm.model_name().to_string();
+    let state = ApiState {
+        pool: storage.pool.clone(),
+        agent_id: Arc::new(RwLock::new("default".to_string())),
+        orchestrator,
+        push_dispatcher: None,
+        transcription_provider: None,
+        tts_provider: None,
+        audio_store: Arc::new(crate::audio_store::AudioStore::new()),
+        event_store: ConversationEventStore::new(storage.pool.clone()),
+        run_broadcaster: RunBroadcaster::new(),
+        attachment_store: AttachmentStore::new(storage.pool.clone()),
+        command_registry: Arc::new(CommandRegistry::new()),
+        command_event_store: CommandEventStore::new(storage.pool.clone()),
+        conversation_broadcaster: Arc::new(InMemoryConversationBroadcaster::new()),
+        conversation_configs: Arc::new(RwLock::new(HashMap::new())),
+        orchestrator_ref,
+        active_turns: Arc::new(RwLock::new(HashMap::new())),
+        default_model,
+    };
+    (state, storage)
+}
+
+pub(crate) fn app(state: ApiState) -> axum::Router {
+    api_router().with_state(state)
+}
+
+pub(crate) async fn body_bytes(body: Body) -> Vec<u8> {
+    body.collect().await.unwrap().to_bytes().to_vec()
+}
+
+pub(crate) async fn body_json(body: Body) -> serde_json::Value {
+    let b = body_bytes(body).await;
+    serde_json::from_slice(&b).unwrap()
+}
+
+// -- Attachment fixtures -------------------------------------------------------
+
+pub(crate) fn tiny_png() -> Vec<u8> {
+    use image::{ImageBuffer, Rgba};
+    let img: ImageBuffer<Rgba<u8>, Vec<u8>> = ImageBuffer::from_pixel(1, 1, Rgba([255, 0, 0, 255]));
+    let mut buf = std::io::Cursor::new(Vec::new());
+    img.write_to(&mut buf, image::ImageFormat::Png).unwrap();
+    buf.into_inner()
+}
+
+/// Build a multipart body with a single `file` field.
+pub(crate) fn multipart_body(
+    field_name: &str,
+    filename: &str,
+    mime: &str,
+    data: &[u8],
+) -> (String, Vec<u8>) {
+    let boundary = "----TestBoundary123";
+    let mut body = Vec::new();
+    body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+    body.extend_from_slice(
+        format!(
+            "Content-Disposition: form-data; name=\"{field_name}\"; filename=\"{filename}\"\r\n"
+        )
+        .as_bytes(),
+    );
+    body.extend_from_slice(format!("Content-Type: {mime}\r\n\r\n").as_bytes());
+    body.extend_from_slice(data);
+    body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+    (format!("multipart/form-data; boundary={boundary}"), body)
+}

--- a/crates/web-ui/src/openapi.rs
+++ b/crates/web-ui/src/openapi.rs
@@ -35,12 +35,13 @@ use utoipa::{
 };
 
 use crate::a2a::handlers;
+use crate::api::attachments::AttachmentMetaResponse;
+use crate::api::capabilities::ServerCapabilities;
 use crate::api::push::{SubscribeRequest, UnsubscribeRequest, VapidKeyResponse};
 use crate::api::{
-    AttachmentMetaResponse, ConversationDetail, ConversationSummary, CreateConversationRequest,
-    MessageSummary, QuickMessageRequest, QuickMessageResponse,
-    SendMessageRequest as ApiSendMessageRequest, ServerCapabilities, SseStatusEvent,
-    SseSubagentCompletedEvent, SseSubagentStartedEvent, SseSubagentStatusEvent,
+    ConversationDetail, ConversationSummary, CreateConversationRequest, MessageSummary,
+    QuickMessageRequest, QuickMessageResponse, SendMessageRequest as ApiSendMessageRequest,
+    SseStatusEvent, SseSubagentCompletedEvent, SseSubagentStartedEvent, SseSubagentStatusEvent,
     SseSubagentThinkingEvent, SseSubagentTokenEvent, SseSubagentToolResultEvent, SseThinkingEvent,
     SseTokenEvent, SseToolResultEvent, StreamRunEventsQuery, ToolCallSummary,
     UpdateConversationRequest,
@@ -189,7 +190,7 @@ pub struct ApiErrorResponse {
     ),
     modifiers(&SecuritySchemesAddon),
     paths(
-        crate::api::get_capabilities,
+        crate::api::capabilities::get_capabilities,
         crate::api::list_conversations,
         crate::api::stream_conversations,
         crate::api::create_conversation,
@@ -200,10 +201,10 @@ pub struct ApiErrorResponse {
         crate::api::quick_message,
         crate::api::send_voice_message,
         crate::api::stream_run_events,
-        crate::api::get_message_audio,
-        crate::api::get_audio,
-        crate::api::upload_attachment,
-        crate::api::serve_attachment,
+        crate::api::audio::get_message_audio,
+        crate::api::audio::get_audio,
+        crate::api::attachments::upload_attachment,
+        crate::api::attachments::serve_attachment,
         crate::api::commands::list_commands,
         crate::api::commands::execute_command,
         crate::api::commands::list_command_events,


### PR DESCRIPTION
## Summary

First slice of the long-standing api/mod.rs split. Pulls three small,
self-contained handler groups out of the 4.4 k-line
`crates/web-ui/src/api/mod.rs` into sibling modules:

- `api/capabilities.rs` — `GET /api/capabilities` + `ServerCapabilities`
- `api/audio.rs` — `GET /api/messages/{id}/audio`, `GET /api/audio/{id}`
- `api/attachments.rs` — `POST /conversations/{id}/attachments`,
  `GET /attachments/{id}`, plus `AttachmentUploadForm`,
  `AttachmentMetaResponse`, `AttachmentServeParams`, and the
  private `resize_image` helper

Test fixtures (`StubTranscriptionProvider`, `mount_llm_reply`, `test_state`,
`event_log_state`, `app`, `body_bytes`, `body_json`, `tiny_png`,
`multipart_body`) move to a new shared `api/test_helpers.rs` so sibling
test modules can pull them via `use super::super::test_helpers::*;`.

Router calls and `openapi.rs` paths are updated to the new locations.

## Test plan
- [x] `cargo test -p assistant-web-ui --lib` — 241 passed (matches main)
- [x] `make lint` — clean
- [x] `cargo fmt --all --check` — clean
- [ ] Follow-up PRs: extract `conversations` (CRUD) and `messages`
      (send/quick/voice/run-events) — those are larger and warrant
      their own reviews.