### PR TITLE
feat(app): Phase 1 — adaptive UI consolidation façade wrappers

### DIFF
--- a/app/lib/shared/platform/adaptive_action_sheet.dart
+++ b/app/lib/shared/platform/adaptive_action_sheet.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import 'platform.dart';
+
+/// A single action in an [showAdaptiveActionSheet] sheet.
+///
+/// [onPressed] receives the sheet's [BuildContext] so the callback can
+/// `Navigator.of(ctx).pop(value)` to return a value to the awaiter.
+class AdaptiveActionSheetAction<T> {
+  const AdaptiveActionSheetAction({
+    required this.label,
+    required this.onPressed,
+    this.isDestructive = false,
+  });
+
+  final String label;
+  final void Function(BuildContext) onPressed;
+  final bool isDestructive;
+}
+
+/// Shows a platform-appropriate action sheet.
+///
+/// - Apple touch platforms: [showCupertinoModalPopup] with
+///   [CupertinoActionSheet].
+/// - Material / macOS: [showModalBottomSheet] with a list of
+///   [ListTile]s.
+///
+/// Returns the value popped by the chosen action, or `null` if dismissed.
+Future<T?> showAdaptiveActionSheet<T>({
+  required BuildContext context,
+  String? title,
+  String? message,
+  required List<AdaptiveActionSheetAction<T>> actions,
+  String cancelLabel = 'Cancel',
+}) {
+  if (isAppleTouch) {
+    return showCupertinoModalPopup<T>(
+      context: context,
+      builder: (ctx) => CupertinoActionSheet(
+        title: title != null ? Text(title) : null,
+        message: message != null ? Text(message) : null,
+        actions: actions
+            .map(
+              (a) => CupertinoActionSheetAction(
+                onPressed: () => a.onPressed(ctx),
+                isDestructiveAction: a.isDestructive,
+                child: Text(a.label),
+              ),
+            )
+            .toList(),
+        cancelButton: CupertinoActionSheetAction(
+          onPressed: () => Navigator.of(ctx).pop(),
+          child: Text(cancelLabel),
+        ),
+      ),
+    );
+  }
+  return showModalBottomSheet<T>(
+    context: context,
+    builder: (ctx) {
+      final cs = Theme.of(ctx).colorScheme;
+      return SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (title != null)
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+                child: Text(title, style: Theme.of(ctx).textTheme.titleMedium),
+              ),
+            if (message != null)
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+                child: Text(message, style: Theme.of(ctx).textTheme.bodyMedium),
+              ),
+            ...actions.map(
+              (a) => ListTile(
+                title: Text(
+                  a.label,
+                  style: a.isDestructive ? TextStyle(color: cs.error) : null,
+                ),
+                onTap: () => a.onPressed(ctx),
+              ),
+            ),
+            ListTile(
+              title: Text(cancelLabel),
+              onTap: () => Navigator.of(ctx).pop(),
+            ),
+          ],
+        ),
+      );
+    },
+  );
+}

--- a/app/lib/shared/platform/adaptive_button.dart
+++ b/app/lib/shared/platform/adaptive_button.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import 'platform.dart';
+
+/// Button that renders Cupertino on Apple touch platforms and Material
+/// elsewhere.
+///
+/// Two variants:
+/// - [AdaptiveButton.filled] — primary, emphasized action.
+///   iOS: [CupertinoButton.filled]; Material: [FilledButton].
+/// - [AdaptiveButton.plain] — secondary, non-emphasized action.
+///   iOS: plain [CupertinoButton]; Material: [TextButton].
+class AdaptiveButton extends StatelessWidget {
+  const AdaptiveButton.filled({
+    super.key,
+    required this.onPressed,
+    required this.child,
+  }) : _filled = true;
+
+  const AdaptiveButton.plain({
+    super.key,
+    required this.onPressed,
+    required this.child,
+  }) : _filled = false;
+
+  final VoidCallback? onPressed;
+  final Widget child;
+  final bool _filled;
+
+  @override
+  Widget build(BuildContext context) {
+    if (isAppleTouch) {
+      if (_filled) {
+        return CupertinoButton.filled(onPressed: onPressed, child: child);
+      }
+      return CupertinoButton(onPressed: onPressed, child: child);
+    }
+    if (_filled) {
+      return FilledButton(onPressed: onPressed, child: child);
+    }
+    return TextButton(onPressed: onPressed, child: child);
+  }
+}

--- a/app/lib/shared/platform/adaptive_icon.dart
+++ b/app/lib/shared/platform/adaptive_icon.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import 'platform.dart';
+
+/// Icon that picks between a Cupertino glyph and a Material glyph based on
+/// the runtime platform.
+///
+/// Use this when the iOS-native (SF Symbols) and Material icon for the
+/// same concept have different [IconData]. Both arguments are required so
+/// that call sites are explicit about the pair.
+class AdaptiveIcon extends StatelessWidget {
+  const AdaptiveIcon({
+    super.key,
+    required this.cupertino,
+    required this.material,
+    this.size,
+    this.color,
+  });
+
+  final IconData cupertino;
+  final IconData material;
+  final double? size;
+  final Color? color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Icon(isAppleTouch ? cupertino : material, size: size, color: color);
+  }
+}

--- a/app/lib/shared/platform/adaptive_list_section.dart
+++ b/app/lib/shared/platform/adaptive_list_section.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import 'platform.dart';
+
+/// Grouped list section that renders [CupertinoListSection.insetGrouped] on
+/// Apple touch platforms and a Material section header + column on
+/// Material / macOS targets.
+///
+/// Compose with [AdaptiveListTile] children. Pass an optional [header] to
+/// render an iOS-style section title (or a Material label above the
+/// children block).
+class AdaptiveListSection extends StatelessWidget {
+  const AdaptiveListSection({super.key, this.header, required this.children});
+
+  final Widget? header;
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    if (isAppleTouch) {
+      return CupertinoListSection.insetGrouped(
+        header: header,
+        children: children,
+      );
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (header != null)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 20, 16, 4),
+            child: DefaultTextStyle.merge(
+              style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                color: Theme.of(context).colorScheme.primary,
+              ),
+              child: header!,
+            ),
+          ),
+        ...children,
+      ],
+    );
+  }
+}

--- a/app/lib/shared/platform/adaptive_list_tile.dart
+++ b/app/lib/shared/platform/adaptive_list_tile.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import 'platform.dart';
+
+/// List tile that renders [CupertinoListTile] on Apple touch platforms and
+/// [ListTile] on Material / macOS targets.
+///
+/// API mirrors the common subset of both underlying tiles: [title],
+/// [subtitle], [leading], [trailing], [onTap]. Use inside an
+/// [AdaptiveListSection] for the iOS Settings idiom.
+class AdaptiveListTile extends StatelessWidget {
+  const AdaptiveListTile({
+    super.key,
+    required this.title,
+    this.subtitle,
+    this.leading,
+    this.trailing,
+    this.onTap,
+  });
+
+  final Widget title;
+  final Widget? subtitle;
+  final Widget? leading;
+  final Widget? trailing;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    if (isAppleTouch) {
+      return CupertinoListTile(
+        title: title,
+        subtitle: subtitle,
+        leading: leading,
+        trailing: trailing,
+        onTap: onTap,
+      );
+    }
+    return ListTile(
+      title: title,
+      subtitle: subtitle,
+      leading: leading,
+      trailing: trailing,
+      onTap: onTap,
+    );
+  }
+}

--- a/app/lib/shared/platform/adaptive_slider.dart
+++ b/app/lib/shared/platform/adaptive_slider.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import 'platform.dart';
+
+/// Slider that renders [CupertinoSlider] on Apple touch platforms and
+/// Material [Slider] on Material / macOS targets.
+///
+/// Common subset of both APIs: [value], [onChanged], [min], [max],
+/// [divisions]. Pass `null` for [onChanged] to render a disabled slider.
+class AdaptiveSlider extends StatelessWidget {
+  const AdaptiveSlider({
+    super.key,
+    required this.value,
+    required this.onChanged,
+    this.min = 0.0,
+    this.max = 1.0,
+    this.divisions,
+  });
+
+  final double value;
+  final ValueChanged<double>? onChanged;
+  final double min;
+  final double max;
+  final int? divisions;
+
+  @override
+  Widget build(BuildContext context) {
+    if (isAppleTouch) {
+      return CupertinoSlider(
+        value: value,
+        onChanged: onChanged,
+        min: min,
+        max: max,
+        divisions: divisions,
+      );
+    }
+    return Slider(
+      value: value,
+      onChanged: onChanged,
+      min: min,
+      max: max,
+      divisions: divisions,
+    );
+  }
+}

--- a/app/lib/shared/platform/adaptive_sliver_nav_bar.dart
+++ b/app/lib/shared/platform/adaptive_sliver_nav_bar.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import 'platform.dart';
+
+/// Sliver navigation bar that renders [CupertinoSliverNavigationBar] (with
+/// large title) on Apple touch platforms and [SliverAppBar] on Material /
+/// macOS targets.
+///
+/// Use this widget inside a [CustomScrollView] for list-style screens that
+/// want the iOS large-title-collapses-on-scroll pattern. On Material the
+/// equivalent is a [SliverAppBar.large] which provides similar behaviour.
+///
+/// On iOS 26 the underlying Cupertino sliver will be swapped for an
+/// `adaptive_platform_ui` UIKit-embedded native nav bar in a later phase;
+/// the wrapper API stays unchanged.
+class AdaptiveSliverNavBar extends StatelessWidget {
+  const AdaptiveSliverNavBar({
+    super.key,
+    required this.title,
+    this.actions,
+    this.leading,
+    this.previousPageTitle,
+  });
+
+  final String title;
+  final List<Widget>? actions;
+  final Widget? leading;
+  final String? previousPageTitle;
+
+  @override
+  Widget build(BuildContext context) {
+    if (isAppleTouch) {
+      return CupertinoSliverNavigationBar(
+        largeTitle: Text(title),
+        leading: leading,
+        previousPageTitle: previousPageTitle,
+        trailing: (actions != null && actions!.isNotEmpty)
+            ? Row(mainAxisSize: MainAxisSize.min, children: actions!)
+            : null,
+      );
+    }
+    return SliverAppBar.large(
+      title: Text(title),
+      leading: leading,
+      actions: actions,
+    );
+  }
+}

--- a/app/lib/shared/platform/adaptive_snack_bar.dart
+++ b/app/lib/shared/platform/adaptive_snack_bar.dart
@@ -1,0 +1,66 @@
+import 'dart:async';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import 'platform.dart';
+
+/// Shows a platform-appropriate transient message.
+///
+/// - Apple touch platforms: a Cupertino-styled toast in the overlay that
+///   auto-dismisses after [duration].
+/// - Material / macOS: a standard Material [SnackBar] via
+///   [ScaffoldMessenger].
+///
+/// Phase 3 may swap the iOS path to a UIKit-embedded equivalent from
+/// `adaptive_platform_ui`; the surface here stays unchanged.
+void showAdaptiveSnackBar(
+  BuildContext context,
+  String message, {
+  Duration duration = const Duration(seconds: 2),
+}) {
+  if (isAppleTouch) {
+    _showCupertinoToast(context, message, duration);
+    return;
+  }
+  ScaffoldMessenger.of(
+    context,
+  ).showSnackBar(SnackBar(content: Text(message), duration: duration));
+}
+
+void _showCupertinoToast(
+  BuildContext context,
+  String message,
+  Duration duration,
+) {
+  final overlay = Overlay.maybeOf(context);
+  if (overlay == null) return;
+
+  late OverlayEntry entry;
+  entry = OverlayEntry(
+    builder: (ctx) => Positioned(
+      left: 16,
+      right: 16,
+      bottom: MediaQuery.of(ctx).padding.bottom + 24,
+      child: IgnorePointer(
+        child: Center(
+          child: CupertinoPopupSurface(
+            isSurfacePainted: true,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              child: Text(
+                message,
+                style: CupertinoTheme.of(ctx).textTheme.textStyle,
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+
+  overlay.insert(entry);
+  Timer(duration, () {
+    if (entry.mounted) entry.remove();
+  });
+}

--- a/app/lib/shared/platform/adaptive_switch.dart
+++ b/app/lib/shared/platform/adaptive_switch.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import 'platform.dart';
+
+/// Switch that renders [CupertinoSwitch] on Apple touch platforms and
+/// Material [Switch] on Material / macOS targets.
+///
+/// [value] is the current state. [onChanged] is the toggle callback;
+/// pass `null` to render the switch as disabled.
+class AdaptiveSwitch extends StatelessWidget {
+  const AdaptiveSwitch({
+    super.key,
+    required this.value,
+    required this.onChanged,
+  });
+
+  final bool value;
+  final ValueChanged<bool>? onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    if (isAppleTouch) {
+      return CupertinoSwitch(value: value, onChanged: onChanged);
+    }
+    return Switch(value: value, onChanged: onChanged);
+  }
+}

--- a/app/lib/shared/platform/adaptive_switch_tile.dart
+++ b/app/lib/shared/platform/adaptive_switch_tile.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import 'platform.dart';
+
+/// Row combining a label, optional subtitle, and a switch.
+///
+/// On Apple touch platforms renders a [CupertinoListTile] with a trailing
+/// [CupertinoSwitch] (the iOS Settings idiom). On Material / macOS renders
+/// a [SwitchListTile].
+class AdaptiveSwitchTile extends StatelessWidget {
+  const AdaptiveSwitchTile({
+    super.key,
+    required this.title,
+    this.subtitle,
+    this.leading,
+    required this.value,
+    required this.onChanged,
+  });
+
+  final Widget title;
+  final Widget? subtitle;
+  final Widget? leading;
+  final bool value;
+  final ValueChanged<bool>? onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    if (isAppleTouch) {
+      return CupertinoListTile(
+        leading: leading,
+        title: title,
+        subtitle: subtitle,
+        trailing: CupertinoSwitch(value: value, onChanged: onChanged),
+      );
+    }
+    return SwitchListTile(
+      secondary: leading,
+      title: title,
+      subtitle: subtitle,
+      value: value,
+      onChanged: onChanged,
+    );
+  }
+}

--- a/app/lib/shared/platform/adaptive_text_field.dart
+++ b/app/lib/shared/platform/adaptive_text_field.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import 'platform.dart';
+
+/// Single-line text input that renders [CupertinoTextField] on Apple touch
+/// platforms and Material [TextField] on Material / macOS targets.
+///
+/// API exposes the common subset of both: [controller], [placeholder],
+/// [onChanged], [onSubmitted], [keyboardType], [obscureText], [autofocus],
+/// and [textInputAction]. The Material path maps [placeholder] to
+/// `InputDecoration.hintText`.
+class AdaptiveTextField extends StatelessWidget {
+  const AdaptiveTextField({
+    super.key,
+    this.controller,
+    this.placeholder,
+    this.onChanged,
+    this.onSubmitted,
+    this.keyboardType,
+    this.obscureText = false,
+    this.autofocus = false,
+    this.textInputAction,
+  });
+
+  final TextEditingController? controller;
+  final String? placeholder;
+  final ValueChanged<String>? onChanged;
+  final ValueChanged<String>? onSubmitted;
+  final TextInputType? keyboardType;
+  final bool obscureText;
+  final bool autofocus;
+  final TextInputAction? textInputAction;
+
+  @override
+  Widget build(BuildContext context) {
+    if (isAppleTouch) {
+      return CupertinoTextField(
+        controller: controller,
+        placeholder: placeholder,
+        onChanged: onChanged,
+        onSubmitted: onSubmitted,
+        keyboardType: keyboardType,
+        obscureText: obscureText,
+        autofocus: autofocus,
+        textInputAction: textInputAction,
+      );
+    }
+    return TextField(
+      controller: controller,
+      decoration: placeholder != null
+          ? InputDecoration(hintText: placeholder)
+          : null,
+      onChanged: onChanged,
+      onSubmitted: onSubmitted,
+      keyboardType: keyboardType,
+      obscureText: obscureText,
+      autofocus: autofocus,
+      textInputAction: textInputAction,
+    );
+  }
+}

--- a/app/test/widget/platform/adaptive_action_sheet_test.dart
+++ b/app/test/widget/platform/adaptive_action_sheet_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/shared/platform/adaptive_action_sheet.dart';
+
+void main() {
+  group('showAdaptiveActionSheet', () {
+    testWidgets('shows CupertinoActionSheet on iOS', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      late BuildContext capturedCtx;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Builder(
+              builder: (ctx) {
+                capturedCtx = ctx;
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        ),
+      );
+
+      showAdaptiveActionSheet<String>(
+        context: capturedCtx,
+        title: 'Pick one',
+        actions: [
+          AdaptiveActionSheetAction(
+            label: 'A',
+            onPressed: (ctx) => Navigator.of(ctx).pop('a'),
+          ),
+          AdaptiveActionSheetAction(
+            label: 'B',
+            onPressed: (ctx) => Navigator.of(ctx).pop('b'),
+            isDestructive: true,
+          ),
+        ],
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CupertinoActionSheet), findsOneWidget);
+      expect(find.text('Pick one'), findsOneWidget);
+      expect(find.text('A'), findsOneWidget);
+      expect(find.text('B'), findsOneWidget);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('shows modal bottom sheet on Android', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      late BuildContext capturedCtx;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (ctx) {
+                capturedCtx = ctx;
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        ),
+      );
+
+      showAdaptiveActionSheet<String>(
+        context: capturedCtx,
+        title: 'Pick one',
+        actions: [
+          AdaptiveActionSheetAction(
+            label: 'A',
+            onPressed: (ctx) => Navigator.of(ctx).pop('a'),
+          ),
+        ],
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CupertinoActionSheet), findsNothing);
+      expect(find.text('Pick one'), findsOneWidget);
+      expect(find.text('A'), findsOneWidget);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('returns selected value on iOS', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      late BuildContext capturedCtx;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Builder(
+              builder: (ctx) {
+                capturedCtx = ctx;
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        ),
+      );
+
+      final future = showAdaptiveActionSheet<String>(
+        context: capturedCtx,
+        title: 'Pick one',
+        actions: [
+          AdaptiveActionSheetAction(
+            label: 'A',
+            onPressed: (ctx) => Navigator.of(ctx).pop('a'),
+          ),
+        ],
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('A'));
+      await tester.pumpAndSettle();
+      expect(await future, 'a');
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+  });
+}

--- a/app/test/widget/platform/adaptive_button_test.dart
+++ b/app/test/widget/platform/adaptive_button_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/shared/platform/adaptive_button.dart';
+
+Widget _harness(Widget child) {
+  return MaterialApp(
+    home: Material(child: Center(child: child)),
+  );
+}
+
+void main() {
+  group('AdaptiveButton', () {
+    testWidgets('filled renders CupertinoButton.filled on iOS', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+      await tester.pumpWidget(
+        _harness(
+          AdaptiveButton.filled(onPressed: () {}, child: const Text('Save')),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CupertinoButton), findsOneWidget);
+      expect(find.byType(FilledButton), findsNothing);
+      expect(find.text('Save'), findsOneWidget);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('filled renders FilledButton on Android', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+      await tester.pumpWidget(
+        _harness(
+          AdaptiveButton.filled(onPressed: () {}, child: const Text('Save')),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(FilledButton), findsOneWidget);
+      expect(find.byType(CupertinoButton), findsNothing);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('plain renders CupertinoButton on iOS', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+      await tester.pumpWidget(
+        _harness(
+          AdaptiveButton.plain(onPressed: () {}, child: const Text('Cancel')),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CupertinoButton), findsOneWidget);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('plain renders TextButton on Android', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+      await tester.pumpWidget(
+        _harness(
+          AdaptiveButton.plain(onPressed: () {}, child: const Text('Cancel')),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(TextButton), findsOneWidget);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('onPressed fires on Material', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      var tapped = false;
+
+      await tester.pumpWidget(
+        _harness(
+          AdaptiveButton.filled(
+            onPressed: () => tapped = true,
+            child: const Text('Click'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byType(FilledButton));
+      expect(tapped, isTrue);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('null onPressed renders disabled', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+      await tester.pumpWidget(
+        _harness(
+          AdaptiveButton.filled(onPressed: null, child: const Text('Click')),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final btn = tester.widget<FilledButton>(find.byType(FilledButton));
+      expect(btn.onPressed, isNull);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+  });
+}

--- a/app/test/widget/platform/adaptive_icon_test.dart
+++ b/app/test/widget/platform/adaptive_icon_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/shared/platform/adaptive_icon.dart';
+
+Widget _harness(Widget child) {
+  return MaterialApp(
+    home: Material(child: Center(child: child)),
+  );
+}
+
+void main() {
+  group('AdaptiveIcon', () {
+    testWidgets('renders Cupertino icon on iOS', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+      await tester.pumpWidget(
+        _harness(
+          const AdaptiveIcon(
+            cupertino: CupertinoIcons.add,
+            material: Icons.add,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(CupertinoIcons.add), findsOneWidget);
+      expect(find.byIcon(Icons.add), findsNothing);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('renders Material icon on Android', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+      await tester.pumpWidget(
+        _harness(
+          const AdaptiveIcon(
+            cupertino: CupertinoIcons.add,
+            material: Icons.add,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.add), findsOneWidget);
+      expect(find.byIcon(CupertinoIcons.add), findsNothing);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('renders Material icon on macOS (fallback)', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+
+      await tester.pumpWidget(
+        _harness(
+          const AdaptiveIcon(
+            cupertino: CupertinoIcons.delete,
+            material: Icons.delete,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.delete), findsOneWidget);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('size and color flow through', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+      await tester.pumpWidget(
+        _harness(
+          const AdaptiveIcon(
+            cupertino: CupertinoIcons.add,
+            material: Icons.add,
+            size: 32,
+            color: Color(0xFFFF0000),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final ic = tester.widget<Icon>(find.byType(Icon));
+      expect(ic.size, 32);
+      expect(ic.color, const Color(0xFFFF0000));
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+  });
+}

--- a/app/test/widget/platform/adaptive_list_section_test.dart
+++ b/app/test/widget/platform/adaptive_list_section_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/shared/platform/adaptive_list_section.dart';
+import 'package:assistant_app/shared/platform/adaptive_list_tile.dart';
+
+Widget _harness(Widget child) {
+  return MaterialApp(home: Material(child: child));
+}
+
+void main() {
+  group('AdaptiveListSection', () {
+    testWidgets('renders CupertinoListSection on iOS', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+      await tester.pumpWidget(
+        _harness(
+          AdaptiveListSection(
+            header: const Text('Section'),
+            children: const [AdaptiveListTile(title: Text('Item'))],
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CupertinoListSection), findsOneWidget);
+      expect(find.text('Section'), findsOneWidget);
+      expect(find.text('Item'), findsOneWidget);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('renders Material header + column on Android', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+      await tester.pumpWidget(
+        _harness(
+          AdaptiveListSection(
+            header: const Text('Section'),
+            children: const [AdaptiveListTile(title: Text('Item'))],
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CupertinoListSection), findsNothing);
+      expect(find.text('Section'), findsOneWidget);
+      expect(find.text('Item'), findsOneWidget);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('renders without header on iOS', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+      await tester.pumpWidget(
+        _harness(
+          AdaptiveListSection(
+            children: const [AdaptiveListTile(title: Text('Item'))],
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CupertinoListSection), findsOneWidget);
+      expect(find.text('Item'), findsOneWidget);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+  });
+}

--- a/app/test/widget/platform/adaptive_list_tile_test.dart
+++ b/app/test/widget/platform/adaptive_list_tile_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/shared/platform/adaptive_list_tile.dart';
+
+Widget _harness(Widget child) {
+  return MaterialApp(home: Material(child: child));
+}
+
+void main() {
+  group('AdaptiveListTile', () {
+    testWidgets('renders CupertinoListTile on iOS', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+      await tester.pumpWidget(
+        _harness(const AdaptiveListTile(title: Text('Hello'))),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CupertinoListTile), findsOneWidget);
+      expect(find.byType(ListTile), findsNothing);
+      expect(find.text('Hello'), findsOneWidget);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('renders ListTile on Android', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+      await tester.pumpWidget(
+        _harness(const AdaptiveListTile(title: Text('Hello'))),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ListTile), findsOneWidget);
+      expect(find.byType(CupertinoListTile), findsNothing);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('renders ListTile on macOS (fallback)', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+
+      await tester.pumpWidget(
+        _harness(const AdaptiveListTile(title: Text('Hello'))),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ListTile), findsOneWidget);
+      expect(find.byType(CupertinoListTile), findsNothing);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('onTap fires on iOS', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      var tapped = false;
+
+      await tester.pumpWidget(
+        _harness(
+          AdaptiveListTile(
+            title: const Text('Tap me'),
+            onTap: () => tapped = true,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byType(CupertinoListTile));
+      expect(tapped, isTrue);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('onTap fires on Material', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      var tapped = false;
+
+      await tester.pumpWidget(
+        _harness(
+          AdaptiveListTile(
+            title: const Text('Tap me'),
+            onTap: () => tapped = true,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byType(ListTile));
+      expect(tapped, isTrue);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+  });
+}

--- a/app/test/widget/platform/adaptive_slider_test.dart
+++ b/app/test/widget/platform/adaptive_slider_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/shared/platform/adaptive_slider.dart';
+
+Widget _harness(Widget child) {
+  return MaterialApp(
+    home: Material(child: Center(child: child)),
+  );
+}
+
+void main() {
+  group('AdaptiveSlider', () {
+    testWidgets('renders CupertinoSlider on iOS', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+      await tester.pumpWidget(
+        _harness(AdaptiveSlider(value: 0.5, onChanged: (_) {})),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CupertinoSlider), findsOneWidget);
+      expect(find.byType(Slider), findsNothing);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('renders Slider on Android', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+      await tester.pumpWidget(
+        _harness(AdaptiveSlider(value: 0.5, onChanged: (_) {})),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(Slider), findsOneWidget);
+      expect(find.byType(CupertinoSlider), findsNothing);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('value and bounds flow through on iOS', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+      await tester.pumpWidget(
+        _harness(
+          AdaptiveSlider(value: 25, min: 0, max: 100, onChanged: (_) {}),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final s = tester.widget<CupertinoSlider>(find.byType(CupertinoSlider));
+      expect(s.value, 25);
+      expect(s.min, 0);
+      expect(s.max, 100);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('null onChanged disables Material slider', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+      await tester.pumpWidget(
+        _harness(const AdaptiveSlider(value: 0.5, onChanged: null)),
+      );
+      await tester.pumpAndSettle();
+
+      final s = tester.widget<Slider>(find.byType(Slider));
+      expect(s.onChanged, isNull);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+  });
+}

--- a/app/test/widget/platform/adaptive_sliver_nav_bar_test.dart
+++ b/app/test/widget/platform/adaptive_sliver_nav_bar_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/shared/platform/adaptive_sliver_nav_bar.dart';
+
+Widget _harness(Widget sliver) {
+  return MaterialApp(
+    home: Material(
+      child: CustomScrollView(
+        slivers: [
+          sliver,
+          const SliverToBoxAdapter(child: SizedBox(height: 100)),
+        ],
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('AdaptiveSliverNavBar', () {
+    testWidgets('renders CupertinoSliverNavigationBar on iOS', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+      await tester.pumpWidget(
+        _harness(const AdaptiveSliverNavBar(title: 'Test Title')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CupertinoSliverNavigationBar), findsOneWidget);
+      expect(find.byType(SliverAppBar), findsNothing);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('renders SliverAppBar on Android', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+      await tester.pumpWidget(
+        _harness(const AdaptiveSliverNavBar(title: 'Test Title')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(SliverAppBar), findsOneWidget);
+      expect(find.byType(CupertinoSliverNavigationBar), findsNothing);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('renders SliverAppBar on macOS', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+
+      await tester.pumpWidget(
+        _harness(const AdaptiveSliverNavBar(title: 'Test Title')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(SliverAppBar), findsOneWidget);
+      expect(find.byType(CupertinoSliverNavigationBar), findsNothing);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('renders title text on iOS', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+      await tester.pumpWidget(
+        _harness(const AdaptiveSliverNavBar(title: 'Hello iOS')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Hello iOS'), findsOneWidget);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('renders title text on Material', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+      await tester.pumpWidget(
+        _harness(const AdaptiveSliverNavBar(title: 'Hello Material')),
+      );
+      await tester.pumpAndSettle();
+
+      // SliverAppBar.large renders both a collapsed and an expanded Text
+      // for the title, so at least one occurrence is enough to verify
+      // the title flows through.
+      expect(find.text('Hello Material'), findsAtLeastNWidgets(1));
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('renders trailing actions on Material', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+      await tester.pumpWidget(
+        _harness(
+          AdaptiveSliverNavBar(
+            title: 'With Actions',
+            actions: [
+              IconButton(icon: const Icon(Icons.add), onPressed: () {}),
+            ],
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.add), findsOneWidget);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+  });
+}

--- a/app/test/widget/platform/adaptive_snack_bar_test.dart
+++ b/app/test/widget/platform/adaptive_snack_bar_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/shared/platform/adaptive_snack_bar.dart';
+
+void main() {
+  group('showAdaptiveSnackBar', () {
+    testWidgets('shows Material SnackBar on Android', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      late BuildContext capturedCtx;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (ctx) {
+                capturedCtx = ctx;
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        ),
+      );
+
+      showAdaptiveSnackBar(capturedCtx, 'Hello world');
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('Hello world'), findsOneWidget);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('shows Cupertino-style overlay on iOS', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      late BuildContext capturedCtx;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (ctx) {
+                capturedCtx = ctx;
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        ),
+      );
+
+      showAdaptiveSnackBar(capturedCtx, 'Hello iOS');
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('Hello iOS'), findsOneWidget);
+      // Should NOT use a Material SnackBar on iOS — we render via overlay.
+      expect(find.byType(SnackBar), findsNothing);
+
+      // Let the timer expire before the test ends.
+      await tester.pump(const Duration(seconds: 3));
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+  });
+}

--- a/app/test/widget/platform/adaptive_switch_test.dart
+++ b/app/test/widget/platform/adaptive_switch_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/shared/platform/adaptive_switch.dart';
+
+Widget _harness(Widget child) {
+  return MaterialApp(
+    home: Material(child: Center(child: child)),
+  );
+}
+
+void main() {
+  group('AdaptiveSwitch', () {
+    testWidgets('renders CupertinoSwitch on iOS', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+      await tester.pumpWidget(
+        _harness(AdaptiveSwitch(value: false, onChanged: (_) {})),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CupertinoSwitch), findsOneWidget);
+      expect(find.byType(Switch), findsNothing);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('renders Switch on Android', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+      await tester.pumpWidget(
+        _harness(AdaptiveSwitch(value: false, onChanged: (_) {})),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(Switch), findsOneWidget);
+      expect(find.byType(CupertinoSwitch), findsNothing);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('renders Switch on macOS (fallback)', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+
+      await tester.pumpWidget(
+        _harness(AdaptiveSwitch(value: false, onChanged: (_) {})),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(Switch), findsOneWidget);
+      expect(find.byType(CupertinoSwitch), findsNothing);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('toggling fires onChanged on iOS', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      bool? captured;
+
+      await tester.pumpWidget(
+        _harness(AdaptiveSwitch(value: false, onChanged: (v) => captured = v)),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byType(CupertinoSwitch));
+      await tester.pumpAndSettle();
+      expect(captured, isTrue);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('null onChanged renders disabled on Material', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+      await tester.pumpWidget(
+        _harness(const AdaptiveSwitch(value: true, onChanged: null)),
+      );
+      await tester.pumpAndSettle();
+
+      final swt = tester.widget<Switch>(find.byType(Switch));
+      expect(swt.onChanged, isNull);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+  });
+}

--- a/app/test/widget/platform/adaptive_switch_tile_test.dart
+++ b/app/test/widget/platform/adaptive_switch_tile_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/shared/platform/adaptive_switch_tile.dart';
+
+Widget _harness(Widget child) {
+  return MaterialApp(home: Material(child: child));
+}
+
+void main() {
+  group('AdaptiveSwitchTile', () {
+    testWidgets('renders CupertinoListTile + CupertinoSwitch on iOS', (
+      tester,
+    ) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+      await tester.pumpWidget(
+        _harness(
+          AdaptiveSwitchTile(
+            title: const Text('Toggle'),
+            value: false,
+            onChanged: (_) {},
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CupertinoListTile), findsOneWidget);
+      expect(find.byType(CupertinoSwitch), findsOneWidget);
+      expect(find.byType(SwitchListTile), findsNothing);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('renders SwitchListTile on Android', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+      await tester.pumpWidget(
+        _harness(
+          AdaptiveSwitchTile(
+            title: const Text('Toggle'),
+            value: false,
+            onChanged: (_) {},
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(SwitchListTile), findsOneWidget);
+      expect(find.byType(CupertinoSwitch), findsNothing);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('toggling fires onChanged on iOS', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      bool? captured;
+
+      await tester.pumpWidget(
+        _harness(
+          AdaptiveSwitchTile(
+            title: const Text('Toggle'),
+            value: false,
+            onChanged: (v) => captured = v,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byType(CupertinoSwitch));
+      await tester.pumpAndSettle();
+      expect(captured, isTrue);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('renders subtitle on iOS', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+      await tester.pumpWidget(
+        _harness(
+          AdaptiveSwitchTile(
+            title: const Text('Toggle'),
+            subtitle: const Text('Description'),
+            value: false,
+            onChanged: (_) {},
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Description'), findsOneWidget);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+  });
+}

--- a/app/test/widget/platform/adaptive_text_field_test.dart
+++ b/app/test/widget/platform/adaptive_text_field_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/shared/platform/adaptive_text_field.dart';
+
+Widget _harness(Widget child) {
+  return MaterialApp(home: Material(child: child));
+}
+
+void main() {
+  group('AdaptiveTextField', () {
+    testWidgets('renders CupertinoTextField on iOS', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+      await tester.pumpWidget(_harness(const AdaptiveTextField()));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CupertinoTextField), findsOneWidget);
+      expect(find.byType(TextField), findsNothing);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('renders TextField on Android', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+      await tester.pumpWidget(_harness(const AdaptiveTextField()));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(TextField), findsOneWidget);
+      expect(find.byType(CupertinoTextField), findsNothing);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('placeholder shows on iOS', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+      await tester.pumpWidget(
+        _harness(const AdaptiveTextField(placeholder: 'Type here')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Type here'), findsOneWidget);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('placeholder maps to hintText on Material', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+      await tester.pumpWidget(
+        _harness(const AdaptiveTextField(placeholder: 'Type here')),
+      );
+      await tester.pumpAndSettle();
+
+      final tf = tester.widget<TextField>(find.byType(TextField));
+      expect(tf.decoration?.hintText, 'Type here');
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('onChanged fires on Material', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      String? captured;
+
+      await tester.pumpWidget(
+        _harness(AdaptiveTextField(onChanged: (v) => captured = v)),
+      );
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField), 'hello');
+      expect(captured, 'hello');
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+  });
+}

--- a/openspec/changes/adaptive-ui-consolidation/.openspec.yaml
+++ b/openspec/changes/adaptive-ui-consolidation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/adaptive-ui-consolidation/design.md
+++ b/openspec/changes/adaptive-ui-consolidation/design.md
@@ -1,0 +1,130 @@
+## Context
+
+The Flutter app at `app/` ships to web (rust-embed SPA), macOS desktop, and iOS 26+ (Designed for iPad on Apple Silicon). A home-grown adaptive façade exists at `app/lib/shared/platform/` with five wrappers (`AdaptiveApp`, `AdaptiveScaffold`, `AdaptiveNavBar`, `showAdaptiveConfirmDialog`, `AdaptiveMediaContextMenu`) keyed off a three-bucket `AppPlatformStyle` enum (`cupertino` / `material` / `macos`). The previous `cupertino-chrome` and `adaptive-widgets` capabilities established the façade pattern and the screens that should adopt iOS-native chrome.
+
+Today, despite the façade, 13 feature screens import `flutter/material.dart` and `flutter/cupertino.dart` directly. Inventory shows the bypasses fall into four patterns:
+
+- **Pattern A (9 screens)** — `CupertinoSliverNavigationBar` inline + Material `Scaffold` fallback. Wrapper does not exist.
+- **Pattern B (1 screen — settings)** — `CupertinoListSection` / `CupertinoListTile` / `CupertinoSwitch` inline. Wrappers do not exist.
+- **Pattern C (1 screen — chat, 2229 LOC)** — `CupertinoTextField`, `CupertinoNavigationBar` + Material `Switch`, `Slider`, `SnackBar`, `Drawer`, `Dialog`. Multiple wrappers missing.
+- **Pattern D (1 screen — nav_shell, 1207 LOC)** — `CupertinoSidebar`, `CupertinoModalPopup`, `CupertinoActionSheet` + Material `NavigationBar`, `NavigationRail`. The Liquid Glass tab bar would land here.
+
+The `adaptive_platform_ui` package (pub.dev v0.1.107) embeds real UIKit views on iOS 26 to provide Liquid Glass nav bars and tab bars that Flutter Cupertino does not yet fully match. Web and macOS are not covered. The package is solo-published by `medialyra.com` and one of its widgets (`iOS26NativeSearchTabBar`) is documented as broken.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Feature code in `app/lib/features/**` and `app/lib/shared/**` (except `lib/shared/platform/`) MUST NOT import `package:flutter/cupertino.dart`. Currently 18 files do.
+- Feature code MUST NOT inline `if (isAppleTouch) … else …` rendering branches; that logic lives in the façade.
+- iOS 26 chrome (nav bar, tab bar) on iPhone/iPad renders with real UIKit views via `adaptive_platform_ui`, achieving visible Liquid Glass blur/tab pill morph.
+- Web, macOS, and Android continue to render Flutter native widgets. No package code paths execute outside iOS.
+- No visual regression on web/macOS/Android. No behaviour change at feature-screen level — pure refactor through Phase 2.
+- A lint rule enforces the façade so the bypass pattern cannot grow back.
+
+**Non-Goals:**
+
+- Visual redesign of any screen.
+- macOS-native rendering pass (the `AppPlatformStyle.macos` bucket continues to alias to Material output; addressed in a future change).
+- Adopting `iOS26NativeSearchTabBar` from the package (upstream broken).
+- Replacing Flutter widgets with package widgets on web/macOS/Android.
+- Touching `app/lib/main.dart`'s root `MaterialApp` / `CupertinoApp` selection beyond what `AdaptiveApp` already does.
+
+## Decisions
+
+### Decision 1: Façade-first sequencing — wrappers before sweep, sweep before package
+
+Order is Phase 1 (add wrappers, pure Flutter) → Phase 2 (migrate screens, one stacked PR each) → Phase 3 (drop package in behind wrappers) → Phase 4 (lint).
+
+**Why:** Each phase is independently shippable and reversible. Phases 1 and 2 produce value even if `adaptive_platform_ui` is never adopted. Phase 3 changes only `lib/shared/platform/` internals — the migration sweep cannot be invalidated by a later package failure. Phase 4 prevents regression but is itself non-blocking work.
+
+**Alternatives considered:**
+
+- Drop the package in first, then migrate. Rejected: couples 13 screen migrations to a v0.1 dependency. If the package proves unstable mid-sweep, we are in a worse state than today.
+- Big-bang single PR. Rejected: 13 screens + new wrappers + dep + lint rule is unreviewable, and the user explicitly prefers stacked atomic PRs (memory: `feedback_stacked_prs.md`).
+
+### Decision 2: Three-bucket platform model preserved (`cupertino` / `material` / `macos`)
+
+`AppPlatformStyle` stays as the single source of truth. Every new wrapper branches on `platformStyle`, not on `Platform.is*` or `defaultTargetPlatform`. The `macos` bucket continues to fall through to Material today but remains distinct so a future macOS-native pass is a localised change.
+
+**Why:** The package collapses macOS into "not handled". Adopting that collapse would lose information we already pay for, and would force a global rewrite the day macOS-native rendering becomes a priority.
+
+**Alternatives considered:**
+
+- Collapse `macos` into `material`. Rejected: irreversible loss of intent in 5 wrappers + every future wrapper.
+
+### Decision 3: `adaptive_platform_ui` lives inside wrappers, never imported by feature code
+
+Feature code only ever imports from `app/lib/shared/platform/`. The package becomes an implementation detail of `AdaptiveNavBar`, `AdaptiveSliverNavBar`, and the tab bar inside `nav_shell`'s façade extraction.
+
+**Why:** Confinement makes the dep swappable. If `adaptive_platform_ui` is abandoned or breaks on a future iOS release, we change wrapper internals; feature code is untouched.
+
+**Alternatives considered:**
+
+- Re-export the package's widgets directly. Rejected: leaks package types into feature code, breaks confinement, makes the `macos` bucket awkward.
+
+### Decision 4: iOS 26 native chrome gated by `Platform.isIOS` only — no version check
+
+`IPHONEOS_DEPLOYMENT_TARGET = 26.0` is the floor. There is no older iOS to fall back to. The gate is simply "is this an iOS runtime", which is `platformStyle == AppPlatformStyle.cupertino` on a non-web build.
+
+**Why:** Adding a runtime iOS version check would be dead code today. If the deployment target ever drops below 26, the version check is a localised addition inside wrappers.
+
+**Alternatives considered:**
+
+- `iOS >= 26` runtime gate. Rejected: no behaviour difference today, complicates wrapper code.
+
+### Decision 5: Package version pinned exact (no caret), Phase-3-only
+
+`adaptive_platform_ui` is added in Phase 3 only, with an exact pin (e.g. `adaptive_platform_ui: 0.1.107`, not `^0.1.107`). Phase 1 and Phase 2 use only Flutter built-ins.
+
+**Why:** Solo publisher, v0.x, 12 days old. A pin freezes the API surface; bumping is a deliberate act with its own PR and golden-test re-baseline.
+
+**Alternatives considered:**
+
+- Vendor the package source. Rejected for now: too much code to maintain proactively. Reconsidered only if upstream goes silent.
+
+### Decision 6: Skip `iOS26NativeSearchTabBar`
+
+The package README documents lifecycle, navigation, hot-reload, and memory-leak issues with this widget. We use the package's regular `iOS26NativeTabBar` if appropriate, and otherwise stay on Flutter Cupertino for the search-tab pattern.
+
+**Why:** Verified-broken widget in v0.1.107.
+
+**Alternatives considered:**
+
+- Try it anyway. Rejected: documented memory leaks are not worth the iteration cost.
+
+### Decision 7: Enforce façade with `custom_lint`
+
+Phase 4 adds a `custom_lint` rule that bans `import 'package:flutter/cupertino.dart'` and `import 'package:flutter/material.dart'` outside `app/lib/shared/platform/**` and `app/lib/main.dart`. Wired into `make lint-flutter` and the existing flutter CI workflow.
+
+**Why:** Without enforcement the bypass pattern grows back. Lint produces a fast, mechanical failure with a clear error message pointing at the façade.
+
+**Alternatives considered:**
+
+- Code review discipline only. Rejected: 30+ active OpenSpec changes touch the Flutter app; relying on reviewers to spot direct imports is brittle.
+- A shell-script grep gate in `make lint-flutter`. Rejected: works but produces worse diagnostics; `custom_lint` integrates with the IDE and `flutter analyze`.
+
+## Risks / Trade-offs
+
+- **Package v0.1.x solo publisher abandons.** → Mitigation: exact pin, confinement to wrapper internals, swap-back to Flutter Cupertino is a localised change in `lib/shared/platform/`. Source is MIT-licensed and small enough to vendor if needed.
+- **Platform-view embedding shifts golden-test pixels.** → Mitigation: re-baseline iOS goldens in the Phase 3 PR and note explicitly in `tasks.md`. Web/macOS goldens unaffected because the package is never invoked there.
+- **Hot-reload caveats from package README.** → Mitigation: dev-docs note in `app/README.md` (Phase 3 PR). Affects developer-machine workflow only, not shipping behaviour.
+- **`chat_screen.dart` is 2229 LOC** — likely the messiest Phase 2 PR. → Mitigation: split internal extraction (e.g. composer, message list) ahead of the import sweep if needed; flagged as a single task that may produce a small stack of sub-PRs.
+- **`nav_shell.dart` is 1207 LOC and owns navigation** — touching it risks routing regressions. → Mitigation: do this PR last in Phase 2, behind the others; ensure widget tests exercise both compact (bottom bar) and regular (sidebar) breakpoints on iOS and Material before/after.
+- **Custom_lint adds a build step.** → Mitigation: only ship the lint rule in Phase 4, after Phase 2 has eliminated all current violations. The rule turning red on Phase-4 land would mean a regression slipped through.
+- **iOS 26 chrome looks different on iPad-on-Mac vs iPhone hardware.** → Mitigation: visual QA on physical iPhone, iPad, and Apple Silicon Mac as part of Phase 3 acceptance.
+
+## Migration Plan
+
+1. **Phase 1** (one PR): add 11 new wrappers under `app/lib/shared/platform/`, each ~40–60 LOC, each with a widget test. No feature code touched. Backwards compatible — old direct imports continue to work.
+2. **Phase 2** (13 stacked PRs, one per screen, in dependency order from `error_screen` outward to `nav_shell`): each PR replaces direct `flutter/cupertino.dart` and/or `flutter/material.dart` imports with façade imports. No behaviour change per PR; widget tests and goldens stay green.
+3. **Phase 3** (one PR or a small stack): add `adaptive_platform_ui` to `pubspec.yaml` (exact pin). Modify `AdaptiveNavBar`, `AdaptiveSliverNavBar`, and the nav-shell tab bar internals to render the package's UIKit widgets on iOS. Re-baseline iOS goldens. Adopt selected input widgets (text field, switch, slider) only after A/B vs Flutter Cupertino on iOS 26.
+4. **Phase 4** (one PR): land `custom_lint` rule + plugin package. Add allowlist for `lib/shared/platform/**` and `lib/main.dart`. Run on CI.
+
+**Rollback:** Each phase is independently revertible. Phase 3 swap-back is a `flutter pub remove adaptive_platform_ui` plus revert of wrapper internals — feature code stays put. Phase 4 rollback is a `dart_pre_commit` allowlist toggle.
+
+## Open Questions
+
+- Does the nav-shell tab bar match the package's `iOS26NativeTabBar` API closely enough to drop in without restructuring `nav_shell.dart`'s route plumbing? Investigation needed in Phase 3 spike.
+- Should `AdaptiveIcons` be a thin enum-keyed lookup (e.g. `AdaptiveIcons.delete`) or a builder receiving both `cupertinoIcon` and `materialIcon`? The existing `AdaptiveContextMenuAction` uses the builder pattern; consistency argues for builder. Decide in Phase 1.
+- Are there iPad-specific affordances (split view, hover) that the package handles differently from Flutter Cupertino? Out of scope for this change but flag for follow-up.

--- a/openspec/changes/adaptive-ui-consolidation/proposal.md
+++ b/openspec/changes/adaptive-ui-consolidation/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The Flutter app has a working adaptive façade at `app/lib/shared/platform/` (5 wrappers, 389 LOC), but 13 feature screens bypass it and import both `flutter/material.dart` and `flutter/cupertino.dart` directly. An inventory shows the façade is under-built (no `AdaptiveSliverNavBar`, no `AdaptiveListSection`, etc.), not wrong — screens go dual-import because the right wrapper does not exist. At the same time, the iOS deployment target is locked to 26.0, so iOS 26 Liquid Glass is the live visual target, and Flutter's Cupertino widgets only partially track it. We need to close the wrapper gaps, sweep feature code onto the façade, and adopt the `adaptive_platform_ui` package strictly inside the façade for the iOS-26-native chrome it provides — without leaking it into feature code.
+
+## What Changes
+
+- **Expand the home-grown façade** at `app/lib/shared/platform/` with the missing wrappers identified by inventory: `AdaptiveSliverNavBar`, `AdaptiveListSection`, `AdaptiveListTile`, `AdaptiveSwitch`, `AdaptiveSwitchTile`, `AdaptiveActionSheet`, `AdaptiveButton`, `AdaptiveIcons`, `AdaptiveTextField`, `AdaptiveSlider`, `AdaptiveSnackBar`. Implementations use plain Flutter Cupertino + Material — no new dependency in this phase.
+- **Migrate 13 feature screens** off direct `flutter/cupertino.dart` and `flutter/material.dart` imports onto the façade. One stacked PR per screen; no behavior change per screen. Order: `error_screen` (trivial) → 8 sliver-nav list screens → `settings_screen` → `chat_screen` → `nav_shell`.
+- **Adopt `adaptive_platform_ui` inside façade wrappers only.** On iOS 26 the `AdaptiveNavBar`, `AdaptiveSliverNavBar`, and nav-shell tab bar render the package's UIKit-embedded chrome. Web, macOS, and Android branches remain on Flutter native widgets. Pin to an exact version (no caret). **EXPLICITLY DO NOT** adopt `iOS26NativeSearchTabBar` (upstream README flags it as broken — lifecycle, navigation, hot-reload, memory leaks). For input widgets (`AdaptiveTextField`, `AdaptiveSwitch`, `AdaptiveSlider`), A/B against Flutter Cupertino under iOS 26 and adopt only where the package visibly beats Flutter — otherwise stay on Flutter.
+- **Enforce the façade via custom_lint.** Add a rule that bans `import 'package:flutter/cupertino.dart'` and `import 'package:flutter/material.dart'` from any file outside `app/lib/shared/platform/` and the root `app/lib/main.dart`. Wire into `make lint-flutter` and CI.
+- **No visual redesign.** Every screen should look identical to today, modulo the iOS 26 chrome upgrade on iOS hardware.
+- **macOS native rendering pass stays out of scope.** The `AppPlatformStyle.macos` bucket continues to fall through to Material; a future change will address it.
+
+## Capabilities
+
+### New Capabilities
+
+- `platform-facade-discipline`: A lint-enforced rule that all platform-conditional rendering in `app/lib/` flows through `app/lib/shared/platform/`. Feature code does not import `flutter/cupertino.dart` directly and does not branch on `defaultTargetPlatform`/`Platform.is*` for rendering decisions.
+
+### Modified Capabilities
+
+- `cupertino-chrome`: Add `AdaptiveSliverNavBar` as a first-class façade widget (currently REQ-3 mandates `CupertinoSliverNavigationBar` on list screens without providing a wrapper, forcing dual-imports). Add a requirement that on iOS 26 the chrome wrappers render the `adaptive_platform_ui` UIKit-embedded nav bars, while web/macOS/Android branches stay on Flutter natives.
+- `adaptive-widgets`: Expand the widget catalogue beyond switches/dialogs/text-field/spinner to include list sections, list tiles, switch tiles, action sheets, sliders, snack bars, and buttons. Mandate that every adaptation lives behind a façade wrapper rather than as scattered `.adaptive` calls or inline platform branches in feature code.
+
+## Impact
+
+- **Code**: ~13 feature screens edited (Phase 2 sweep, one stacked PR each); ~11 new wrapper files under `app/lib/shared/platform/`; existing `AdaptiveNavBar`/`AdaptiveScaffold`/`AdaptiveDialog` internals modified in Phase 3 to gate on iOS 26.
+- **Dependencies**: Adds `adaptive_platform_ui` (pinned exact version) and `custom_lint` + a local lint package for the import-discipline rule. No removals.
+- **Build & CI**: `make lint-flutter` gains the custom_lint pass. iOS golden-test baselines re-captured once after Phase 3 lands (platform-view embedding may shift pixels). Existing `flutter analyze --fatal-infos` and `flutter test` stay green throughout.
+- **Risk**: `adaptive_platform_ui` is v0.1.x and solo-published (medialyra.com); the change mitigates this by (a) pinning exact version, (b) confining usage to façade internals so a swap is local, (c) skipping the upstream-broken `iOS26NativeSearchTabBar`, and (d) leaving Flutter natives as the fallback on every non-iOS-26 path.
+- **No runtime regressions for older iOS** — iOS 26 is already the deployment-target floor.
+- **No web/macOS regressions** — those branches remain on Flutter widgets; the package is never invoked there.

--- a/openspec/changes/adaptive-ui-consolidation/specs/adaptive-widgets/spec.md
+++ b/openspec/changes/adaptive-ui-consolidation/specs/adaptive-widgets/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: Expanded façade widget catalogue
+
+The façade at `app/lib/shared/platform/` SHALL provide adaptive wrappers for the following widgets, each branching on `AppPlatformStyle` from `platform.dart` and rendering platform-appropriate underlyings: `AdaptiveListSection`, `AdaptiveListTile`, `AdaptiveSwitch`, `AdaptiveSwitchTile`, `AdaptiveActionSheet`, `AdaptiveButton`, `AdaptiveIcons`, `AdaptiveTextField`, `AdaptiveSlider`, `AdaptiveSnackBar`. Each wrapper SHALL ship with a widget test exercising the iOS, Material, and macOS paths.
+
+#### Scenario: Settings screen on iOS uses adaptive list section
+
+- **WHEN** the Settings screen is built on iPhone or iPad running iOS 26
+- **THEN** sections SHALL render as `CupertinoListSection.insetGrouped` with `CupertinoListTile` rows
+- **THEN** switches inside those rows SHALL render as `CupertinoSwitch`
+- **THEN** the Settings screen file SHALL NOT import `package:flutter/cupertino.dart`
+
+#### Scenario: Settings screen on web uses Material list
+
+- **WHEN** the Settings screen is built in a desktop browser
+- **THEN** sections SHALL render with Material list styling (section header + tiles)
+- **THEN** switches SHALL render as Material `Switch`
+- **THEN** the file SHALL NOT import `package:flutter/cupertino.dart`
+
+#### Scenario: Chat composer uses adaptive text field on iOS
+
+- **WHEN** the Chat screen composer is built on iOS 26
+- **THEN** the text input SHALL render as a `CupertinoTextField` (or its `adaptive_platform_ui` iOS 26 native equivalent if adopted in Phase 3)
+- **THEN** the Chat screen file SHALL NOT import `package:flutter/cupertino.dart`
+
+#### Scenario: Action sheets use adaptive wrapper
+
+- **WHEN** a destructive action (delete conversation, delete persona, etc.) requests confirmation on iOS
+- **THEN** the rendered sheet SHALL be a `CupertinoActionSheet` presented via `showCupertinoModalPopup`
+- **WHEN** the same action is requested in a desktop browser
+- **THEN** the rendered sheet SHALL be a Material modal bottom sheet
+
+### Requirement: Phase 3 adoption of adaptive_platform_ui input widgets
+
+For each of `AdaptiveTextField`, `AdaptiveSwitch`, `AdaptiveSlider`, and `AdaptiveSnackBar`, the iOS path SHALL use the `adaptive_platform_ui` package widget IF an A/B comparison against Flutter Cupertino on iOS 26 hardware shows a visible improvement. Otherwise the iOS path SHALL stay on Flutter Cupertino. The decision per widget SHALL be recorded in the change's `tasks.md` and the wrapper file's docstring. Web, macOS, and Android paths SHALL NOT invoke the package under any circumstance.
+
+#### Scenario: Adoption decision is recorded per widget
+
+- **WHEN** Phase 3 lands
+- **THEN** each of the four wrappers above SHALL contain a comment naming the iOS implementation (`adaptive_platform_ui` widget name OR `CupertinoXxx`) and the rationale for the choice
+- **THEN** `tasks.md` SHALL list the A/B outcome for each widget
+
+#### Scenario: Web path is unchanged
+
+- **WHEN** any of the four wrappers above is built in a desktop browser
+- **THEN** the package code path SHALL NOT execute
+- **THEN** the rendered widget SHALL be the Material equivalent
+
+### Requirement: No direct platform branching in feature code
+
+Files under `app/lib/features/**` and `app/lib/shared/**` (excluding `app/lib/shared/platform/**`) SHALL NOT branch on `defaultTargetPlatform`, `Theme.of(context).platform`, or `Platform.is*` for rendering decisions. Platform-conditional rendering SHALL flow through the façade wrappers. Non-rendering platform branches (e.g. choosing a file-system API in services) remain permitted.
+
+#### Scenario: A new feature screen needs platform-specific UI
+
+- **WHEN** a developer writes a feature screen that needs a different widget on iOS vs Material
+- **THEN** the developer SHALL extend or compose existing façade wrappers, or add a new wrapper under `app/lib/shared/platform/`
+- **THEN** the feature screen file SHALL NOT contain `if (Platform.isIOS)` or `if (defaultTargetPlatform == TargetPlatform.iOS)` for rendering decisions
+
+#### Scenario: Existing non-rendering branch is allowed
+
+- **WHEN** a service file (e.g. `installer_launcher.dart`, `share_service.dart`) checks `Platform.isMacOS` to decide which subprocess to spawn
+- **THEN** the lint SHALL allow it (no façade exists for non-rendering decisions)

--- a/openspec/changes/adaptive-ui-consolidation/specs/cupertino-chrome/spec.md
+++ b/openspec/changes/adaptive-ui-consolidation/specs/cupertino-chrome/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: AdaptiveSliverNavBar wrapper
+
+The façade at `app/lib/shared/platform/` SHALL provide an `AdaptiveSliverNavBar` widget that renders `CupertinoSliverNavigationBar` (with `largeTitle`) on Apple touch platforms, a `SliverAppBar` on Material/macOS, and supports the same title/leading/trailing surface as the existing `AdaptiveNavBar`. Screens that need the iOS large-title-collapse-on-scroll pattern SHALL use this wrapper instead of importing `package:flutter/cupertino.dart` directly.
+
+#### Scenario: List screen uses the wrapper on iOS
+
+- **WHEN** a list screen (Traces, Logs, Personas, Skills, Webhooks, Agents, Analytics, Workflows, Contexts) is built on an iPhone or iPad running iOS 26
+- **THEN** the rendered top chrome SHALL be a `CupertinoSliverNavigationBar` with the large title visible at rest
+- **THEN** scrolling the body downward SHALL collapse the large title into the standard nav bar height
+- **THEN** the screen file SHALL NOT import `package:flutter/cupertino.dart`
+
+#### Scenario: Same screen on web
+
+- **WHEN** the same list screen is built in a desktop browser
+- **THEN** the rendered top chrome SHALL be a `SliverAppBar` with Material styling
+- **THEN** the screen file SHALL NOT import `package:flutter/cupertino.dart`
+
+#### Scenario: Same screen on macOS native
+
+- **WHEN** the same list screen is built in the `flutter build macos` app
+- **THEN** the rendered top chrome SHALL be a `SliverAppBar` (Material fallback for the `macos` bucket)
+- **THEN** no regression vs the pre-change Material rendering is visible
+
+### Requirement: iOS 26 native chrome via adaptive_platform_ui
+
+On Apple touch platforms, `AdaptiveNavBar` and `AdaptiveSliverNavBar` SHALL render the `adaptive_platform_ui` package's UIKit-embedded native iOS 26 navigation bars (Liquid Glass blur). The package SHALL only be invoked from within `app/lib/shared/platform/`. The `iOS26NativeSearchTabBar` widget from the package SHALL NOT be used.
+
+#### Scenario: iPhone running iOS 26 sees Liquid Glass nav bar
+
+- **WHEN** any screen using `AdaptiveNavBar` or `AdaptiveSliverNavBar` is built on iOS 26 hardware
+- **THEN** the nav bar SHALL render with the iOS 26 Liquid Glass blur backdrop produced by the package's platform view
+- **THEN** the underlying widget tree SHALL be the `adaptive_platform_ui` native nav bar, not Flutter's `CupertinoNavigationBar`
+
+#### Scenario: Web browser ignores the package
+
+- **WHEN** the same screen is built in a desktop browser
+- **THEN** the package code path SHALL NOT execute
+- **THEN** the rendered chrome SHALL be `AppBar` or `SliverAppBar` (Material)
+
+#### Scenario: macOS native ignores the package
+
+- **WHEN** the same screen is built via `flutter build macos`
+- **THEN** the package code path SHALL NOT execute
+- **THEN** the rendered chrome SHALL be `AppBar` or `SliverAppBar` (Material fallback for the `macos` bucket)
+
+#### Scenario: SearchTabBar is not used
+
+- **WHEN** the codebase is grepped for `iOS26NativeSearchTabBar`
+- **THEN** no references SHALL exist in `app/lib/`
+- **THEN** the nav-shell tab bar SHALL use a non-search-pill variant on iOS
+
+### Requirement: Feature code does not import flutter/cupertino directly
+
+No file under `app/lib/features/**` or `app/lib/shared/**` (excluding `app/lib/shared/platform/**`) SHALL import `package:flutter/cupertino.dart`. The façade is the only place that may import Cupertino widgets directly.
+
+#### Scenario: Lint catches a stray Cupertino import
+
+- **WHEN** a developer adds `import 'package:flutter/cupertino.dart';` to a file under `app/lib/features/` or `app/lib/shared/` (outside `lib/shared/platform/`)
+- **THEN** `make lint-flutter` SHALL fail with a clear diagnostic naming the file and pointing to the façade
+- **THEN** the CI Flutter workflow SHALL block merge
+
+#### Scenario: Wrapper file is allowed
+
+- **WHEN** a file under `app/lib/shared/platform/` imports `package:flutter/cupertino.dart`
+- **THEN** the lint SHALL accept it without error

--- a/openspec/changes/adaptive-ui-consolidation/specs/platform-facade-discipline/spec.md
+++ b/openspec/changes/adaptive-ui-consolidation/specs/platform-facade-discipline/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: Façade is the sole entry point for adaptive rendering
+
+All platform-conditional rendering in the Flutter app SHALL flow through `app/lib/shared/platform/`. Feature code (anything under `app/lib/features/**` or `app/lib/shared/**` other than `lib/shared/platform/`) SHALL NOT import `package:flutter/cupertino.dart`, and SHALL NOT branch on `defaultTargetPlatform`, `Theme.of(context).platform`, or `Platform.is*` for rendering purposes. Non-rendering platform checks in service-layer code (subprocess spawning, file-system APIs, etc.) remain permitted.
+
+#### Scenario: New widget needs iOS-specific rendering
+
+- **WHEN** a developer needs a widget that looks different on iOS vs Material
+- **THEN** they SHALL add or extend a wrapper under `app/lib/shared/platform/`
+- **THEN** the feature code SHALL consume that wrapper without conditional imports
+
+#### Scenario: Service-layer platform check is permitted
+
+- **WHEN** a non-widget file (e.g. `installer_launcher.dart`) checks `Platform.isMacOS` to choose a subprocess
+- **THEN** this SHALL be permitted and SHALL NOT trigger a lint failure
+
+### Requirement: Lint enforcement via custom_lint
+
+The repository SHALL include a `custom_lint` rule that fires on any `import 'package:flutter/cupertino.dart'` or `import 'package:flutter/material.dart'` statement in a file outside the allowlist. The allowlist SHALL contain `app/lib/shared/platform/**` and `app/lib/main.dart`. The rule SHALL run as part of `make lint-flutter` and the Flutter CI workflow.
+
+#### Scenario: Disallowed Cupertino import is flagged
+
+- **WHEN** a developer commits a file under `app/lib/features/` that imports `package:flutter/cupertino.dart`
+- **THEN** `make lint-flutter` SHALL exit non-zero with a diagnostic naming the file, the offending import, and a hint pointing to `app/lib/shared/platform/`
+- **THEN** the CI Flutter workflow SHALL block merge of the PR
+
+#### Scenario: Disallowed Material import is flagged
+
+- **WHEN** the same situation occurs with `package:flutter/material.dart`
+- **THEN** the same diagnostic and CI behaviour SHALL occur
+
+#### Scenario: Allowlisted file is not flagged
+
+- **WHEN** a file under `app/lib/shared/platform/` or the root `app/lib/main.dart` imports either Cupertino or Material
+- **THEN** the lint SHALL accept the import without error
+
+#### Scenario: Defensive sweep at Phase 4 landing
+
+- **WHEN** the lint rule is enabled in the repo (Phase 4)
+- **THEN** running `make lint-flutter` against the codebase SHALL pass with zero violations
+- **THEN** no file outside the allowlist SHALL import `package:flutter/cupertino.dart` or `package:flutter/material.dart`
+
+### Requirement: adaptive_platform_ui dependency is confined to the façade
+
+The `adaptive_platform_ui` package SHALL be imported only from files under `app/lib/shared/platform/`. No feature screen or shared widget outside the façade SHALL import `package:adaptive_platform_ui/...`.
+
+#### Scenario: Stray package import is rejected
+
+- **WHEN** a developer imports `package:adaptive_platform_ui/...` from a file outside `app/lib/shared/platform/`
+- **THEN** `make lint-flutter` SHALL fail with a diagnostic instructing the developer to add the needed widget to the façade
+
+#### Scenario: Package version is pinned exact
+
+- **WHEN** `app/pubspec.yaml` declares `adaptive_platform_ui`
+- **THEN** the version constraint SHALL be an exact pin (e.g. `0.1.107`) and SHALL NOT use a caret (`^`) or range operator
+
+### Requirement: AppPlatformStyle three-bucket model is preserved
+
+The `AppPlatformStyle` enum in `app/lib/shared/platform/platform.dart` SHALL keep its three values: `cupertino`, `material`, and `macos`. Wrappers SHALL branch on this enum (or its convenience getters `isAppleTouch`, `isMaterial`, `isMacOS`) rather than on `Platform.is*` or `defaultTargetPlatform` directly. The `macos` bucket SHALL remain a distinct branch in every new wrapper even when its current rendering aliases to the Material output, so a future macOS-native rendering pass is a local change.
+
+#### Scenario: New wrapper branches on AppPlatformStyle
+
+- **WHEN** a developer adds a new wrapper under `app/lib/shared/platform/`
+- **THEN** the wrapper SHALL branch on `platformStyle` (or `isAppleTouch`/`isMaterial`/`isMacOS`) and SHALL NOT call `Platform.is*` or `defaultTargetPlatform` directly
+
+#### Scenario: macos bucket remains addressable
+
+- **WHEN** a future change introduces a macOS-native widget for a wrapper
+- **THEN** the change SHALL only need to edit the wrapper's `isMacOS` branch
+- **THEN** no feature code SHALL need to change

--- a/openspec/changes/adaptive-ui-consolidation/tasks.md
+++ b/openspec/changes/adaptive-ui-consolidation/tasks.md
@@ -1,0 +1,106 @@
+## 1. Phase 1 — Expand the home-grown façade (one PR)
+
+- [x] 1.1 Write failing widget test for `AdaptiveSliverNavBar` covering Cupertino, Material, and macOS branches
+- [x] 1.2 Implement `app/lib/shared/platform/adaptive_sliver_nav_bar.dart` — minimum code to pass 1.1
+- [x] 1.3 Write failing widget test for `AdaptiveListSection` (Cupertino insetGrouped vs Material section header)
+- [x] 1.4 Implement `app/lib/shared/platform/adaptive_list_section.dart`
+- [x] 1.5 Write failing widget test for `AdaptiveListTile` (CupertinoListTile vs ListTile)
+- [x] 1.6 Implement `app/lib/shared/platform/adaptive_list_tile.dart`
+- [x] 1.7 Write failing widget test for `AdaptiveSwitch` (CupertinoSwitch vs Material Switch)
+- [x] 1.8 Implement `app/lib/shared/platform/adaptive_switch.dart`
+- [x] 1.9 Write failing widget test for `AdaptiveSwitchTile` (CupertinoListTile + Switch vs SwitchListTile)
+- [x] 1.10 Implement `app/lib/shared/platform/adaptive_switch_tile.dart`
+- [x] 1.11 Write failing widget test for `AdaptiveActionSheet` (CupertinoActionSheet vs modal bottom sheet)
+- [x] 1.12 Implement `app/lib/shared/platform/adaptive_action_sheet.dart`
+- [x] 1.13 Write failing widget test for `AdaptiveButton` (CupertinoButton vs FilledButton/TextButton variants)
+- [x] 1.14 Implement `app/lib/shared/platform/adaptive_button.dart`
+- [x] 1.15 Write failing widget test for `AdaptiveIcon` lookup (Cupertino vs Material icon mapping)
+- [x] 1.16 Implement `app/lib/shared/platform/adaptive_icon.dart` — chose builder-with-both-icons pattern (constructor takes `cupertino` + `material` IconData; matches existing `AdaptiveContextMenuAction` style)
+- [x] 1.17 Write failing widget test for `AdaptiveTextField` (CupertinoTextField vs Material TextField with rounded decoration)
+- [x] 1.18 Implement `app/lib/shared/platform/adaptive_text_field.dart`
+- [x] 1.19 Write failing widget test for `AdaptiveSlider` (CupertinoSlider vs Material Slider)
+- [x] 1.20 Implement `app/lib/shared/platform/adaptive_slider.dart`
+- [x] 1.21 Write failing widget test for `AdaptiveSnackBar` (Cupertino-style overlay vs Material SnackBar)
+- [x] 1.22 Implement `app/lib/shared/platform/adaptive_snack_bar.dart`
+- [x] 1.23 Run `make lint-flutter && make test-flutter` — green (933 tests pass, dart_pre_commit clean)
+- [x] 1.24 Run `cd app && flutter analyze --fatal-infos` — zero issues
+- [ ] 1.25 Open Phase 1 PR with stacked-PR-base flag set; merge before Phase 2
+
+## 2. Phase 2.1 — Trivial sweep (1 PR)
+
+- [ ] 2.1.1 Remove the vestigial `package:flutter/material.dart` import from `app/lib/shared/error_screen.dart`; verify the file still compiles and the existing widget test passes
+
+## 3. Phase 2.2 — Sliver-nav list screens (9 stacked PRs, one per screen)
+
+- [ ] 3.1 `traces_screen.dart`: replace inline `if (isAppleTouch) CupertinoSliverNavigationBar` with `AdaptiveSliverNavBar`; drop `package:flutter/cupertino.dart` import; existing tests stay green
+- [ ] 3.2 `logs_screen.dart`: same treatment
+- [ ] 3.3 `agents_screen.dart`: same treatment + replace `CupertinoButton`/`CupertinoIcons` with `AdaptiveButton`/`AdaptiveIcons`
+- [ ] 3.4 `workflows_screen.dart`: same as 3.3
+- [ ] 3.5 `personas_screen.dart`: same treatment
+- [ ] 3.6 `skills_screen.dart`: same treatment
+- [ ] 3.7 `webhooks_screen.dart`: same as 3.3
+- [ ] 3.8 `analytics_screen.dart`: same as 3.3
+- [ ] 3.9 `contexts/screens/context_switcher_screen.dart`: same treatment + adopt `AdaptiveActionSheet` for delete confirmation
+
+## 4. Phase 2.3 — Settings screen (1 PR)
+
+- [ ] 4.1 `settings_screen.dart`: replace `CupertinoListSection`/`CupertinoListTile`/`CupertinoSwitchTile` with `AdaptiveListSection`/`AdaptiveListTile`/`AdaptiveSwitchTile`; drop `package:flutter/cupertino.dart` import; update Playwright screenshot baseline if visual diff is non-zero on web
+
+## 5. Phase 2.4 — Chat screen (likely small stack inside one PR)
+
+- [ ] 5.1 Spike: read `chat_screen.dart` (2229 LOC) and decide whether to extract composer + message list into separate files before the import sweep; record decision in PR description
+- [ ] 5.2 If extracted: move composer to `app/lib/features/chat/chat_composer.dart` with widget test; verify chat screen still renders identically
+- [ ] 5.3 If extracted: move message list to `app/lib/features/chat/chat_messages_view.dart` with widget test
+- [ ] 5.4 Replace `CupertinoTextField` with `AdaptiveTextField`
+- [ ] 5.5 Replace `CupertinoNavigationBar` with `AdaptiveNavBar` (regular, non-large-title — per `cupertino-chrome` REQ-4)
+- [ ] 5.6 Replace Material `Switch`, `Slider`, `SnackBar` with `AdaptiveSwitch`/`AdaptiveSlider`/`AdaptiveSnackBar`
+- [ ] 5.7 Drop both `package:flutter/cupertino.dart` and any unnecessary `package:flutter/material.dart` imports
+- [ ] 5.8 Update widget tests; update Playwright baselines if visual diff is non-zero on web
+
+## 6. Phase 2.5 — Nav shell (1 PR, last in Phase 2)
+
+- [ ] 6.1 Write widget tests for both compact (bottom bar) and regular (sidebar) breakpoints on iOS and Material if not already present
+- [ ] 6.2 Replace inline `CupertinoSidebar`, `CupertinoModalPopup`, `CupertinoActionSheet` with façade wrappers (`AdaptiveActionSheet` for the "More" overflow sheet per `adaptive-shell` REQ-4)
+- [ ] 6.3 Replace inline `CupertinoButton`/`CupertinoIcons`/`CupertinoColors` with `AdaptiveButton`/`AdaptiveIcons`
+- [ ] 6.4 Drop `package:flutter/cupertino.dart` from `nav_shell.dart`
+- [ ] 6.5 Verify route-based active-state highlighting still works on iPhone, iPad, web, and macOS (per `adaptive-shell` REQ-6)
+- [ ] 6.6 Update Playwright baselines for nav_shell screenshots if diff is non-zero
+
+## 7. Phase 3 — Wire adaptive_platform_ui inside façade (one PR or small stack)
+
+- [ ] 7.1 Add `adaptive_platform_ui` to `app/pubspec.yaml` with an exact pin (e.g. `adaptive_platform_ui: 0.1.107` — no caret); run `flutter pub get`
+- [ ] 7.2 Spike: build a minimal iOS-only test page that renders the package's native nav bar + tab bar; verify on iPhone Simulator running iOS 26 and on Apple Silicon Mac (Designed for iPad). Record findings in PR description
+- [ ] 7.3 Modify `app/lib/shared/platform/adaptive_nav_bar.dart` internals: on `isAppleTouch`, render the package's native iOS 26 nav bar (do NOT use `iOS26NativeSearchTabBar`). Material/macOS branches unchanged
+- [ ] 7.4 Modify `app/lib/shared/platform/adaptive_sliver_nav_bar.dart` internals: same treatment
+- [ ] 7.5 Replace nav_shell's iOS tab bar with the package's `iOS26NativeTabBar` (or equivalent non-search variant). EXPLICITLY skip `iOS26NativeSearchTabBar` (upstream broken)
+- [ ] 7.6 A/B test `AdaptiveTextField` vs Flutter Cupertino on iOS 26 hardware; if package version wins, swap; record decision in wrapper docstring + this task
+- [ ] 7.7 A/B test `AdaptiveSwitch` vs Flutter Cupertino on iOS 26; same protocol as 7.6
+- [ ] 7.8 A/B test `AdaptiveSlider` vs Flutter Cupertino on iOS 26; same protocol
+- [ ] 7.9 A/B test `AdaptiveSnackBar` vs Flutter Cupertino on iOS 26; same protocol
+- [ ] 7.10 Re-baseline iOS goldens; document the visual diff in PR description
+- [ ] 7.11 Add a "developer notes" section to `app/README.md` documenting the package's hot-reload caveats
+- [ ] 7.12 Verify web + macOS builds: no `adaptive_platform_ui` code path executes; `flutter analyze --fatal-infos` passes for both targets
+- [ ] 7.13 Run `make lint-flutter && make test-flutter`
+
+## 8. Phase 4 — Lint enforcement (one PR)
+
+- [ ] 8.1 Add `custom_lint` to `app/dev_dependencies` (exact pin)
+- [ ] 8.2 Create a local lint package at `app/packages/platform_facade_lints/` with a single rule `avoid_direct_platform_imports` that fires on `package:flutter/cupertino.dart`, `package:flutter/material.dart`, and `package:adaptive_platform_ui/*` imports outside the allowlist
+- [ ] 8.3 Configure the rule's allowlist to `app/lib/shared/platform/**` and `app/lib/main.dart`
+- [ ] 8.4 Wire `custom_lint` into `app/analysis_options.yaml`
+- [ ] 8.5 Update `make lint-flutter` to invoke `dart run custom_lint` and fail on any violation
+- [ ] 8.6 Update `.github/workflows/flutter.yml` to run the lint
+- [ ] 8.7 Write a failing unit test for the lint rule against a fixture file with a banned import; confirm red
+- [ ] 8.8 Make the test pass
+- [ ] 8.9 Run `make lint-flutter` against the codebase post-Phase-2/3 — must report zero violations
+- [ ] 8.10 Document the rule and how to add new façade wrappers in `app/lib/shared/platform/README.md` (create if absent)
+
+## 9. Final verification
+
+- [ ] 9.1 Grep `app/lib/` for `package:flutter/cupertino.dart` — must return only files under `app/lib/shared/platform/`
+- [ ] 9.2 Grep `app/lib/features/` and `app/lib/shared/` (excluding `lib/shared/platform/`) for `if (Platform.isIOS)`, `Platform.isMacOS` in widget files, and `defaultTargetPlatform` — must return zero rendering-related hits (service-layer hits remain permitted)
+- [ ] 9.3 Run `make lint && make format` (Rust side untouched, but the precommit hook covers the whole tree)
+- [ ] 9.4 Run `make lint-flutter && make test-flutter`
+- [ ] 9.5 Run `flutter analyze --fatal-infos` in `app/`
+- [ ] 9.6 Manual visual QA on iPhone (iOS 26), iPad (iOS 26 / iPadOS), Apple Silicon Mac (Designed for iPad), Chrome browser, and `flutter run -d macos`
+- [ ] 9.7 Update `app/lib/shared/platform/README.md` with the final wrapper catalogue and the discipline rules


### PR DESCRIPTION
## Summary

Phase 1 of the [`adaptive-ui-consolidation`](openspec/changes/adaptive-ui-consolidation/) OpenSpec change — expand the home-grown façade at `app/lib/shared/platform/` with 11 missing wrappers so feature code can stop importing `package:flutter/cupertino.dart` directly. No new dependencies, no behaviour change in any existing screen.

- Adds 11 platform-adaptive widget wrappers (`AdaptiveSliverNavBar`, `AdaptiveListSection`, `AdaptiveListTile`, `AdaptiveSwitch`, `AdaptiveSwitchTile`, `AdaptiveActionSheet`, `AdaptiveButton`, `AdaptiveIcon`, `AdaptiveTextField`, `AdaptiveSlider`, `AdaptiveSnackBar`) — each branches on `AppPlatformStyle` (cupertino/material/macos) using only Flutter built-ins.
- Adds 47 widget tests across iOS/Material/macOS branches; total suite 933/933 green; `flutter analyze --fatal-infos` clean.
- Captures the broader four-phase plan as an OpenSpec change (proposal/design/specs/tasks).

Inventory motivating this: 13 feature screens currently import both `flutter/material.dart` and `flutter/cupertino.dart` because the right wrappers don't exist yet. This PR fills the gap so Phase 2 can mechanically migrate those screens.

## Stack

This is the base PR of a stacked series. Subsequent PRs migrate screens onto these wrappers (Phase 2), drop in `adaptive_platform_ui` for iOS 26 Liquid Glass chrome (Phase 3), and add a `custom_lint` rule banning direct Cupertino/Material imports outside the façade (Phase 4).

- **Phase 1 — this PR** — façade wrappers
- Phase 2 — migrate 13 screens (stacked, one per screen)
- Phase 3 — adopt `adaptive_platform_ui` inside wrappers (iOS-only)
- Phase 4 — lint enforcement

## Design decisions captured

- `AdaptiveIcon` uses a builder pattern (`cupertino:` + `material:` IconData both required) matching the existing `AdaptiveContextMenuAction` style — resolves an open question from `design.md`.
- `AdaptiveButton` exposes two named constructors (`.filled` / `.plain`) covering primary and secondary actions.
- `AdaptiveSnackBar` iOS path uses a `CupertinoPopupSurface` overlay with a self-dismiss timer; Phase 3 may swap to `adaptive_platform_ui` with the same public API.
- `AdaptiveSwitchTile` branches explicitly (`CupertinoListTile + CupertinoSwitch` vs `SwitchListTile`) rather than `SwitchListTile.adaptive` — gives full iOS Settings idiom, not just the switch glyph.

## Test plan

- [x] `flutter test` — 933/933 pass
- [x] `flutter analyze --fatal-infos` — 0 issues
- [x] `make lint-flutter` (dart_pre_commit) — clean
- [x] Pre-commit hook (rust fmt + clippy + machete + dart_pre_commit + flutter test) — passed on both commits
- [ ] Visual smoke check on iPhone Simulator / iPad / web (deferred — no feature screens use the new wrappers yet; Phase 2 PRs will verify per screen)

## Refs

OpenSpec: `openspec/changes/adaptive-ui-consolidation/` (Phase 1, tasks 1.1–1.24 complete).