### PR TITLE
refactor(transcription): ratchet panic-free lints to deny

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,8 +203,8 @@ Currently ratcheted to `deny`:
   `assistant-core`, `assistant-interfaces`, `assistant-llm-provider`,
   `assistant-mcp-client`, `assistant-mcp-server`, `assistant-runtime`,
   `assistant-skills`, `assistant-storage`, `assistant-tool-executor`,
-  `assistant-web-ui`, `assistant-workflow`, `assistant-workflow-http`,
-  `opentelemetry-exporter-iceberg`.
+  `assistant-transcription`, `assistant-web-ui`, `assistant-workflow`,
+  `assistant-workflow-http`, `opentelemetry-exporter-iceberg`.
 
 The remaining crates still inherit the workspace `warn` default. Promoting
 a crate from `warn` to `deny` is a self-contained follow-up PR: clean the

--- a/crates/transcription/Cargo.toml
+++ b/crates/transcription/Cargo.toml
@@ -24,5 +24,19 @@ url            = { workspace = true }
 tokio = { workspace = true }
 wiremock = { workspace = true }
 
-[lints]
-workspace = true
+# Panic-free contract: production code propagates errors via `anyhow::Result`.
+# Tests are exempt because `make lint` (`cargo clippy --workspace`) does not
+# check `#[cfg(test)]` modules. Cargo forbids combining `[lints] workspace = true`
+# with per-crate overrides, so this crate manually replays the workspace
+# baseline and raises the panic-free lints to deny. Keep this block in sync
+# with the workspace baseline in the root Cargo.toml.
+# See openspec/changes/workspace-lint-policy/.
+[lints.clippy]
+unwrap_used = "deny"
+expect_used = "deny"
+panic = "deny"
+unimplemented = "warn"
+todo = "warn"
+
+[lints.rust]
+unused_must_use = "deny"


### PR DESCRIPTION
Pure lint-policy change — all panicky calls are in test code. `cargo clippy --lib -- -D warnings` passes.