### PR TITLE
refactor: ratchet panic-free lints to deny for mcp-client, mcp-server, workflow-http

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,15 +194,20 @@ The workspace declares its baseline lint set in the root `Cargo.toml`
   workspace lints must be replayed manually.
 
 **Panic-free contract.** `clippy::unwrap_used`, `clippy::expect_used`, and
-`clippy::panic` are `warn` at the workspace baseline. The following crates
-ratchet them to `deny` at the crate level:
+`clippy::panic` are `warn` at the workspace baseline. Most crates ratchet
+them to `deny` at the crate level via a manual replay of the workspace
+lint block in their `Cargo.toml` (`[lints.clippy]` + `[lints.rust]`).
+Currently ratcheted to `deny`:
 
-- `assistant-storage` — enforced via `crates/storage/Cargo.toml [lints.clippy]`.
+- `assistant-auth`, `assistant-backup`, `assistant-core`,
+  `assistant-interfaces`, `assistant-llm-provider`, `assistant-mcp-client`,
+  `assistant-mcp-server`, `assistant-runtime`, `assistant-storage`,
+  `assistant-tool-executor`, `assistant-web-ui`, `assistant-workflow-http`.
 
-All other crates currently `allow` the panic-free lints with a
-`TODO(workspace-lint-policy)` comment recording the ratchet target. Promoting
-a crate from `allow` to `deny` is a self-contained follow-up PR: clean the
-unwraps, flip the lint level, run `make lint && make test`.
+The remaining crates still inherit the workspace `warn` default. Promoting
+a crate from `warn` to `deny` is a self-contained follow-up PR: clean the
+unwraps in production code, replace `[lints]\nworkspace = true` with the
+manual replay block, run `make lint && make test`.
 
 Test code (`#[cfg(test)]` modules and `tests/` directories) is exempt: the
 default `cargo clippy --workspace` invocation used by `make lint` and CI

--- a/crates/mcp-client/Cargo.toml
+++ b/crates/mcp-client/Cargo.toml
@@ -30,5 +30,19 @@ reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 
-[lints]
-workspace = true
+# Panic-free contract: production code propagates errors via `anyhow::Result`.
+# Tests are exempt because `make lint` (`cargo clippy --workspace`) does not
+# check `#[cfg(test)]` modules. Cargo forbids combining `[lints] workspace = true`
+# with per-crate overrides, so this crate manually replays the workspace
+# baseline and raises the panic-free lints to deny. Keep this block in sync
+# with the workspace baseline in the root Cargo.toml.
+# See openspec/changes/workspace-lint-policy/.
+[lints.clippy]
+unwrap_used = "deny"
+expect_used = "deny"
+panic = "deny"
+unimplemented = "warn"
+todo = "warn"
+
+[lints.rust]
+unused_must_use = "deny"

--- a/crates/mcp-server/Cargo.toml
+++ b/crates/mcp-server/Cargo.toml
@@ -21,5 +21,19 @@ anyhow = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 
-[lints]
-workspace = true
+# Panic-free contract: production code propagates errors via `anyhow::Result`.
+# Tests are exempt because `make lint` (`cargo clippy --workspace`) does not
+# check `#[cfg(test)]` modules. Cargo forbids combining `[lints] workspace = true`
+# with per-crate overrides, so this crate manually replays the workspace
+# baseline and raises the panic-free lints to deny. Keep this block in sync
+# with the workspace baseline in the root Cargo.toml.
+# See openspec/changes/workspace-lint-policy/.
+[lints.clippy]
+unwrap_used = "deny"
+expect_used = "deny"
+panic = "deny"
+unimplemented = "warn"
+todo = "warn"
+
+[lints.rust]
+unused_must_use = "deny"

--- a/crates/workflow-http/Cargo.toml
+++ b/crates/workflow-http/Cargo.toml
@@ -14,5 +14,19 @@ serde_json = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }
 
-[lints]
-workspace = true
+# Panic-free contract: production code propagates errors via `anyhow::Result`.
+# Tests are exempt because `make lint` (`cargo clippy --workspace`) does not
+# check `#[cfg(test)]` modules. Cargo forbids combining `[lints] workspace = true`
+# with per-crate overrides, so this crate manually replays the workspace
+# baseline and raises the panic-free lints to deny. Keep this block in sync
+# with the workspace baseline in the root Cargo.toml.
+# See openspec/changes/workspace-lint-policy/.
+[lints.clippy]
+unwrap_used = "deny"
+expect_used = "deny"
+panic = "deny"
+unimplemented = "warn"
+todo = "warn"
+
+[lints.rust]
+unused_must_use = "deny"


### PR DESCRIPTION
## Summary

Promote three more crates from the workspace `warn` baseline to crate-level
`deny` for the panic-free lint set (`unwrap_used`, `expect_used`, `panic`):

- `assistant-mcp-client`
- `assistant-mcp-server`
- `assistant-workflow-http`

These have no `.unwrap()`/`.expect()`/`panic!()` in production code (test
code is exempt — `make lint` runs `cargo clippy --workspace` without
`--all-targets`), so this is a pure lint-policy change with no code edits
required.

Also refreshes the panic-free contract section of `AGENTS.md` to enumerate
the currently-ratcheted crates (twelve so far, including these three).

## Test plan
- [x] `make lint` — clean across the workspace
- [x] `cargo clippy -p assistant-mcp-client -p assistant-mcp-server -p assistant-workflow-http --lib -- -D warnings` — clean
- [x] `make test` — passing

## Follow-ups (stacked)

Nine crates still inherit the workspace `warn` default. In rough order
of effort:

- Low: `a2a-json-schema` (~10 panicky), `opentelemetry-exporter-iceberg` (~10)
- Med: `skills` (~12), `workflow` (~22), `transcription` (~23)
- High: `bus-nats` (~37), `opentelemetry-exporter-sqlite` (~47), `interface-cli` (~68)

(Counts include test-mod usages that production lint would exempt.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workspace lint policy documentation to reflect expanded crate coverage for the panic-free contract.

* **Chores**
  * Strengthened lint enforcement across multiple crates by implementing explicit per-crate error-handling configurations.
  * Applied stricter rules for unwrap, expect, and panic patterns alongside unused result enforcement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cedricziel/assistant/pull/776?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->