### PR TITLE
openspec: propose legacy-token removal + PAT management UI

### DIFF
--- a/openspec/changes/api-key-management-ui/design.md
+++ b/openspec/changes/api-key-management-ui/design.md
@@ -1,0 +1,170 @@
+## Context
+
+The API key surface is mostly built. Inventory:
+
+| Layer    | Status                                                                                                                                         |
+| -------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Storage  | `ApiKeyRecord` has `scopes: Vec<Scope>` and `expires_at: Option<DateTime>`                                                                     |
+| Resolver | `resolve_key` rejects expired keys (`crates/auth/src/api_keys.rs:102-105`) and applies scopes when building `AuthContext`                      |
+| REST     | `POST/GET/DELETE /api/users/me/api-keys`. `CreateApiKeyRequest` has `name` and `Option<Vec<String>>` scopes — but no expiry field              |
+| OpenAPI  | Documented; security scopes `api_keys:read` and `api_keys:write` defined                                                                       |
+| CLI      | `assistant api-keys list / create --scopes / revoke`                                                                                           |
+| Flutter  | `ApiKeysScreen` (list, create-name-only, revoke); `api_keys_provider.dart` (AsyncNotifier); route `/api-keys` registered but unlinked from nav |
+
+The only backend code change in this proposal is adding `expires_in_days`
+to `CreateApiKeyRequest`. Everything else is UI work and one settings link.
+
+## Decisions
+
+### Decision 1: Expiry shape — `expires_in_days` not `expires_at`
+
+The API accepts `expires_in_days: Option<u32>` rather than an absolute
+`expires_at: Option<DateTime<Utc>>`.
+
+Reasons:
+
+- Matches how users think ("expires in 90 days"), not how the database
+  stores it.
+- Avoids client/server clock-skew bugs at boundary values.
+- Server computes `expires_at = Utc::now() + Duration::days(n)` at create
+  time; the absolute timestamp is what's stored and returned in `ApiKeySummary`.
+- Trivially encodes "never" as `None` without overloading sentinel dates.
+
+Open hand: this rules out "expires at a specific calendar date" (e.g.,
+"end of fiscal year"). Acceptable — GitHub doesn't offer that either at
+PAT-create time, and a follow-up can add an absolute variant if real
+demand emerges.
+
+### Decision 2: Preset chips for expiry, not a date input
+
+The Flutter create dialog offers `30 days / 60 days / 90 days / 1 year /
+No expiry` as chip-style choices. No free-form numeric input, no calendar
+picker.
+
+Reasons:
+
+- 95% of PAT users pick a preset (GitHub, Slack, GitLab all bear this
+  out).
+- Free-form numeric input invites typos that go undetected ("3" instead
+  of "30").
+- Preset chips compress to a single row on mobile breakpoints.
+- "No expiry" gets a subdued warning hint so it's not the silent default.
+
+The default selection on the screen is `90 days`.
+
+### Decision 3: Scope picker — multi-select chips against the canonical set
+
+The scope picker enumerates the `ResourceKind × Action` combinations
+documented in `docs/authentication.md`:
+
+| Resource        | Actions allowed                      |
+| --------------- | ------------------------------------ |
+| `personas`      | `read`, `write`, `delete`            |
+| `conversations` | `read`, `write`, `delete`            |
+| `messages`      | `read`, `write`                      |
+| `skills`        | `read`, `write`, `delete`, `execute` |
+| `interfaces`    | `read`, `write`, `manage`            |
+| `bindings`      | `read`, `write`                      |
+| `users`         | `read`, `write`, `manage`            |
+| `org`           | `read`, `manage`                     |
+| `api_keys`      | `read`, `write`                      |
+| `spaces`        | `read`, `write`, `manage`            |
+
+Rendered as collapsible per-resource groups (10 groups, ~30 scopes total).
+On viewport <= 640 dp the groups render as accordion sections; on
+desktop they render as a 2-column grid.
+
+The picker submits `scopes: Vec<String>` in `"resource:action"` form,
+which is what the backend already expects.
+
+Default selection: empty (key has no scopes, falls back to user's space
+roles). This matches today's behaviour. Add a "Read everything" preset
+and a "Read + write everything" preset as quick-fills.
+
+### Decision 4: Nav discoverability — Settings entry, not top-level
+
+The screen does not deserve a top-level nav slot. Most users will create
+a key once and never visit the screen again. Surface it via
+Settings → API keys (or wherever the existing Settings landing routes).
+
+If no Settings landing screen exists, add a minimal one with a single
+list tile for now. Future settings entries (themes, notifications,
+personas-mgmt) can land beside it.
+
+### Decision 5: Date formatting — relative, with absolute on hover/tap
+
+`createdAt` and `expiresAt` render as relative strings ("3 days ago",
+"in 87 days"). On hover (desktop) or tap (mobile) the absolute timestamp
+is shown via tooltip / bottom sheet.
+
+Use `package:intl` (already a transitive dep via `flutter_localizations`)
+for absolute formatting. For relative, prefer a small in-app helper —
+`timeago` is a small package but adding a dep for ~10 lines of formatting
+isn't justified.
+
+### Decision 6: Keep the terminology "API key"
+
+Don't rename to "Personal access token" anywhere in code, models, OpenAPI,
+or CLI. The codebase consistently uses "API key" across all layers and
+the generated Flutter client uses `ApiKeySummary` etc. Renaming would
+touch ~50 identifiers and the generated client without changing behaviour.
+
+User-facing description copy can include "personal access token" as
+clarification — e.g., "API keys are personal access tokens for
+programmatic access to your account" — but the noun stays "API key".
+
+## Test surface
+
+**Backend:**
+
+- `POST /api/users/me/api-keys` with `expires_in_days: 30` → response has
+  `expires_at` ~30 days in the future (±1 minute).
+- `POST /api/users/me/api-keys` with `expires_in_days: None` →
+  `expires_at: null`.
+- `POST /api/users/me/api-keys` with `expires_in_days: 0` → 400 (don't
+  silently mint pre-expired keys).
+- `POST /api/users/me/api-keys` with `expires_in_days` larger than some
+  ceiling (e.g., 366) → 400. (Optional — GitHub allows 400 days; we can
+  match.)
+- Regression: existing tests that don't set `expires_in_days` continue to
+  pass with `expires_at: null`.
+
+**Flutter:**
+
+- Widget: create dialog renders the scope groups, the expiry chips, and
+  the name field; submitting builds the right `CreateApiKeyRequest`.
+- Widget: list tile renders relative dates and scope chips.
+- Widget: tapping "API keys" in Settings navigates to `/api-keys`.
+
+## Migration
+
+No data migration. New field is optional on the request; existing keys
+stay as they are. Generated Dart client picks up the new field via
+`make generate-flutter-client`.
+
+## Risks
+
+- **Picker complexity.** The scope picker with 10 resources × ~3 actions
+  each could overwhelm users who just want "a key that works". Mitigated
+  by the two presets ("Read everything" / "Read + write everything") and
+  by leaving "no scopes" as the default (falls back to space role).
+- **Backend mismatch on key submit.** If a user picks a scope that isn't
+  legal for their space role, the backend currently accepts it but the
+  key won't work in practice. This is pre-existing — out of scope here.
+  File a follow-up to validate scope subset at create time.
+- **Generated-client drift.** `expires_in_days` is a new field; any
+  Flutter callers of `createApiKey` outside `api_keys_provider.dart` need
+  to be checked. There shouldn't be any — `api_keys_provider.dart` is
+  the only call site as of writing.
+
+## Out of scope
+
+- `last_used_at` tracking. Wants a separate change because the write
+  amplification is non-trivial (every authenticated request touches the
+  row); we'd need a batched update strategy.
+- Copy-prefix-to-clipboard button on each row.
+- Expiry warning banners ("expires in 3 days").
+- Email notification when a key is about to expire.
+- A "regenerate" affordance (revoke + create new with same name and
+  scopes) — common in PAT UIs.
+- Bulk revoke / select-all.

--- a/openspec/changes/api-key-management-ui/proposal.md
+++ b/openspec/changes/api-key-management-ui/proposal.md
@@ -1,0 +1,112 @@
+## Why
+
+The `remove-legacy-token-auth` change makes API keys (`ask_live_…`) the only
+mechanism for programmatic access to the server (alongside short-lived JWTs
+from OAuth flows). After that change, the question "how does a user create or
+revoke a key from a browser?" becomes more pressing.
+
+Most of the API key surface already exists:
+
+- Backend: full CRUD at `/api/users/me/api-keys` (list, create, delete),
+  scope-aware via `Scope` from `assistant-core::identity`, expiry-aware
+  (`resolve_key` rejects expired keys at
+  `crates/auth/src/api_keys.rs:102-105`).
+- CLI: `assistant api-keys list / create --scopes / revoke`.
+- Flutter: `ApiKeysScreen` + `api_keys_provider.dart`, route registered at
+  `app_router.dart:374` as `AppRoutes.apiKeys = '/api-keys'`.
+
+What is missing, in order of severity:
+
+1. **The screen has no nav entry.** It's reachable only by typing `/api-keys`
+   into the address bar.
+2. **The create dialog only asks for a name.** There is no scope picker and
+   no expiry picker, even though the backend supports both. Every key is
+   created with default scopes and no expiry.
+3. **`CreateApiKeyRequest` has no `expires_at` field.** The store model and
+   `resolve_key` honour `expires_at`, but the create endpoint can't set it.
+4. **Date columns render raw RFC3339 strings.** "Created
+   `2026-04-12T13:22:09.181Z`" is not a useful UX for revocation decisions.
+
+This proposal closes those gaps at MVP scope. "Last used at" tracking,
+copy-prefix affordances, expiry warning banners, and scope-pretty-printing
+are out of scope and can ship as follow-ups if needed.
+
+## What Changes
+
+**Backend (`crates/web-ui/src/api/api_keys.rs`):**
+
+- Add `expires_in_days: Option<u32>` to `CreateApiKeyRequest`. When set,
+  the handler computes `expires_at = now + days` and persists it. When
+  `None`, key has no expiry (current behaviour).
+- Add `expires_at` to the underlying create call. No other backend changes
+  required — `resolve_key` already enforces expiry.
+
+**Flutter (`app/lib/features/api_keys/`):**
+
+- `_CreateApiKeyDialog`: add a scope picker (multi-select chips backed by
+  the canonical scope set) and an expiry picker (preset chips: 30 days /
+  60 days / 90 days / 1 year / no expiry). The "no expiry" option must
+  show a subdued warning hint.
+- `_ApiKeyTile`: render `createdAt` and `expiresAt` as relative timestamps
+  (`intl` `DateFormat.yMd().add_jm()` or `timeago` if already a workspace
+  dep). Render scope summary as chips when there are <=3, "N scopes" when
+  more.
+- Settings landing screen: add an "API keys" entry that navigates to
+  `/api-keys`. The screen is too power-user for a top-level nav slot; gate
+  discovery through Settings.
+
+**Generated client:**
+
+- `make dump-openapi` after the `CreateApiKeyRequest` change.
+- `make generate-flutter-client` so the Dart `CreateApiKeyRequest` builder
+  picks up the new field.
+
+**Docs:**
+
+- `docs/authentication.md`: document the `expires_in_days` field in the
+  create endpoint section. Add a one-paragraph "Managing keys in the web
+  UI" section pointing at Settings → API keys.
+
+## Capabilities
+
+### Added
+
+- `api-key-management`: a user can view, create, and revoke their own API
+  keys from the Flutter web/macOS app. Creation supports scope and expiry
+  selection.
+
+## Impact
+
+**Code:**
+
+- `crates/web-ui/src/api/api_keys.rs` — add `expires_in_days`, compute and
+  pass `expires_at` on create
+- `app/lib/features/api_keys/api_keys_screen.dart` — scope picker, expiry
+  picker, relative dates, scope chips
+- `app/lib/features/api_keys/api_keys_provider.dart` — pass new fields
+  through `createKey`
+- `app/lib/features/settings/settings_screen.dart` (or equivalent
+  Settings landing) — link to `/api-keys`
+- `openapi.json` — regenerated
+- `app/packages/assistant_api/` — regenerated
+
+**Out of scope (deliberate, can ship as follow-ups):**
+
+- `last_used_at` tracking — needs schema migration plus middleware writes;
+  worth a separate change with its own write-amplification analysis.
+- Copy-prefix button on rows.
+- Expiry warning banners ("3 days until expiry").
+- Scope-pretty-printing (`personas:read` → "Read personas").
+- Renaming the noun to "Personal access token" — codebase consistently
+  uses "API key" across model, OpenAPI, CLI, screen title; renaming is a
+  separate bikeshed.
+
+**Sequencing relative to `remove-legacy-token-auth`:**
+
+- This change does NOT block `remove-legacy-token-auth`. The minimal
+  existing ApiKeysScreen + CLI is sufficient for users who lose the legacy
+  bypass.
+- Ship `remove-legacy-token-auth` first (security cleanup); ship this
+  second.
+- The two changes share the same review surface for the create flow
+  (Flutter dialog), so coordinating PR order avoids merge churn.

--- a/openspec/changes/api-key-management-ui/specs/api-key-management/spec.md
+++ b/openspec/changes/api-key-management-ui/specs/api-key-management/spec.md
@@ -1,0 +1,144 @@
+## ADDED Requirements
+
+### Requirement: API key creation accepts an expiry in days
+
+The `POST /api/users/me/api-keys` endpoint SHALL accept an optional
+`expires_in_days` field of type unsigned integer. When set the server
+SHALL compute `expires_at = now() + days` and persist it on the new
+record. When absent or null the new key SHALL have no expiry.
+
+#### Scenario: Key created with a 90-day expiry
+
+- **WHEN** a client submits `POST /api/users/me/api-keys` with body
+  `{"name": "ci", "expires_in_days": 90}`
+- **THEN** the response SHALL include an `expires_at` ISO-8601 timestamp
+  approximately 90 days in the future (±1 minute)
+- **THEN** the persisted record's `expires_at` SHALL match the response
+- **THEN** subsequent `GET /api/users/me/api-keys` SHALL list the key with
+  the same `expires_at`
+
+#### Scenario: Key created without expiry
+
+- **WHEN** a client submits `POST /api/users/me/api-keys` with body
+  `{"name": "ci"}` (no `expires_in_days` field)
+- **THEN** the response SHALL have `expires_at: null`
+- **THEN** the persisted record's `expires_at` SHALL be `None`
+
+#### Scenario: Zero or negative expiry rejected
+
+- **WHEN** a client submits `POST /api/users/me/api-keys` with
+  `expires_in_days: 0`
+- **THEN** the server SHALL respond with `400 Bad Request` and a clear
+  error message
+- **THEN** no record SHALL be persisted
+
+#### Scenario: Expiry above ceiling rejected
+
+- **WHEN** a client submits `POST /api/users/me/api-keys` with
+  `expires_in_days` greater than `400`
+- **THEN** the server SHALL respond with `400 Bad Request`
+- **THEN** no record SHALL be persisted
+
+### Requirement: API keys screen is reachable from Settings
+
+The Flutter app SHALL surface a navigation entry to the API keys
+management screen from a Settings landing screen. The API keys screen
+SHALL NOT occupy a top-level nav shell destination.
+
+#### Scenario: Settings entry navigates to API keys
+
+- **WHEN** the user opens the Settings landing screen AND taps the
+  "API keys" entry
+- **THEN** the router SHALL navigate to `/api-keys`
+- **THEN** the existing `ApiKeysScreen` SHALL render
+
+#### Scenario: API keys screen not in top-level nav
+
+- **WHEN** the nav shell renders on any breakpoint (desktop rail,
+  tablet hamburger, mobile bottom bar)
+- **THEN** "API keys" SHALL NOT appear as a primary or overflow nav
+  destination
+- **THEN** the only path to `/api-keys` SHALL be via Settings or a
+  direct URL
+
+### Requirement: API key create dialog supports scope and expiry selection
+
+The Flutter API key create dialog SHALL allow the user to pick a set of
+scopes and an expiry duration in addition to a name.
+
+#### Scenario: Dialog renders all three inputs
+
+- **WHEN** the user taps the floating action button on `/api-keys`
+- **THEN** the create dialog SHALL render a name text field, a scope
+  picker, and an expiry chip row
+- **THEN** the expiry chip row SHALL default to the `90 days` chip
+  selected
+- **THEN** the scope picker SHALL default to no scopes selected
+
+#### Scenario: Submit with selected scopes
+
+- **WHEN** the user enters a name, selects `personas:read` and
+  `conversations:write` in the scope picker, and submits
+- **THEN** the request body SHALL include
+  `"scopes": ["personas:read", "conversations:write"]`
+
+#### Scenario: Submit with selected expiry
+
+- **WHEN** the user selects the `30 days` chip and submits
+- **THEN** the request body SHALL include `"expires_in_days": 30`
+
+#### Scenario: Submit with "No expiry"
+
+- **WHEN** the user selects the `No expiry` chip and submits
+- **THEN** the request body SHALL OMIT `expires_in_days` (or send it
+  as `null`)
+- **THEN** the chip SHALL be visually annotated with a subdued warning
+  hint before submission
+
+#### Scenario: "Read everything" preset
+
+- **WHEN** the user taps the `Read everything` quick-fill button
+- **THEN** all `<resource>:read` scopes SHALL become selected
+- **THEN** all non-read scopes SHALL be deselected
+
+#### Scenario: "Read + write everything" preset
+
+- **WHEN** the user taps the `Read + write everything` quick-fill button
+- **THEN** all `<resource>:read` and `<resource>:write` scopes SHALL
+  become selected
+- **THEN** all other actions (delete, execute, manage) SHALL be
+  deselected
+
+### Requirement: API key list tile shows human-readable metadata
+
+Each tile in the API keys list SHALL render the key's creation date and
+expiry as relative timestamps, and SHALL summarise scopes.
+
+#### Scenario: Relative dates
+
+- **WHEN** a key was created 3 days ago
+- **THEN** the tile SHALL render "Created 3 days ago" (or the
+  locale-appropriate equivalent)
+- **WHEN** the user hovers (desktop) or long-presses (mobile) the date
+- **THEN** the absolute ISO-8601 timestamp SHALL be revealed in a
+  tooltip or bottom sheet
+
+#### Scenario: Expiry rendering
+
+- **WHEN** a key has `expires_at` 87 days in the future
+- **THEN** the tile SHALL render "Expires in 87 days" with subdued
+  styling
+- **WHEN** a key has `expires_at: null`
+- **THEN** the tile SHALL render "No expiry"
+
+#### Scenario: Scope summary, few scopes
+
+- **WHEN** a key has 1-3 scopes
+- **THEN** the tile SHALL render each scope as a small chip with the
+  `resource:action` label
+
+#### Scenario: Scope summary, many scopes
+
+- **WHEN** a key has more than 3 scopes
+- **THEN** the tile SHALL render the count as "N scopes" with an affordance
+  to expand the full list

--- a/openspec/changes/api-key-management-ui/tasks.md
+++ b/openspec/changes/api-key-management-ui/tasks.md
@@ -1,0 +1,100 @@
+## Tasks
+
+TDD discipline: every implementation task is preceded by a failing test.
+
+### Backend: `expires_in_days` on create
+
+- [ ] Write failing test: `POST /api/users/me/api-keys` with
+      `{"name": "t", "expires_in_days": 30}` → response has
+      `expires_at` set to ~30 days from now (±1 minute tolerance).
+- [ ] Write failing test: same endpoint with `expires_in_days: null` or
+      field absent → `expires_at: null`.
+- [ ] Write failing test: `expires_in_days: 0` → 400.
+- [ ] Write failing test: `expires_in_days: 401` → 400 (ceiling of 400
+      days, matching GitHub).
+- [ ] Add `expires_in_days: Option<u32>` to `CreateApiKeyRequest`
+      (`crates/web-ui/src/api/api_keys.rs:48`).
+- [ ] Compute `expires_at = Utc::now() + Duration::days(n)` in the create
+      handler, pass to the store record.
+- [ ] Validate the field server-side (`0` and `>400` → 400 with a clear
+      error body).
+- [ ] Regenerate `openapi.json` via `make dump-openapi`.
+
+### Generated Flutter client
+
+- [ ] Run `make generate-flutter-client`.
+- [ ] Verify the only diff in `app/packages/assistant_api/` is the new
+      field on `CreateApiKeyRequest` (plus serialization). No unrelated
+      churn.
+
+### Flutter: create dialog rebuild
+
+- [ ] Write failing widget test: opening the create dialog renders the
+      name field, the scope picker, and the expiry chip row.
+- [ ] Write failing widget test: submitting with no scopes selected
+      builds a `CreateApiKeyRequest` with `scopes: []` (or omitted).
+- [ ] Write failing widget test: selecting `personas:read` and
+      `conversations:write` builds a request with those two scope strings.
+- [ ] Write failing widget test: selecting the "90 days" chip sends
+      `expires_in_days: 90`.
+- [ ] Write failing widget test: selecting "No expiry" sends
+      `expires_in_days: null` (or omitted).
+- [ ] Write failing widget test: tapping "Read everything" preset selects
+      all `*:read` scopes and nothing else.
+- [ ] Build the scope picker widget (collapsible per-resource groups,
+      responsive layout: 1 col on <=640dp, 2 cols on desktop).
+- [ ] Build the expiry chip row: 30 / 60 / 90 / 1y / No expiry, default
+      90, "No expiry" with subdued warning hint.
+- [ ] Build the "Read everything" and "Read + write everything"
+      quick-fill buttons.
+- [ ] Wire the new fields through `api_keys_provider.dart`
+      `createKey({String name, List<String> scopes, int? expiresInDays})`.
+- [ ] Keep the existing "key created, copy to clipboard" success state
+      unchanged.
+
+### Flutter: list rendering
+
+- [ ] Write failing widget test: tile renders relative `createdAt`
+      ("3 days ago"); on hover (desktop) or long-press (mobile) shows
+      absolute timestamp.
+- [ ] Write failing widget test: tile with `expiresAt` shows "expires in
+      N days" with subdued styling; tile with null `expiresAt` shows
+      "No expiry".
+- [ ] Write failing widget test: tile with <=3 scopes renders them as
+      chips; tile with >3 scopes renders "N scopes" with a tap-to-expand.
+- [ ] Implement a small `relativeDate(DateTime)` helper in
+      `app/lib/shared/time/` (no new package dep).
+- [ ] Update `_ApiKeyTile` to render the new subtitle layout.
+
+### Flutter: settings entry
+
+- [ ] Write failing widget test: from the settings landing screen,
+      tapping "API keys" navigates to `/api-keys`.
+- [ ] If a settings landing screen does not exist, create a minimal one
+      under `app/lib/features/settings/` with a single list tile linked
+      to `/api-keys`. Register the route.
+- [ ] Add the settings entry to the nav shell overflow destinations
+      (`_NavDest` in `app/lib/shared/nav_shell.dart`). The API-keys
+      screen is _not_ a top-level nav entry — it's reachable through
+      Settings.
+
+### Docs
+
+- [ ] `docs/authentication.md`: document `expires_in_days` in the create
+      endpoint description; add a "Managing keys in the web UI"
+      subsection that points at Settings → API keys.
+
+### Final sweep
+
+- [ ] `make lint && make format && make test`.
+- [ ] `cd app && flutter analyze && flutter test`.
+- [ ] Smoke test (web): log in, navigate Settings → API keys, create a
+      key with 90-day expiry and `personas:read` scope. Verify it appears
+      in the list with the right metadata, copy it to clipboard, revoke
+      it.
+- [ ] Smoke test (CLI): `assistant api-keys list` shows the same keys
+      created via the UI; `assistant api-keys revoke <id>` reflects in
+      the UI after refresh.
+- [ ] Smoke test: create a key with `expires_in_days: 1` via the UI,
+      manually fast-forward the system clock (or use a test record), and
+      verify `resolve_key` rejects it with 401.

--- a/openspec/changes/remove-legacy-token-auth/design.md
+++ b/openspec/changes/remove-legacy-token-auth/design.md
@@ -1,0 +1,413 @@
+## Context
+
+The current bearer-token resolver (`resolve_bearer` in `crates/web-ui/src/auth.rs:83`
+and the mirror in `crates/auth/src/middleware.rs:107`) has three branches:
+
+1. JWT validation
+2. API key resolution (prefix `ask_live_`)
+3. **Legacy static-token match** — if the configured `ASSISTANT_WEB_TOKEN`
+   string equals the bearer, return a pre-built org-admin `AuthContext`.
+
+Branch 3 is the bypass. It has no user binding, no scope, no audit identity
+beyond `client_id: "legacy"`, and any holder of the string is an org admin.
+
+The same env var doubles as the initial admin-password seed in
+`crates/auth/src/bootstrap.rs:45`. Two distinct roles, one variable name.
+
+The web `/login` POST handler (`crates/web-ui/src/auth.rs:394`) accepts a single
+`token: String` form field and runs it through `resolve_bearer`. In practice
+this means the only thing a fresh deployment can paste there is the legacy
+token — JWTs and API keys can be sent on every request directly. So killing
+branch 3 without rebuilding `/login` would leave the page broken.
+
+Email+password auth already exists at `POST /oauth/authorize`
+(`crates/web-ui/src/oauth/authorize.rs:171`) and uses `argon2id` via
+`password::verify_password`. The user store has the hashed password.
+
+## Decisions
+
+### Decision 1: One bundled change, not two
+
+Removing the bypass and rebuilding the login form are technically separate but
+operationally inseparable. Doing only A leaves the login form broken; doing
+only B leaves the security hole. Bundling avoids a window where users can't
+log in via the UI.
+
+### Decision 2: Kill `ASSISTANT_WEB_TOKEN` entirely
+
+Both roles go away:
+
+- **As a bearer bypass** — gone with branch 3.
+- **As a seed password** — bootstrap always generates a random 24-char password
+  and writes it to `admin_credentials_file` with mode 0600
+  (`crates/web-ui/src/install.rs:94`). That file already exists in the migration
+  flow; we just remove the `ASSISTANT_WEB_TOKEN` branch in `bootstrap.rs:45`.
+
+Rejected alternative: keep `ASSISTANT_WEB_TOKEN` as seed-only. Adds a code path
+nobody will exercise after the first run, and keeping the env var name alive
+invites confusion (operators will paste it into Bearer headers expecting it to
+work).
+
+### Decision 3: Delete server-side `/login` entirely — Flutter owns login UI
+
+This decision changed mid-proposal once we discovered the full
+`AssistantContext` credential model (see Decision 5). The original plan
+was to rebuild `/login`'s POST handler to accept email+password and set a
+session cookie. That plan no longer fits because:
+
+- The Flutter SPA is the only browser-facing UI. It has its own `/login`
+  route rendered client-side by `login_screen.dart`.
+- An unauthenticated request to `/login` hits the SPA fallback (the
+  catch-all that serves `index.html` for unknown paths), which loads the
+  Flutter app, which navigates to its client-side `/login`.
+- The Flutter app needs **access + refresh tokens** (to populate
+  `OAuthCredentials`), not a session cookie. The right protocol is
+  `/oauth/authorize` + `/oauth/token` via PKCE — which already exists and
+  is what `login_screen.dart`'s "email + password mode" already calls.
+
+So the server-side `/login` GET and POST handlers, the `LoginForm` struct,
+the `login_html` renderer, and the `SESSION_COOKIE` machinery in
+`crates/web-ui/src/auth.rs` are **deleted, not rebuilt**. The capability
+spec's old "Email + password login form" requirement, which described an
+HTML form posted to the server, is replaced by "Flutter login screen uses
+OAuth2 PKCE to obtain credentials".
+
+What stays:
+
+- `/oauth/authorize` already renders an email+password form (for browser
+  clients that bounce through it during the auth code flow). No change
+  needed.
+- `/oauth/device/verify` similarly already takes email+password for the
+  device-code flow. No change.
+- The `assistant_session` cookie semantics — they're set by the
+  `/oauth/callback` handler today and remain unchanged.
+
+Rejected alternative: keep `/login` as a thin email+password form that
+itself initiates the OAuth flow (server-side redirect to `/oauth/authorize`
+on submit). Adds a second login surface for no real user benefit; better
+to make the SPA the single owner.
+
+### Decision 4: Recovery via `assistant admin reset-password`
+
+Existing deployments using `ASSISTANT_WEB_TOKEN` need a way to log in once the
+bypass is gone. Two cases:
+
+- **Migrated deployment (has an admin user in `org.db`)** — use the
+  credentials in `admin_credentials_file`, or run reset-password to pick a new
+  one.
+- **Never-migrated deployment** — the bootstrap path runs on every fresh
+  startup if no admin user exists. After this change, on first boot post-
+  upgrade, the bootstrap creates the user and writes the credentials file.
+
+`assistant admin reset-password` is a small but necessary new affordance: a
+CLI that opens `org.db` directly, finds the user, prompts for a new password
+via TTY, and updates the `password_hash`. No JWT auth required because it
+runs as the OS user with file access to the SQLite database. Mirrors the
+existing `account change-password` CLI but without needing a session.
+
+### Decision 5: Collapse `AssistantContext` to OAuth2-only credentials
+
+`AssistantContext` is a richer model than initially scoped. It carries:
+
+```dart
+enum AuthMode { legacyToken, oauth2 }
+
+class AssistantContext {
+  final String?            authToken;        // legacy slot
+  final OAuthCredentials?  oauthCredentials; // oauth slot
+  final AuthMode           authMode = legacyToken;  // default!
+  String? get effectiveToken { /* branches on authMode */ }
+  bool    get needsTokenRefresh => /* oauth-only guard */;
+}
+```
+
+`AuthMode.legacyToken` is "ye olde" on the client side — the same era and
+mental model as the server's `ASSISTANT_WEB_TOKEN` bypass. `AuthMode.oauth2`
+already has full plumbing (refresh tokens, expiry checks, the 401
+interceptor's refresh logic). The honest endpoint is to remove the dead
+mode, not merely narrow how it's filled:
+
+```
+BEFORE                              AFTER
+─────────────────────────           ─────────────────────────────
+
+class AssistantContext {            class AssistantContext {
+  String?        authToken;           // authToken: REMOVED
+  OAuthCreds?    oauthCreds;          OAuthCreds  oauthCreds;  // now required
+  AuthMode       authMode;            // authMode: REMOVED
+  effectiveToken {…branches…}        String get bearerToken =>
+}                                      oauthCredentials.bearerToken;
+                                     bool get needsTokenRefresh =>
+                                       oauthCredentials.isExpired();
+                                   }
+```
+
+Knock-on cleanups:
+
+- `effectiveToken` collapses to a direct field access — rename to
+  `bearerToken` to drop the misleading prefix while we're touching it.
+- `needsTokenRefresh` loses its mode guard.
+- `copyWith`'s `clearAuthToken` flag is removed; `clearOAuthCredentials`
+  stays (signals "log out this context but keep it listed").
+- `toJson` / `fromJson` drop the `authMode` key on write. `fromJson` keeps
+  reading it for one release to support migration (see Decision 7).
+- ~40 references in `app/test/unit/contexts/` and `app/test/unit/auth/`
+  switch from `authToken: 'tok'` to `oauthCredentials: OAuthCredentials(...)`.
+
+**login_screen.dart.** Drops the legacy-token toggle and the `_tokenCtrl`
+path. The "email + password" branch — which already calls the OAuth2 PKCE
+flow — becomes the only path.
+
+**ConnectionScreen.** Keeps the URL field. The token field is replaced
+with email + password. On submit, the screen runs the OAuth2 PKCE flow
+against the chosen server's `/oauth/authorize` + `/oauth/token`, captures
+the access + refresh tokens, and saves the context with `oauthCredentials`
+populated. The `?_token=` query-param handling is deleted; `?_url=`
+continues to pre-fill the URL field only and no longer auto-submits.
+
+**Edit-context.** The inline token field is removed. The screen shows
+name + URL (editable) plus a "Re-authenticate" button that launches the
+OAuth2 PKCE flow against the context's stored URL; on success it writes
+fresh `oauthCredentials`. No `authToken` to edit.
+
+**The embedded-server path on macOS** does not need credentials at all
+(server is local, started by the app, no auth). ConnectionScreen's
+existing embedded-mode branch is unchanged.
+
+**OIDC mode interaction.** `/oauth/authorize` already redirects to the
+upstream IdP when the server is configured in OIDC mode. The Flutter
+screens don't need to know — they kick off PKCE, the browser does the
+IdP dance, and the callback delivers tokens.
+
+### Decision 6: E2E rig skips the UI auth flow via localStorage seed
+
+The Playwright suite under `crates/web-ui/e2e/` depends on the legacy token
+in three places:
+
+- `playwright.config.ts:82-83` — server boot uses `--auth-token test-token`
+- 4 test specs use `page.goto('/setup?_token=test-token')` — relying on
+  ConnectionScreen's `?_token=` auto-submit which is being removed
+- The `apiGet` helper sends `Authorization: Bearer test-token` directly
+
+The migration plan needs to account for the `?_token=` auto-submit being
+deleted. Three options were considered:
+
+- (a) Have tests log in via the new email+password form. Reliable but adds
+  4 form interactions per spec and exercises auth UX in visual-regression
+  tests that don't care about it.
+- (b) Pre-seed `AssistantContext` directly into `localStorage` via
+  `page.evaluate()` before navigation. Skips auth UI entirely.
+- (c) Set `Authorization` via Playwright `extraHTTPHeaders`. Doesn't work —
+  the Flutter dio client builds the header from the stored context, not
+  from the page's headers.
+
+Option (b) wins. The end-to-end migration:
+
+1. Drop `--auth-token` from the webServer command.
+2. Add a Playwright `globalSetup` that:
+   - Polls `/health` until the server is up,
+   - Reads the admin password from `~/.assistant/orgs/default/admin_credentials.txt`
+     (written by the bootstrap on first start, mode 0600),
+   - Runs the OAuth password→code→token dance against `/oauth/authorize`
+     and `/oauth/token` to obtain a short-lived JWT,
+   - `POST /api/users/me/api-keys` with that JWT to mint an `ask_live_…`
+     key scoped to whatever the e2e suite needs,
+   - Writes the key to `process.env.E2E_API_KEY`.
+3. Add `tests/_helpers/seedContext.ts` exporting `seedContext(page)`. It
+   uses `page.evaluate()` to write a JSON-encoded `AssistantContext` (with
+   `authToken = process.env.E2E_API_KEY`) into `localStorage` under the
+   `shared_preferences` keys the Flutter app reads. The exact key names
+   come from `app/lib/features/contexts/data/context_repository.dart`.
+4. Replace every `page.goto('/setup?_token=...')` with
+   `await seedContext(page); await page.goto('/chat');`.
+5. `apiGet` is unchanged — same Bearer shape, value comes from
+   `process.env.E2E_API_KEY`.
+
+After this, e2e exercises the real production auth path (API key through
+`resolve_bearer` branch 2) instead of a bypass that doesn't exist for real
+users. The `globalSetup` adds ~2 seconds to test start; visual-regression
+tests already do `FLUTTER_SETTLE_MS = 3000` per spec so it's noise.
+
+Rejected alternative: add an env-gated `ASSISTANT_TEST_SEED_API_KEY` flag
+to the bootstrap that mints a deterministic key on first start. Faster (no
+OAuth round-trip) but bakes a test-only code path into the production
+binary; rejected on principle.
+
+### Decision 7: Migrate existing legacy-token contexts on first launch
+
+Local installs in the wild may have one or more `AssistantContext` rows
+persisted in `localStorage` (web) or `flutter_secure_storage` (native)
+with `authMode == "legacyToken"` and `authToken` populated. After the
+model collapses, those rows have no usable credentials.
+
+Three options were considered:
+
+- (a) **Drop legacy contexts silently on launch.** Surprising — users
+  lose servers they configured and don't know why.
+- (b) **Keep rows; mark them as needing re-authentication.** Surface
+  them in the contexts list with a "Sign in again" affordance. Users see
+  what they had and re-auth on demand.
+- (c) **Upgrade in place.** If `authToken` happens to decode as a JWT,
+  mint a refresh token server-side and write to `oauthCredentials`. Too
+  clever; doesn't work for the common case (a real static legacy token);
+  not worth the code path.
+
+Option (b) wins. The migration:
+
+1. `AssistantContext.fromJson` keeps reading the `authMode` key for one
+   release. When it sees `"legacyToken"`, it constructs a context with
+   `oauthCredentials: null` and an additional in-memory flag
+   `requiresReauth: true` (similar in spirit to `credentialsCorrupted`).
+2. `ContextRepository.loadContexts` runs this conversion on every read.
+   The persisted JSON is rewritten without `authMode` and without any
+   secret slot the next time `saveContext` runs.
+3. The contexts list / switcher screen shows rows with
+   `requiresReauth == true` in a degraded state ("Sign in again" instead
+   of "Connect").
+4. Selecting such a row routes through the OAuth2 PKCE flow against the
+   context's stored URL.
+5. After a successful re-auth, the row gets fresh `oauthCredentials` and
+   `requiresReauth` flips to false.
+
+The persisted JSON maintains **forward** compatibility for new clients:
+`fromJson` ignores unrecognised keys (`authMode`, etc.) gracefully.
+
+## Auth resolution: before / after
+
+```
+BEFORE                              AFTER
+─────────────────────────────       ─────────────────────────────
+
+Authorization: Bearer <X>           Authorization: Bearer <X>
+        │                                   │
+        ▼                                   ▼
+  ┌──────────┐                        ┌──────────┐
+  │   JWT?   │─yes→ ctx               │   JWT?   │─yes→ ctx
+  └──────────┘                        └──────────┘
+        │                                   │
+        ▼                                   ▼
+  ┌──────────┐                        ┌──────────┐
+  │ ask_live │─yes→ ctx               │ ask_live │─yes→ ctx
+  └──────────┘                        └──────────┘
+        │                                   │
+        ▼                                   ▼
+  ┌──────────┐                            401
+  │  legacy  │─yes→ admin
+  └──────────┘
+        │
+       401
+```
+
+## Login surface: before / after
+
+```
+BEFORE                              AFTER
+─────────────────────────────       ─────────────────────────────
+
+Server-rendered /login form         No server-rendered login form.
+  POST /login token=<string>         Flutter SPA fallback serves
+        │                            index.html for /login; SPA
+        ▼                            renders its own login UI.
+  resolve_bearer() →                       │
+   JWT / API key / legacy                  ▼
+        │                            Flutter login UI runs
+        ▼                            OAuth2 PKCE against
+  jwt_manager.sign + Set-Cookie       /oauth/authorize + /oauth/token
+                                            │
+                                            ▼
+                                     OAuthCredentials persisted
+                                     in flutter_secure_storage
+```
+
+The server keeps `/oauth/authorize` and `/oauth/token` unchanged. The
+`/login` GET, POST, `LoginForm`, `login_html`, and the `SESSION_COOKIE`
+machinery in `crates/web-ui/src/auth.rs` are deleted.
+
+## Test surface
+
+**Server tests to add (failing first, TDD):**
+
+- Bearer-only requests with no token → 401 (regression: same as today minus
+  branch 3).
+- `resolve_bearer` no longer has a legacy branch — unit test asserts only
+  JWT + API key paths exist.
+- Request to `GET /login` → SPA fallback (200 with index.html), not the old
+  server-rendered HTML form.
+
+**Server tests to delete:**
+
+- `crates/auth/src/middleware.rs:393` — `extract_legacy_token`.
+- `crates/web-ui/src/auth.rs:608` — `bearer_legacy_token_produces_admin_context`.
+- All `crates/web-ui/src/auth.rs` tests that exercise `LoginForm`,
+  `login_submit`, `login_page`, or `logout` (the entire suite around the
+  deleted handlers).
+- Any test that constructs `AuthState` with `legacy_token: Some(...)`.
+
+**Flutter tests to add:**
+
+- Widget test: login screen renders only email + password fields (no token
+  toggle, no token field). Submit triggers OAuth PKCE — verify via mocked
+  `OAuthClient`.
+- Widget test: ConnectionScreen in remote mode renders URL + email +
+  password fields. Submit triggers OAuth PKCE against the entered URL.
+- Widget test: `/setup?_url=https://x` pre-fills URL only; no auto-submit.
+- Widget test: `/setup?_token=x` ignores the param entirely.
+- Widget test: edit-context renders no token field; "Re-authenticate"
+  button triggers OAuth PKCE.
+- Unit test: `AssistantContext` has no `authToken` field; constructor takes
+  required `oauthCredentials`.
+- Unit test: `AssistantContext.fromJson` reading legacy JSON with
+  `authMode == "legacyToken"` and `authToken` → context with
+  `requiresReauth: true`, `oauthCredentials: null`.
+- Unit test: `AssistantContext.toJson` does not write `authMode` or
+  `authToken`.
+
+**Flutter tests to delete/rewrite:**
+
+- `app/test/widget/login/login_screen_test.dart` — delete the "legacy
+  token mode" scenarios (lines 43, 85 and similar).
+- `app/test/unit/contexts/context_model_test.dart` — replace every
+  `makeCtx(authToken: 'tok')` with `makeCtx(oauthCredentials: ...)`.
+  Delete the `effectiveToken returns authToken for legacyToken mode`
+  scenario (line 187) and similar legacy-mode assertions. Estimated ~25
+  references.
+- `app/test/unit/contexts/context_repository_test.dart`,
+  `context_repository_upsert_test.dart` — same sweep, ~15 references.
+- `app/test/unit/auth/auth_provider_test.dart` — same sweep, ~5
+  references.
+- `app/test/widget/contexts/edit_context_test.dart` — drop the
+  `authToken: 'my-token'` fixture path; assert that the screen has no
+  token field.
+
+## Migration sequencing
+
+1. Land the change behind a feature-detection-friendly migration: on first
+   startup after the upgrade, if no admin user exists in `org.db`, run the
+   bootstrap and log the credentials file path prominently.
+2. Release notes call out: "If you were using `ASSISTANT_WEB_TOKEN`, look up
+   your admin password in `~/.assistant/orgs/{slug}/admin_credentials.txt`
+   or run `assistant admin reset-password user@host`."
+3. For schorschvm specifically: verify the admin credentials file before
+   restarting the service (covered by the existing multi-org-cutover babysit
+   procedure documented at `docs/operations/multi-org-cutover.md`).
+
+## Risks
+
+- **Operator lockout.** If a deployment never ran the migration (legacy
+  single-user setup with `assistant.db` and `ASSISTANT_WEB_TOKEN` only), and
+  also never wrote `admin_credentials_file`, the operator has no way in. The
+  reset-password CLI is the safety net but they need SSH access. Acceptable
+  risk because (a) bootstrap writes the file on the very first migration, (b)
+  pre-existing migrations already happened in 2026-04, so most installs are
+  through it, and (c) reset-password runs as a local OS user.
+- **Forgotten doc surface.** Search before merge: `rg "ASSISTANT_WEB_TOKEN|--auth-token|legacy.token"`.
+- **OpenAPI consumers.** Anyone reading `openapi.json` will see different
+  bearer-auth wording. No breaking change to the protocol, just to the prose.
+
+## Out of scope
+
+- API keys — kept as-is. They're scoped programmatic credentials with audit
+  identity, not "olde tokens".
+- OIDC mode — kept. Username/password is still the user experience at the IdP.
+- OAuth2 authorize / device flows — kept; already email+password.
+- JWT format, issuer, signing key rotation — unchanged.

--- a/openspec/changes/remove-legacy-token-auth/proposal.md
+++ b/openspec/changes/remove-legacy-token-auth/proposal.md
@@ -1,0 +1,182 @@
+## Why
+
+The web UI's `/login` page asks users to paste a "token" instead of an email and
+password, and the auth middleware accepts a single static string
+(`ASSISTANT_WEB_TOKEN`) as a global org-admin bypass. The bypass branch sits in
+`resolve_bearer` after JWT validation and API key resolution and grants full
+org-admin authority to anyone who knows the value — with no user binding, no
+scope, no audit trail. The crate's own doc-comments label it the "legacy" path
+and a "migration bridge".
+
+Meanwhile, the system already runs a complete OAuth2 server with email/password
+authentication (`POST /oauth/authorize`), argon2id password hashing
+(`crates/auth/src/password.rs`), and a user store seeded by the migration
+bootstrap (`crates/auth/src/bootstrap.rs`). The legacy bypass is the only
+shortcut around it, and the token-paste login form is the only user-facing
+affordance that still depends on it. Removing both unifies authentication on
+the password flow that already exists.
+
+## What Changes
+
+**Server:**
+
+- Remove `legacy_token` and `legacy_context` fields from `AuthState`
+  (`crates/auth/src/middleware.rs`) and `WebAuthConfig`
+  (`crates/web-ui/src/auth.rs`).
+- Remove the third branch of `resolve_bearer` (the legacy-token match) and
+  the matching branch in `AuthExtractor::from_request_parts`.
+- Remove `--auth-token` / `ASSISTANT_WEB_TOKEN` from the `assistant webui serve`
+  CLI args (`crates/web-ui/src/lib.rs:91`) and the bootstrap seed-password
+  path (`crates/auth/src/bootstrap.rs:45`). Always generate a random initial
+  password and write it to the existing `admin_credentials_file` (0600).
+- **Delete the server-side `/login` page entirely**: GET/POST handlers,
+  `LoginForm`, `login_html`, `SESSION_COOKIE` machinery in
+  `crates/web-ui/src/auth.rs`. The Flutter SPA owns login UX going forward
+  (see Decision 3). Unauthenticated requests to `/login` hit the SPA
+  catch-all, which loads the Flutter app, which renders its own login
+  screen.
+
+**Flutter app:**
+
+The Flutter `AssistantContext` model has two parallel credential slots
+(`authToken` for legacy mode, `oauthCredentials` for OAuth2 mode) selected
+by an `authMode` enum. After this change the legacy mode and its slot are
+gone — `oauthCredentials` becomes the only credential storage:
+
+- **Collapse `AssistantContext`** (`app/lib/features/contexts/models/context_model.dart`).
+  Remove `authToken`, `AuthMode`, the `effectiveToken` branch. `oauthCredentials`
+  becomes required. Add `bearerToken` getter as a direct accessor. `fromJson`
+  keeps reading the `authMode` key for one release to support migration.
+- **`/login`** (`app/lib/features/login/login_screen.dart`) — drop the
+  legacy-token toggle, `_tokenCtrl`, `_tokenFocus`, `_tokenVisible`, the
+  `token` branch of `_submit`. The "email + password" branch — which
+  already calls the OAuth2 PKCE flow — becomes the only path.
+- **`/setup`** (`app/lib/features/connection/connection_screen.dart`) — replace
+  the token field with email + password fields. The URL field stays.
+  Submit runs the OAuth2 PKCE flow against the entered URL. Delete the
+  `?_token=` query-param branch and its auto-submit. Keep `?_url=`
+  pre-fill (no auto-submit).
+- **`/contexts/{id}/edit`** (`app/lib/features/contexts/screens/edit_context_screen.dart`)
+  — remove the inline token field. Add a "Re-authenticate" button that
+  runs the OAuth2 PKCE flow against the context's stored URL and writes
+  fresh `oauthCredentials`. Name and URL stay editable.
+- **Migration of existing contexts.** On load, contexts whose persisted
+  JSON contains `authMode == "legacyToken"` are surfaced in a degraded
+  state (`requiresReauth: true`, `oauthCredentials: null`). The context
+  switcher / list shows them with a "Sign in again" affordance that
+  triggers the OAuth2 PKCE flow. See Decision 7 in design.md.
+
+**Operations:**
+
+- New CLI: `assistant admin reset-password` — read an email, prompt for a new
+  password, update the user. Recovery path for deployments that have lost
+  access (or were running pure legacy-token before the upgrade).
+- Migration note in release notes pointing operators at the
+  `admin_credentials_file` written during the first-run bootstrap.
+
+**E2E test rig (`crates/web-ui/e2e/`):**
+
+The `/setup?_token=…` deep-link goes away (the token field is removed from
+ConnectionScreen). Tests skip the UI auth flow entirely by seeding the
+active context directly in `localStorage` before navigation.
+
+- Drop `--auth-token test-token` from `playwright.config.ts` webServer cmd.
+- Add a Playwright `globalSetup` that, once the server is up, reads the
+  admin password from `admin_credentials_file`, performs the OAuth
+  password→code→token dance against `/oauth/authorize` + `/oauth/token` to
+  obtain a JWT, then `POST /api/users/me/api-keys` to mint an
+  `ask_live_…` key. The key is exposed to tests via `process.env.E2E_API_KEY`.
+- Add a Playwright `test.beforeEach` helper that uses `page.evaluate()` to
+  write an `AssistantContext` (with `oauthCredentials.accessToken` = the
+  minted API key) into `localStorage` under the `shared_preferences` keys
+  the Flutter app reads from, then navigates straight to `/chat`. Replaces
+  every existing `page.goto('/setup?_token=...')` call.
+- Replace `const AUTH_TOKEN = "test-token"` in each spec with a read of
+  `process.env.E2E_API_KEY` (via the shared helper).
+- `apiGet()` continues unchanged — it sends `Authorization: Bearer <token>`
+  directly and the value is now the minted API key.
+
+**Docs:**
+
+- `docs/authentication.md` — delete "Quick start (single-token mode)" section,
+  drop step 4 from "Auth middleware resolution order", add a password-login
+  quick start.
+- `docs/web-ui.md` — fix Quick start, CLI options table, plain-HTTP example.
+- `docs/multi-user.md` — drop legacy-token bullets from "Backward
+  compatibility".
+- `docs/siri-shortcut.md` — replace `--auth-token` prereq with API-key
+  instructions.
+- `README.md` — fix Quick start and Docker examples.
+- `crates/web-ui/src/openapi.rs:104,187` — update bearer-auth descriptions;
+  regenerate `openapi.json` via `make dump-openapi`.
+- New ADR documenting the removal (ADR-0007 stays as historical record).
+
+## Capabilities
+
+### Modified
+
+- `web-login`: the Flutter SPA owns all login UI; the server-side `/login`
+  HTML form is removed. Login is performed via OAuth2 PKCE against
+  `/oauth/authorize` + `/oauth/token`. `/setup` and edit-context screens
+  use the same flow. Migration: existing `AssistantContext` rows with
+  `authMode == "legacyToken"` are surfaced as needing re-authentication.
+
+## Impact
+
+**Code:**
+
+- `crates/auth/src/middleware.rs` — drop legacy fields and branch
+- `crates/auth/src/bootstrap.rs` — drop `ASSISTANT_WEB_TOKEN` seed path
+- `crates/web-ui/src/auth.rs` — delete `LoginForm`, `login_page`,
+  `login_submit`, `login_html`, `SESSION_COOKIE`, `logout`. Drop legacy
+  bearer-resolution branch. Drop legacy fields from `WebAuthConfig`.
+- `crates/web-ui/src/lib.rs` — drop `--auth-token` arg + threading; drop
+  legacy-context construction; unregister the `/login` GET/POST routes
+- `crates/web-ui/src/openapi.rs` — update auth descriptions; remove
+  `/login` from documented paths
+- `crates/interface-cli/src/main.rs` — drop the legacy-token-as-seed log
+  line; add `admin reset-password` subcommand
+- `app/lib/features/contexts/models/context_model.dart` — collapse to
+  OAuth2-only: remove `authToken`, `AuthMode`, `effectiveToken` branch;
+  add `bearerToken` getter; keep `requiresReauth` migration flag
+- `app/lib/features/contexts/data/context_repository.dart` — detect and
+  flag legacy contexts on load; rewrite persisted JSON without `authMode`
+- `app/lib/features/login/login_screen.dart` — drop token toggle + field;
+  OAuth2 PKCE becomes only path
+- `app/lib/features/connection/connection_screen.dart` — replace token
+  field with email + password; submit triggers OAuth2 PKCE; drop
+  `?_token=` auto-submit; keep `?_url=` pre-fill
+- `app/lib/features/contexts/screens/edit_context_screen.dart` — remove
+  token field; add "Re-authenticate" button that runs OAuth2 PKCE
+- `app/lib/router/app_router.dart` — `/setup` redirect-guard logic stays;
+  the route is _not_ removed (only its credential input changes)
+- `app/test/unit/contexts/*.dart`, `app/test/unit/auth/*.dart`,
+  `app/test/widget/contexts/edit_context_test.dart`,
+  `app/test/widget/login/login_screen_test.dart` — sweep ~40
+  `authToken:` references; rewrite to use `oauthCredentials:`
+- `crates/web-ui/e2e/playwright.config.ts` — drop `--auth-token` from
+  webServer cmd; add `globalSetup` to mint an API key
+- `crates/web-ui/e2e/tests/_helpers/seedContext.ts` (new) — writes an
+  `AssistantContext` into `localStorage` so tests skip the UI auth flow
+- `crates/web-ui/e2e/tests/*.spec.ts` — replace every
+  `page.goto('/setup?_token=...')` with `seedContext(page)` + direct
+  navigation; replace `const AUTH_TOKEN = "test-token"` with a read of
+  `process.env.E2E_API_KEY`
+- `openapi.json` — regenerated via `make dump-openapi`
+
+**Operational:**
+
+- Deployments using `ASSISTANT_WEB_TOKEN` as their only credential must use
+  the admin user created at migration time (already in `org.db`) or run
+  `assistant admin reset-password`. Surface this prominently in release
+  notes.
+- schorschvm is in this category — verify the admin credentials file exists
+  on disk before rollout, or run reset-password as part of the cutover.
+
+**Out of scope:**
+
+- API keys (`ask_live_…`) — kept; they're scoped programmatic credentials
+- OIDC mode — kept; delegated auth is still username/password at the IdP
+- OAuth2 authorize / device flows — kept; already password-based
+- JWT issuance / refresh tokens — kept; these are the result of password
+  auth, not an alternative

--- a/openspec/changes/remove-legacy-token-auth/specs/web-login/spec.md
+++ b/openspec/changes/remove-legacy-token-auth/specs/web-login/spec.md
@@ -1,0 +1,198 @@
+## MODIFIED Requirements
+
+### Requirement: Flutter login screen uses OAuth2 PKCE
+
+The Flutter `/login` screen SHALL display email and password input fields
+only. The server URL SHALL be pre-filled from `Uri.base.origin` on web and
+SHALL NOT be editable by the user. The legacy single-token input field
+and the email-password vs token toggle SHALL be removed. On submission
+the system SHALL run the OAuth2 authorization-code flow with PKCE against
+`/oauth/authorize` and `/oauth/token` to obtain access and refresh
+tokens; it SHALL NOT POST credentials to a server `/login` endpoint.
+
+#### Scenario: Login screen renders with pre-filled URL and credential fields
+
+- **WHEN** the user navigates to `/login` on the web platform
+- **THEN** the screen SHALL display the server URL derived from `Uri.base.origin` as read-only text
+- **THEN** the screen SHALL display a text field for `email` (`TextInputType.emailAddress`)
+- **THEN** the screen SHALL display a password-style text field for `password`
+- **THEN** the screen SHALL NOT display a token field or a credential-type toggle
+
+#### Scenario: Empty fields rejected client-side
+
+- **WHEN** the user submits the form with an empty email or password
+- **THEN** the form SHALL display a validation error AND SHALL NOT issue a network request
+
+#### Scenario: Successful login uses OAuth2 PKCE and stores credentials
+
+- **WHEN** the user enters valid email + password and submits the login form
+- **THEN** the system SHALL run the OAuth2 PKCE flow against `Uri.base.origin`
+- **THEN** on success the system SHALL save (or update) an `AssistantContext`
+  with `oauthCredentials` populated (access + refresh tokens)
+- **THEN** the system SHALL activate that context
+- **THEN** the router SHALL navigate to `/chat`
+
+#### Scenario: Invalid credentials show inline error
+
+- **WHEN** the OAuth flow returns an authentication failure
+- **THEN** the system SHALL display a generic "Invalid email or password" error
+- **THEN** the system SHALL NOT create or activate a context
+- **THEN** the system SHALL keep the entered email and clear the password field
+
+### Requirement: Setup screen uses email + password and OAuth2 PKCE
+
+The `/setup` screen (`ConnectionScreen`) SHALL display a server URL field
+together with email + password fields when running in remote mode. The
+legacy single-token input field SHALL be removed. The `?_token=`
+query-parameter handling and its auto-submit on first frame SHALL be
+removed. The `?_url=` query-parameter SHALL continue to pre-fill the URL
+field but SHALL NOT auto-submit the form. On submission the screen SHALL
+run the OAuth2 PKCE flow against the entered URL.
+
+#### Scenario: Setup renders remote-mode form
+
+- **WHEN** the user navigates to `/setup` on web (or on macOS in remote mode)
+- **THEN** the screen SHALL display a server URL field
+- **THEN** the screen SHALL display an email field
+- **THEN** the screen SHALL display a password-style text field
+- **THEN** the screen SHALL NOT display a token field or credential-type toggle
+
+#### Scenario: URL query parameter pre-fills URL only
+
+- **WHEN** the user navigates to `/setup?_url=https://server.example.com`
+- **THEN** the URL field SHALL be pre-filled with `https://server.example.com`
+- **THEN** the form SHALL NOT auto-submit
+- **THEN** the email and password fields SHALL be empty
+
+#### Scenario: Token query parameter is ignored
+
+- **WHEN** the user navigates to `/setup?_token=anything`
+- **THEN** the system SHALL NOT pre-fill any field with that value
+- **THEN** the form SHALL NOT auto-submit
+- **THEN** no `AssistantContext` SHALL be created from the query parameter
+
+#### Scenario: Setup submission creates a context via OAuth2 PKCE
+
+- **WHEN** the user enters URL + valid email + password and submits
+- **THEN** the system SHALL run the OAuth2 PKCE flow against `<url>`
+- **THEN** on success the system SHALL save an `AssistantContext` with the
+  URL and populated `oauthCredentials`
+- **THEN** the system SHALL activate the context and navigate to `/chat`
+
+#### Scenario: Embedded-server mode unaffected
+
+- **WHEN** the user is on macOS with `EmbeddedServerService.isAvailable == true`
+  AND selects "Embedded (local)" mode
+- **THEN** the screen SHALL show the embedded-server startup progress
+- **THEN** no credential fields SHALL be displayed (no auth needed for embedded)
+
+### Requirement: Edit-context screen has no raw token input
+
+The edit-context screen (`/contexts/{id}/edit`) SHALL NOT display a
+free-form text field that writes credentials directly. Re-acquiring
+credentials for an existing context SHALL go through the OAuth2 PKCE flow
+targeted at the context's stored server URL.
+
+#### Scenario: Edit-context renders without token field
+
+- **WHEN** the user opens the edit screen for an existing context
+- **THEN** the screen SHALL display name and URL fields as editable
+- **THEN** the screen SHALL NOT display a free-form token input
+- **THEN** the screen SHALL display a "Re-authenticate" button
+
+#### Scenario: Re-authenticate runs OAuth2 PKCE
+
+- **WHEN** the user taps the "Re-authenticate" button
+- **THEN** the system SHALL run the OAuth2 PKCE flow against
+  `context.serverUrl`
+- **THEN** on success the system SHALL replace the context's
+  `oauthCredentials` with the freshly issued tokens
+
+### Requirement: AssistantContext stores only OAuth2 credentials
+
+The `AssistantContext` model SHALL carry exactly one credential slot,
+`oauthCredentials` (access + refresh tokens). The legacy `authToken`
+field, the `AuthMode` enum, and the `effectiveToken` branch-based getter
+SHALL be removed. A `bearerToken` getter SHALL return
+`oauthCredentials.bearerToken` directly.
+
+#### Scenario: Constructor requires OAuth credentials
+
+- **WHEN** code instantiates an `AssistantContext` for an authenticated server
+- **THEN** the constructor SHALL accept `oauthCredentials` (non-null) and
+  SHALL NOT accept any `authToken` parameter
+
+#### Scenario: bearerToken is a direct field access
+
+- **WHEN** code reads `context.bearerToken`
+- **THEN** the getter SHALL return `oauthCredentials.bearerToken` without
+  any mode branching
+
+#### Scenario: JSON serialisation omits legacy fields
+
+- **WHEN** `toJson` is called on any `AssistantContext`
+- **THEN** the resulting map SHALL NOT include `authMode` or `authToken` keys
+
+### Requirement: Existing legacy-token contexts migrate on first load
+
+`ContextRepository.loadContexts` SHALL detect persisted rows that were
+written under the legacy model (`authMode == "legacyToken"`) and surface
+them in a degraded state requiring re-authentication. The next write of
+each such row SHALL strip the legacy keys.
+
+#### Scenario: Legacy row produces a context needing re-auth
+
+- **WHEN** the repository reads a stored JSON payload containing
+  `authMode == "legacyToken"`
+- **THEN** the resulting `AssistantContext` SHALL have
+  `oauthCredentials == null` AND `requiresReauth == true`
+
+#### Scenario: Re-auth flow upgrades a legacy context
+
+- **WHEN** the user signs in again on a legacy context via the OAuth2 PKCE flow
+- **THEN** the context's `oauthCredentials` SHALL be populated
+- **THEN** the context's `requiresReauth` SHALL become false
+- **THEN** the next `saveContext` SHALL persist a JSON payload with no
+  `authMode` key and no `authToken` key
+
+#### Scenario: Switcher shows re-auth affordance
+
+- **WHEN** the contexts list / switcher renders a context with
+  `requiresReauth == true`
+- **THEN** the row SHALL display a "Sign in again" affordance
+- **THEN** the row SHALL NOT allow direct connection without re-auth
+
+### Requirement: Server `/login` page is removed
+
+The server SHALL NOT expose a `/login` GET or POST endpoint. Requests to
+the path `/login` SHALL be handled by the SPA catch-all so the Flutter
+app renders its own client-side login screen.
+
+#### Scenario: GET /login returns the SPA
+
+- **WHEN** an unauthenticated client requests `GET /login`
+- **THEN** the server SHALL respond with `200 OK` and the SPA `index.html`
+  payload (same as any other catch-all path)
+- **THEN** the response SHALL NOT contain a server-rendered HTML login form
+
+#### Scenario: POST /login is unrouted
+
+- **WHEN** a client submits `POST /login`
+- **THEN** the server SHALL respond with `404 Not Found` (the route is
+  not registered)
+
+### Requirement: Server login endpoint honours OIDC mode
+
+The server SHALL detect OIDC configuration and route authentication
+traffic through the OIDC authorization-code flow. When `auth_mode =
+"oidc"` is configured, `/oauth/authorize` SHALL redirect to the upstream
+IdP for credential collection. The Flutter SPA's login flow is unchanged
+in OIDC mode — it kicks off the same OAuth2 PKCE handshake, which the
+server then forwards to the IdP.
+
+#### Scenario: OIDC-mode authorize redirects to IdP
+
+- **WHEN** the server is in OIDC mode AND a browser hits `/oauth/authorize`
+- **THEN** the server SHALL respond with `302 Found` to the configured
+  upstream IdP authorize URL, carrying the original `client_id`, `state`,
+  and `code_challenge` parameters

--- a/openspec/changes/remove-legacy-token-auth/tasks.md
+++ b/openspec/changes/remove-legacy-token-auth/tasks.md
@@ -1,0 +1,270 @@
+## Tasks
+
+TDD discipline: every implementation task is preceded by a failing test.
+
+### Server: delete `/login` HTML page
+
+- [ ] Write failing test: request to `GET /login` returns the SPA
+      fallback (200, content-type text/html with the Flutter app bundle),
+      not a server-rendered login form.
+- [ ] Delete `LoginForm`, `login_page`, `login_submit`, `login_html`,
+      `logout`, `SESSION_COOKIE`, and `redirect_with_cookie` from
+      `crates/web-ui/src/auth.rs`.
+- [ ] Unregister the `/login` GET and POST routes (and `/logout`) in
+      `crates/web-ui/src/lib.rs`. The SPA catch-all handles unauthenticated
+      paths.
+- [ ] Delete the existing `login_*` tests in `crates/web-ui/src/auth.rs`
+      (they exercise the deleted handlers).
+- [ ] Verify `/oauth/authorize` and `/oauth/device/verify` are unaffected;
+      they have their own credential forms and continue to function.
+
+### Server: remove legacy bypass
+
+- [ ] Write failing test (or modify existing): `AuthState` no longer has
+      `legacy_token` / `legacy_context` fields — tests that construct it must
+      compile without those fields.
+- [ ] Delete the legacy match branch in `crates/auth/src/middleware.rs`
+      `AuthExtractor::from_request_parts` and its mirror in
+      `crates/web-ui/src/auth.rs:resolve_bearer`.
+- [ ] Delete `legacy_token` and `legacy_context` fields from `AuthState`
+      and `WebAuthConfig`. Update `WebAuthConfig::new` signature.
+- [ ] Delete `extract_legacy_token` and
+      `bearer_legacy_token_produces_admin_context` tests.
+- [ ] Update remaining tests to drop the legacy-context arguments.
+
+### Server: remove `ASSISTANT_WEB_TOKEN` plumbing
+
+- [ ] Delete `--auth-token` / `ASSISTANT_WEB_TOKEN` arg from
+      `crates/web-ui/src/lib.rs` (`Args`, `legacy_token` resolution, threading
+      into `WebAuthConfig::new`).
+- [ ] Delete the `ASSISTANT_WEB_TOKEN` seed-password branch in
+      `crates/auth/src/bootstrap.rs:45`; always generate.
+- [ ] Delete the "Password: (your ASSISTANT_WEB_TOKEN value)" branch in
+      `crates/web-ui/src/lib.rs:241` and the matching line in
+      `crates/interface-cli/src/main.rs:1501`.
+
+### Recovery CLI: `assistant admin reset-password`
+
+- [ ] Write failing test: integration test that runs the CLI against a temp
+      `org.db` with a seeded user, supplies a new password via stdin, then
+      verifies the new password against the updated hash and the old one
+      fails.
+- [ ] Implement subcommand in `crates/interface-cli/src/main.rs` under an
+      `admin` group: parses `<email>`, reads the password from TTY via
+      `rpassword`, opens `org.db` directly via `OrgPoolFactory`, calls
+      `password::hash_password`, updates the row.
+- [ ] Add `--org` flag (defaults to `default`); fail clearly if the user is
+      not found.
+
+### Flutter app: collapse `AssistantContext` credential model
+
+- [ ] Write failing unit test: `AssistantContext` constructor signature
+      takes required `OAuthCredentials`; no `authToken` parameter; no
+      `authMode` parameter.
+- [ ] Write failing unit test: `bearerToken` getter returns
+      `oauthCredentials.bearerToken` directly (no mode branching).
+- [ ] Write failing unit test: `needsTokenRefresh` returns
+      `oauthCredentials.isExpired()` (no mode guard).
+- [ ] Write failing unit test: `toJson` does not include `authMode` or
+      `authToken` keys; `fromJson` reading a payload with `authMode ==
+  "legacyToken"` produces a context with `requiresReauth: true`,
+      `oauthCredentials: null`.
+- [ ] Write failing unit test: `fromJson` reading a payload with no
+      `authMode` key (post-migration) produces a normal context.
+- [ ] Remove `authToken`, `AuthMode`, `effectiveToken` from
+      `app/lib/features/contexts/models/context_model.dart`. Make
+      `oauthCredentials` required in the constructor (or keep optional
+      paired with `requiresReauth`).
+- [ ] Add `bearerToken` getter as a direct field access.
+- [ ] Add `requiresReauth: bool` in-memory flag (default false, never
+      serialised).
+- [ ] Update `copyWith`: drop `authToken` and `clearAuthToken`; keep
+      `clearOAuthCredentials`; add `requiresReauth`.
+- [ ] Update `AssistantContext.create` factory: take required
+      `oauthCredentials` instead of optional `authToken` / `authMode`.
+
+### Flutter app: legacy context migration
+
+- [ ] Write failing test: `ContextRepository.loadContexts` reading a
+      stored row with `authMode == "legacyToken"` returns a context with
+      `requiresReauth: true` and `oauthCredentials: null`. The next
+      `saveContext` rewrites the persisted JSON without `authMode`.
+- [ ] Write failing widget test: contexts list / switcher renders a
+      `requiresReauth: true` context with a "Sign in again" affordance
+      instead of the normal connect button.
+- [ ] Write failing widget test: tapping "Sign in again" launches the
+      OAuth2 PKCE flow against the context's stored URL; on success the
+      context's `requiresReauth` flips to false and `oauthCredentials`
+      is populated.
+- [ ] Implement the legacy detection in
+      `app/lib/features/contexts/data/context_repository.dart`.
+- [ ] Update `AssistantContext.fromJson` to detect `authMode ==
+  "legacyToken"` and emit `requiresReauth: true`.
+- [ ] Implement the "Sign in again" affordance in the contexts
+      list/switcher.
+
+### Flutter app: `/login` screen
+
+- [ ] Write failing widget test: login screen renders email + password
+      inputs only (no token TextField, no credential-type toggle).
+- [ ] Write failing widget test: submitting with valid credentials runs
+      the OAuth2 PKCE flow (mocked `OAuthClient`) and stores the
+      resulting `OAuthCredentials` on the active `AssistantContext`.
+- [ ] Remove the legacy-token toggle, `_tokenCtrl`, `_tokenFocus`,
+      `_tokenVisible`, and the `token` branch of `_submit` in
+      `app/lib/features/login/login_screen.dart`.
+- [ ] The submit handler keeps the existing OAuth2 PKCE call path (it
+      already exists for the "email + password" branch); only the dead
+      legacy branch is removed.
+
+### Flutter app: `/setup` screen (ConnectionScreen)
+
+- [ ] Write failing widget test: ConnectionScreen in remote mode renders
+      URL + email + password fields (no token field).
+- [ ] Write failing widget test: navigating to `/setup?_url=https://x`
+      pre-fills the URL field but does NOT auto-submit.
+- [ ] Write failing widget test: `/setup?_token=foo` does NOT pre-fill or
+      submit anything (the query param is ignored).
+- [ ] Write failing widget test: submitting valid credentials runs the
+      OAuth2 PKCE flow against the entered URL and saves an
+      `AssistantContext` with `oauthCredentials` populated.
+- [ ] Replace `_tokenController` and the token TextFormField with
+      `_emailController` + `_passwordController` and matching fields in
+      `app/lib/features/connection/connection_screen.dart`.
+- [ ] Delete the `?_token=` query-param branch in `initState` and the
+      `WidgetsBinding.instance.addPostFrameCallback` auto-submit. Keep
+      `?_url=` pre-fill.
+- [ ] Update `_connect` to run the OAuth2 PKCE flow (re-using
+      `login_screen.dart`'s existing helpers) against the entered URL,
+      then build the `AssistantContext` with the resulting
+      `oauthCredentials`.
+- [ ] Verify the embedded-mode branch (macOS bundled binary) is unchanged.
+
+### Flutter app: edit-context screen
+
+- [ ] Write failing widget test: edit-context screen renders name + URL
+      fields and a "Re-authenticate" button (no token input).
+- [ ] Write failing widget test: tapping "Re-authenticate" launches the
+      OAuth2 PKCE flow against `context.serverUrl`; on success the
+      context's `oauthCredentials` is replaced.
+- [ ] Remove `_tokenCtrl`, `_tokenVisible`, and the token TextFormField
+      from `app/lib/features/contexts/screens/edit_context_screen.dart`.
+- [ ] Add the "Re-authenticate" affordance that triggers the same
+      OAuth2 PKCE flow used by `/login`.
+
+### Flutter app: test sweep
+
+- [ ] Sweep `app/test/unit/contexts/context_model_test.dart` (~25
+      references): replace `makeCtx(authToken: 'tok')` with
+      `makeCtx(oauthCredentials: ...)`. Delete the `effectiveToken
+  returns authToken for legacyToken mode` scenario.
+- [ ] Sweep `app/test/unit/contexts/context_repository_test.dart` and
+      `context_repository_upsert_test.dart` (~15 references): same
+      pattern.
+- [ ] Sweep `app/test/unit/auth/auth_provider_test.dart` (~5
+      references): same pattern.
+- [ ] Update `app/test/widget/contexts/edit_context_test.dart` (drop
+      `authToken: 'my-token'` fixture; assert no token field).
+- [ ] Delete legacy-mode scenarios from
+      `app/test/widget/login/login_screen_test.dart` (lines 43, 85
+      and similar — see the file's `_switchToLegacy()` helper).
+- [ ] `grep -rn "authToken\|AuthMode\|legacyToken\|effectiveToken" app/lib app/test`
+      — must return zero hits outside the migration code path in
+      `context_model.dart` and `context_repository.dart`.
+
+### Flutter app: cleanup
+
+- [ ] Run `flutter analyze --fatal-infos`.
+- [ ] Run `flutter test`.
+
+### E2E test rig (`crates/web-ui/e2e/`)
+
+- [ ] Add `globalSetup.ts` that polls `/health`, reads
+      `~/.assistant/orgs/default/admin_credentials.txt`, runs the OAuth
+      password→code→token dance, mints an `ask_live_…` API key via
+      `POST /api/users/me/api-keys`, and writes the key to
+      `process.env.E2E_API_KEY`.
+- [ ] Wire `globalSetup` into `playwright.config.ts`. Remove
+      `--auth-token test-token` from the `webServer.command`.
+- [ ] Inspect `app/lib/features/contexts/data/context_repository.dart` to
+      determine the exact `shared_preferences` key names used for the
+      contexts list and the active-context id on web.
+- [ ] Add `tests/_helpers/seedContext.ts` exporting `seedContext(page)`.
+      Uses `page.evaluate()` to write a JSON-encoded `AssistantContext`
+      (with `authToken = process.env.E2E_API_KEY`) into `localStorage`
+      under the keys identified above, and marks it as the active
+      context. Throws clearly if `E2E_API_KEY` is unset.
+- [ ] Add `tests/_helpers/auth.ts` exporting `getAuthToken()` that returns
+      `process.env.E2E_API_KEY` (used by `apiGet` and any direct REST
+      callers in tests).
+- [ ] Replace every `page.goto('/setup?_token=...')` call in the four
+      specs with `await seedContext(page); await page.goto('/chat');`.
+- [ ] Replace `const AUTH_TOKEN = "test-token"` in:
+      `visual-regression.spec.ts`, `trace-tool-call-rendering.spec.ts`,
+      `platform-io-web.spec.ts`, `sidebar-collapse-ipad.spec.ts` with
+      `getAuthToken()`.
+- [ ] Run the suite locally end-to-end: `npm run test` from
+      `crates/web-ui/e2e/`. Verify all four specs pass without ever
+      visiting `/login` or `/setup`.
+- [ ] Document the new e2e bootstrap flow in
+      `crates/web-ui/e2e/README.md` (create if absent), including the
+      `seedContext` mechanism and how to regenerate the admin password
+      if the credentials file is missing.
+
+### OpenAPI
+
+- [ ] Update bearer-auth descriptions in `crates/web-ui/src/openapi.rs:104,187`
+      to drop `--auth-token` / `ASSISTANT_WEB_TOKEN` references.
+- [ ] Run `make dump-openapi` to regenerate `openapi.json`.
+- [ ] Run `make generate-flutter-client`; verify no diff beyond the auth-doc
+      text.
+
+### Docs
+
+- [ ] `docs/authentication.md`: delete "Quick start (single-token mode)"
+      section, drop step 4 from "Auth middleware resolution order", add a
+      password-login quick start under "Quick start".
+- [ ] `docs/web-ui.md`: fix Quick start example (L11-12), the "enter the
+      server URL and token" copy (L18-20), the `--auth-token` row in the CLI
+      table (L132), the plain-HTTP example (L152).
+- [ ] `docs/multi-user.md`: rewrite the "Backward compatibility" bullets
+      (L183-184) to drop legacy-token mentions.
+- [ ] `docs/siri-shortcut.md`: replace the `--auth-token` prereq (L8) with
+      an API-key prereq.
+- [ ] `README.md`: fix L318 (web-ui quick start) and L433 (Docker example).
+- [ ] Add `docs/adr/adr-0012-remove-legacy-token-auth.md` (or next available
+      number) documenting the decision, with a backlink from ADR-0007.
+
+### Final sweep
+
+- [ ] `rg "ASSISTANT_WEB_TOKEN|--auth-token|legacy.token|legacy_context|test-token"` —
+      must return zero hits outside this change's own files and the new ADR.
+- [ ] `rg "authToken|AuthMode|legacyToken|effectiveToken|LoginForm|login_html|login_submit"`
+      across `crates/` and `app/lib/` — must return zero hits outside the
+      Flutter migration code path (`context_model.dart`, `context_repository.dart`).
+- [ ] `make lint && make format && make test`.
+- [ ] `cd app && flutter analyze && flutter test`.
+- [ ] Smoke test (server): fresh deployment (no `org.db`), confirm bootstrap
+      creates the admin user and writes `admin_credentials_file`. Confirm
+      `GET /login` returns the SPA (not a server-rendered form).
+- [ ] Smoke test (Flutter web): on a fresh deployment, navigate to the
+      Flutter login screen, enter email + password, and confirm the OAuth2
+      PKCE flow completes and the app lands on `/chat`.
+- [ ] Smoke test: existing deployment (with admin user), confirm Bearer
+      auth still works with JWTs and API keys.
+- [ ] Smoke test: `assistant admin reset-password admin@localhost` updates
+      the password and a subsequent Flutter-app sign-in succeeds.
+- [ ] Smoke test (Flutter web): `/setup` accepts URL + email + password and
+      saves an active context with populated `oauthCredentials`. Verify
+      `?_url=https://x.example.com` pre-fills the URL but does not
+      auto-submit.
+- [ ] Smoke test (Flutter web): `/setup?_token=anything` does not pre-fill
+      or submit a token (the query param is silently ignored).
+- [ ] Smoke test (Flutter web): edit-context's "Re-authenticate" flow runs
+      the OAuth2 PKCE flow against the context's URL and refreshes the
+      stored credentials.
+- [ ] Smoke test (migration): with a context written under the legacy
+      model (`authMode == "legacyToken"`), confirm the app surfaces it
+      as needing re-authentication, the "Sign in again" affordance
+      launches OAuth2 PKCE, and the next save persists JSON without
+      `authMode`.


### PR DESCRIPTION
## Summary

Two related OpenSpec change proposals for cleaning up the auth story.
No implementation — just captured thinking from an exploration session.

### `remove-legacy-token-auth` (86 tasks)

Removes the `ASSISTANT_WEB_TOKEN` legacy bypass in `resolve_bearer`
branch 3, collapses the Flutter `AssistantContext` credential model from
two-mode (`legacyToken` | `oauth2`) to OAuth2-only, and unifies all four
Flutter auth surfaces on OAuth2 PKCE.

Notable design decisions (in `design.md`):

- **Delete server `/login` entirely**, don't rebuild. The Flutter SPA
  owns login UX and needs OAuth tokens, not a cookie. The SPA catch-all
  handles unauthenticated `/login` requests.
- **Collapse `AssistantContext`**: remove `authToken`, `AuthMode`,
  `effectiveToken` branching. `oauthCredentials` becomes the only
  credential storage.
- **Migrate existing legacy contexts** in place — they surface in a
  degraded "Sign in again" state instead of being silently dropped.
- **E2E rig** skips the UI auth flow entirely: `globalSetup` mints an
  API key via OAuth, `seedContext()` writes the context to
  `localStorage` before tests run.
- **New `assistant admin reset-password` CLI** as the recovery path for
  deployments that lose access.

### `api-key-management-ui` (35 tasks)

M-sized follow-on: surface the existing `ApiKeysScreen` through
Settings, add scope picker + expiry picker to the create dialog
(backend already supports scopes; needs one new `expires_in_days` field
for expiry), render relative dates and scope chips.

Backend lift is one field. Most of the work is Flutter UX. Sequencing:
ships independently of `remove-legacy-token-auth`, but becomes more
important once that lands.

### Open threads worth noting (not yet captured)

The design.md for `remove-legacy-token-auth` flags six items as worth
another pass during apply (recovery-CLI org disambiguation,
`/oauth/authorize` × `/login` handler reuse, login attempt audit logs,
API-key expiry ceiling, OIDC × new login form, active sessions during
cutover). Not blocking — surface during implementation.

## Test plan

This PR is proposal-only; no code changes. Validation:

- [x] `openspec validate remove-legacy-token-auth` passes
- [x] `openspec validate api-key-management-ui` passes
- [ ] `/opsx:apply remove-legacy-token-auth` when ready to start
      implementation
- [ ] `/opsx:apply api-key-management-ui` after the first lands