### PR TITLE
refactor(app): migrate traces_screen onto AdaptiveSliverNavBar

### DIFF
--- a/app/lib/features/traces/traces_screen.dart
+++ b/app/lib/features/traces/traces_screen.dart
@@ -1,17 +1,16 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:assistant_api/assistant_api.dart';
 
-import '../../shared/platform/platform.dart';
+import '../../shared/platform/adaptive_sliver_nav_bar.dart';
 import 'traces_provider.dart';
 
 /// Observability screen that lists recent assistant traces.
 ///
 /// Each row shows timestamp, persona, duration, and status.
-/// Expanding a row reveals the span breakdown.
+/// Tapping a row navigates to the full trace detail.
 class TracesScreen extends ConsumerWidget {
   const TracesScreen({super.key});
 
@@ -19,97 +18,49 @@ class TracesScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final tracesAsync = ref.watch(tracesProvider);
 
-    if (isAppleTouch) {
-      return Scaffold(
-        body: CustomScrollView(
-          slivers: [
-            CupertinoSliverNavigationBar(
-              largeTitle: const Text('Traces'),
-              trailing: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  IconButton(
-                    icon: const Icon(Icons.refresh),
-                    onPressed: () =>
-                        ref.read(tracesProvider.notifier).refresh(),
-                  ),
-                ],
-              ),
-            ),
-            tracesAsync.when(
-              loading: () => const SliverFillRemaining(
-                child: Center(child: CircularProgressIndicator.adaptive()),
-              ),
-              error: (err, _) => SliverFillRemaining(
-                child: _ErrorView(
-                  error: err.toString(),
-                  onRetry: () => ref.read(tracesProvider.notifier).refresh(),
-                ),
-              ),
-              data: (state) {
-                if (state.error != null) {
-                  return SliverFillRemaining(
-                    child: _ErrorView(
-                      error: state.error!,
-                      onRetry: () =>
-                          ref.read(tracesProvider.notifier).refresh(),
-                    ),
-                  );
-                }
-                if (state.traces.isEmpty) {
-                  return const SliverFillRemaining(child: _EmptyView());
-                }
-                return SliverList(
-                  delegate: SliverChildBuilderDelegate((context, index) {
-                    return _TraceRow(trace: state.traces[index]);
-                  }, childCount: state.traces.length),
-                );
-              },
-            ),
-          ],
-        ),
-      );
-    }
-
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Traces'),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () => context.go('/chat'),
-        ),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.refresh),
-            onPressed: () => ref.read(tracesProvider.notifier).refresh(),
+      body: CustomScrollView(
+        slivers: [
+          AdaptiveSliverNavBar(
+            title: 'Traces',
+            actions: [
+              IconButton(
+                icon: const Icon(Icons.refresh),
+                onPressed: () => ref.read(tracesProvider.notifier).refresh(),
+              ),
+            ],
+          ),
+          tracesAsync.when(
+            loading: () => const SliverFillRemaining(
+              child: Center(child: CircularProgressIndicator.adaptive()),
+            ),
+            error: (err, _) => SliverFillRemaining(
+              child: _ErrorView(
+                error: err.toString(),
+                onRetry: () => ref.read(tracesProvider.notifier).refresh(),
+              ),
+            ),
+            data: (state) {
+              if (state.error != null) {
+                return SliverFillRemaining(
+                  child: _ErrorView(
+                    error: state.error!,
+                    onRetry: () => ref.read(tracesProvider.notifier).refresh(),
+                  ),
+                );
+              }
+              if (state.traces.isEmpty) {
+                return const SliverFillRemaining(child: _EmptyView());
+              }
+              return SliverList(
+                delegate: SliverChildBuilderDelegate(
+                  (context, index) => _TraceRow(trace: state.traces[index]),
+                  childCount: state.traces.length,
+                ),
+              );
+            },
           ),
         ],
-      ),
-      body: tracesAsync.when(
-        loading: () =>
-            const Center(child: CircularProgressIndicator.adaptive()),
-        error: (err, _) => _ErrorView(
-          error: err.toString(),
-          onRetry: () => ref.read(tracesProvider.notifier).refresh(),
-        ),
-        data: (state) {
-          if (state.error != null) {
-            return _ErrorView(
-              error: state.error!,
-              onRetry: () => ref.read(tracesProvider.notifier).refresh(),
-            );
-          }
-          if (state.traces.isEmpty) {
-            return const _EmptyView();
-          }
-          return ListView.builder(
-            itemCount: state.traces.length,
-            itemBuilder: (context, index) {
-              final trace = state.traces[index];
-              return _TraceRow(trace: trace);
-            },
-          );
-        },
       ),
     );
   }

--- a/openspec/changes/adaptive-ui-consolidation/tasks.md
+++ b/openspec/changes/adaptive-ui-consolidation/tasks.md
@@ -24,15 +24,15 @@
 - [x] 1.22 Implement `app/lib/shared/platform/adaptive_snack_bar.dart`
 - [x] 1.23 Run `make lint-flutter && make test-flutter` — green (933 tests pass, dart_pre_commit clean)
 - [x] 1.24 Run `cd app && flutter analyze --fatal-infos` — zero issues
-- [ ] 1.25 Open Phase 1 PR with stacked-PR-base flag set; merge before Phase 2
+- [x] 1.25 Open Phase 1 PR with stacked-PR-base flag set; merge before Phase 2 (PR #789)
 
 ## 2. Phase 2.1 — Trivial sweep (1 PR)
 
-- [ ] 2.1.1 Remove the vestigial `package:flutter/material.dart` import from `app/lib/shared/error_screen.dart`; verify the file still compiles and the existing widget test passes
+- [ ] 2.1.1 ~~Remove the vestigial `package:flutter/material.dart` import from `app/lib/shared/error_screen.dart`~~ **Deferred.** Original inventory was wrong: the file legitimately uses `Material()` widget (background colour), `Theme.of(context)`, `Icons.error_outline`, and `ExpansionTile`. It's a special-case bootstrap widget rendered via `ErrorWidget.builder` before the app's normal widget tree may be available. Decision: add `app/lib/shared/error_screen.dart` to the Phase 4 lint allowlist as a known exception. Migration to `AdaptiveScaffold` + `AdaptiveIcon` is possible but requires a small visual change (AppBar on Material path) and is out of scope here.
 
 ## 3. Phase 2.2 — Sliver-nav list screens (9 stacked PRs, one per screen)
 
-- [ ] 3.1 `traces_screen.dart`: replace inline `if (isAppleTouch) CupertinoSliverNavigationBar` with `AdaptiveSliverNavBar`; drop `package:flutter/cupertino.dart` import; existing tests stay green
+- [x] 3.1 `traces_screen.dart`: replace inline `if (isAppleTouch) CupertinoSliverNavigationBar` with `AdaptiveSliverNavBar`; drop `package:flutter/cupertino.dart` import; existing tests stay green. Unified both platform paths into a single CustomScrollView with the wrapper. Material visual change: SliverAppBar.large (collapsing) replaces fixed AppBar, and the explicit `IconButton(arrow_back) → /chat` is dropped (top-level nav screen — sidebar/tab bar already provides home access; matches the existing iOS path which had no back button).
 - [ ] 3.2 `logs_screen.dart`: same treatment
 - [ ] 3.3 `agents_screen.dart`: same treatment + replace `CupertinoButton`/`CupertinoIcons` with `AdaptiveButton`/`AdaptiveIcons`
 - [ ] 3.4 `workflows_screen.dart`: same as 3.3


### PR DESCRIPTION
## Summary

First Phase 2 migration in the [`adaptive-ui-consolidation`](openspec/changes/adaptive-ui-consolidation/) series. Drops the inline `if (isAppleTouch) CupertinoSliverNavigationBar else AppBar` branch in `traces_screen.dart` and replaces it with `AdaptiveSliverNavBar` from the façade added in #789. Both platform paths now share a single `CustomScrollView` body; the wrapper picks the right top chrome.

- Net diff: 42 insertions, 91 deletions (-49 LOC).
- `flutter/cupertino.dart` import dropped from this file.
- `flutter/material.dart` import stays (file uses `Card`, `InkWell`, `IconButton`, `Theme.of`, `FilledButton`, `Icons.*`, `CircularProgressIndicator.adaptive`). Phase 4 lint will ban direct **cupertino** imports outside `lib/shared/platform/` only — `material.dart` remains the default rendering toolkit.

## Behavioural notes

- **iOS path: unchanged** — `CupertinoSliverNavigationBar` (large-title-collapses) inside a `CustomScrollView` is exactly what the wrapper produces.
- **Material path: AppBar → SliverAppBar.large** via the wrapper. This matches the `cupertino-chrome` spec's Material scenario (Material equivalent of the large-title pattern). On scroll, the large title collapses, just like iOS.
- **Material path: explicit `IconButton(arrow_back) → /chat` dropped.** Traces is a top-level nav destination (reachable from sidebar / bottom tab bar), so an explicit "home" button is redundant and the iOS path never had one. If we decide the explicit back is needed for accessibility on web, we can re-add via `leading:` on `AdaptiveSliverNavBar` in a follow-up.

## Scope correction recorded in tasks.md

While doing the inventory, the Phase 2.1 "trivial sweep" of `error_screen.dart` was deferred. That file legitimately uses `Material()` widget for background colour, `Theme.of`, `Icons.error_outline`, and `ExpansionTile` — not vestigial, just a bootstrap widget that handles errors before the normal widget tree is up. Will be added to the Phase 4 lint allowlist as a known exception.

## Stack

This is the second PR in the `adaptive-ui-consolidation` series, stacked on `main` after #789 (Phase 1) merged.

- ✅ Phase 1 (#789) — façade wrappers
- 👉 **This PR** — Phase 2.2.1, traces screen
- Phase 2.2.2–9 (next) — `logs_screen`, `agents_screen`, `workflows_screen`, `personas_screen`, `skills_screen`, `webhooks_screen`, `analytics_screen`, `context_switcher_screen`

## Test plan

- [x] `flutter test test/widget/features/traces/traces_screen_test.dart` — 7/7 pass
- [x] `flutter test` — 933/933 pass
- [x] `flutter analyze --fatal-infos lib/features/traces/traces_screen.dart` — 0 issues
- [x] Pre-commit hook (rust fmt + clippy + machete + dart_pre_commit + flutter test) — passed
- [ ] Visual smoke check on iPhone Simulator (iOS 26): large-title collapses correctly, refresh button works
- [ ] Visual smoke check on Chrome browser: SliverAppBar.large collapses correctly, no explicit back-to-chat button (intentional)

## Refs

OpenSpec: `openspec/changes/adaptive-ui-consolidation/` (Phase 2.2, task 3.1 complete).