### PR TITLE
fix(app): fall back to conversation fetch when SSE stream stalls

### DIFF
--- a/app/lib/features/chat/chat_provider.dart
+++ b/app/lib/features/chat/chat_provider.dart
@@ -884,6 +884,18 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
   /// Base delay for exponential backoff between retries (1s, 2s, 4s).
   static const _baseRetryDelay = Duration(seconds: 1);
 
+  /// How long to wait after Send for the first non-[RunStartedEvent] from
+  /// the SSE stream before treating the stream as stalled and falling back
+  /// to a direct conversation fetch.
+  ///
+  /// Motivated by iOS Dio / dart:io HttpClient buffering: the response
+  /// headers arrive (so [RunStartedEvent] fires from the `X-Run-Id`
+  /// header) but no body chunks reach the parser until the connection
+  /// closes, leaving the user staring at "jumpy dots" until the byte-
+  /// level 90 s heartbeat finally trips. 12 s is short enough to feel
+  /// responsive and long enough to absorb a brief first-token delay.
+  static const _initialStallTimeout = Duration(seconds: 12);
+
   /// Whether a transient stream interruption occurred that should be retried
   /// on app resume.
   bool get needsReconnect => _needsReconnect;
@@ -1515,13 +1527,35 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
       ),
     );
 
+    // Arm the initial-stall watchdog as a per-event timeout on the SSE
+    // stream. Until we see a UI-visible event (anything other than
+    // [RunStartedEvent]), a quiet interval of [_initialStallTimeout]
+    // triggers a fallback to a direct conversation fetch. After progress
+    // has been observed, the byte-level heartbeat (90 s) handles longer
+    // silences that may legitimately occur during tool execution.
+    var sawProgress = false;
+    final source = api
+        .streamMessages(
+          conversationId,
+          message,
+          attachmentIds: attachmentIds.isNotEmpty ? attachmentIds : null,
+        )
+        .timeout(
+          _initialStallTimeout,
+          onTimeout: (sink) {
+            if (sawProgress) return;
+            // Recover synchronously so the placeholder clears immediately
+            // (the synchronous prefix of [_recoverStalledStream] runs
+            // before its first await), then close the stream so the
+            // await-for loop exits cleanly.
+            unawaited(_recoverStalledStream(conversationId, userMsgId));
+            sink.close();
+          },
+        );
+
     // Stream SSE events.
     try {
-      await for (final event in api.streamMessages(
-        conversationId,
-        message,
-        attachmentIds: attachmentIds.isNotEmpty ? attachmentIds : null,
-      )) {
+      await for (final event in source) {
         if (_cancelled) break;
         final chatState = state.value ?? const ChatState();
 
@@ -1530,7 +1564,11 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
           _currentRunId = event.runId;
           _lastSeq = (event.sequenceId ?? _lastSeq) + 1;
           continue;
-        } else if (event is TokenEvent) {
+        }
+        // Any non-RunStartedEvent counts as progress — the initial-stall
+        // watchdog won't fire on subsequent quiet periods.
+        sawProgress = true;
+        if (event is TokenEvent) {
           _lastSeq = (event.sequenceId ?? _lastSeq) + 1;
           tokenController.add(event.token);
           final newContent = chatState.streamingContent + event.token;
@@ -1647,6 +1685,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
       // Stream ended without DoneEvent — close token controller and treat
       // accumulated buffer as final.
       unawaited(tokenController.close());
+      if (!ref.mounted) return;
       final finalState = state.value ?? const ChatState();
       if (finalState.isSending) {
         final msgs = List<ChatMessage>.from(finalState.messages);
@@ -1679,6 +1718,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
     } catch (e) {
       unawaited(tokenController.close());
       _closeThinkingController();
+      if (!ref.mounted) return;
 
       // Transient error with a run ID: retry with exponential backoff,
       // then defer to app-resume reconnection if all retries fail.
@@ -1733,6 +1773,78 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
         ),
       );
     }
+  }
+
+  /// Recover from a stalled SSE stream by fetching the conversation
+  /// directly. Triggered by the [_initialStallTimeout] watchdog when the
+  /// stream produces no UI-visible event in time — primarily the iOS
+  /// case where Dio buffers the chunked body until the connection
+  /// closes.
+  ///
+  /// On success, replaces the streaming placeholder with the server-
+  /// persisted message list. On failure, clears the placeholder and
+  /// surfaces an error so the user can retry.
+  Future<void> _recoverStalledStream(
+    String conversationId,
+    String userMsgId,
+  ) async {
+    if (_cancelled || !ref.mounted) return;
+    _cancelled = true; // stop the await-for loop on its next iteration
+
+    // Step 1: clear the placeholder synchronously so the user immediately
+    // sees that the stream stalled and gets out of the dots state.
+    final current = state.value ?? const ChatState();
+    _clearStalledPlaceholder(
+      current,
+      userMsgId,
+      error: 'Response is taking longer than expected. Refreshing…',
+    );
+
+    // Step 2: in the background, fetch the conversation from the server.
+    // The user reported that a manual reload surfaces the actual reply, so
+    // a direct GET typically resolves the missing message.
+    final api = _api;
+    if (api == null) return;
+    try {
+      final response = await api.conversations.getConversation(
+        id: conversationId,
+      );
+      if (!ref.mounted) return;
+      final messages = chatMessagesFromHistory(response.data!.messages);
+      final latest = state.value ?? const ChatState();
+      state = AsyncData(
+        ChatState(
+          conversationId: conversationId,
+          messages: messages,
+          pendingQueue: latest.pendingQueue,
+        ),
+      );
+    } catch (_) {
+      // Fetch failed — keep the cleared placeholder and the error message
+      // already surfaced above so the user can retry.
+    }
+  }
+
+  void _clearStalledPlaceholder(
+    ChatState from,
+    String userMsgId, {
+    required String error,
+  }) {
+    if (!ref.mounted) return;
+    final msgs = List<ChatMessage>.from(from.messages)
+      ..removeWhere((m) => m.id == 'assistant-streaming');
+    final userIdx = msgs.indexWhere((m) => m.id == userMsgId);
+    if (userIdx != -1) {
+      msgs[userIdx] = msgs[userIdx].copyWith(status: MessageStatus.failed);
+    }
+    state = AsyncData(
+      from.copyWith(
+        messages: msgs,
+        isSending: false,
+        streamingContent: '',
+        error: error,
+      ),
+    );
   }
 
   /// Returns `true` if [error] looks like a transient connection failure

--- a/app/test/unit/chat/chat_provider_test.dart
+++ b/app/test/unit/chat/chat_provider_test.dart
@@ -1584,4 +1584,92 @@ void main() {
       );
     });
   });
+
+  // -- Stalled-stream recovery (iPhone/iPad bug: dots forever) ---------------
+  //
+  // Reproduces the user-reported behaviour:
+  //   "I send a message and I see the three jumpy dots indefinitely on my
+  //    iPhone. […] reload the conversation via menu and a new message
+  //    appears."
+  //
+  // What we know from that report:
+  //   - POST /messages succeeds: the server receives, runs, and persists
+  //     the assistant reply (it's there on reload).
+  //   - The SSE response stream never delivers any events to the iPhone
+  //     in real time (likely iOS Dio / dart:io HttpClient buffering).
+  //   - ChatNotifier's existing recovery is the byte-level heartbeat
+  //     timeout (90 s) followed by up to three replay-run retries, each
+  //     with its own 90 s budget. That is "forever" from a user POV.
+  //
+  // This test pins a stronger user contract: a stream that delivers no
+  // useful events within ~15 s of the user pressing Send MUST NOT leave
+  // the UI in the "isStreaming, no content, dots showing" state. The fix
+  // is intentionally not prescribed by this test — surfacing an error,
+  // polling the conversation endpoint, exposing a retry button, or
+  // shortening the no-progress deadline are all acceptable.
+  group('ChatNotifier — stalled SSE stream recovery', () {
+    testWidgets('stream that emits no tokens within 15s does not leave the UI in '
+        'indefinite "streaming dots" state', (tester) async {
+      final fakeApi = _FakeApiClient();
+      final ctrl = fakeApi.enqueueStream();
+      addTearDown(() async {
+        if (!ctrl.isClosed) await ctrl.close();
+      });
+
+      final notifier = await _pumpTestApp(tester, fakeApi);
+
+      // User hits Send. The notifier inserts a user bubble and an
+      // empty assistant-streaming placeholder, then awaits the SSE
+      // stream.
+      unawaited(notifier.sendMessage('hello'));
+      await tester.pump();
+
+      // Server acknowledges the run (matches the X-Run-Id header path)
+      // but never emits a token, status, or done event afterwards —
+      // exactly what iOS sees when Dio buffers the chunked body.
+      ctrl.add(const RunStartedEvent('run-1'));
+      await tester.pump();
+
+      // Precondition: we are in the "dots" state right now.
+      final initial = notifier.state.value!;
+      final initialPlaceholder = initial.messages.firstWhere(
+        (m) => m.id == 'assistant-streaming',
+        orElse: () =>
+            ChatMessage(id: 'missing', role: 'assistant', content: ''),
+      );
+      expect(
+        initialPlaceholder.isStreaming && initialPlaceholder.content.isEmpty,
+        isTrue,
+        reason:
+            'precondition: right after Send we expect the dots-state '
+            'placeholder to be present',
+      );
+
+      // Advance time past the no-progress watchdog. 15 s is well above
+      // what a user will tolerate while staring at jumpy dots, and well
+      // below the current 90 s heartbeat × 3-retry total. The trailing
+      // pump drains microtasks scheduled by the timeout-driven error
+      // propagation through the stream subscription.
+      await tester.pump(const Duration(seconds: 15));
+      await tester.pumpAndSettle();
+
+      final after = notifier.state.value!;
+      final stillInDots = after.messages.any(
+        (m) =>
+            m.id == 'assistant-streaming' && m.isStreaming && m.content.isEmpty,
+      );
+
+      expect(
+        stillInDots,
+        isFalse,
+        reason:
+            'After 15s with no SSE progress the UI must exit the '
+            '"dots forever" state — surface an error, fall back to a '
+            'fetch of the conversation, or clear the placeholder. '
+            'Current state: isSending=${after.isSending}, '
+            'error=${after.error}, '
+            'messages=${after.messages.map((m) => '(${m.id}, streaming=${m.isStreaming}, content="${m.content}")').toList()}',
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary

- On iPhone/iPad, sending a message shows the "jumpy dots" indefinitely. Server has the reply (a manual reload surfaces it) but the SSE response on iOS never delivers token events in real time — dio over `dart:io HttpClient` appears to buffer the chunked body until the connection closes, so only the `X-Run-Id` header (→ `RunStartedEvent`) reaches the client. The byte-level 90 s heartbeat + 3 replay retries means the placeholder sits for minutes before recovery; users perceive it as "never appears".
- Adds a 12 s no-progress watchdog via `Stream.timeout` on the SSE source in `ChatNotifier._streamMessage`. Until any non-`RunStartedEvent` is observed, a quiet interval of 12 s triggers `_recoverStalledStream` which synchronously clears the placeholder + surfaces "Refreshing…", then issues a direct `GET /conversations/{id}` to replace the message list with the server-persisted history.
- After progress has been observed, the watchdog stays armed but never fires — the existing 90 s byte-level heartbeat continues to handle legitimate silences during tool execution.
- Two `if (!ref.mounted) return;` guards added in the post-loop and outer catch to prevent disposal races with the auto-dispose provider.

## Test plan

- [x] New TDD red-then-green test in `chat_provider_test.dart`: `ChatNotifier — stalled SSE stream recovery` — pins the user contract that 15 s without SSE progress cannot leave the UI in dots state.
- [x] `flutter test test/unit/chat/chat_provider_test.dart` — 44/44 pass (includes new test).
- [x] `flutter test` — 885/885 pass.
- [x] `flutter analyze --fatal-infos` — no issues.
- [x] `dart format` — clean.
- [ ] Manual verification on iPhone/iPad device: the assistant bubble must clear within ~12 s and the actual reply must appear after the fallback GET. (Cannot do this from CI; intentionally left for reviewer.)

## Not in this PR

- The root-cause network fix (likely swapping to `cupertino_http` Dio adapter on iOS so SSE actually streams in real time). This PR is the safety net so users are never stuck even if/when that lands.
- `_streamVoiceMessage` has the same shape; if voice on iPhone shows the same symptom, apply the same watchdog as a follow-up.