### PR TITLE
refactor(interface-cli): ratchet panic-free lints to deny — closes out workspace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,12 +200,17 @@ lint block in their `Cargo.toml` (`[lints.clippy]` + `[lints.rust]`).
 Currently ratcheted to `deny`:
 
 - `assistant-a2a-json-schema`, `assistant-auth`, `assistant-backup`,
-  `assistant-bus-nats`, `assistant-core`, `assistant-interfaces`,
-  `assistant-llm-provider`, `assistant-mcp-client`, `assistant-mcp-server`,
-  `assistant-runtime`, `assistant-skills`, `assistant-storage`,
-  `assistant-tool-executor`, `assistant-transcription`, `assistant-web-ui`,
-  `assistant-workflow`, `assistant-workflow-http`,
+  `assistant-bus-nats`, `assistant-cli`, `assistant-core`,
+  `assistant-interfaces`, `assistant-llm-provider`, `assistant-mcp-client`,
+  `assistant-mcp-server`, `assistant-runtime`, `assistant-skills`,
+  `assistant-storage`, `assistant-tool-executor`, `assistant-transcription`,
+  `assistant-web-ui`, `assistant-workflow`, `assistant-workflow-http`,
   `opentelemetry-exporter-iceberg`, `opentelemetry-exporter-sqlite`.
+
+All non-tests-only crates are now panic-free at `deny`. The only crate
+still on the workspace `warn` baseline is `assistant-integration-tests`,
+which has no production library code (its `src/lib.rs` is a stub for
+shared test helpers).
 
 The remaining crates still inherit the workspace `warn` default. Promoting
 a crate from `warn` to `deny` is a self-contained follow-up PR: clean the

--- a/crates/interface-cli/Cargo.toml
+++ b/crates/interface-cli/Cargo.toml
@@ -65,5 +65,19 @@ similar = { workspace = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 
-[lints]
-workspace = true
+# Panic-free contract: production code propagates errors via `anyhow::Result`.
+# Tests are exempt because `make lint` (`cargo clippy --workspace`) does not
+# check `#[cfg(test)]` modules. Cargo forbids combining `[lints] workspace = true`
+# with per-crate overrides, so this crate manually replays the workspace
+# baseline and raises the panic-free lints to deny. Keep this block in sync
+# with the workspace baseline in the root Cargo.toml.
+# See openspec/changes/workspace-lint-policy/.
+[lints.clippy]
+unwrap_used = "deny"
+expect_used = "deny"
+panic = "deny"
+unimplemented = "warn"
+todo = "warn"
+
+[lints.rust]
+unused_must_use = "deny"


### PR DESCRIPTION
## Summary

Promote `assistant-cli` from workspace `warn` to crate-level `deny` for
`unwrap_used`, `expect_used`, and `panic`. All panicky calls are in
`#[cfg(test)]` modules, so this is a pure lint-policy change.

This closes out the panic-free contract across every non-tests-only
crate in the workspace. The only remaining crate on the `warn`
baseline is `assistant-integration-tests`, which has no production
library code (`src/lib.rs` is a stub for shared test helpers).

## Test plan
- [x] `cargo clippy -p assistant-cli --lib --bin assistant -- -D warnings` — clean
- [x] `make lint` — clean across the workspace