### PR TITLE
chore(web-ui): sync openapi.json + restore two doc wordings

### DIFF
--- a/crates/web-ui/src/api/conversations.rs
+++ b/crates/web-ui/src/api/conversations.rs
@@ -30,7 +30,7 @@ use super::{ApiState, sse_response};
 
 // -- Response types ----------------------------------------------------------
 
-/// A conversation summary (no message history).
+/// A conversation summary (no messages).
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct ConversationSummary {
     pub id: Uuid,
@@ -110,7 +110,7 @@ pub struct UpdateConversationRequest {
 
 // -- Handlers ----------------------------------------------------------------
 
-/// `GET /api/conversations` — list all conversations.
+/// `GET /api/conversations` — list all conversations, newest first.
 #[utoipa::path(
     get,
     path = "/api/conversations",

--- a/openapi.json
+++ b/openapi.json
@@ -6228,6 +6228,7 @@
           {
             "name": "code_challenge_method",
             "in": "query",
+            "description": "Accepted per RFC 7636 §4.3 for forward-compatibility. We only support\n`S256` and assume it implicitly; the value is not yet validated.",
             "required": false,
             "schema": {
               "type": [
@@ -9823,7 +9824,7 @@
       },
       "RevokeRequest": {
         "type": "object",
-        "description": "POST /oauth/revoke request body.",
+        "description": "POST /oauth/revoke request body.\n\n`token_type_hint` (RFC 7009 §2.1) and `client_id` are accepted for\nspec compliance but currently informational — revocation looks up\ntokens by value alone. Kept on the struct so the OpenAPI surface\nmatches the RFC.",
         "required": [
           "token"
         ],


### PR DESCRIPTION
## Summary

`make dump-openapi` on main produced four drifts vs the committed spec.

Two were drifts I introduced when moving handlers into
`api/conversations.rs` (#759):
- `list_conversations` summary lost ", newest first"
- `ConversationSummary` doc flipped "no messages" → "no message history"

Restored the original wording in `conversations.rs` so the API surface
is unchanged across the api/mod.rs split.

The other two were pre-existing doc additions in `oauth/authorize.rs`
(`code_challenge_method` query param) and `oauth/revoke.rs`
(`RevokeRequest` struct) whose openapi.json snapshot was never
regenerated. Captured here.

## Test plan
- [x] `make dump-openapi` produces a no-op diff after this PR
- [x] `cargo test -p assistant-web-ui --lib` — 241 passed
- [x] No route additions/removals; no schema shape changes