### PR TITLE
refactor(skills): ratchet panic-free lints to deny

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,8 +202,9 @@ Currently ratcheted to `deny`:
 - `assistant-a2a-json-schema`, `assistant-auth`, `assistant-backup`,
   `assistant-core`, `assistant-interfaces`, `assistant-llm-provider`,
   `assistant-mcp-client`, `assistant-mcp-server`, `assistant-runtime`,
-  `assistant-storage`, `assistant-tool-executor`, `assistant-web-ui`,
-  `assistant-workflow-http`, `opentelemetry-exporter-iceberg`.
+  `assistant-skills`, `assistant-storage`, `assistant-tool-executor`,
+  `assistant-web-ui`, `assistant-workflow-http`,
+  `opentelemetry-exporter-iceberg`.
 
 The remaining crates still inherit the workspace `warn` default. Promoting
 a crate from `warn` to `deny` is a self-contained follow-up PR: clean the

--- a/crates/skills/Cargo.toml
+++ b/crates/skills/Cargo.toml
@@ -16,5 +16,19 @@ tracing = { workspace = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 
-[lints]
-workspace = true
+# Panic-free contract: production code propagates errors via `anyhow::Result`.
+# Tests are exempt because `make lint` (`cargo clippy --workspace`) does not
+# check `#[cfg(test)]` modules. Cargo forbids combining `[lints] workspace = true`
+# with per-crate overrides, so this crate manually replays the workspace
+# baseline and raises the panic-free lints to deny. Keep this block in sync
+# with the workspace baseline in the root Cargo.toml.
+# See openspec/changes/workspace-lint-policy/.
+[lints.clippy]
+unwrap_used = "deny"
+expect_used = "deny"
+panic = "deny"
+unimplemented = "warn"
+todo = "warn"
+
+[lints.rust]
+unused_must_use = "deny"


### PR DESCRIPTION
Pure lint-policy change — all panicky calls are in test code. `cargo clippy --lib -- -D warnings` passes.