### PR TITLE
refactor(bus-nats): ratchet panic-free lints to deny

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,11 +200,12 @@ lint block in their `Cargo.toml` (`[lints.clippy]` + `[lints.rust]`).
 Currently ratcheted to `deny`:
 
 - `assistant-a2a-json-schema`, `assistant-auth`, `assistant-backup`,
-  `assistant-core`, `assistant-interfaces`, `assistant-llm-provider`,
-  `assistant-mcp-client`, `assistant-mcp-server`, `assistant-runtime`,
-  `assistant-skills`, `assistant-storage`, `assistant-tool-executor`,
-  `assistant-transcription`, `assistant-web-ui`, `assistant-workflow`,
-  `assistant-workflow-http`, `opentelemetry-exporter-iceberg`.
+  `assistant-bus-nats`, `assistant-core`, `assistant-interfaces`,
+  `assistant-llm-provider`, `assistant-mcp-client`, `assistant-mcp-server`,
+  `assistant-runtime`, `assistant-skills`, `assistant-storage`,
+  `assistant-tool-executor`, `assistant-transcription`, `assistant-web-ui`,
+  `assistant-workflow`, `assistant-workflow-http`,
+  `opentelemetry-exporter-iceberg`.
 
 The remaining crates still inherit the workspace `warn` default. Promoting
 a crate from `warn` to `deny` is a self-contained follow-up PR: clean the

--- a/crates/bus-nats/Cargo.toml
+++ b/crates/bus-nats/Cargo.toml
@@ -22,5 +22,19 @@ uuid = { workspace = true }
 testcontainers = { workspace = true }
 testcontainers-modules = { workspace = true }
 
-[lints]
-workspace = true
+# Panic-free contract: production code propagates errors via `anyhow::Result`.
+# Tests are exempt because `make lint` (`cargo clippy --workspace`) does not
+# check `#[cfg(test)]` modules. Cargo forbids combining `[lints] workspace = true`
+# with per-crate overrides, so this crate manually replays the workspace
+# baseline and raises the panic-free lints to deny. Keep this block in sync
+# with the workspace baseline in the root Cargo.toml.
+# See openspec/changes/workspace-lint-policy/.
+[lints.clippy]
+unwrap_used = "deny"
+expect_used = "deny"
+panic = "deny"
+unimplemented = "warn"
+todo = "warn"
+
+[lints.rust]
+unused_must_use = "deny"


### PR DESCRIPTION
Pure lint-policy change — all panicky calls are in test code. `cargo clippy --lib -- -D warnings` passes.