### PR TITLE
refactor(interface-cli): extract small helpers into cli_helpers.rs

### DIFF
--- a/crates/interface-cli/src/cli_helpers.rs
+++ b/crates/interface-cli/src/cli_helpers.rs
@@ -1,0 +1,101 @@
+//! Small CLI helpers used by `main`: config loading, interactive
+//! confirmation prompt, and worker-interface name normalisation/filtering.
+
+use std::collections::HashSet;
+use std::io::{self, Write as IoWrite};
+use std::path::Path;
+
+use assistant_core::types::agent::AssistantConfig;
+use assistant_runtime::orchestrator::ConfirmationCallback;
+
+/// Interactive confirmation callback for tool execution — prints a prompt
+/// and reads a line from stdin.
+pub struct CliConfirmation;
+
+impl ConfirmationCallback for CliConfirmation {
+    fn confirm(&self, skill_name: &str, params: &serde_json::Value) -> bool {
+        let params_str = serde_json::to_string_pretty(params).unwrap_or_default();
+        print!(
+            "\nTool '{}' requires confirmation.\nParams: {}\nProceed? [y/N] ",
+            skill_name, params_str
+        );
+        io::stdout().flush().ok();
+
+        let mut buf = String::new();
+        if io::stdin().read_line(&mut buf).is_err() {
+            return false;
+        }
+        matches!(buf.trim().to_lowercase().as_str(), "y" | "yes")
+    }
+}
+
+// ── Config loading ────────────────────────────────────────────────────────────
+
+pub enum ConfigLoadMessage {
+    Info(String),
+    Warn(String),
+}
+
+pub fn load_config_messages(config_path: &Path) -> (AssistantConfig, Vec<ConfigLoadMessage>) {
+    if !config_path.exists() {
+        return (AssistantConfig::default(), Vec::new());
+    }
+
+    let mut messages = Vec::new();
+    let raw = match std::fs::read_to_string(config_path) {
+        Ok(s) => s,
+        Err(e) => {
+            messages.push(ConfigLoadMessage::Warn(format!(
+                "Failed to read config at {}: {e}",
+                config_path.display()
+            )));
+            return (AssistantConfig::default(), messages);
+        }
+    };
+
+    match toml::from_str::<AssistantConfig>(&raw) {
+        Ok(cfg) => {
+            messages.push(ConfigLoadMessage::Info(format!(
+                "Loaded config from {}",
+                config_path.display()
+            )));
+            (cfg, messages)
+        }
+        Err(e) => {
+            messages.push(ConfigLoadMessage::Warn(format!(
+                "Failed to parse config at {}: {e}",
+                config_path.display()
+            )));
+            (AssistantConfig::default(), messages)
+        }
+    }
+}
+
+// ── Worker-interface name normalisation ───────────────────────────────────────
+
+pub fn normalize_worker_interface(interface: &str) -> Option<String> {
+    match interface.trim().to_lowercase().as_str() {
+        "" | "any" | "all" => None,
+        "slack" => Some("Slack".to_string()),
+        "mattermost" => Some("Mattermost".to_string()),
+        "nextcloud" => Some("Nextcloud".to_string()),
+        "web" | "webui" => Some("Web".to_string()),
+        "signal" => Some("Signal".to_string()),
+        other => Some(other.to_string()),
+    }
+}
+
+pub fn parse_interface_selection(input: Option<&str>) -> HashSet<String> {
+    input
+        .map(|raw| {
+            raw.split(',')
+                .map(|v| v.trim().to_lowercase())
+                .filter(|v| !v.is_empty())
+                .collect::<HashSet<_>>()
+        })
+        .unwrap_or_default()
+}
+
+pub fn interface_selected(selected: &HashSet<String>, interface: &str) -> bool {
+    selected.is_empty() || selected.contains(interface)
+}

--- a/crates/interface-cli/src/main.rs
+++ b/crates/interface-cli/src/main.rs
@@ -1,4 +1,5 @@
 mod bootstrap;
+mod cli_helpers;
 mod cmd_account;
 mod cmd_backup;
 mod cmd_doctor;
@@ -10,6 +11,11 @@ mod cmd_review;
 mod cmd_skill;
 mod credentials;
 mod skill_diff;
+
+use cli_helpers::{
+    CliConfirmation, ConfigLoadMessage, interface_selected, load_config_messages,
+    normalize_worker_interface, parse_interface_selection,
+};
 
 use std::collections::{HashMap, HashSet};
 use std::io::{self, Write as IoWrite};
@@ -25,7 +31,6 @@ use tokio::sync::mpsc;
 use tracing::{info, warn};
 use uuid::Uuid;
 
-use assistant_core::types::agent::AssistantConfig;
 use assistant_core::types::conversation::Interface;
 use assistant_core::{
     ConversationConfig, apply_agent_context, default_workspace_dir, set_runtime_agent_root,
@@ -332,98 +337,6 @@ pub enum SkillCommand {
         /// Natural-language description of what the skill should do.
         description: String,
     },
-}
-
-// ── CLI confirmation callback ─────────────────────────────────────────────────
-
-/// Implements `ConfirmationCallback` by printing a `[y/N]` prompt to stdout
-/// and reading a line from stdin.
-struct CliConfirmation;
-
-impl ConfirmationCallback for CliConfirmation {
-    fn confirm(&self, skill_name: &str, params: &serde_json::Value) -> bool {
-        let params_str = serde_json::to_string_pretty(params).unwrap_or_default();
-        print!(
-            "\nTool '{}' requires confirmation.\nParams: {}\nProceed? [y/N] ",
-            skill_name, params_str
-        );
-        io::stdout().flush().ok();
-
-        let mut buf = String::new();
-        if io::stdin().read_line(&mut buf).is_err() {
-            return false;
-        }
-        matches!(buf.trim().to_lowercase().as_str(), "y" | "yes")
-    }
-}
-
-// ── Config loading ────────────────────────────────────────────────────────────
-
-enum ConfigLoadMessage {
-    Info(String),
-    Warn(String),
-}
-
-fn load_config_messages(config_path: &Path) -> (AssistantConfig, Vec<ConfigLoadMessage>) {
-    if !config_path.exists() {
-        return (AssistantConfig::default(), Vec::new());
-    }
-
-    let mut messages = Vec::new();
-    let raw = match std::fs::read_to_string(config_path) {
-        Ok(s) => s,
-        Err(e) => {
-            messages.push(ConfigLoadMessage::Warn(format!(
-                "Failed to read config at {}: {e}",
-                config_path.display()
-            )));
-            return (AssistantConfig::default(), messages);
-        }
-    };
-
-    match toml::from_str::<AssistantConfig>(&raw) {
-        Ok(cfg) => {
-            messages.push(ConfigLoadMessage::Info(format!(
-                "Loaded config from {}",
-                config_path.display()
-            )));
-            (cfg, messages)
-        }
-        Err(e) => {
-            messages.push(ConfigLoadMessage::Warn(format!(
-                "Failed to parse config at {}: {e}",
-                config_path.display()
-            )));
-            (AssistantConfig::default(), messages)
-        }
-    }
-}
-
-fn normalize_worker_interface(interface: &str) -> Option<String> {
-    match interface.trim().to_lowercase().as_str() {
-        "" | "any" | "all" => None,
-        "slack" => Some("Slack".to_string()),
-        "mattermost" => Some("Mattermost".to_string()),
-        "nextcloud" => Some("Nextcloud".to_string()),
-        "web" | "webui" => Some("Web".to_string()),
-        "signal" => Some("Signal".to_string()),
-        other => Some(other.to_string()),
-    }
-}
-
-fn parse_interface_selection(input: Option<&str>) -> HashSet<String> {
-    input
-        .map(|raw| {
-            raw.split(',')
-                .map(|v| v.trim().to_lowercase())
-                .filter(|v| !v.is_empty())
-                .collect::<HashSet<_>>()
-        })
-        .unwrap_or_default()
-}
-
-fn interface_selected(selected: &HashSet<String>, interface: &str) -> bool {
-    selected.is_empty() || selected.contains(interface)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Stacked on #786. Pull three small clusters out of \`main.rs\` into a new
\`crates/interface-cli/src/cli_helpers.rs\`:

- \`CliConfirmation\` — interactive confirmation prompt
- \`ConfigLoadMessage\` + \`load_config_messages\` — deferred-logging config reader
- \`normalize_worker_interface\`, \`parse_interface_selection\`,
  \`interface_selected\` — worker-interface name normalisation + filter

## Test plan
- [x] \`cargo test -p assistant-cli\` — 59 lib tests passing
- [x] \`make lint\` — clean
- [x] \`cargo fmt --all --check\` — clean
- [x] \`main.rs\` shrinks 1693 → 1606 lines (-87)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization by consolidating internal CLI utilities into a dedicated module for enhanced maintainability and code structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cedricziel/assistant/pull/787?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->