### PR TITLE
fix(app): iOS streaming follow-ups — native HTTP adapter + voice path watchdog

### DIFF
--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -4,6 +4,9 @@ PODS:
     - FlutterMacOS
   - connectivity_plus (0.0.1):
     - Flutter
+  - cupertino_http (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - device_info_plus (0.0.1):
     - Flutter
   - DKImagePickerController/Core (4.3.9):
@@ -72,6 +75,7 @@ PODS:
 DEPENDENCIES:
   - audioplayers_darwin (from `.symlinks/plugins/audioplayers_darwin/darwin`)
   - connectivity_plus (from `.symlinks/plugins/connectivity_plus/ios`)
+  - cupertino_http (from `.symlinks/plugins/cupertino_http/darwin`)
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
   - file_picker (from `.symlinks/plugins/file_picker/ios`)
   - Flutter (from `Flutter`)
@@ -98,6 +102,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/audioplayers_darwin/darwin"
   connectivity_plus:
     :path: ".symlinks/plugins/connectivity_plus/ios"
+  cupertino_http:
+    :path: ".symlinks/plugins/cupertino_http/darwin"
   device_info_plus:
     :path: ".symlinks/plugins/device_info_plus/ios"
   file_picker:
@@ -128,6 +134,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   audioplayers_darwin: 835ced6edd4c9fc8ebb0a7cc9e294a91d99917d5
   connectivity_plus: cb623214f4e1f6ef8fe7403d580fdad517d2f7dd
+  cupertino_http: 94ac07f5ff090b8effa6c5e2c47871d48ab7c86c
   device_info_plus: 21fcca2080fbcd348be798aa36c3e5ed849eefbe
   DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
   DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60

--- a/app/lib/api/api_client.dart
+++ b/app/lib/api/api_client.dart
@@ -6,9 +6,12 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'dart:io' show Platform;
+
 import 'package:assistant_api/assistant_api.dart' hide ServerCapabilities;
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
+import 'package:native_dio_adapter/native_dio_adapter.dart';
 
 import 'auth_interceptor.dart';
 import 'event_source_stream.dart';
@@ -33,6 +36,12 @@ class ApiAuthException implements Exception {
   String toString() => message;
 }
 
+/// True when the current process is the `flutter test` runner. Used to
+/// avoid installing native-platform Dio adapters whose plugin bindings
+/// aren't initialized in unit-test mode.
+bool get _runningInFlutterTest =>
+    !kIsWeb && Platform.environment.containsKey('FLUTTER_TEST');
+
 /// Configured client bundle: generated API instances + SSE streaming helper.
 class ApiClient {
   ApiClient({
@@ -48,6 +57,24 @@ class ApiClient {
         receiveTimeout: const Duration(minutes: 10),
       ),
     );
+
+    // Use the platform-native HTTP stack on iOS / macOS (NSURLSession via
+    // cupertino_http) and Android (Cronet) so chunked-transfer SSE
+    // responses stream in real time. dart:io's HttpClient — Dio's default
+    // — buffers SSE bodies on iOS / iPadOS until the connection closes,
+    // which is the root cause of the "jumpy dots forever" behaviour
+    // mitigated at the application layer by `_recoverStalledStream`.
+    //
+    // Skipped in two cases:
+    //   - Web: Dio's BrowserHttpClientAdapter already routes through the
+    //     browser's `fetch` and streams correctly.
+    //   - `flutter test`: NativeAdapter eagerly instantiates a native
+    //     URLSession via cupertino_http, which requires the iOS / macOS
+    //     platform binding. Unit tests run without that binding, so we
+    //     fall back to dart:io there.
+    if (!kIsWeb && !_runningInFlutterTest) {
+      _dio.httpClientAdapter = NativeAdapter();
+    }
 
     if (refreshTokens != null && onAuthExpired != null) {
       final interceptor = AuthRecoveryInterceptor(

--- a/app/lib/features/chat/chat_provider.dart
+++ b/app/lib/features/chat/chat_provider.dart
@@ -1309,13 +1309,27 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
       ),
     );
 
+    // Arm the same initial-stall watchdog used by the text path. The voice
+    // SSE response carries TranscriptEvent + token/status events; any event
+    // counts as progress. Until the first event arrives, a quiet interval
+    // of [_initialStallTimeout] triggers a fallback to a direct
+    // conversation fetch (iOS Dio buffering safety net).
+    var sawProgress = false;
+    final source = api
+        .sendVoiceMessage(conversationId, audioBytes, mimeType)
+        .timeout(
+          _initialStallTimeout,
+          onTimeout: (sink) {
+            if (sawProgress) return;
+            unawaited(_recoverStalledStream(conversationId, userMsgId));
+            sink.close();
+          },
+        );
+
     try {
-      await for (final event in api.sendVoiceMessage(
-        conversationId,
-        audioBytes,
-        mimeType,
-      )) {
+      await for (final event in source) {
         if (_cancelled) break;
+        sawProgress = true;
         final chatState = state.value ?? const ChatState();
 
         if (event is TranscriptEvent) {

--- a/app/macos/Podfile.lock
+++ b/app/macos/Podfile.lock
@@ -4,6 +4,9 @@ PODS:
     - FlutterMacOS
   - connectivity_plus (0.0.1):
     - FlutterMacOS
+  - cupertino_http (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - desktop_drop (0.0.1):
     - FlutterMacOS
   - device_info_plus (0.0.1):
@@ -44,6 +47,7 @@ PODS:
 DEPENDENCIES:
   - audioplayers_darwin (from `Flutter/ephemeral/.symlinks/plugins/audioplayers_darwin/darwin`)
   - connectivity_plus (from `Flutter/ephemeral/.symlinks/plugins/connectivity_plus/macos`)
+  - cupertino_http (from `Flutter/ephemeral/.symlinks/plugins/cupertino_http/darwin`)
   - desktop_drop (from `Flutter/ephemeral/.symlinks/plugins/desktop_drop/macos`)
   - device_info_plus (from `Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos`)
   - file_picker (from `Flutter/ephemeral/.symlinks/plugins/file_picker/macos`)
@@ -67,6 +71,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/audioplayers_darwin/darwin
   connectivity_plus:
     :path: Flutter/ephemeral/.symlinks/plugins/connectivity_plus/macos
+  cupertino_http:
+    :path: Flutter/ephemeral/.symlinks/plugins/cupertino_http/darwin
   desktop_drop:
     :path: Flutter/ephemeral/.symlinks/plugins/desktop_drop/macos
   device_info_plus:
@@ -105,6 +111,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   audioplayers_darwin: 835ced6edd4c9fc8ebb0a7cc9e294a91d99917d5
   connectivity_plus: 4adf20a405e25b42b9c9f87feff8f4b6fde18a4e
+  cupertino_http: 94ac07f5ff090b8effa6c5e2c47871d48ab7c86c
   desktop_drop: 10a3e6a7fa9dbe350541f2574092fecfa345a07b
   device_info_plus: 4fb280989f669696856f8b129e4a5e3cd6c48f76
   file_picker: 7584aae6fa07a041af2b36a2655122d42f578c1a

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -248,6 +248,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.15.0"
+  cronet_http:
+    dependency: transitive
+    description:
+      name: cronet_http
+      sha256: "8e77bc6f203e0bc9126e6a9092508a3435dbcb04da3b53ed1a358909385c5e0e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.8.0"
   cross_file:
     dependency: transitive
     description:
@@ -264,6 +272,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
+  cupertino_http:
+    dependency: transitive
+    description:
+      name: cupertino_http
+      sha256: "82cbec60c90bf785a047a9525688b6dacac444e177e1d5a5876963d3c50369e8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -636,6 +652,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  http_profile:
+    dependency: transitive
+    description:
+      name: http_profile
+      sha256: "7e679e355b09aaee2ab5010915c932cce3f2d1c11c3b2dc177891687014ffa78"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0"
   image:
     dependency: "direct dev"
     description:
@@ -688,18 +712,10 @@ packages:
     dependency: transitive
     description:
       name: jni
-      sha256: c2230682d5bc2362c1c9e8d3c7f406d9cbba23ab3f2e203a025dd47e0fb2e68f
+      sha256: "8706a77e94c76fe9ec9315e18949cc9479cc03af97085ca9c1077b61323ea12d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
-  jni_flutter:
-    dependency: transitive
-    description:
-      name: jni_flutter
-      sha256: "8b59e590786050b1cd866677dddaf76b1ade5e7bc751abe04b86e84d379d3ba6"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.1"
+    version: "0.15.2"
   js:
     dependency: transitive
     description:
@@ -796,6 +812,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  native_dio_adapter:
+    dependency: "direct main"
+    description:
+      name: native_dio_adapter
+      sha256: "9bbfa5221fd287eb063962bbe6534290e5f87933e576fac210149fb80253b89a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.1"
   native_toolchain_c:
     dependency: transitive
     description:
@@ -912,10 +936,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "69cbd515a62b94d32a7944f086b2f82b4ac40a1d45bebfc00813a430ab2dabcd"
+      sha256: "149441ca6e4f38193b2e004c0ca6376a3d11f51fa5a77552d8bd4d2b0c0912ba"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.2.23"
   path_provider_foundation:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   flutter_secure_storage: ^10.2.0
   http: ^1.6.0
   dio: ^5.9.2
+  native_dio_adapter: ^1.5.1
   uuid: ^4.5.3
   collection: ^1.19.1
   pub_semver: ^2.2.0
@@ -58,8 +59,8 @@ flutter_launcher_icons:
   web:
     generate: true
     image_path: icon_source.png
-    background_color: '#080C1A'
-    theme_color: '#080C1A'
+    background_color: "#080C1A"
+    theme_color: "#080C1A"
 flutter:
   uses-material-design: true
   assets:

--- a/app/test/unit/chat/chat_provider_test.dart
+++ b/app/test/unit/chat/chat_provider_test.dart
@@ -1671,5 +1671,59 @@ void main() {
             'messages=${after.messages.map((m) => '(${m.id}, streaming=${m.isStreaming}, content="${m.content}")').toList()}',
       );
     });
+
+    // The voice-send path has the same shape as the text path: it inserts a
+    // voice placeholder + an empty assistant-streaming bubble and then awaits
+    // an SSE stream. Same iOS Dio buffering risk → same user contract: a
+    // stream that delivers no useful events within ~15 s must not leave the
+    // UI in dots state.
+    testWidgets('voice stream that emits no events within 15s does not leave the '
+        'UI in indefinite "streaming dots" state', (tester) async {
+      final fakeApi = _FakeApiClient();
+      final ctrl = fakeApi.enqueueVoiceStream();
+      addTearDown(() async {
+        if (!ctrl.isClosed) await ctrl.close();
+      });
+
+      final notifier = await _pumpTestApp(tester, fakeApi);
+
+      unawaited(
+        notifier.sendVoiceMessage(Uint8List.fromList([1, 2, 3]), 'audio/webm'),
+      );
+      await tester.pump();
+
+      // Precondition: the assistant-streaming placeholder is showing dots.
+      final initial = notifier.state.value!;
+      final initialPlaceholder = initial.messages.firstWhere(
+        (m) => m.id == 'assistant-streaming',
+        orElse: () =>
+            ChatMessage(id: 'missing', role: 'assistant', content: ''),
+      );
+      expect(
+        initialPlaceholder.isStreaming && initialPlaceholder.content.isEmpty,
+        isTrue,
+        reason:
+            'precondition: voice send should insert the dots-state '
+            'placeholder',
+      );
+
+      await tester.pump(const Duration(seconds: 15));
+      await tester.pumpAndSettle();
+
+      final after = notifier.state.value!;
+      final stillInDots = after.messages.any(
+        (m) =>
+            m.id == 'assistant-streaming' && m.isStreaming && m.content.isEmpty,
+      );
+      expect(
+        stillInDots,
+        isFalse,
+        reason:
+            'After 15s with no voice-stream progress the UI must exit the '
+            '"dots forever" state. Current: isSending=${after.isSending}, '
+            'error=${after.error}, '
+            'messages=${after.messages.map((m) => '(${m.id}, streaming=${m.isStreaming}, content="${m.content}")').toList()}',
+      );
+    });
   });
 }


### PR DESCRIPTION
Follow-ups to #760, which added an application-layer fallback for the iPhone/iPad "jumpy dots forever" bug. Two atomic commits.

## Commit 1 — `fix(app): extend SSE stall watchdog to voice message path`

`_streamVoiceMessage` has the same shape as the text path: optimistic placeholder + `await for` on an SSE stream. Same iOS Dio buffering risk. Mirrors the `Stream.timeout` + `_recoverStalledStream` pattern from #760 onto `api.sendVoiceMessage(...)`. Voice events don't include a `RunStartedEvent` prelude, so any event counts as progress and disarms the watchdog. TDD test pins the same user contract.

## Commit 2 — `fix(app): route Dio through NativeAdapter on iOS/macOS/Android`

Root-cause fix. `dart:io`'s `HttpClient` (Dio's default) buffers SSE bodies on iOS/iPadOS until the connection closes — that's why the watchdog in #760 has to exist. This commit wires `native_dio_adapter ^1.5.1` into `ApiClient`, which routes Dio through `cupertino_http` (NSURLSession) on iOS/macOS and `cronet_http` on Android. Both stream chunked transfers in real time, so the fallback fetch from #760 should typically not be needed.

- Web keeps Dio's `BrowserHttpClientAdapter` (already streams via `fetch`).
- `flutter test` keeps `dart:io`: `NativeAdapter` eagerly instantiates a native URLSession via `cupertino_http`, which needs the iOS/macOS platform binding that the test runner doesn't provide. Detected via `FLUTTER_TEST` env var.

## Test plan

- [x] `flutter test` — 886/886 pass.
- [x] `flutter analyze --fatal-infos` — no issues.
- [x] `flutter build macos` — reaches the link stage; pre-existing `ShareExtension` signing failure unrelated.
- [x] Both `ios/Podfile.lock` and `macos/Podfile.lock` updated with cupertino_http resolution.
- [ ] **On-device verification on iPhone/iPad**: send a chat message — assistant tokens must stream in real time (no "dots", no 12 s fallback fetch). Voice send must show the transcript and reply streaming as they arrive.
- [ ] **On-device verification on macOS**: same as above, no regression on web or Android.

## Stacking note

These are stacked atomic commits on one branch rather than two PRs because commit 2 logically supersedes commit 1's purpose (the watchdog only fires when buffering occurs; with `NativeAdapter` it shouldn't). Happy to split if reviewers prefer two PRs.