### PR TITLE
feat(app): adopt fresh_dio for proactive OAuth token refresh

### DIFF
--- a/app/lib/api/api_client.dart
+++ b/app/lib/api/api_client.dart
@@ -9,7 +9,9 @@ import 'dart:convert';
 import 'package:assistant_api/assistant_api.dart' hide ServerCapabilities;
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
+import 'package:fresh_dio/fresh_dio.dart';
 
+import '../features/auth/oauth_credentials.dart';
 import 'auth_interceptor.dart';
 import 'event_source_stream.dart';
 import 'event_source_stream_stub.dart'
@@ -38,12 +40,76 @@ class ApiAuthException implements Exception {
 
 /// Configured client bundle: generated API instances + SSE streaming helper.
 class ApiClient {
+  /// Legacy / static-bearer constructor.
+  ///
+  /// Used for API-key contexts (`ask_live_...`) and during password-mode
+  /// onboarding where the bearer never changes during the session.
   ApiClient({
     required String baseUrl,
     required String token,
     RefreshTokensCallback? refreshTokens,
     OnAuthExpiredCallback? onAuthExpired,
-  }) : _token = token {
+  }) : _staticToken = token,
+       _tokenStorage = null {
+    _setupDio(baseUrl: baseUrl);
+
+    if (refreshTokens != null && onAuthExpired != null) {
+      final interceptor = AuthRecoveryInterceptor(
+        dio: _dio,
+        refreshTokens: refreshTokens,
+        onAuthExpired: onAuthExpired,
+      );
+      _dio.interceptors.add(interceptor);
+    }
+
+    _generatedApi.setBearerAuth('bearer_token', token);
+  }
+
+  /// OAuth2 constructor: installs `fresh_dio` so the bearer is fetched from
+  /// [tokenStorage] on every request, refreshed proactively when expired, and
+  /// retried-once reactively on a 401. [onAuthExpired] fires when refresh
+  /// throws [RevokeTokenException] (or fresh_dio otherwise transitions to
+  /// `unauthenticated`), so the wiring layer can deactivate the context and
+  /// the router can redirect to `/login`.
+  ApiClient.oauth2({
+    required String baseUrl,
+    required TokenStorage<OAuthCredentials> tokenStorage,
+    required Future<OAuthCredentials> Function(
+      OAuthCredentials? token,
+      Dio client,
+    )
+    refreshToken,
+    required OnAuthExpiredCallback onAuthExpired,
+  }) : _staticToken = null,
+       _tokenStorage = tokenStorage {
+    _setupDio(baseUrl: baseUrl);
+
+    // fresh_dio uses a separate Dio for refresh + reactive-401 retry. Passing
+    // the main `_dio` would trip its no-self-recursion assertion. We give it a
+    // dedicated client with the same baseUrl + native adapter, but NO Fresh
+    // interceptor of its own.
+    _refreshDio = Dio(BaseOptions(baseUrl: baseUrl));
+    native_http_adapter.installNativeHttpAdapter(_refreshDio!);
+
+    final fresh = Fresh<OAuthCredentials>(
+      tokenStorage: tokenStorage,
+      httpClient: _refreshDio,
+      tokenHeader: (creds) => {'Authorization': 'Bearer ${creds.bearerToken}'},
+      shouldRefreshBeforeRequest: (_, creds) =>
+          creds != null && creds.isExpired(),
+      refreshToken: refreshToken,
+    );
+    _dio.interceptors.add(fresh);
+
+    _authStatusSub = fresh.authenticationStatus.listen((status) {
+      if (status == AuthenticationStatus.unauthenticated) {
+        onAuthExpired();
+      }
+    });
+  }
+
+  /// Shared Dio + generated-API setup used by both constructors.
+  void _setupDio({required String baseUrl}) {
     _dio = Dio(
       BaseOptions(
         baseUrl: baseUrl,
@@ -67,22 +133,50 @@ class ApiClient {
     // dart:io is available.
     native_http_adapter.installNativeHttpAdapter(_dio);
 
-    if (refreshTokens != null && onAuthExpired != null) {
-      final interceptor = AuthRecoveryInterceptor(
-        dio: _dio,
-        refreshTokens: refreshTokens,
-        onAuthExpired: onAuthExpired,
-      );
-      _dio.interceptors.add(interceptor);
-    }
-
     _generatedApi = AssistantApi(dio: _dio, basePathOverride: baseUrl);
-    _generatedApi.setBearerAuth('bearer_token', token);
   }
 
-  final String _token;
+  /// Static bearer for legacy/API-key contexts; `null` on the OAuth path.
+  final String? _staticToken;
+
+  /// Token storage for the OAuth path; `null` on the legacy path. Used by SSE
+  /// methods to read the current bearer (so they pick up refreshed tokens
+  /// without rebuilding the client).
+  final TokenStorage<OAuthCredentials>? _tokenStorage;
+
+  StreamSubscription<AuthenticationStatus>? _authStatusSub;
+
   late final Dio _dio;
   late final AssistantApi _generatedApi;
+
+  /// Secondary Dio used by fresh_dio for token refresh and reactive 401
+  /// retries. Kept separate from `_dio` to avoid fresh_dio's self-recursion
+  /// assertion (an interceptor must not be installed on its own httpClient).
+  Dio? _refreshDio;
+
+  @visibleForTesting
+  Dio get dioForTesting => _dio;
+
+  /// The Dio fresh_dio uses for refresh + retry. Tests inject the same
+  /// HttpClientAdapter on both so retries see the mocked responses.
+  @visibleForTesting
+  Dio? get refreshDioForTesting => _refreshDio;
+
+  /// Disposes the auth-status subscription. Call when the active context
+  /// changes; safe to call multiple times.
+  void close() {
+    _authStatusSub?.cancel();
+    _authStatusSub = null;
+  }
+
+  /// Returns the bearer the SSE methods should send. Reads from token storage
+  /// on the OAuth path so refreshes are picked up automatically; falls back to
+  /// the static bearer otherwise.
+  Future<String> _currentBearer() async {
+    if (_staticToken != null) return _staticToken;
+    final creds = await _tokenStorage?.read();
+    return creds?.bearerToken ?? '';
+  }
 
   ConversationsApi get conversations => _generatedApi.getConversationsApi();
   AttachmentsApi get attachments => _generatedApi.getAttachmentsApi();
@@ -119,6 +213,7 @@ class ApiClient {
     if (attachmentIds != null && attachmentIds.isNotEmpty) {
       body['attachment_ids'] = attachmentIds;
     }
+    final bearer = await _currentBearer();
     final Response<ResponseBody> response;
     try {
       response = await _dio.post<ResponseBody>(
@@ -129,7 +224,7 @@ class ApiClient {
           headers: {
             'Content-Type': 'application/json',
             'Accept': 'text/event-stream',
-            'Authorization': 'Bearer $_token',
+            'Authorization': 'Bearer $bearer',
           },
         ),
       );
@@ -158,6 +253,7 @@ class ApiClient {
     String runId, {
     int since = 0,
   }) async* {
+    final bearer = await _currentBearer();
     final Response<ResponseBody> response;
     try {
       response = await _dio.get<ResponseBody>(
@@ -167,7 +263,7 @@ class ApiClient {
           responseType: ResponseType.stream,
           headers: {
             'Accept': 'text/event-stream',
-            'Authorization': 'Bearer $_token',
+            'Authorization': 'Bearer $bearer',
           },
         ),
       );
@@ -220,6 +316,7 @@ class ApiClient {
       ),
     });
 
+    final bearer = await _currentBearer();
     final Response<ResponseBody> response;
     try {
       response = await _dio.post<ResponseBody>(
@@ -229,7 +326,7 @@ class ApiClient {
           responseType: ResponseType.stream,
           headers: {
             'Accept': 'text/event-stream',
-            'Authorization': 'Bearer $_token',
+            'Authorization': 'Bearer $bearer',
           },
         ),
       );
@@ -246,11 +343,12 @@ class ApiClient {
     String messageId,
   ) async {
     try {
+      final bearer = await _currentBearer();
       final response = await _dio.get<List<int>>(
         '/api/messages/$messageId/audio',
         options: Options(
           responseType: ResponseType.bytes,
-          headers: {'Authorization': 'Bearer $_token'},
+          headers: {'Authorization': 'Bearer $bearer'},
         ),
       );
       if (response.statusCode == 200 && response.data != null) {
@@ -268,11 +366,12 @@ class ApiClient {
     String audioId,
   ) async {
     try {
+      final bearer = await _currentBearer();
       final response = await _dio.get<List<int>>(
         '/api/audio/$audioId',
         options: Options(
           responseType: ResponseType.bytes,
-          headers: {'Authorization': 'Bearer $_token'},
+          headers: {'Authorization': 'Bearer $bearer'},
         ),
       );
       if (response.statusCode == 200 && response.data != null) {
@@ -305,10 +404,11 @@ class ApiClient {
 
   Stream<ConversationListEvent> _streamConversationsViaEventSource({
     String? agentId,
-  }) {
+  }) async* {
     final base = _dio.options.baseUrl;
+    final bearer = await _currentBearer();
     final qp = <String, String>{
-      'access_token': _token,
+      'access_token': bearer,
       // ignore: use_null_aware_elements — value is nullable, key is not.
       if (agentId != null) 'agent_id': agentId,
     };
@@ -320,7 +420,7 @@ class ApiClient {
         .join('&');
     final url = '$base/api/conversations/stream?$query';
     final adapter = event_source.openEventSourceAdapter(url: url);
-    return openConversationListStream(adapter: adapter);
+    yield* openConversationListStream(adapter: adapter);
   }
 
   Stream<ConversationListEvent> _streamConversationsViaDio({
@@ -329,6 +429,7 @@ class ApiClient {
     final queryParams = <String, dynamic>{};
     if (agentId != null) queryParams['agent_id'] = agentId;
 
+    final bearer = await _currentBearer();
     final Response<ResponseBody> response;
     try {
       response = await _dio.get<ResponseBody>(
@@ -338,7 +439,7 @@ class ApiClient {
           responseType: ResponseType.stream,
           headers: {
             'Accept': 'text/event-stream',
-            'Authorization': 'Bearer $_token',
+            'Authorization': 'Bearer $bearer',
           },
         ),
       );

--- a/app/lib/api/context_token_storage.dart
+++ b/app/lib/api/context_token_storage.dart
@@ -1,0 +1,50 @@
+import 'package:fresh_dio/fresh_dio.dart';
+
+import '../features/auth/oauth_credentials.dart';
+import '../features/contexts/data/context_repository.dart';
+import '../features/contexts/models/context_model.dart';
+
+/// Bridges fresh_dio's [TokenStorage] contract to [ContextRepository].
+///
+/// Scoped to a single [contextId]: every write goes through
+/// `repository.saveContext(ctx.copyWith(...))` so credentials survive a
+/// restart. [read] is on fresh_dio's hot path — it returns from an in-memory
+/// cache seeded by [initial] and refreshed by every [write]/[delete].
+class ContextTokenStorage implements TokenStorage<OAuthCredentials> {
+  ContextTokenStorage({
+    required this.contextId,
+    required this.repository,
+    OAuthCredentials? initial,
+  }) : _current = initial;
+
+  final String contextId;
+  final ContextRepository repository;
+  OAuthCredentials? _current;
+
+  @override
+  Future<OAuthCredentials?> read() async => _current;
+
+  @override
+  Future<void> write(OAuthCredentials token) async {
+    _current = token;
+    final ctx = await _loadCtx();
+    if (ctx == null) return;
+    await repository.saveContext(ctx.copyWith(oauthCredentials: token));
+  }
+
+  @override
+  Future<void> delete() async {
+    _current = null;
+    final ctx = await _loadCtx();
+    if (ctx == null) return;
+    await repository.saveContext(ctx.copyWith(clearOAuthCredentials: true));
+  }
+
+  Future<AssistantContext?> _loadCtx() async {
+    final all = await repository.loadContexts();
+    for (final c in all) {
+      if (c.id == contextId) return c;
+    }
+    return null;
+  }
+}

--- a/app/lib/features/connection/connection_provider.dart
+++ b/app/lib/features/connection/connection_provider.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:fresh_dio/fresh_dio.dart';
 
 import '../../api/api_client.dart';
+import '../../api/context_token_storage.dart';
 import '../../api/models/server_profile.dart';
 import '../auth/oauth_service.dart';
+import '../contexts/models/context_model.dart';
 import '../contexts/providers/context_providers.dart';
 import '../spaces/space_provider.dart';
 
@@ -56,12 +59,44 @@ final activeProfileProvider = Provider<ServerProfile?>((ref) {
 /// All feature providers should watch this in their [AsyncNotifier.build]
 /// so they rebuild reactively when the connection becomes available.
 final apiClientProvider = Provider<ApiClient?>((ref) {
-  final profile = ref.watch(activeProfileProvider);
-  if (profile == null) return null;
+  final ctxAsync = ref.watch(activeContextProvider);
+  final ctx = ctxAsync.value;
+  if (ctx == null) return null;
 
+  // OAuth2 context with credentials → fresh_dio path (proactive refresh,
+  // reactive 401 retry, single-flight, auth-status stream).
+  if (ctx.authMode == AuthMode.oauth2 && ctx.oauthCredentials != null) {
+    final repo = ref.watch(contextRepositoryProvider);
+    final storage = ContextTokenStorage(
+      contextId: ctx.id,
+      repository: repo,
+      initial: ctx.oauthCredentials,
+    );
+    final client = ApiClient.oauth2(
+      baseUrl: ctx.serverUrl,
+      tokenStorage: storage,
+      refreshToken: (oldCreds, _) async {
+        if (oldCreds == null) throw RevokeTokenException();
+        try {
+          final service = OAuthService(serverUrl: ctx.serverUrl);
+          return await service.refresh(
+            refreshToken: oldCreds.refreshToken,
+            clientId: oldCreds.clientId,
+          );
+        } catch (_) {
+          throw RevokeTokenException();
+        }
+      },
+      onAuthExpired: () => _handleAuthExpired(ref),
+    );
+    ref.onDispose(client.close);
+    return client;
+  }
+
+  // Legacy / API-key path: static bearer, no refresh.
   return ApiClient(
-    baseUrl: profile.baseUrl,
-    token: profile.token,
+    baseUrl: ctx.serverUrl,
+    token: ctx.effectiveToken ?? '',
     refreshTokens: () => _refreshAccessToken(ref),
     onAuthExpired: () => _handleAuthExpired(ref),
   );

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -572,6 +572,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
+  fresh:
+    dependency: transitive
+    description:
+      name: fresh
+      sha256: "2fe5ddb4ffac9da905e1c4c44256b87b2f826bc5941e344af637ade61bfa95a6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.1"
+  fresh_dio:
+    dependency: "direct main"
+    description:
+      name: fresh_dio
+      sha256: ac86867f2015e9f6d80051bb95144597cb7ae9029cfe17d5c7179538a7cfa7ad
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0"
   frontend_server_client:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   flutter_secure_storage: ^10.2.0
   http: ^1.6.0
   dio: ^5.9.2
+  fresh_dio: ^0.6.0
   native_dio_adapter: ^1.5.1
   uuid: ^4.5.3
   collection: ^1.19.1
@@ -59,8 +60,8 @@ flutter_launcher_icons:
   web:
     generate: true
     image_path: icon_source.png
-    background_color: '#080C1A'
-    theme_color: '#080C1A'
+    background_color: "#080C1A"
+    theme_color: "#080C1A"
 flutter:
   uses-material-design: true
   assets:

--- a/app/test/unit/api/api_client_oauth_test.dart
+++ b/app/test/unit/api/api_client_oauth_test.dart
@@ -1,0 +1,262 @@
+// Tests that ApiClient.oauth2() wires fresh_dio correctly:
+//   1. Proactive refresh when the cached token is expired (no 401 dance).
+//   2. Reactive refresh on 401 (the safety net).
+//   3. Refresh callback throwing RevokeTokenException → onAuthExpired fires
+//      and the request fails with a propagated 401.
+//
+// All three are covered against a sequenced HttpClientAdapter so we never
+// touch the network.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fresh_dio/fresh_dio.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:assistant_app/api/api_client.dart';
+import 'package:assistant_app/api/context_token_storage.dart';
+import 'package:assistant_app/features/auth/oauth_credentials.dart';
+import 'package:assistant_app/features/contexts/data/context_repository.dart';
+
+class _Reply {
+  const _Reply({this.statusCode = 200, this.body = const {}});
+  final int statusCode;
+  final Map<String, dynamic> body;
+}
+
+/// Records each [RequestOptions] and returns a pre-canned sequence of replies
+/// per path. Mirrors the helper in auth_interceptor_test.
+class _SequencedAdapter implements HttpClientAdapter {
+  _SequencedAdapter(this._plan);
+
+  final Map<String, List<_Reply>> _plan;
+  final List<RequestOptions> requests = [];
+
+  int countFor(String path) => requests.where((r) => r.path == path).length;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<dynamic>? cancelFuture,
+  ) async {
+    requests.add(options);
+    final replies = _plan[options.path];
+    if (replies == null) {
+      throw StateError('No mock plan for ${options.path}');
+    }
+    final idx = countFor(options.path) - 1;
+    if (idx >= replies.length) {
+      throw StateError('Plan exhausted for ${options.path} at idx $idx');
+    }
+    final reply = replies[idx];
+    final bytes = utf8.encode(jsonEncode(reply.body));
+    return ResponseBody.fromBytes(
+      bytes,
+      reply.statusCode,
+      headers: {
+        'content-type': ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+class _FakeSecureStorage implements SecureKeyValueStorage {
+  final Map<String, String> _data = {};
+
+  @override
+  Future<String?> read({required String key}) async => _data[key];
+
+  @override
+  Future<void> write({required String key, required String value}) async {
+    _data[key] = value;
+  }
+
+  @override
+  Future<void> delete({required String key}) async => _data.remove(key);
+}
+
+OAuthCredentials _creds({
+  String accessToken = 'access-current',
+  String refreshToken = 'refresh-current',
+  required DateTime expiresAt,
+}) {
+  return OAuthCredentials(
+    accessToken: accessToken,
+    refreshToken: refreshToken,
+    expiresAt: expiresAt,
+    clientId: 'client-1',
+  );
+}
+
+void main() {
+  late ContextRepository repo;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    repo = ContextRepository(prefs: prefs, secureStorage: _FakeSecureStorage());
+  });
+
+  group('ApiClient.oauth2', () {
+    test(
+      'proactively refreshes an expired token before the first request',
+      () async {
+        final expired = _creds(
+          accessToken: 'expired-jwt',
+          expiresAt: DateTime.now().toUtc().subtract(
+            const Duration(seconds: 30),
+          ),
+        );
+        final storage = ContextTokenStorage(
+          contextId: 'ctx-1',
+          repository: repo,
+          initial: expired,
+        );
+
+        var refreshCalls = 0;
+        var expiredCalls = 0;
+        final client = ApiClient.oauth2(
+          baseUrl: 'http://localhost',
+          tokenStorage: storage,
+          refreshToken: (old, _) async {
+            refreshCalls++;
+            return _creds(
+              accessToken: 'refreshed-jwt',
+              refreshToken: 'refresh-2',
+              expiresAt: DateTime.now().toUtc().add(const Duration(hours: 1)),
+            );
+          },
+          onAuthExpired: () async {
+            expiredCalls++;
+          },
+        );
+
+        final adapter = _SequencedAdapter({
+          '/api/capabilities': [
+            const _Reply(body: {'voice_send': false}),
+          ],
+        });
+        client.dioForTesting.httpClientAdapter = adapter;
+        client.refreshDioForTesting?.httpClientAdapter = adapter;
+
+        await client.dioForTesting.get<dynamic>('/api/capabilities');
+
+        expect(
+          refreshCalls,
+          1,
+          reason: 'token was expired → refresh runs before request',
+        );
+        expect(expiredCalls, 0);
+        expect(adapter.countFor('/api/capabilities'), 1);
+        expect(
+          adapter.requests.single.headers['Authorization'],
+          'Bearer refreshed-jwt',
+        );
+      },
+    );
+
+    test('reactive 401 triggers refresh + retry with the new bearer', () async {
+      final valid = _creds(
+        accessToken: 'looks-valid',
+        expiresAt: DateTime.now().toUtc().add(const Duration(hours: 1)),
+      );
+      final storage = ContextTokenStorage(
+        contextId: 'ctx-1',
+        repository: repo,
+        initial: valid,
+      );
+
+      var refreshCalls = 0;
+      final client = ApiClient.oauth2(
+        baseUrl: 'http://localhost',
+        tokenStorage: storage,
+        refreshToken: (old, _) async {
+          refreshCalls++;
+          return _creds(
+            accessToken: 'refreshed-after-401',
+            refreshToken: 'refresh-2',
+            expiresAt: DateTime.now().toUtc().add(const Duration(hours: 1)),
+          );
+        },
+        onAuthExpired: () async {},
+      );
+
+      final adapter = _SequencedAdapter({
+        '/api/personas': [
+          const _Reply(statusCode: 401, body: {'error': 'expired upstream'}),
+          const _Reply(body: {'personas': []}),
+        ],
+      });
+      client.dioForTesting.httpClientAdapter = adapter;
+      client.refreshDioForTesting?.httpClientAdapter = adapter;
+
+      final response = await client.dioForTesting.get<dynamic>('/api/personas');
+
+      expect(response.statusCode, 200);
+      expect(refreshCalls, 1);
+      expect(adapter.countFor('/api/personas'), 2);
+      expect(
+        adapter.requests[1].headers['Authorization'],
+        'Bearer refreshed-after-401',
+      );
+    });
+
+    test(
+      'refresh throwing RevokeTokenException fires onAuthExpired and clears credentials',
+      () async {
+        final valid = _creds(
+          accessToken: 'looks-valid',
+          expiresAt: DateTime.now().toUtc().add(const Duration(hours: 1)),
+        );
+        final storage = ContextTokenStorage(
+          contextId: 'ctx-1',
+          repository: repo,
+          initial: valid,
+        );
+
+        var expiredCalls = 0;
+        final expiredFired = Completer<void>();
+        final client = ApiClient.oauth2(
+          baseUrl: 'http://localhost',
+          tokenStorage: storage,
+          refreshToken: (old, _) async {
+            throw RevokeTokenException();
+          },
+          onAuthExpired: () async {
+            expiredCalls++;
+            if (!expiredFired.isCompleted) expiredFired.complete();
+          },
+        );
+
+        final adapter = _SequencedAdapter({
+          '/api/personas': [
+            const _Reply(statusCode: 401, body: {'error': 'expired upstream'}),
+          ],
+        });
+        client.dioForTesting.httpClientAdapter = adapter;
+        client.refreshDioForTesting?.httpClientAdapter = adapter;
+
+        Object? caught;
+        try {
+          await client.dioForTesting.get<dynamic>('/api/personas');
+        } on DioException catch (e) {
+          caught = e;
+        }
+
+        // Wait for the unauthenticated status stream to flush.
+        await expiredFired.future.timeout(const Duration(seconds: 1));
+
+        expect(caught, isA<DioException>());
+        expect(expiredCalls, greaterThanOrEqualTo(1));
+        expect(await storage.read(), isNull, reason: 'fresh_dio cleared cache');
+      },
+    );
+  });
+}

--- a/app/test/unit/api/context_token_storage_test.dart
+++ b/app/test/unit/api/context_token_storage_test.dart
@@ -1,0 +1,144 @@
+// Tests for ContextTokenStorage — the adapter that bridges fresh_dio's
+// TokenStorage<OAuthCredentials> contract to our ContextRepository.
+//
+// The adapter is scoped to a specific context ID at construction. read() is
+// hot-path (called by fresh_dio on every request to attach the bearer), so it
+// returns from an in-memory cache. write()/delete() update the cache AND
+// persist through ContextRepository so the new credentials survive restart.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:assistant_app/api/context_token_storage.dart';
+import 'package:assistant_app/features/auth/oauth_credentials.dart';
+import 'package:assistant_app/features/contexts/data/context_repository.dart';
+import 'package:assistant_app/features/contexts/models/context_model.dart';
+
+class _FakeSecureStorage implements SecureKeyValueStorage {
+  final Map<String, String> _data = {};
+
+  @override
+  Future<String?> read({required String key}) async => _data[key];
+
+  @override
+  Future<void> write({required String key, required String value}) async {
+    _data[key] = value;
+  }
+
+  @override
+  Future<void> delete({required String key}) async => _data.remove(key);
+}
+
+OAuthCredentials _creds({
+  String accessToken = 'access-1',
+  String refreshToken = 'refresh-1',
+  DateTime? expiresAt,
+}) {
+  return OAuthCredentials(
+    accessToken: accessToken,
+    refreshToken: refreshToken,
+    expiresAt: expiresAt ?? DateTime.utc(2030, 1, 1),
+    clientId: 'client-1',
+  );
+}
+
+AssistantContext _ctx({String id = 'ctx-1', OAuthCredentials? oauth}) {
+  return AssistantContext(
+    id: id,
+    name: 'Work',
+    serverUrl: 'https://work.example.com',
+    authMode: AuthMode.oauth2,
+    oauthCredentials: oauth,
+    createdAt: DateTime.utc(2024, 1, 1),
+  );
+}
+
+void main() {
+  late SharedPreferences prefs;
+  late _FakeSecureStorage secure;
+  late ContextRepository repo;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    secure = _FakeSecureStorage();
+    repo = ContextRepository(prefs: prefs, secureStorage: secure);
+  });
+
+  group('ContextTokenStorage', () {
+    test(
+      'read() returns the initial credentials supplied at construction',
+      () async {
+        final initial = _creds(accessToken: 'initial');
+        final storage = ContextTokenStorage(
+          contextId: 'ctx-1',
+          repository: repo,
+          initial: initial,
+        );
+
+        expect(await storage.read(), initial);
+      },
+    );
+
+    test('read() returns null when no initial credentials given', () async {
+      final storage = ContextTokenStorage(contextId: 'ctx-1', repository: repo);
+
+      expect(await storage.read(), isNull);
+    });
+
+    test('write() persists new credentials to the repository', () async {
+      await repo.saveContext(_ctx(oauth: _creds(accessToken: 'old')));
+      final storage = ContextTokenStorage(
+        contextId: 'ctx-1',
+        repository: repo,
+        initial: _creds(accessToken: 'old'),
+      );
+
+      final fresh = _creds(accessToken: 'fresh', refreshToken: 'fresh-r');
+      await storage.write(fresh);
+
+      // In-memory cache reflects the new token.
+      expect(await storage.read(), fresh);
+
+      // Repository was updated.
+      final loaded = await repo.loadContexts();
+      expect(loaded.single.oauthCredentials?.accessToken, 'fresh');
+      expect(loaded.single.oauthCredentials?.refreshToken, 'fresh-r');
+    });
+
+    test('delete() clears credentials in cache and repository', () async {
+      await repo.saveContext(_ctx(oauth: _creds(accessToken: 'old')));
+      final storage = ContextTokenStorage(
+        contextId: 'ctx-1',
+        repository: repo,
+        initial: _creds(accessToken: 'old'),
+      );
+
+      await storage.delete();
+
+      expect(await storage.read(), isNull);
+      final loaded = await repo.loadContexts();
+      expect(loaded.single.oauthCredentials, isNull);
+    });
+
+    test(
+      'write() is a no-op on persistence when the context has been deleted',
+      () async {
+        // No context with id 'ctx-1' exists in the repository.
+        final storage = ContextTokenStorage(
+          contextId: 'ctx-1',
+          repository: repo,
+        );
+
+        final fresh = _creds(accessToken: 'fresh');
+        // Must not throw.
+        await storage.write(fresh);
+
+        // Cache still reflects the write (fresh_dio will retry against an empty
+        // repository on next read — that's the deactivated-context case).
+        expect(await storage.read(), fresh);
+        expect(await repo.loadContexts(), isEmpty);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- Replaces the cold-open 401 storm with a proactive `fresh_dio` refresh on the OAuth path. Initial Dio requests previously fired in parallel with a stale bearer, each producing a 401 before converging on the single-flight refresh — now the refresh runs *before* the first request fires.
- New `ApiClient.oauth2()` constructor wires `Fresh<OAuthCredentials>` with `shouldRefreshBeforeRequest: creds.isExpired()` + the built-in reactive 401 retry. `authenticationStatus.unauthenticated` calls `onAuthExpired`, which deactivates the active context so the router redirects to `/login` — preserves the `web-401-recovery` spec contract.
- Affects both web and native (macOS Keychain has the same cold-cache profile).

## What changed

- `ContextTokenStorage` adapter bridges `fresh_dio`'s `TokenStorage<OAuthCredentials>` to our `ContextRepository`. In-memory cache for the hot `read()` path; writes flow through `repository.saveContext` so refreshed credentials survive restart.
- A separate `_refreshDio` is used for `fresh_dio`'s refresh + retry HTTP calls — fresh asserts an interceptor can't be installed on its own httpClient.
- SSE methods now read the current bearer from token storage (via `_currentBearer()`) so an in-progress stream picks up refreshed tokens. Web's `EventSource` `access_token` query param also reads it before opening.
- Legacy / API-key contexts unchanged — still use the static-bearer `ApiClient()` + `AuthRecoveryInterceptor`. `_refreshAccessToken` returns `null` for non-OAuth contexts, so the existing refresh-then-deactivate path is identical to before.

## Test plan

- [x] `flutter analyze --fatal-infos` clean
- [x] All 894 Flutter tests pass (`make lint-flutter` precommit suite)
- [x] New unit tests:
  - `ContextTokenStorage`: read/write/delete + in-memory cache semantics + deleted-context safety
  - `ApiClient.oauth2`: proactive refresh of expired token before first request, reactive 401 retry, `RevokeTokenException` → `onAuthExpired` + cache cleared
- [ ] Manual: cold-open the web app with a stale OAuth context — network panel should show no 401s on initial paint
- [ ] Manual: cold-open the macOS app with a stale OAuth context — same expectation
- [ ] Manual: API-key (`ask_live_…`) context still works (legacy path unchanged)

## Notes

- `AuthRecoveryInterceptor` is retained for the legacy path; a follow-up could replace it with a minimal "on-401-deactivate" interceptor.
- One latent bug fixed by side effect: previously, after `_refreshAccessToken` saved new credentials, the *existing* `ApiClient` instance still held the old token in `_token`/Dio defaults until something rebuilt `apiClientProvider`. SSE methods now resolve the bearer at call time.