### PR TITLE
feat(app): add façade barrel re-export shim (Option C)

### DIFF
--- a/app/lib/features/traces/traces_screen.dart
+++ b/app/lib/features/traces/traces_screen.dart
@@ -1,10 +1,9 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:assistant_api/assistant_api.dart';
 
-import '../../shared/platform/adaptive_sliver_nav_bar.dart';
+import '../../shared/platform/widgets.dart';
 import 'traces_provider.dart';
 
 /// Observability screen that lists recent assistant traces.
@@ -18,7 +17,7 @@ class TracesScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final tracesAsync = ref.watch(tracesProvider);
 
-    return Scaffold(
+    return AdaptiveScaffold(
       body: CustomScrollView(
         slivers: [
           AdaptiveSliverNavBar(
@@ -91,7 +90,7 @@ class _TraceRow extends StatelessWidget {
                 width: 8,
                 height: 8,
                 decoration: BoxDecoration(
-                  color: isError ? colorScheme.error : Colors.green,
+                  color: isError ? colorScheme.error : colorScheme.tertiary,
                   shape: BoxShape.circle,
                 ),
               ),
@@ -212,7 +211,7 @@ class _ErrorView extends StatelessWidget {
           const SizedBox(height: 12),
           Text(error, textAlign: TextAlign.center),
           const SizedBox(height: 12),
-          FilledButton(onPressed: onRetry, child: const Text('Retry')),
+          AdaptiveButton.filled(onPressed: onRetry, child: const Text('Retry')),
         ],
       ),
     );

--- a/app/lib/shared/platform/widgets.dart
+++ b/app/lib/shared/platform/widgets.dart
@@ -1,0 +1,138 @@
+/// Façade barrel — the single public surface for UI primitives in feature code.
+///
+/// Feature code under `app/lib/features/**` and `app/lib/shared/**`
+/// (excluding `app/lib/shared/platform/**` itself) SHOULD import this file
+/// rather than `package:flutter/cupertino.dart` or
+/// `package:flutter/material.dart` directly.
+///
+/// The Phase 4 lint rule will forbid direct cupertino.dart and material.dart
+/// imports outside the allowlist (`lib/shared/platform/**` and `lib/main.dart`).
+/// This barrel is the only sanctioned way for feature code to reach Material
+/// primitives.
+///
+/// What's exported:
+///
+/// 1. Everything from `flutter/widgets.dart` (the neutral Flutter layer —
+///    Container, Padding, Row, Column, Text, GestureDetector, etc.).
+///
+/// 2. A curated subset of `flutter/material.dart` for widgets that have no
+///    meaningful iOS counterpart and for theming/type access. The `show`
+///    list below is the discipline boundary — adding to it is a deliberate
+///    act, and every new `Adaptive*` wrapper added in later phases removes
+///    one entry from it (ratchet pattern).
+///
+/// 3. `CupertinoIcons` (constants only) from `flutter/cupertino.dart`, so
+///    feature code can pass `cupertino:` IconData to `AdaptiveIcon` without
+///    importing cupertino.dart directly. No Cupertino widget classes are
+///    re-exported — those are reachable only via the `Adaptive*` wrappers.
+///
+/// 4. All `Adaptive*` wrappers from `lib/shared/platform/`, plus the
+///    `platformStyle` / `AppPlatformStyle` helpers. Feature code needs only
+///    one import to get the entire UI vocabulary.
+///
+/// Intentionally NOT in the material `show` list (force migration to
+/// wrappers): `Scaffold`, `AppBar`, `ListTile`, `SwitchListTile`, `Switch`,
+/// `TextField`, `Slider`, `SnackBar`, `AlertDialog`, `FilledButton`,
+/// `TextButton`. Also NOT re-exported: `Colors` (gated by
+/// `scripts/check_no_raw_colors.sh`).
+library;
+
+// 1. Neutral Flutter widgets — always safe.
+export 'package:flutter/widgets.dart';
+
+// 2. Curated Material subset.
+export 'package:flutter/material.dart'
+    show
+        // Surface primitives without iOS equivalents.
+        Card,
+        InkWell,
+        Material,
+        MaterialType,
+        // Icon glyph constants (Material side).
+        Icons,
+        // Theme access — Theme.of(context) and the data types it returns.
+        Theme,
+        ThemeData,
+        ColorScheme,
+        TextTheme,
+        Brightness,
+        // Indicators — CircularProgressIndicator.adaptive picks the right
+        // glyph automatically, so the static class itself is re-exported.
+        CircularProgressIndicator,
+        // Buttons without a wrapper yet. AdaptiveIconButton, AdaptiveButton.outlined,
+        // and AdaptivePopupMenu are future work; until they exist, these
+        // remain in the show list. Each new wrapper removes one entry.
+        IconButton,
+        OutlinedButton,
+        PopupMenuButton,
+        PopupMenuItem,
+        CheckedPopupMenuItem,
+        PopupMenuDivider,
+        PopupMenuEntry,
+        // Material-only concepts (no Cupertino equivalent at all).
+        FloatingActionButton,
+        Tooltip,
+        Divider,
+        VerticalDivider,
+        ExpansionTile,
+        // Snackbar control surface — AdaptiveSnackBar wraps the rendering,
+        // but feature code occasionally needs ScaffoldMessenger for in-flight
+        // control (clearing snackbars, etc.).
+        ScaffoldMessenger,
+        ScaffoldMessengerState,
+        SnackBarAction,
+        // Navigation primitives used in router config.
+        MaterialPageRoute,
+        MaterialApp,
+        // Drawer / TabBar are used in nav_shell — wrappers TBD.
+        Drawer,
+        DrawerHeader,
+        TabBar,
+        Tab,
+        TabBarView,
+        TabController,
+        DefaultTabController,
+        // Chip / Badge style widgets — no iOS equivalent.
+        Chip,
+        Badge,
+        // Form-aware list tile, occasionally used in settings.
+        // (Settings will migrate to AdaptiveSwitchTile, but `CheckboxListTile`
+        // is occasionally useful and has no Cupertino equivalent.)
+        CheckboxListTile,
+        // Ink ripple / hover / focus support used with InkWell.
+        Ink,
+        // Stepper for multi-step flows (Material-only pattern).
+        Stepper,
+        Step,
+        // Bottom sheets — `showModalBottomSheet` is used via
+        // AdaptiveActionSheet on iOS; the function itself is sometimes
+        // needed directly for non-action sheets.
+        showModalBottomSheet,
+        // Dialogs — `showDialog` is sometimes needed for custom dialogs.
+        // AdaptiveDialog covers the confirm pattern; this is the lower-level
+        // entry point.
+        showDialog,
+        // Material localisations (used in date/time pickers).
+        DefaultMaterialLocalizations;
+
+// 3. Cupertino constants only — never Cupertino widget classes.
+export 'package:flutter/cupertino.dart' show CupertinoIcons;
+
+// 4. Façade wrappers and platform helpers.
+export 'adaptive_action_sheet.dart';
+export 'adaptive_app.dart';
+export 'adaptive_button.dart';
+export 'adaptive_context_menu.dart';
+export 'adaptive_dialog.dart';
+export 'adaptive_icon.dart';
+export 'adaptive_list_section.dart';
+export 'adaptive_list_tile.dart';
+export 'adaptive_nav_bar.dart';
+export 'adaptive_scaffold.dart';
+export 'adaptive_slider.dart';
+export 'adaptive_sliver_nav_bar.dart';
+export 'adaptive_snack_bar.dart';
+export 'adaptive_switch.dart';
+export 'adaptive_switch_tile.dart';
+export 'adaptive_text_field.dart';
+export 'platform.dart';

--- a/app/test/widget/platform/widgets_barrel_test.dart
+++ b/app/test/widget/platform/widgets_barrel_test.dart
@@ -1,0 +1,104 @@
+// Compile/import test for the façade barrel.
+//
+// This file imports ONLY the façade barrel and exercises a representative
+// sample of widgets and types. If a `show`-list entry is accidentally
+// dropped (or removed without a wrapper replacement), this file will fail
+// to compile and the test will fail at load time — surfacing the show-list
+// regression immediately.
+
+import 'package:assistant_app/shared/platform/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Façade barrel — show-list reachability', () {
+    test('flutter/widgets.dart neutral primitives reachable', () {
+      // These come from flutter/widgets.dart (always re-exported).
+      // ignore: unnecessary_statements
+      const SizedBox(width: 1, height: 1);
+      // ignore: unnecessary_statements
+      const Padding(padding: EdgeInsets.zero, child: SizedBox.shrink());
+      // ignore: unnecessary_statements
+      const Text('hi');
+      // ignore: unnecessary_statements
+      const Icon(IconData(0x100));
+    });
+
+    test('curated material widgets reachable via barrel', () {
+      // Surface widgets without iOS equivalents (Card, InkWell, etc.)
+      // ignore: unnecessary_statements
+      const Card(child: SizedBox.shrink());
+      // ignore: unnecessary_statements
+      const Material(child: SizedBox.shrink());
+      // ignore: unnecessary_statements
+      const Divider();
+      // ignore: unused_local_variable
+      final ink = InkWell(onTap: () {}, child: const SizedBox.shrink());
+      expect(ink, isNotNull);
+    });
+
+    test('icon glyph constants reachable from both worlds', () {
+      // Material icons — high-volume use across features (299 sites).
+      expect(Icons.refresh, isNotNull);
+      expect(Icons.error_outline, isNotNull);
+      expect(Icons.timeline, isNotNull);
+      // Cupertino icons — needed for AdaptiveIcon's cupertino: arg without
+      // importing cupertino.dart directly in feature code.
+      expect(CupertinoIcons.refresh, isNotNull);
+      expect(CupertinoIcons.back, isNotNull);
+      expect(CupertinoIcons.add, isNotNull);
+    });
+
+    test('theme types reachable for Theme.of() reads', () {
+      // Theme types are needed for type annotations on `Theme.of(context).colorScheme`.
+      const ColorScheme cs = ColorScheme.light();
+      expect(cs.error, isNotNull);
+      // ignore: unnecessary_statements
+      ThemeData;
+      // ignore: unnecessary_statements
+      TextTheme;
+      // ignore: unnecessary_statements
+      Brightness.dark;
+    });
+
+    test('progress indicator reachable', () {
+      // ignore: unnecessary_statements
+      const CircularProgressIndicator.adaptive();
+    });
+
+    test('Material-only widgets reachable (no iOS equivalent)', () {
+      // FAB has no Cupertino convention; re-exported as-is.
+      // ignore: unused_local_variable
+      final fab = FloatingActionButton(
+        onPressed: () {},
+        child: const SizedBox.shrink(),
+      );
+      expect(fab, isNotNull);
+      // Tooltip — iOS has no native tooltip; re-exported.
+      // ignore: unnecessary_statements
+      const Tooltip(message: 'hi', child: SizedBox.shrink());
+    });
+
+    test('adaptive wrappers reachable through the barrel', () {
+      // These are the Phase 1 wrappers + the pre-existing AdaptiveScaffold/
+      // AdaptiveNavBar. Re-exported alongside the curated material subset so
+      // feature code only needs the one barrel import.
+      // ignore: unused_local_variable
+      const navBar = AdaptiveNavBar(title: 'x');
+      // ignore: unused_local_variable
+      const sliverNav = AdaptiveSliverNavBar(title: 'x');
+      // ignore: unused_local_variable
+      const listTile = AdaptiveListTile(title: Text('x'));
+      // ignore: unused_local_variable
+      final btn = AdaptiveButton.filled(
+        onPressed: () {},
+        child: const Text('x'),
+      );
+      expect(btn, isNotNull);
+    });
+
+    test('platform-style helpers reachable', () {
+      // platformStyle is the single source of truth for adaptive branching.
+      expect(platformStyle, isA<AppPlatformStyle>());
+    });
+  });
+}

--- a/openspec/changes/adaptive-ui-consolidation/design.md
+++ b/openspec/changes/adaptive-ui-consolidation/design.md
@@ -104,6 +104,32 @@ Phase 4 adds a `custom_lint` rule that bans `import 'package:flutter/cupertino.d
 - Code review discipline only. Rejected: 30+ active OpenSpec changes touch the Flutter app; relying on reviewers to spot direct imports is brittle.
 - A shell-script grep gate in `make lint-flutter`. Rejected: works but produces worse diagnostics; `custom_lint` integrates with the IDE and `flutter analyze`.
 
+### Decision 8: Material ban implemented via re-export shim (Option C)
+
+Feature code is genuinely Material-heavy: 299 `Icons.*` references, 233 `Theme.of(context)` reads, 78 `IconButton`, 28 `Card`, 22 `Divider`, plus `InkWell`, `FloatingActionButton`, `Tooltip` — many of which have no meaningful iOS equivalent. Building Adaptive wrappers for every one of them would invent fake adaptivity for Material-only concepts (a `Card` is just a visual surface trick; iOS has no equivalent). Banning `flutter/material.dart` directly in features and rebuilding all of these would be weeks of mostly-cosmetic work for no rendering improvement.
+
+Instead, we enforce the import boundary while keeping Material widgets where they belong: add `app/lib/shared/platform/widgets.dart` as a barrel file that re-exports a **curated subset** of `flutter/material.dart` (plus all `flutter/widgets.dart` neutral widgets, plus all adaptive wrappers, plus `CupertinoIcons` from `flutter/cupertino.dart`). Feature code imports the barrel and gets one stable surface; the Phase 4 lint bans direct `flutter/material.dart` and `flutter/cupertino.dart` imports outside the façade.
+
+The `show` list in the barrel is the **discipline boundary** — adding a widget to it is a deliberate act. As Adaptive wrappers grow, re-exports are removed (e.g. when `AdaptiveIconButton` lands, `IconButton` drops out of the barrel). The boundary moves; the lint never weakens.
+
+**Why:**
+
+- Gives the lint enforcement immediately, before the migration sweep finishes.
+- Avoids inventing Cupertino variants of Material-only concepts (`Card`, `InkWell`, `FAB`).
+- Single import surface for feature code (`import 'package:assistant_app/shared/platform/widgets.dart';`) — also re-exports the adaptive wrappers so feature files need only one import.
+- Iterative ratchet: every Adaptive wrapper added in Phase 3 or later removes one re-export. Visibility into "how much Material is leaking" is one grep through the barrel's `show` list.
+- `CupertinoIcons` lives in `flutter/cupertino.dart` but is just a constants class, not a widget. Re-exporting it from the barrel lets feature code reference it for `AdaptiveIcon(cupertino: CupertinoIcons.refresh, material: Icons.refresh)` without importing `cupertino.dart` directly.
+
+**Alternatives considered:**
+
+- **Option A — full façade pass.** Build ~20 more wrappers (`AdaptiveCard`, `AdaptiveInkWell`, `AdaptiveIconButton`, …) plus an `AppTheme.of(context)` shim. Migrate ~700 call sites. Rejected: weeks of work, much of it inventing iOS variants of Material-only concepts.
+- **Option B — `flutter/widgets.dart` baseline.** Feature code imports only the neutral widgets layer; everything styled comes through the façade. Rejected: even bigger scope than A (need to reimplement `Card`, `InkWell`, theme machinery from scratch).
+- **Option D — theme-only ban.** Narrow the lint to `Theme.of(context).colorScheme.*` access. Rejected: doesn't address widget-level fragmentation (the original problem statement was "13 screens mix Material + Cupertino directly").
+
+**Show-list scope:**
+
+Initial barrel re-exports include: `Card`, `InkWell`, `Material` (widget), `Icons` (constants), `CupertinoIcons` (constants, from cupertino.dart), `Theme`, `ThemeData`, `ColorScheme`, `TextTheme`, `Brightness`, `IconButton`, `FloatingActionButton`, `Tooltip`, `Divider`, `CircularProgressIndicator`, `MaterialPageRoute`, `ScaffoldMessenger`, `Drawer`, `TabBar`, `Tab`, `PopupMenuButton`, `PopupMenuItem`, `OutlinedButton`. Notably **NOT** re-exported (force migration to wrappers): `Scaffold`, `AppBar`, `ListTile`, `SwitchListTile`, `Switch`, `TextField`, `Slider`, `SnackBar`, `AlertDialog`, `FilledButton`, `TextButton`. Also **NOT** re-exported (already gated): `Colors`.
+
 ## Risks / Trade-offs
 
 - **Package v0.1.x solo publisher abandons.** → Mitigation: exact pin, confinement to wrapper internals, swap-back to Flutter Cupertino is a localised change in `lib/shared/platform/`. Source is MIT-licensed and small enough to vendor if needed.

--- a/openspec/changes/adaptive-ui-consolidation/specs/platform-facade-discipline/spec.md
+++ b/openspec/changes/adaptive-ui-consolidation/specs/platform-facade-discipline/spec.md
@@ -41,6 +41,36 @@ The repository SHALL include a `custom_lint` rule that fires on any `import 'pac
 - **THEN** running `make lint-flutter` against the codebase SHALL pass with zero violations
 - **THEN** no file outside the allowlist SHALL import `package:flutter/cupertino.dart` or `package:flutter/material.dart`
 
+### Requirement: Material widgets are accessed via the façade barrel re-export
+
+Feature code SHALL import `package:assistant_app/shared/platform/widgets.dart` (the barrel file) rather than `package:flutter/material.dart` directly. The barrel re-exports a **curated subset** of `flutter/material.dart`, all of `flutter/widgets.dart`, all adaptive wrappers, and `CupertinoIcons` (constants only) from `flutter/cupertino.dart`. The Phase 4 lint rule SHALL forbid direct `flutter/material.dart` imports outside the allowlist, with the barrel as the sole exception.
+
+The barrel's `show` list SHALL exclude any widget for which a corresponding `Adaptive*` wrapper exists: `Scaffold`, `AppBar`, `ListTile`, `SwitchListTile`, `Switch`, `TextField`, `Slider`, `SnackBar`, `AlertDialog`, `FilledButton`, `TextButton`. The barrel SHALL also exclude `Colors` (already gated by `check_no_raw_colors.sh`). Adding new entries to the `show` list is a deliberate, reviewable change.
+
+#### Scenario: Feature code imports the barrel
+
+- **WHEN** a feature file needs `Card`, `IconButton`, or `Icons.refresh`
+- **THEN** the file SHALL import `package:assistant_app/shared/platform/widgets.dart`
+- **THEN** the file SHALL NOT import `package:flutter/material.dart` directly
+
+#### Scenario: A new wrapper lands and its re-export is removed
+
+- **WHEN** a new `Adaptive*` wrapper is added in the façade (e.g. `AdaptiveIconButton`)
+- **THEN** the corresponding raw widget (`IconButton`) SHALL be removed from the barrel's `show` list in the same PR
+- **THEN** any feature code still using the raw widget SHALL be migrated to the wrapper in the same PR or marked for follow-up
+
+#### Scenario: CupertinoIcons is reachable without importing cupertino.dart
+
+- **WHEN** a feature file calls `AdaptiveIcon(cupertino: CupertinoIcons.refresh, material: Icons.refresh)`
+- **THEN** the file SHALL be able to reference `CupertinoIcons.refresh` via the barrel re-export
+- **THEN** the file SHALL NOT need to import `package:flutter/cupertino.dart`
+
+#### Scenario: Cupertino widget classes are NOT re-exported
+
+- **WHEN** a developer tries to use `CupertinoSwitch`, `CupertinoTextField`, or any other Cupertino widget class in feature code via the barrel
+- **THEN** the symbol SHALL NOT be available (the barrel only re-exports `CupertinoIcons` from cupertino.dart, not widget classes)
+- **THEN** the developer SHALL be forced to use the corresponding `Adaptive*` wrapper
+
 ### Requirement: adaptive_platform_ui dependency is confined to the façade
 
 The `adaptive_platform_ui` package SHALL be imported only from files under `app/lib/shared/platform/`. No feature screen or shared widget outside the façade SHALL import `package:adaptive_platform_ui/...`.

--- a/openspec/changes/adaptive-ui-consolidation/tasks.md
+++ b/openspec/changes/adaptive-ui-consolidation/tasks.md
@@ -30,6 +30,13 @@
 
 - [ ] 2.1.1 ~~Remove the vestigial `package:flutter/material.dart` import from `app/lib/shared/error_screen.dart`~~ **Deferred.** Original inventory was wrong: the file legitimately uses `Material()` widget (background colour), `Theme.of(context)`, `Icons.error_outline`, and `ExpansionTile`. It's a special-case bootstrap widget rendered via `ErrorWidget.builder` before the app's normal widget tree may be available. Decision: add `app/lib/shared/error_screen.dart` to the Phase 4 lint allowlist as a known exception. Migration to `AdaptiveScaffold` + `AdaptiveIcon` is possible but requires a small visual change (AppBar on Material path) and is out of scope here.
 
+## 2b. Phase 2.0 — Façade barrel re-export shim (1 PR, see Decision 8)
+
+- [x] 2b.1 Create `app/lib/shared/platform/widgets.dart` barrel that re-exports `flutter/widgets.dart` (everything), a curated subset of `flutter/material.dart` via `show` clause, `CupertinoIcons` from `flutter/cupertino.dart`, and all `adaptive_*.dart` wrappers + `platform.dart`. Excluded from material's show list: any widget with an Adaptive wrapper (Scaffold, AppBar, ListTile, etc.) and Colors (already gated).
+- [x] 2b.2 Write a widget/compile test that imports only the barrel and verifies the curated widgets are reachable. Catches accidental show-list regressions.
+- [x] 2b.3 Update `traces_screen.dart` (migrated in PR #793) to import the barrel instead of `flutter/material.dart` directly — barrel surfaced 3 more uses to fix: `Scaffold` → `AdaptiveScaffold`, `Colors.green` → `colorScheme.tertiary` (the success token), `FilledButton` → `AdaptiveButton.filled`. The barrel's `show` list correctly forced all three through the façade.
+- [ ] 2b.5 Add a "How to add a façade wrapper" section to `app/lib/shared/platform/README.md` (create if absent) explaining the ratchet: every new Adaptive wrapper drops one re-export from the barrel. Defer to Phase 4.
+
 ## 3. Phase 2.2 — Sliver-nav list screens (9 stacked PRs, one per screen)
 
 - [x] 3.1 `traces_screen.dart`: replace inline `if (isAppleTouch) CupertinoSliverNavigationBar` with `AdaptiveSliverNavBar`; drop `package:flutter/cupertino.dart` import; existing tests stay green. Unified both platform paths into a single CustomScrollView with the wrapper. Material visual change: SliverAppBar.large (collapsing) replaces fixed AppBar, and the explicit `IconButton(arrow_back) → /chat` is dropped (top-level nav screen — sidebar/tab bar already provides home access; matches the existing iOS path which had no back button).


### PR DESCRIPTION
## Summary

Captures the **Option C** decision from the design discussion: ban direct `flutter/material.dart` imports in feature code, route everything through a curated barrel at `app/lib/shared/platform/widgets.dart`, and let the `show` list be the discipline boundary that ratchets tighter over time.

Adds:
- The barrel file (`lib/shared/platform/widgets.dart`, ~115 LOC of comments + a `show` list of ~30 curated entries).
- A reachability test that catches accidental show-list drops.
- A demonstration migration of `traces_screen.dart` (already migrated to `AdaptiveSliverNavBar` in #793) onto the barrel.
- OpenSpec updates capturing the decision (`design.md` Decision 8, new requirement in `platform-facade-discipline/spec.md`).

## Why Option C (the short version)

Feature code is genuinely Material-heavy. The data from `features/`:

```
  USE COUNT
  ─────────
  299  Icons.*               ← Material icon glyphs, no iOS equivalent
  233  Theme.of(context)     ← colorScheme/textTheme access
   78  IconButton            ← no Cupertino tile equivalent
   28  Card                  ← Material-only visual concept
   22  Divider, etc.
```

Building Adaptive wrappers for all of these (~30 wrappers + an `AppTheme.of` shim + ~700 call-site migrations) would invent fake adaptivity for Material-only concepts. Card/InkWell/FAB have no meaningful iOS counterpart.

**Option C instead:** enforce the import boundary via a barrel. Widgets render the same as today; feature code just doesn't see Material directly. Then iteratively ratchet — every new `Adaptive*` wrapper drops one entry from the barrel's `show` list.

## What the barrel exports

```
  flutter/widgets.dart  → re-exported in full (neutral layer)
  flutter/material.dart → curated show-list: Card, InkWell, Material,
                          Icons, Theme, ColorScheme, IconButton, FAB,
                          Tooltip, Divider, CircularProgressIndicator,
                          ExpansionTile, ScaffoldMessenger, Drawer,
                          TabBar, PopupMenuButton, OutlinedButton,
                          MaterialPageRoute, MaterialApp, …
  flutter/cupertino.dart → ONLY CupertinoIcons (constants for
                           AdaptiveIcon's `cupertino:` arg — never
                           Cupertino widget classes)
  Adaptive wrappers      → all 16 of them, re-exported so feature code
                           needs just the one import
```

**Intentionally NOT in the material show list** (force migration to wrappers):
`Scaffold`, `AppBar`, `ListTile`, `SwitchListTile`, `Switch`, `TextField`, `Slider`, `SnackBar`, `AlertDialog`, `FilledButton`, `TextButton`. Also NOT re-exported: `Colors` (already gated by `scripts/check_no_raw_colors.sh`).

## The barrel earned its keep on first contact

Switching `traces_screen.dart` (migrated in #793) to import the barrel surfaced three more façade violations in a screen I thought was "clean":

| Direct usage | Migrated to |
|---|---|
| `Scaffold(body: …)` | `AdaptiveScaffold(body: …)` |
| `Colors.green` | `Theme.of(context).colorScheme.tertiary` (the success token in `assistant_colors.dart`) |
| `FilledButton(onPressed, child)` | `AdaptiveButton.filled(onPressed, child)` |

That's exactly the value Option C delivers: the show-list is the boundary, and any feature-code violation surfaces at compile time the moment that file is migrated. The pattern for subsequent Phase 2.2 PRs is now: switch the import, fix what the compiler complains about.

## Stack

- ✅ #789 (merged) — Phase 1 façade wrappers
- ✅ #793 (merged) — Phase 2.2.1 traces migration to `AdaptiveSliverNavBar`
- 👉 **This PR** — Phase 2.0 barrel shim + traces switched to barrel
- Phase 2.2.2+ (next) — `logs_screen`, `agents_screen`, `workflows_screen`, etc. (will use the barrel from day one)

## Test plan

- [x] `flutter test test/widget/platform/widgets_barrel_test.dart` — 8/8 pass (reachability check)
- [x] `flutter test test/widget/features/traces/traces_screen_test.dart` — 7/7 pass
- [x] `flutter test` — 949/949 pass
- [x] `flutter analyze --fatal-infos` — 0 issues
- [x] Pre-commit hook (rust fmt + clippy + machete + dart_pre_commit + flutter test) — passed

## Refs

OpenSpec: `openspec/changes/adaptive-ui-consolidation/` (Phase 2.0, tasks 2b.1–2b.4 complete; Decision 8 in design.md captures the rationale).