### PR TITLE
refactor(interface-cli): extract bootstrap into its own module

### DIFF
--- a/crates/interface-cli/src/bootstrap.rs
+++ b/crates/interface-cli/src/bootstrap.rs
@@ -1,0 +1,289 @@
+//! Common bootstrap — build the shared `StorageLayer` / `SkillRegistry` /
+//! `ToolExecutor` / `Orchestrator` tuple used by every CLI subcommand.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use tracing::info;
+
+use assistant_core::types::agent::AssistantConfig;
+use assistant_core::types::llm::{EmbeddingConfig, EmbeddingProviderKind};
+use assistant_core::types::storage::BusKind;
+use assistant_core::{
+    EmbeddingProvider, LlmEmbedder, LlmProvider, MessageBus, WithEmbeddingOverride,
+};
+use assistant_llm_provider::{
+    OllamaConfig, OllamaProvider, OpenAIProvider, OpenAIProviderConfig, VoyageConfig,
+    VoyageEmbedder,
+};
+use assistant_runtime::{Orchestrator, orchestrator::ConfirmationCallback};
+use assistant_skills::SkillSource;
+use assistant_storage::{StorageLayer, registry::SkillRegistry};
+use assistant_tool_executor::ToolExecutor;
+
+/// Build a dedicated [`EmbeddingProvider`] from an [`EmbeddingConfig`].
+///
+/// Falls back to provider-specific env vars for API keys.
+fn build_embedding_provider(
+    emb_cfg: &EmbeddingConfig,
+    main_cfg: &assistant_core::types::llm::LlmConfig,
+) -> Result<Arc<dyn EmbeddingProvider>> {
+    match emb_cfg.provider {
+        EmbeddingProviderKind::Ollama => {
+            let ollama_cfg = OllamaConfig {
+                model: "unused".to_string(),
+                base_url: emb_cfg
+                    .base_url
+                    .clone()
+                    .unwrap_or_else(|| main_cfg.base_url.clone()),
+                timeout_secs: main_cfg.timeout_secs,
+                embedding_model: emb_cfg
+                    .model
+                    .clone()
+                    .unwrap_or_else(|| "nomic-embed-text".to_string()),
+            };
+            let provider = OllamaProvider::new(ollama_cfg)
+                .context("Failed to create Ollama embedding provider")?;
+            Ok(Arc::new(LlmEmbedder(Arc::new(provider))))
+        }
+        EmbeddingProviderKind::OpenAI => {
+            let api_key = emb_cfg
+                .api_key
+                .clone()
+                .or_else(|| std::env::var("OPENAI_API_KEY").ok())
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "OpenAI embedding provider requires an API key. \
+                         Set api_key in [llm.embeddings] or OPENAI_API_KEY env var."
+                    )
+                })?;
+            let provider_cfg = OpenAIProviderConfig {
+                model: "unused".to_string(),
+                base_url: emb_cfg
+                    .base_url
+                    .clone()
+                    .unwrap_or_else(|| "https://api.openai.com/v1".to_string()),
+                timeout_secs: main_cfg.timeout_secs,
+                max_tokens: 8192,
+                embedding_model: emb_cfg
+                    .model
+                    .clone()
+                    .unwrap_or_else(|| "text-embedding-3-small".to_string()),
+                web_search: None,
+            };
+            let provider = OpenAIProvider::new(provider_cfg, &api_key)
+                .context("Failed to create OpenAI embedding provider")?;
+            Ok(Arc::new(LlmEmbedder(Arc::new(provider))))
+        }
+        EmbeddingProviderKind::Voyage => {
+            let api_key = emb_cfg
+                .api_key
+                .clone()
+                .or_else(|| std::env::var("VOYAGE_API_KEY").ok())
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Voyage AI embedding provider requires an API key. \
+                         Set api_key in [llm.embeddings] or VOYAGE_API_KEY env var."
+                    )
+                })?;
+            let mut voyage_cfg = VoyageConfig::new(api_key);
+            if let Some(ref url) = emb_cfg.base_url {
+                voyage_cfg = voyage_cfg.with_base_url(url.clone());
+            }
+            if let Some(ref model) = emb_cfg.model {
+                voyage_cfg = voyage_cfg.with_model(model.clone());
+            }
+            let embedder = VoyageEmbedder::new(voyage_cfg)
+                .context("Failed to create Voyage AI embedding provider")?;
+            Ok(Arc::new(embedder))
+        }
+    }
+}
+
+// ── Common bootstrap ──────────────────────────────────────────────────────────
+
+pub struct Bootstrap {
+    pub config: AssistantConfig,
+    pub storage: Arc<StorageLayer>,
+    pub registry: Arc<SkillRegistry>,
+    pub executor: Arc<ToolExecutor>,
+    pub orchestrator: Arc<Orchestrator>,
+    pub user_skills_dir: PathBuf,
+    pub llm: Arc<dyn LlmProvider>,
+}
+
+pub async fn bootstrap(
+    home: &Path,
+    confirmation_cb: Arc<dyn ConfirmationCallback>,
+    storage: Arc<StorageLayer>,
+    config: AssistantConfig,
+) -> Result<Bootstrap> {
+    let assistant_dir = home.join(".assistant");
+    let user_skills_dir = assistant_dir.join("skills");
+
+    // Build skill registry.
+    let registry = SkillRegistry::new(storage.pool.clone())
+        .await
+        .context("Failed to create skill registry")?;
+
+    let project_root = std::env::current_dir().ok();
+    let dirs_to_scan = assistant_runtime::bootstrap::skill_dirs(&config, project_root.as_deref());
+    let dirs_ref: Vec<(&Path, SkillSource)> = dirs_to_scan
+        .iter()
+        .map(|(p, s)| (p.as_path(), s.clone()))
+        .collect();
+
+    registry
+        .load_embedded()
+        .await
+        .context("Failed to load embedded builtin skills")?;
+
+    // Sync embedded builtin skills to ~/.assistant/skills/ so on-disk copies
+    // stay in sync with the binary.  Stale or missing files are overwritten;
+    // user skills with different names are never touched.
+    if let Some(home) = dirs::home_dir() {
+        let builtin_target = home.join(".assistant").join("skills");
+        match registry.sync_builtins_to_disk(&builtin_target) {
+            Ok(updated) if !updated.is_empty() => {
+                tracing::info!(
+                    "Synced {} built-in skill(s) to disk: {}",
+                    updated.len(),
+                    updated.join(", ")
+                );
+            }
+            Err(e) => {
+                tracing::warn!("Failed to sync built-in skills to disk: {e}");
+            }
+            _ => {}
+        }
+    }
+
+    registry
+        .load_from_dirs(&dirs_ref)
+        .await
+        .context("Failed to load skills from directories")?;
+
+    let registry = Arc::new(registry);
+
+    // Build LLM client — dispatch on configured provider.
+    let llm: Arc<dyn LlmProvider> = assistant_llm_provider::create_provider(&config.llm)
+        .context("Failed to create LLM provider")?;
+
+    // Optionally wrap with a dedicated embedding provider.
+    let llm: Arc<dyn LlmProvider> = if let Some(ref emb_cfg) = config.llm.embeddings {
+        let embedder = build_embedding_provider(emb_cfg, &config.llm)
+            .context("Failed to build dedicated embedding provider")?;
+        info!(
+            provider = ?emb_cfg.provider,
+            model = emb_cfg.model.as_deref().unwrap_or("(default)"),
+            "Using dedicated embedding provider"
+        );
+        Arc::new(WithEmbeddingOverride::new(llm, embedder))
+    } else {
+        llm
+    };
+
+    // Build tool executor.
+    let executor = Arc::new(ToolExecutor::new(
+        storage.clone(),
+        llm.clone(),
+        registry.clone(),
+        Arc::new(config.clone()),
+    ));
+
+    // Build message bus.
+    // When the `nats` feature is enabled and `[bus] kind = "nats"` is
+    // configured, use NATS JetStream to avoid SQLite write-lock contention
+    // between the bus and the rest of the storage layer.  Otherwise fall
+    // back to the SQLite-backed bus.
+    let bus: Arc<dyn MessageBus> = {
+        #[cfg(feature = "nats")]
+        {
+            if config.bus.kind == BusKind::Nats {
+                info!("Using NATS message bus");
+                Arc::new(
+                    assistant_bus_nats::NatsMessageBus::connect(&config.bus)
+                        .await
+                        .context("failed to connect to NATS")?,
+                )
+            } else {
+                Arc::new(storage.message_bus())
+            }
+        }
+        #[cfg(not(feature = "nats"))]
+        {
+            if config.bus.kind == BusKind::Nats {
+                anyhow::bail!(
+                    "[bus] kind = \"nats\" configured but this binary was built without the `nats` feature"
+                );
+            }
+            Arc::new(storage.message_bus())
+        }
+    };
+
+    // Build orchestrator, applying the per-persona turn timeout if set.
+    let persona_timeout = storage
+        .persona_store()
+        .get(&config.agent.id)
+        .await
+        .ok()
+        .flatten()
+        .and_then(|p| p.turn_timeout_secs);
+    let audio_store = Arc::new(assistant_transcription::AudioStore::new());
+    let orchestrator = Arc::new({
+        let mut o = Orchestrator::new(
+            llm,
+            storage.clone(),
+            executor.clone(),
+            registry.clone(),
+            bus,
+            &config,
+        )
+        .with_confirmation_callback(confirmation_cb)
+        .with_audio_store(audio_store.clone());
+        if let Some(secs) = persona_timeout {
+            o = o.with_submit_timeout(secs);
+        }
+        o
+    });
+
+    // Wire up subagent support (breaks the init-time circular dep).
+    executor.set_subagent_runner(orchestrator.clone());
+
+    // Connect to configured external MCP servers and register their tools.
+    if !config.mcp.servers.is_empty() {
+        let mcp_manager =
+            Arc::new(assistant_mcp_client::McpClientManager::start(&config.mcp.servers).await?);
+        let mcp_tools = mcp_manager.tool_handlers().await;
+        for handler in &mcp_tools {
+            executor.register_ambient_tool(handler.clone());
+        }
+        info!(
+            servers = mcp_manager.server_count().await,
+            tools = mcp_tools.len(),
+            "registered MCP client tools"
+        );
+
+        // Spawn background health-check loop for reconnection.
+        let exec_register = executor.clone();
+        let exec_unregister = executor.clone();
+        mcp_manager.spawn_health_loop(
+            Arc::new(move |h| exec_register.register_ambient_tool(h)),
+            Arc::new(move |prefix| exec_unregister.unregister_tools_by_prefix(prefix)),
+        );
+    }
+
+    // Keep a reference to the LLM for the memory indexer.
+    let llm = orchestrator.llm.clone();
+
+    Ok(Bootstrap {
+        config,
+        storage,
+        registry,
+        executor,
+        orchestrator,
+        user_skills_dir,
+        llm,
+    })
+}

--- a/crates/interface-cli/src/main.rs
+++ b/crates/interface-cli/src/main.rs
@@ -1,3 +1,4 @@
+mod bootstrap;
 mod cmd_account;
 mod cmd_backup;
 mod cmd_doctor;
@@ -26,23 +27,16 @@ use uuid::Uuid;
 
 use assistant_core::types::agent::AssistantConfig;
 use assistant_core::types::conversation::Interface;
-use assistant_core::types::llm::{EmbeddingConfig, EmbeddingProviderKind};
-use assistant_core::types::storage::BusKind;
 use assistant_core::{
-    ConversationConfig, MessageBus, apply_agent_context, default_workspace_dir,
-    set_runtime_agent_root, set_runtime_workspace_dir, validate_agent_id,
+    ConversationConfig, apply_agent_context, default_workspace_dir, set_runtime_agent_root,
+    set_runtime_workspace_dir, validate_agent_id,
 };
-use assistant_core::{EmbeddingProvider, LlmEmbedder, LlmProvider, WithEmbeddingOverride};
-use assistant_llm_provider::{OllamaConfig, OllamaProvider, OpenAIProvider, OpenAIProviderConfig};
-use assistant_llm_provider::{VoyageConfig, VoyageEmbedder};
 use assistant_runtime::{
-    CommandContext, CommandRegistry, Orchestrator, init_tracing,
-    orchestrator::ConfirmationCallback, spawn_memory_indexer, spawn_scheduler,
-    start_conversation_context,
+    CommandContext, CommandRegistry, init_tracing, orchestrator::ConfirmationCallback,
+    spawn_memory_indexer, spawn_scheduler, start_conversation_context,
 };
-use assistant_skills::SkillSource;
-use assistant_storage::{OrgPoolFactory, StorageLayer, registry::SkillRegistry};
-use assistant_tool_executor::{ToolExecutor, install_skill_from_source};
+use assistant_storage::{OrgPoolFactory, StorageLayer};
+use assistant_tool_executor::install_skill_from_source;
 
 // ── Argument parsing ──────────────────────────────────────────────────────────
 
@@ -752,272 +746,6 @@ pub fn home_agent_root(agent_id: &str) -> Result<PathBuf> {
 
 // ── Embedding provider factory ────────────────────────────────────────────────
 
-/// Build a dedicated [`EmbeddingProvider`] from an [`EmbeddingConfig`].
-///
-/// Falls back to provider-specific env vars for API keys.
-fn build_embedding_provider(
-    emb_cfg: &EmbeddingConfig,
-    main_cfg: &assistant_core::types::llm::LlmConfig,
-) -> Result<Arc<dyn EmbeddingProvider>> {
-    match emb_cfg.provider {
-        EmbeddingProviderKind::Ollama => {
-            let ollama_cfg = OllamaConfig {
-                model: "unused".to_string(),
-                base_url: emb_cfg
-                    .base_url
-                    .clone()
-                    .unwrap_or_else(|| main_cfg.base_url.clone()),
-                timeout_secs: main_cfg.timeout_secs,
-                embedding_model: emb_cfg
-                    .model
-                    .clone()
-                    .unwrap_or_else(|| "nomic-embed-text".to_string()),
-            };
-            let provider = OllamaProvider::new(ollama_cfg)
-                .context("Failed to create Ollama embedding provider")?;
-            Ok(Arc::new(LlmEmbedder(Arc::new(provider))))
-        }
-        EmbeddingProviderKind::OpenAI => {
-            let api_key = emb_cfg
-                .api_key
-                .clone()
-                .or_else(|| std::env::var("OPENAI_API_KEY").ok())
-                .ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "OpenAI embedding provider requires an API key. \
-                         Set api_key in [llm.embeddings] or OPENAI_API_KEY env var."
-                    )
-                })?;
-            let provider_cfg = OpenAIProviderConfig {
-                model: "unused".to_string(),
-                base_url: emb_cfg
-                    .base_url
-                    .clone()
-                    .unwrap_or_else(|| "https://api.openai.com/v1".to_string()),
-                timeout_secs: main_cfg.timeout_secs,
-                max_tokens: 8192,
-                embedding_model: emb_cfg
-                    .model
-                    .clone()
-                    .unwrap_or_else(|| "text-embedding-3-small".to_string()),
-                web_search: None,
-            };
-            let provider = OpenAIProvider::new(provider_cfg, &api_key)
-                .context("Failed to create OpenAI embedding provider")?;
-            Ok(Arc::new(LlmEmbedder(Arc::new(provider))))
-        }
-        EmbeddingProviderKind::Voyage => {
-            let api_key = emb_cfg
-                .api_key
-                .clone()
-                .or_else(|| std::env::var("VOYAGE_API_KEY").ok())
-                .ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "Voyage AI embedding provider requires an API key. \
-                         Set api_key in [llm.embeddings] or VOYAGE_API_KEY env var."
-                    )
-                })?;
-            let mut voyage_cfg = VoyageConfig::new(api_key);
-            if let Some(ref url) = emb_cfg.base_url {
-                voyage_cfg = voyage_cfg.with_base_url(url.clone());
-            }
-            if let Some(ref model) = emb_cfg.model {
-                voyage_cfg = voyage_cfg.with_model(model.clone());
-            }
-            let embedder = VoyageEmbedder::new(voyage_cfg)
-                .context("Failed to create Voyage AI embedding provider")?;
-            Ok(Arc::new(embedder))
-        }
-    }
-}
-
-// ── Common bootstrap ──────────────────────────────────────────────────────────
-
-struct Bootstrap {
-    config: AssistantConfig,
-    storage: Arc<StorageLayer>,
-    registry: Arc<SkillRegistry>,
-    executor: Arc<ToolExecutor>,
-    orchestrator: Arc<Orchestrator>,
-    user_skills_dir: PathBuf,
-    llm: Arc<dyn LlmProvider>,
-}
-
-async fn bootstrap(
-    home: &Path,
-    confirmation_cb: Arc<dyn ConfirmationCallback>,
-    storage: Arc<StorageLayer>,
-    config: AssistantConfig,
-) -> Result<Bootstrap> {
-    let assistant_dir = home.join(".assistant");
-    let user_skills_dir = assistant_dir.join("skills");
-
-    // Build skill registry.
-    let registry = SkillRegistry::new(storage.pool.clone())
-        .await
-        .context("Failed to create skill registry")?;
-
-    let project_root = std::env::current_dir().ok();
-    let dirs_to_scan = assistant_runtime::bootstrap::skill_dirs(&config, project_root.as_deref());
-    let dirs_ref: Vec<(&Path, SkillSource)> = dirs_to_scan
-        .iter()
-        .map(|(p, s)| (p.as_path(), s.clone()))
-        .collect();
-
-    registry
-        .load_embedded()
-        .await
-        .context("Failed to load embedded builtin skills")?;
-
-    // Sync embedded builtin skills to ~/.assistant/skills/ so on-disk copies
-    // stay in sync with the binary.  Stale or missing files are overwritten;
-    // user skills with different names are never touched.
-    if let Some(home) = dirs::home_dir() {
-        let builtin_target = home.join(".assistant").join("skills");
-        match registry.sync_builtins_to_disk(&builtin_target) {
-            Ok(updated) if !updated.is_empty() => {
-                tracing::info!(
-                    "Synced {} built-in skill(s) to disk: {}",
-                    updated.len(),
-                    updated.join(", ")
-                );
-            }
-            Err(e) => {
-                tracing::warn!("Failed to sync built-in skills to disk: {e}");
-            }
-            _ => {}
-        }
-    }
-
-    registry
-        .load_from_dirs(&dirs_ref)
-        .await
-        .context("Failed to load skills from directories")?;
-
-    let registry = Arc::new(registry);
-
-    // Build LLM client — dispatch on configured provider.
-    let llm: Arc<dyn LlmProvider> = assistant_llm_provider::create_provider(&config.llm)
-        .context("Failed to create LLM provider")?;
-
-    // Optionally wrap with a dedicated embedding provider.
-    let llm: Arc<dyn LlmProvider> = if let Some(ref emb_cfg) = config.llm.embeddings {
-        let embedder = build_embedding_provider(emb_cfg, &config.llm)
-            .context("Failed to build dedicated embedding provider")?;
-        info!(
-            provider = ?emb_cfg.provider,
-            model = emb_cfg.model.as_deref().unwrap_or("(default)"),
-            "Using dedicated embedding provider"
-        );
-        Arc::new(WithEmbeddingOverride::new(llm, embedder))
-    } else {
-        llm
-    };
-
-    // Build tool executor.
-    let executor = Arc::new(ToolExecutor::new(
-        storage.clone(),
-        llm.clone(),
-        registry.clone(),
-        Arc::new(config.clone()),
-    ));
-
-    // Build message bus.
-    // When the `nats` feature is enabled and `[bus] kind = "nats"` is
-    // configured, use NATS JetStream to avoid SQLite write-lock contention
-    // between the bus and the rest of the storage layer.  Otherwise fall
-    // back to the SQLite-backed bus.
-    let bus: Arc<dyn MessageBus> = {
-        #[cfg(feature = "nats")]
-        {
-            if config.bus.kind == BusKind::Nats {
-                info!("Using NATS message bus");
-                Arc::new(
-                    assistant_bus_nats::NatsMessageBus::connect(&config.bus)
-                        .await
-                        .context("failed to connect to NATS")?,
-                )
-            } else {
-                Arc::new(storage.message_bus())
-            }
-        }
-        #[cfg(not(feature = "nats"))]
-        {
-            if config.bus.kind == BusKind::Nats {
-                anyhow::bail!(
-                    "[bus] kind = \"nats\" configured but this binary was built without the `nats` feature"
-                );
-            }
-            Arc::new(storage.message_bus())
-        }
-    };
-
-    // Build orchestrator, applying the per-persona turn timeout if set.
-    let persona_timeout = storage
-        .persona_store()
-        .get(&config.agent.id)
-        .await
-        .ok()
-        .flatten()
-        .and_then(|p| p.turn_timeout_secs);
-    let audio_store = Arc::new(assistant_transcription::AudioStore::new());
-    let orchestrator = Arc::new({
-        let mut o = Orchestrator::new(
-            llm,
-            storage.clone(),
-            executor.clone(),
-            registry.clone(),
-            bus,
-            &config,
-        )
-        .with_confirmation_callback(confirmation_cb)
-        .with_audio_store(audio_store.clone());
-        if let Some(secs) = persona_timeout {
-            o = o.with_submit_timeout(secs);
-        }
-        o
-    });
-
-    // Wire up subagent support (breaks the init-time circular dep).
-    executor.set_subagent_runner(orchestrator.clone());
-
-    // Connect to configured external MCP servers and register their tools.
-    if !config.mcp.servers.is_empty() {
-        let mcp_manager =
-            Arc::new(assistant_mcp_client::McpClientManager::start(&config.mcp.servers).await?);
-        let mcp_tools = mcp_manager.tool_handlers().await;
-        for handler in &mcp_tools {
-            executor.register_ambient_tool(handler.clone());
-        }
-        info!(
-            servers = mcp_manager.server_count().await,
-            tools = mcp_tools.len(),
-            "registered MCP client tools"
-        );
-
-        // Spawn background health-check loop for reconnection.
-        let exec_register = executor.clone();
-        let exec_unregister = executor.clone();
-        mcp_manager.spawn_health_loop(
-            Arc::new(move |h| exec_register.register_ambient_tool(h)),
-            Arc::new(move |prefix| exec_unregister.unregister_tools_by_prefix(prefix)),
-        );
-    }
-
-    // Keep a reference to the LLM for the memory indexer.
-    let llm = orchestrator.llm.clone();
-
-    Ok(Bootstrap {
-        config,
-        storage,
-        registry,
-        executor,
-        orchestrator,
-        user_skills_dir,
-        llm,
-    })
-}
-
 // ── Main ──────────────────────────────────────────────────────────────────────
 
 #[tokio::main]
@@ -1276,7 +1004,7 @@ async fn main() -> Result<()> {
         }
     }
 
-    let bs = bootstrap(&home, confirmation_cb, storage.clone(), config).await?;
+    let bs = bootstrap::bootstrap(&home, confirmation_cb, storage.clone(), config).await?;
 
     // 5a. Skill generate — one-shot turn, print result, exit.
     if let Some(Command::Skill {


### PR DESCRIPTION
## Summary

Stacked on #785. Pull the 184-line \`bootstrap\` function + \`Bootstrap\`
struct + \`build_embedding_provider\` helper out of \`main.rs\` into a new
\`crates/interface-cli/src/bootstrap.rs\` — the shared setup that builds
\`StorageLayer\`, \`SkillRegistry\`, \`ToolExecutor\`, \`Orchestrator\`,
the LLM provider, and the optional embedding provider.

\`Bootstrap\` struct + fields flip to \`pub\` so \`main()\` can keep
destructuring. A pile of \`use\` statements that were only needed by
bootstrap drops out of \`main.rs\`.

## Test plan
- [x] \`cargo test -p assistant-cli\` — 59 lib tests passing
- [x] \`make lint\` — clean
- [x] \`cargo fmt --all --check\` — clean
- [x] \`main.rs\` shrinks 1965 → 1693 lines (-272)