### PR TITLE
refactor(core,storage,bus-nats): add MessageBus::has_active_message

### DIFF
--- a/crates/bus-nats/src/lib.rs
+++ b/crates/bus-nats/src/lib.rs
@@ -533,6 +533,18 @@ impl MessageBus for NatsMessageBus {
         debug!("NATS purge: no-op (JetStream MaxAge handles expiration)");
         Ok(0)
     }
+
+    /// **NATS behavioural note:** Conservative `true` placeholder.
+    ///
+    /// JetStream doesn't expose a per-(conversation_id, topic) "is there an
+    /// active message" query without scanning the stream. Returning `true`
+    /// preserves the crash-recovery invariant ("if in doubt, assume the run
+    /// may still complete") at the cost of leaving orphaned SSE runs open
+    /// slightly longer than necessary. Implement properly when we need it.
+    async fn has_active_message(&self, _conversation_id: &str, _topic: &str) -> Result<bool> {
+        debug!("NATS has_active_message: returning true (no JetStream scan available)");
+        Ok(true)
+    }
 }
 
 // -- Helpers ----------------------------------------------------------------

--- a/crates/core/src/bus.rs
+++ b/crates/core/src/bus.rs
@@ -372,4 +372,17 @@ pub trait MessageBus: Send + Sync {
     /// Backends with broker-managed retention windows may implement this as a
     /// no-op.
     async fn purge(&self, older_than: DateTime<Utc>) -> Result<u64>;
+
+    /// Return `true` if any `Pending` or `Claimed` message exists for the
+    /// given `(conversation_id, topic)` pair.
+    ///
+    /// Used by crash-recovery flows (e.g. orphaned SSE run reaper) to decide
+    /// whether a half-complete run might still receive delivery — if a
+    /// message for that conversation+topic is still active in the bus, the
+    /// run may complete after redelivery, so no synthetic terminal event
+    /// should be appended.
+    ///
+    /// `conversation_id` is the stringified UUID (matching the format stored
+    /// in `BusMessage::conversation_id`).
+    async fn has_active_message(&self, conversation_id: &str, topic: &str) -> Result<bool>;
 }

--- a/crates/runtime/src/scheduler.rs
+++ b/crates/runtime/src/scheduler.rs
@@ -24,7 +24,6 @@ use opentelemetry::{
     KeyValue,
     trace::{Span as _, SpanKind},
 };
-use sqlx::SqlitePool;
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
@@ -606,7 +605,10 @@ pub(crate) async fn reap_stale_and_recover(storage: &StorageLayer, bus: &dyn Mes
 
     // Step 3 & 4: for each orphan, check bus and potentially close.
     for (run_id, conversation_id) in orphans {
-        let has_active = match has_active_bus_message(&storage.pool, &conversation_id).await {
+        let has_active = match bus
+            .has_active_message(&conversation_id, topic::TURN_REQUEST)
+            .await
+        {
             Ok(v) => v,
             Err(e) => {
                 warn!(
@@ -648,22 +650,6 @@ pub(crate) async fn reap_stale_and_recover(storage: &StorageLayer, bus: &dyn Mes
             ),
         }
     }
-}
-
-/// Check whether there is a Pending or Claimed `turn.request` bus message for a
-/// conversation.  Only `turn.request` messages initiate orchestrator runs; other
-/// topics (e.g. `schedule.trigger`) should not block orphan recovery.
-async fn has_active_bus_message(pool: &SqlitePool, conversation_id: &str) -> Result<bool> {
-    let count: i64 = sqlx::query_scalar(
-        "SELECT COUNT(*) FROM bus_messages \
-         WHERE conversation_id = ?1 \
-           AND topic = 'turn.request' \
-           AND status IN ('pending', 'claimed')",
-    )
-    .bind(conversation_id)
-    .fetch_one(pool)
-    .await?;
-    Ok(count > 0)
 }
 
 // -- Tests ------------------------------------------------------------------

--- a/crates/storage/src/message_bus.rs
+++ b/crates/storage/src/message_bus.rs
@@ -259,6 +259,20 @@ impl MessageBus for SqliteMessageBus {
         }
         Ok(count)
     }
+
+    async fn has_active_message(&self, conversation_id: &str, topic: &str) -> Result<bool> {
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM bus_messages \
+             WHERE conversation_id = ?1 \
+               AND topic = ?2 \
+               AND status IN ('pending', 'claimed')",
+        )
+        .bind(conversation_id)
+        .bind(topic)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(count > 0)
+    }
 }
 
 // -- Row parsing ------------------------------------------------------------


### PR DESCRIPTION
## Summary

Lift the \"is there a Pending or Claimed message for this
\`(conversation_id, topic)\`?\" query off raw \`sqlx::query_scalar\`
in \`crates/runtime/src/scheduler.rs\` and onto the
\`MessageBus\` trait.

\`\`\`rust
async fn has_active_message(
    &self,
    conversation_id: &str,
    topic: &str,
) -> Result<bool>;
\`\`\`

- **\`SqliteMessageBus\`**: keeps the original query, now parameterised on
  \`topic\` rather than hard-coded \`'turn.request'\`.
- **\`NatsMessageBus\`**: returns \`Ok(true)\` with a behavioural note —
  JetStream doesn't expose this without scanning the stream, so the
  conservative answer preserves the crash-recovery invariant
  (\"if in doubt, assume the run may complete\") at the cost of
  leaving orphans open slightly longer.
- Scheduler call site becomes a single line; the raw-SQL helper +
  its \`SqlitePool\` import disappear.

Restores the storage-boundary discipline that the rest of runtime
respects — runtime no longer reaches past the bus trait into the
underlying SQLite schema.

## Test plan
- [x] \`cargo test -p assistant-runtime --lib\` — 220 passing
- [x] \`cargo test -p assistant-storage --lib\` — 234 passing
- [x] \`make lint\` — clean
- [x] \`cargo fmt --all --check\` — clean