### PR TITLE
refactor(a2a-json-schema): ratchet panic-free lints to deny

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,10 +199,11 @@ them to `deny` at the crate level via a manual replay of the workspace
 lint block in their `Cargo.toml` (`[lints.clippy]` + `[lints.rust]`).
 Currently ratcheted to `deny`:
 
-- `assistant-auth`, `assistant-backup`, `assistant-core`,
-  `assistant-interfaces`, `assistant-llm-provider`, `assistant-mcp-client`,
-  `assistant-mcp-server`, `assistant-runtime`, `assistant-storage`,
-  `assistant-tool-executor`, `assistant-web-ui`, `assistant-workflow-http`.
+- `assistant-a2a-json-schema`, `assistant-auth`, `assistant-backup`,
+  `assistant-core`, `assistant-interfaces`, `assistant-llm-provider`,
+  `assistant-mcp-client`, `assistant-mcp-server`, `assistant-runtime`,
+  `assistant-storage`, `assistant-tool-executor`, `assistant-web-ui`,
+  `assistant-workflow-http`.
 
 The remaining crates still inherit the workspace `warn` default. Promoting
 a crate from `warn` to `deny` is a self-contained follow-up PR: clean the

--- a/crates/a2a-json-schema/Cargo.toml
+++ b/crates/a2a-json-schema/Cargo.toml
@@ -19,5 +19,19 @@ utoipa = { workspace = true, optional = true }
 [dev-dependencies]
 serde_json = { workspace = true }
 
-[lints]
-workspace = true
+# Panic-free contract: production code propagates errors via `anyhow::Result`.
+# Tests are exempt because `make lint` (`cargo clippy --workspace`) does not
+# check `#[cfg(test)]` modules. Cargo forbids combining `[lints] workspace = true`
+# with per-crate overrides, so this crate manually replays the workspace
+# baseline and raises the panic-free lints to deny. Keep this block in sync
+# with the workspace baseline in the root Cargo.toml.
+# See openspec/changes/workspace-lint-policy/.
+[lints.clippy]
+unwrap_used = "deny"
+expect_used = "deny"
+panic = "deny"
+unimplemented = "warn"
+todo = "warn"
+
+[lints.rust]
+unused_must_use = "deny"


### PR DESCRIPTION
## Summary

Promote `assistant-a2a-json-schema` from workspace `warn` to crate-level
`deny` for `unwrap_used`, `expect_used`, and `panic`. All existing
`.unwrap()`/`.expect()` calls live in `#[cfg(test)]` modules (which
`make lint` doesn't check), so this is a pure lint-policy change.

## Test plan
- [x] `cargo clippy -p assistant-a2a-json-schema --lib -- -D warnings` — clean
- [x] `make lint` — clean across the workspace