### PR TITLE
refactor(scheduler): split scheduler.rs into a directory module

### DIFF
--- a/crates/runtime/src/scheduler/heartbeat.rs
+++ b/crates/runtime/src/scheduler/heartbeat.rs
@@ -1,0 +1,57 @@
+//! Heartbeat dispatcher — reads `HEARTBEAT.md` and publishes its contents
+//! as a `TurnRequest` on the bus every `HEARTBEAT_INTERVAL`.
+
+use anyhow::Result;
+use tracing::info;
+use uuid::Uuid;
+
+use assistant_core::{strip_html_comments, types::conversation::Interface};
+
+use super::tasks::dispatch_scheduler_turn_request;
+use crate::orchestrator::Orchestrator;
+use crate::otel_spans::start_interface_root_context;
+
+/// Read `HEARTBEAT.md` (from the configured path) and dispatch its contents
+/// as a [`TurnRequest`] through the message bus.
+///
+/// Does nothing (silently) if the file does not exist or is empty.
+pub(crate) async fn run_heartbeat(orchestrator: &Orchestrator) -> Result<()> {
+    let heartbeat_path = orchestrator.heartbeat_path();
+
+    if !heartbeat_path.exists() {
+        return Ok(());
+    }
+
+    let raw = tokio::fs::read_to_string(&heartbeat_path).await?;
+    let prompt = strip_html_comments(&raw);
+
+    if prompt.is_empty() {
+        return Ok(());
+    }
+
+    info!("Dispatching heartbeat from {}", heartbeat_path.display());
+
+    let conversation_id = Uuid::new_v4();
+    let interface_cx = start_interface_root_context(
+        &Interface::Scheduler,
+        "heartbeat.dispatch",
+        Some(conversation_id),
+    );
+
+    let storage = orchestrator.storage.clone();
+    dispatch_scheduler_turn_request(
+        &storage,
+        orchestrator,
+        prompt,
+        conversation_id,
+        &interface_cx,
+    )
+    .await?;
+
+    info!(
+        conversation_id = %conversation_id,
+        "Heartbeat dispatched to bus"
+    );
+
+    Ok(())
+}

--- a/crates/runtime/src/scheduler/mod.rs
+++ b/crates/runtime/src/scheduler/mod.rs
@@ -6,30 +6,41 @@
 //! The orchestrator's [`run_worker`](crate::Orchestrator::run_worker) loop
 //! claims and processes them asynchronously.
 
-use std::collections::HashMap;
-use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
-use assistant_core::{
-    ChannelContent, ChannelMessage, ChannelUser, MessageBus, PublishRequest, bus_messages,
-    strip_html_comments, topic, types::conversation::ChannelType, types::conversation::Interface,
-};
-use assistant_storage::StorageLayer;
 use async_trait::async_trait;
-use chrono::Utc;
-use cron::Schedule;
-use opentelemetry::{
-    KeyValue,
-    trace::{Span as _, SpanKind},
-};
-use tracing::{error, info, warn};
-use uuid::Uuid;
+use tracing::{error, info};
+
+use assistant_storage::StorageLayer;
 
 use crate::orchestrator::Orchestrator;
-use crate::otel_spans::{start_interface_root_context, traceparent_from_context};
-use crate::webhook_dispatch;
+
+mod heartbeat;
+mod prune;
+mod reap;
+mod tasks;
+
+// Re-export crate-visible helpers so the in-file `mod tests` (and the
+// existing `super::*` imports inside it) continue to work without
+// per-test path updates.
+#[allow(unused_imports)]
+pub(crate) use heartbeat::run_heartbeat;
+#[allow(unused_imports)]
+pub(crate) use prune::prune_conversation_events;
+#[allow(unused_imports)]
+pub(crate) use reap::reap_stale_and_recover;
+#[allow(unused_imports)]
+pub(crate) use tasks::{compute_next_run, resolve_home_channel_tools, run_due_tasks};
+
+// Re-imported here so `mod tests`'s `use super::*;` keeps working.
+#[cfg(test)]
+#[allow(unused_imports)]
+use assistant_core::bus_messages;
+#[cfg(test)]
+#[allow(unused_imports)]
+use uuid::Uuid;
 
 /// How often the heartbeat prompt is run (30 minutes).
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30 * 60);
@@ -134,7 +145,7 @@ impl PeriodicTask for ReapStale {
         "reap-stale"
     }
     fn interval(&self) -> Duration {
-        REAP_STALE_INTERVAL
+        reap::REAP_STALE_INTERVAL
     }
     fn run_before_loop(&self) -> bool {
         true
@@ -205,449 +216,6 @@ async fn run_scheduler_loop(
                 error!(task = task.name(), error = %e, "Periodic task error");
             }
             last_run[idx] = Instant::now();
-        }
-    }
-}
-
-/// Dispatch due scheduled tasks by publishing [`TurnRequest`] messages to the
-/// bus.  The worker loop processes them asynchronously.
-pub(crate) async fn run_due_tasks(
-    storage: &StorageLayer,
-    orchestrator: &Orchestrator,
-) -> Result<()> {
-    let now = Utc::now();
-    let task_store = storage.scheduled_task_store_for_agent(&orchestrator.agent_id);
-    let due = task_store.due_tasks(now).await?;
-
-    for task in due {
-        info!(task_name = %task.name, "Dispatching scheduled task");
-
-        let conversation_id = Uuid::new_v4();
-        let interface_cx = start_interface_root_context(
-            &Interface::Scheduler,
-            "schedule.dispatch",
-            Some(conversation_id),
-        );
-
-        // Fire schedule.trigger webhook + bus event before the TurnRequest so
-        // external listeners see the cron fire even if the turn fails to
-        // dispatch.
-        publish_schedule_trigger(
-            storage,
-            orchestrator,
-            &task,
-            now,
-            conversation_id,
-            &interface_cx,
-        )
-        .await;
-
-        let dispatched = match dispatch_scheduler_turn_request(
-            storage,
-            orchestrator,
-            task.prompt.clone(),
-            conversation_id,
-            &interface_cx,
-        )
-        .await
-        {
-            Ok(()) => {
-                info!(
-                    task_name = %task.name,
-                    conversation_id = %conversation_id,
-                    "Scheduled task dispatched to bus"
-                );
-                true
-            }
-            Err(e) => {
-                error!(
-                    task_name = %task.name,
-                    error = %e,
-                    "Failed to dispatch scheduled task"
-                );
-                false
-            }
-        };
-
-        if !dispatched {
-            continue;
-        }
-
-        if task.once {
-            // One-shot task: record the run and disable it.
-            task_store.record_run(task.id, now, None).await?;
-            task_store.disable(task.id).await?;
-            info!(task_name = %task.name, "One-shot task disabled after dispatch");
-        } else {
-            // Recurring task: compute the next run from the cron expression.
-            let next_run = compute_next_run(&task.cron_expr);
-            task_store.record_run(task.id, now, next_run).await?;
-        }
-    }
-
-    Ok(())
-}
-
-/// Fire the `schedule.trigger` webhook and publish the same payload as a
-/// bus event so external listeners observe every cron fire. Both arms log
-/// (but never propagate) their failures — the caller still tries to
-/// dispatch the TurnRequest regardless.
-async fn publish_schedule_trigger(
-    storage: &StorageLayer,
-    orchestrator: &Orchestrator,
-    task: &assistant_storage::ScheduledTask,
-    now: chrono::DateTime<Utc>,
-    conversation_id: Uuid,
-    interface_cx: &opentelemetry::Context,
-) {
-    let trigger = serde_json::json!({
-        "task_id": task.id,
-        "task_name": task.name.clone(),
-        "conversation_id": conversation_id,
-        "triggered_at": now,
-    });
-
-    if let Err(e) = webhook_dispatch::dispatch_event(
-        storage,
-        &orchestrator.agent_id,
-        topic::SCHEDULE_TRIGGER,
-        trigger.clone(),
-    )
-    .await
-    {
-        error!(task_name = %task.name, error = %e, "Failed to dispatch schedule.trigger webhooks");
-    }
-
-    let mut span = crate::otel_spans::start_bus_span(
-        SpanKind::Producer,
-        topic::SCHEDULE_TRIGGER,
-        Some(conversation_id),
-        interface_cx,
-    );
-    match orchestrator
-        .bus()
-        .publish(
-            PublishRequest::new(topic::SCHEDULE_TRIGGER, trigger)
-                .with_agent_id(orchestrator.agent_id.clone())
-                .with_conversation_id(conversation_id)
-                .with_interface(format!("{:?}", Interface::Scheduler))
-                .with_user_id(SCHEDULER_USER_ID),
-        )
-        .await
-    {
-        Ok(message_id) => {
-            span.set_attribute(KeyValue::new("bus.message_id", message_id.to_string()));
-            span.set_attribute(KeyValue::new("bus.status", "ok"));
-        }
-        Err(e) => {
-            span.set_attribute(KeyValue::new("bus.status", "error"));
-            span.set_attribute(KeyValue::new("error", true));
-            span.set_attribute(KeyValue::new("error.message", e.to_string()));
-            error!(task_name = %task.name, error = %e, "Failed to publish schedule.trigger event");
-        }
-    }
-    span.end();
-}
-
-/// Build a [`TurnRequest`] for a scheduler-originated dispatch, publish it
-/// to the bus with proper OTel spans, and register any home-channel
-/// platform tools beforehand.
-///
-/// Shared entry point for [`run_due_tasks`] and [`run_heartbeat`] — both
-/// resolve persona-owner identity, home-channel tools, build the same
-/// envelope, and publish to [`topic::TURN_REQUEST`]. Returns `Ok(())` on
-/// success; `Err` if envelope serialisation or publish fails (caller
-/// decides whether to propagate or merely log).
-async fn dispatch_scheduler_turn_request(
-    storage: &StorageLayer,
-    orchestrator: &Orchestrator,
-    prompt: String,
-    conversation_id: Uuid,
-    interface_cx: &opentelemetry::Context,
-) -> Result<()> {
-    // Resolve home-channel tools and register them before publishing so the
-    // worker can find them when it claims the message.
-    let home_tools = resolve_home_channel_tools(storage, orchestrator, conversation_id).await;
-    if !home_tools.is_empty() {
-        orchestrator
-            .register_extensions(conversation_id, home_tools, vec![])
-            .await;
-    }
-
-    // Resolve the persona's owner so scheduler-driven turns carry identity.
-    let persona_owner = storage
-        .persona_store()
-        .get(&orchestrator.agent_id)
-        .await
-        .ok()
-        .flatten()
-        .and_then(|p| p.owner_user_id);
-
-    let turn_req = bus_messages::TurnRequest {
-        prompt,
-        conversation_id,
-        extension_tools: vec![],
-        timestamp: Some(Utc::now()),
-        traceparent: traceparent_from_context(interface_cx),
-        attachment_ids: vec![],
-        user_id: persona_owner,
-        org_id: None,
-        space_id: None,
-    };
-
-    let mut span = crate::otel_spans::start_bus_span(
-        SpanKind::Producer,
-        topic::TURN_REQUEST,
-        Some(conversation_id),
-        interface_cx,
-    );
-    let publish_result = orchestrator
-        .bus()
-        .publish(
-            PublishRequest::new(topic::TURN_REQUEST, serde_json::to_value(&turn_req)?)
-                .with_agent_id(orchestrator.agent_id.clone())
-                .with_conversation_id(conversation_id)
-                .with_interface(format!("{:?}", Interface::Scheduler))
-                .with_user_id(SCHEDULER_USER_ID),
-        )
-        .await;
-    match publish_result {
-        Ok(message_id) => {
-            span.set_attribute(KeyValue::new("bus.message_id", message_id.to_string()));
-            span.set_attribute(KeyValue::new("bus.status", "ok"));
-            span.end();
-            Ok(())
-        }
-        Err(e) => {
-            span.set_attribute(KeyValue::new("bus.status", "error"));
-            span.set_attribute(KeyValue::new("error", true));
-            span.set_attribute(KeyValue::new("error.message", e.to_string()));
-            span.end();
-            Err(e)
-        }
-    }
-}
-
-/// Resolve home-channel platform tools for a scheduler-originated turn.
-///
-/// Loads the active persona's `home_channel`, looks up the matching live
-/// adapter in the registry, and returns the adapter's platform tools pre-bound
-/// to the configured channel address.  Returns an empty vec (with a warning
-/// log) when no home channel is configured or no matching adapter is running.
-async fn resolve_home_channel_tools(
-    storage: &StorageLayer,
-    orchestrator: &Orchestrator,
-    conversation_id: Uuid,
-) -> Vec<Arc<dyn assistant_core::ToolHandler>> {
-    let persona_store = storage.persona_store();
-    let persona = match persona_store.get(&orchestrator.agent_id).await {
-        Ok(Some(p)) => p,
-        Ok(None) => return vec![],
-        Err(e) => {
-            warn!(error = %e, "Failed to load persona for home channel resolution");
-            return vec![];
-        }
-    };
-
-    let hc = match &persona.home_channel {
-        Some(hc) => hc.clone(),
-        None => return vec![],
-    };
-
-    let adapter = match orchestrator.adapter_registry.get(&hc.home_interface).await {
-        Some(a) => a,
-        None => {
-            warn!(
-                interface = %hc.home_interface,
-                channel = %hc.home_channel,
-                "No live adapter found for home_interface — scheduler turn has no output tools"
-            );
-            return vec![];
-        }
-    };
-
-    let channel_type = match hc.home_interface.as_str() {
-        "slack" => ChannelType::Slack,
-        "mattermost" => ChannelType::Mattermost,
-        "matrix" => ChannelType::Matrix,
-        "nextcloud" => ChannelType::Nextcloud,
-        "signal" => ChannelType::Signal,
-        other => ChannelType::Custom(other.to_string()),
-    };
-
-    let synthetic_msg = ChannelMessage {
-        channel_type,
-        platform_message_id: None,
-        sender: ChannelUser {
-            platform_id: hc.home_channel.clone(),
-            display_name: None,
-        },
-        content: ChannelContent::Text(String::new()),
-        thread_id: None,
-        timestamp: Utc::now(),
-        metadata: HashMap::new(),
-    };
-
-    adapter.platform_tools(&synthetic_msg, conversation_id)
-}
-
-/// Compute the next occurrence after now for a cron expression.
-/// Accepts both 5-field (standard) and 7-field (with seconds) expressions.
-pub(crate) fn compute_next_run(cron_expr: &str) -> Option<chrono::DateTime<Utc>> {
-    let schedule = Schedule::from_str(cron_expr)
-        .or_else(|_| Schedule::from_str(&format!("0 {}", cron_expr)))
-        .ok()?;
-    schedule.upcoming(Utc).next()
-}
-
-/// Read `HEARTBEAT.md` (from the configured path) and dispatch its contents
-/// as a [`TurnRequest`] through the message bus.
-///
-/// Does nothing (silently) if the file does not exist or is empty.
-pub(crate) async fn run_heartbeat(orchestrator: &Orchestrator) -> Result<()> {
-    let heartbeat_path = orchestrator.heartbeat_path();
-
-    if !heartbeat_path.exists() {
-        return Ok(());
-    }
-
-    let raw = tokio::fs::read_to_string(&heartbeat_path).await?;
-    let prompt = strip_html_comments(&raw);
-
-    if prompt.is_empty() {
-        return Ok(());
-    }
-
-    info!("Dispatching heartbeat from {}", heartbeat_path.display());
-
-    let conversation_id = Uuid::new_v4();
-    let interface_cx = start_interface_root_context(
-        &Interface::Scheduler,
-        "heartbeat.dispatch",
-        Some(conversation_id),
-    );
-
-    let storage = orchestrator.storage.clone();
-    dispatch_scheduler_turn_request(
-        &storage,
-        orchestrator,
-        prompt,
-        conversation_id,
-        &interface_cx,
-    )
-    .await?;
-
-    info!(
-        conversation_id = %conversation_id,
-        "Heartbeat dispatched to bus"
-    );
-
-    Ok(())
-}
-
-// -- Conversation event pruning --------------------------------------------
-
-/// Delete expired conversation events. Logs the result at debug level.
-async fn prune_conversation_events(storage: &StorageLayer) {
-    let store = storage.conversation_event_store();
-    match store.prune_expired().await {
-        Ok(n) if n > 0 => info!("Pruned {n} expired conversation event(s)"),
-        Ok(_) => {}
-        Err(e) => warn!("Failed to prune conversation events: {e}"),
-    }
-}
-
-// -- Crash recovery ---------------------------------------------------------
-
-/// How often stale bus messages and orphaned SSE runs are checked (5 minutes).
-const REAP_STALE_INTERVAL: Duration = Duration::from_secs(5 * 60);
-
-/// A claimed bus message older than this is considered stale (5 minutes).
-const STALE_CLAIM_TIMEOUT: Duration = Duration::from_secs(5 * 60);
-
-/// Reclaim stale bus messages and close orphaned SSE event streams.
-///
-/// 1. Calls `bus.reap_stale()` to reset stale `Claimed` → `Pending` messages.
-/// 2. Finds runs that have a `run_started` event but no terminal event and are
-///    older than `STALE_CLAIM_TIMEOUT`.
-/// 3. For each orphan, checks whether an active (Pending/Claimed) bus message
-///    still references that conversation — if so, the run may still complete
-///    after bus redelivery, so we skip it.
-/// 4. Otherwise, appends a synthetic `agent_error` event so clients see a
-///    terminal event and can retry cleanly.
-pub(crate) async fn reap_stale_and_recover(storage: &StorageLayer, bus: &dyn MessageBus) {
-    // Step 1: reclaim stale bus messages.
-    match bus.reap_stale(STALE_CLAIM_TIMEOUT).await {
-        Ok(n) if n > 0 => info!("Reaped {n} stale bus message(s)"),
-        Ok(_) => {}
-        Err(e) => warn!("Failed to reap stale bus messages: {e}"),
-    }
-
-    // Step 2: find orphaned SSE runs.
-    let event_store = storage.conversation_event_store();
-    let stale_timeout = chrono::Duration::from_std(STALE_CLAIM_TIMEOUT).unwrap_or_default();
-    let orphans = match event_store.find_incomplete_runs(stale_timeout).await {
-        Ok(v) => v,
-        Err(e) => {
-            warn!("Failed to find incomplete runs: {e}");
-            return;
-        }
-    };
-
-    if orphans.is_empty() {
-        return;
-    }
-
-    info!(
-        count = orphans.len(),
-        "Found orphaned SSE run(s), checking for active bus messages"
-    );
-
-    // Step 3 & 4: for each orphan, check bus and potentially close.
-    for (run_id, conversation_id) in orphans {
-        let has_active = match bus
-            .has_active_message(&conversation_id, topic::TURN_REQUEST)
-            .await
-        {
-            Ok(v) => v,
-            Err(e) => {
-                warn!(
-                    run_id = %run_id,
-                    error = %e,
-                    "Failed to check bus messages for orphan — skipping"
-                );
-                continue;
-            }
-        };
-
-        if has_active {
-            info!(
-                run_id = %run_id,
-                conversation_id = %conversation_id,
-                "Orphaned run still has active bus message — skipping (may recover)"
-            );
-            continue;
-        }
-
-        match event_store
-            .append_synthetic_terminal(
-                &run_id,
-                &conversation_id,
-                "Server restarted — this run was interrupted. You may retry your message.",
-            )
-            .await
-        {
-            Ok(seq) => info!(
-                run_id = %run_id,
-                conversation_id = %conversation_id,
-                sequence = seq,
-                "Appended synthetic agent_error to orphaned run"
-            ),
-            Err(e) => warn!(
-                run_id = %run_id,
-                error = %e,
-                "Failed to append synthetic terminal for orphaned run"
-            ),
         }
     }
 }

--- a/crates/runtime/src/scheduler/prune.rs
+++ b/crates/runtime/src/scheduler/prune.rs
@@ -1,0 +1,16 @@
+//! Periodic conversation-event pruning — drops rows that have aged past
+//! their configured TTL.
+
+use tracing::{info, warn};
+
+use assistant_storage::StorageLayer;
+
+/// Delete expired conversation events. Logs the result at debug level.
+pub(crate) async fn prune_conversation_events(storage: &StorageLayer) {
+    let store = storage.conversation_event_store();
+    match store.prune_expired().await {
+        Ok(n) if n > 0 => info!("Pruned {n} expired conversation event(s)"),
+        Ok(_) => {}
+        Err(e) => warn!("Failed to prune conversation events: {e}"),
+    }
+}

--- a/crates/runtime/src/scheduler/reap.rs
+++ b/crates/runtime/src/scheduler/reap.rs
@@ -1,0 +1,102 @@
+//! Crash-recovery sweep: reclaim stale bus messages and close orphaned
+//! SSE event streams left over after a server restart.
+
+use std::time::Duration;
+
+use tracing::{info, warn};
+
+use assistant_core::{MessageBus, topic};
+use assistant_storage::StorageLayer;
+
+/// How often stale bus messages and orphaned SSE runs are checked (5 minutes).
+pub(super) const REAP_STALE_INTERVAL: Duration = Duration::from_secs(5 * 60);
+
+/// A claimed bus message older than this is considered stale (5 minutes).
+const STALE_CLAIM_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+
+/// Reclaim stale bus messages and close orphaned SSE event streams.
+///
+/// 1. Calls `bus.reap_stale()` to reset stale `Claimed` → `Pending` messages.
+/// 2. Finds runs that have a `run_started` event but no terminal event and are
+///    older than `STALE_CLAIM_TIMEOUT`.
+/// 3. For each orphan, checks whether an active (Pending/Claimed) bus message
+///    still references that conversation — if so, the run may still complete
+///    after bus redelivery, so we skip it.
+/// 4. Otherwise, appends a synthetic `agent_error` event so clients see a
+///    terminal event and can retry cleanly.
+pub(crate) async fn reap_stale_and_recover(storage: &StorageLayer, bus: &dyn MessageBus) {
+    // Step 1: reclaim stale bus messages.
+    match bus.reap_stale(STALE_CLAIM_TIMEOUT).await {
+        Ok(n) if n > 0 => info!("Reaped {n} stale bus message(s)"),
+        Ok(_) => {}
+        Err(e) => warn!("Failed to reap stale bus messages: {e}"),
+    }
+
+    // Step 2: find orphaned SSE runs.
+    let event_store = storage.conversation_event_store();
+    let stale_timeout = chrono::Duration::from_std(STALE_CLAIM_TIMEOUT).unwrap_or_default();
+    let orphans = match event_store.find_incomplete_runs(stale_timeout).await {
+        Ok(v) => v,
+        Err(e) => {
+            warn!("Failed to find incomplete runs: {e}");
+            return;
+        }
+    };
+
+    if orphans.is_empty() {
+        return;
+    }
+
+    info!(
+        count = orphans.len(),
+        "Found orphaned SSE run(s), checking for active bus messages"
+    );
+
+    // Step 3 & 4: for each orphan, check bus and potentially close.
+    for (run_id, conversation_id) in orphans {
+        let has_active = match bus
+            .has_active_message(&conversation_id, topic::TURN_REQUEST)
+            .await
+        {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(
+                    run_id = %run_id,
+                    error = %e,
+                    "Failed to check bus messages for orphan — skipping"
+                );
+                continue;
+            }
+        };
+
+        if has_active {
+            info!(
+                run_id = %run_id,
+                conversation_id = %conversation_id,
+                "Orphaned run still has active bus message — skipping (may recover)"
+            );
+            continue;
+        }
+
+        match event_store
+            .append_synthetic_terminal(
+                &run_id,
+                &conversation_id,
+                "Server restarted — this run was interrupted. You may retry your message.",
+            )
+            .await
+        {
+            Ok(seq) => info!(
+                run_id = %run_id,
+                conversation_id = %conversation_id,
+                sequence = seq,
+                "Appended synthetic agent_error to orphaned run"
+            ),
+            Err(e) => warn!(
+                run_id = %run_id,
+                error = %e,
+                "Failed to append synthetic terminal for orphaned run"
+            ),
+        }
+    }
+}

--- a/crates/runtime/src/scheduler/tasks.rs
+++ b/crates/runtime/src/scheduler/tasks.rs
@@ -1,0 +1,320 @@
+//! Scheduled-task dispatcher: cron-driven user tasks, the shared
+//! `TurnRequest` publisher used by both tasks and heartbeats, the
+//! `schedule.trigger` webhook/bus fan-out, home-channel tool resolution,
+//! and the cron parser.
+
+use std::collections::HashMap;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use anyhow::Result;
+use chrono::{self, Utc};
+use cron::Schedule;
+use opentelemetry::{
+    KeyValue,
+    trace::{Span as _, SpanKind},
+};
+use tracing::{error, info, warn};
+use uuid::Uuid;
+
+use assistant_core::{
+    ChannelContent, ChannelMessage, ChannelUser, PublishRequest, bus_messages, topic,
+    types::conversation::ChannelType, types::conversation::Interface,
+};
+use assistant_storage::StorageLayer;
+
+use super::SCHEDULER_USER_ID;
+use crate::orchestrator::Orchestrator;
+use crate::otel_spans::{start_interface_root_context, traceparent_from_context};
+use crate::webhook_dispatch;
+
+/// Dispatch due scheduled tasks by publishing [`TurnRequest`] messages to the
+/// bus.  The worker loop processes them asynchronously.
+pub(crate) async fn run_due_tasks(
+    storage: &StorageLayer,
+    orchestrator: &Orchestrator,
+) -> Result<()> {
+    let now = Utc::now();
+    let task_store = storage.scheduled_task_store_for_agent(&orchestrator.agent_id);
+    let due = task_store.due_tasks(now).await?;
+
+    for task in due {
+        info!(task_name = %task.name, "Dispatching scheduled task");
+
+        let conversation_id = Uuid::new_v4();
+        let interface_cx = start_interface_root_context(
+            &Interface::Scheduler,
+            "schedule.dispatch",
+            Some(conversation_id),
+        );
+
+        // Fire schedule.trigger webhook + bus event before the TurnRequest so
+        // external listeners see the cron fire even if the turn fails to
+        // dispatch.
+        publish_schedule_trigger(
+            storage,
+            orchestrator,
+            &task,
+            now,
+            conversation_id,
+            &interface_cx,
+        )
+        .await;
+
+        let dispatched = match dispatch_scheduler_turn_request(
+            storage,
+            orchestrator,
+            task.prompt.clone(),
+            conversation_id,
+            &interface_cx,
+        )
+        .await
+        {
+            Ok(()) => {
+                info!(
+                    task_name = %task.name,
+                    conversation_id = %conversation_id,
+                    "Scheduled task dispatched to bus"
+                );
+                true
+            }
+            Err(e) => {
+                error!(
+                    task_name = %task.name,
+                    error = %e,
+                    "Failed to dispatch scheduled task"
+                );
+                false
+            }
+        };
+
+        if !dispatched {
+            continue;
+        }
+
+        if task.once {
+            // One-shot task: record the run and disable it.
+            task_store.record_run(task.id, now, None).await?;
+            task_store.disable(task.id).await?;
+            info!(task_name = %task.name, "One-shot task disabled after dispatch");
+        } else {
+            // Recurring task: compute the next run from the cron expression.
+            let next_run = compute_next_run(&task.cron_expr);
+            task_store.record_run(task.id, now, next_run).await?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Fire the `schedule.trigger` webhook and publish the same payload as a
+/// bus event so external listeners observe every cron fire. Both arms log
+/// (but never propagate) their failures — the caller still tries to
+/// dispatch the TurnRequest regardless.
+async fn publish_schedule_trigger(
+    storage: &StorageLayer,
+    orchestrator: &Orchestrator,
+    task: &assistant_storage::ScheduledTask,
+    now: chrono::DateTime<Utc>,
+    conversation_id: Uuid,
+    interface_cx: &opentelemetry::Context,
+) {
+    let trigger = serde_json::json!({
+        "task_id": task.id,
+        "task_name": task.name.clone(),
+        "conversation_id": conversation_id,
+        "triggered_at": now,
+    });
+
+    if let Err(e) = webhook_dispatch::dispatch_event(
+        storage,
+        &orchestrator.agent_id,
+        topic::SCHEDULE_TRIGGER,
+        trigger.clone(),
+    )
+    .await
+    {
+        error!(task_name = %task.name, error = %e, "Failed to dispatch schedule.trigger webhooks");
+    }
+
+    let mut span = crate::otel_spans::start_bus_span(
+        SpanKind::Producer,
+        topic::SCHEDULE_TRIGGER,
+        Some(conversation_id),
+        interface_cx,
+    );
+    match orchestrator
+        .bus()
+        .publish(
+            PublishRequest::new(topic::SCHEDULE_TRIGGER, trigger)
+                .with_agent_id(orchestrator.agent_id.clone())
+                .with_conversation_id(conversation_id)
+                .with_interface(format!("{:?}", Interface::Scheduler))
+                .with_user_id(SCHEDULER_USER_ID),
+        )
+        .await
+    {
+        Ok(message_id) => {
+            span.set_attribute(KeyValue::new("bus.message_id", message_id.to_string()));
+            span.set_attribute(KeyValue::new("bus.status", "ok"));
+        }
+        Err(e) => {
+            span.set_attribute(KeyValue::new("bus.status", "error"));
+            span.set_attribute(KeyValue::new("error", true));
+            span.set_attribute(KeyValue::new("error.message", e.to_string()));
+            error!(task_name = %task.name, error = %e, "Failed to publish schedule.trigger event");
+        }
+    }
+    span.end();
+}
+
+/// Build a [`TurnRequest`] for a scheduler-originated dispatch, publish it
+/// to the bus with proper OTel spans, and register any home-channel
+/// platform tools beforehand.
+///
+/// Shared entry point for [`run_due_tasks`] and the heartbeat dispatcher —
+/// both resolve persona-owner identity, home-channel tools, build the same
+/// envelope, and publish to [`topic::TURN_REQUEST`]. Returns `Ok(())` on
+/// success; `Err` if envelope serialisation or publish fails (caller
+/// decides whether to propagate or merely log).
+pub(super) async fn dispatch_scheduler_turn_request(
+    storage: &StorageLayer,
+    orchestrator: &Orchestrator,
+    prompt: String,
+    conversation_id: Uuid,
+    interface_cx: &opentelemetry::Context,
+) -> Result<()> {
+    // Resolve home-channel tools and register them before publishing so the
+    // worker can find them when it claims the message.
+    let home_tools = resolve_home_channel_tools(storage, orchestrator, conversation_id).await;
+    if !home_tools.is_empty() {
+        orchestrator
+            .register_extensions(conversation_id, home_tools, vec![])
+            .await;
+    }
+
+    // Resolve the persona's owner so scheduler-driven turns carry identity.
+    let persona_owner = storage
+        .persona_store()
+        .get(&orchestrator.agent_id)
+        .await
+        .ok()
+        .flatten()
+        .and_then(|p| p.owner_user_id);
+
+    let turn_req = bus_messages::TurnRequest {
+        prompt,
+        conversation_id,
+        extension_tools: vec![],
+        timestamp: Some(Utc::now()),
+        traceparent: traceparent_from_context(interface_cx),
+        attachment_ids: vec![],
+        user_id: persona_owner,
+        org_id: None,
+        space_id: None,
+    };
+
+    let mut span = crate::otel_spans::start_bus_span(
+        SpanKind::Producer,
+        topic::TURN_REQUEST,
+        Some(conversation_id),
+        interface_cx,
+    );
+    let publish_result = orchestrator
+        .bus()
+        .publish(
+            PublishRequest::new(topic::TURN_REQUEST, serde_json::to_value(&turn_req)?)
+                .with_agent_id(orchestrator.agent_id.clone())
+                .with_conversation_id(conversation_id)
+                .with_interface(format!("{:?}", Interface::Scheduler))
+                .with_user_id(SCHEDULER_USER_ID),
+        )
+        .await;
+    match publish_result {
+        Ok(message_id) => {
+            span.set_attribute(KeyValue::new("bus.message_id", message_id.to_string()));
+            span.set_attribute(KeyValue::new("bus.status", "ok"));
+            span.end();
+            Ok(())
+        }
+        Err(e) => {
+            span.set_attribute(KeyValue::new("bus.status", "error"));
+            span.set_attribute(KeyValue::new("error", true));
+            span.set_attribute(KeyValue::new("error.message", e.to_string()));
+            span.end();
+            Err(e)
+        }
+    }
+}
+
+/// Resolve home-channel platform tools for a scheduler-originated turn.
+///
+/// Loads the active persona's `home_channel`, looks up the matching live
+/// adapter in the registry, and returns the adapter's platform tools pre-bound
+/// to the configured channel address.  Returns an empty vec (with a warning
+/// log) when no home channel is configured or no matching adapter is running.
+pub(crate) async fn resolve_home_channel_tools(
+    storage: &StorageLayer,
+    orchestrator: &Orchestrator,
+    conversation_id: Uuid,
+) -> Vec<Arc<dyn assistant_core::ToolHandler>> {
+    let persona_store = storage.persona_store();
+    let persona = match persona_store.get(&orchestrator.agent_id).await {
+        Ok(Some(p)) => p,
+        Ok(None) => return vec![],
+        Err(e) => {
+            warn!(error = %e, "Failed to load persona for home channel resolution");
+            return vec![];
+        }
+    };
+
+    let hc = match &persona.home_channel {
+        Some(hc) => hc.clone(),
+        None => return vec![],
+    };
+
+    let adapter = match orchestrator.adapter_registry.get(&hc.home_interface).await {
+        Some(a) => a,
+        None => {
+            warn!(
+                interface = %hc.home_interface,
+                channel = %hc.home_channel,
+                "No live adapter found for home_interface — scheduler turn has no output tools"
+            );
+            return vec![];
+        }
+    };
+
+    let channel_type = match hc.home_interface.as_str() {
+        "slack" => ChannelType::Slack,
+        "mattermost" => ChannelType::Mattermost,
+        "matrix" => ChannelType::Matrix,
+        "nextcloud" => ChannelType::Nextcloud,
+        "signal" => ChannelType::Signal,
+        other => ChannelType::Custom(other.to_string()),
+    };
+
+    let synthetic_msg = ChannelMessage {
+        channel_type,
+        platform_message_id: None,
+        sender: ChannelUser {
+            platform_id: hc.home_channel.clone(),
+            display_name: None,
+        },
+        content: ChannelContent::Text(String::new()),
+        thread_id: None,
+        timestamp: Utc::now(),
+        metadata: HashMap::new(),
+    };
+
+    adapter.platform_tools(&synthetic_msg, conversation_id)
+}
+
+/// Compute the next occurrence after now for a cron expression.
+/// Accepts both 5-field (standard) and 7-field (with seconds) expressions.
+pub(crate) fn compute_next_run(cron_expr: &str) -> Option<chrono::DateTime<Utc>> {
+    let schedule = Schedule::from_str(cron_expr)
+        .or_else(|_| Schedule::from_str(&format!("0 {}", cron_expr)))
+        .ok()?;
+    schedule.upcoming(Utc).next()
+}


### PR DESCRIPTION
## Summary

Convert the 1321-line \`crates/runtime/src/scheduler.rs\` into a
directory module:

\`\`\`
crates/runtime/src/scheduler/
├── mod.rs       (PeriodicTask + SchedulerCtx + spawn_scheduler +
│                 run_scheduler_loop + mod tests + constants)
├── tasks.rs     (run_due_tasks, dispatch_scheduler_turn_request,
│                 publish_schedule_trigger,
│                 resolve_home_channel_tools, compute_next_run)
├── heartbeat.rs (run_heartbeat — file read + dispatch helper)
├── prune.rs     (prune_conversation_events)
└── reap.rs      (reap_stale_and_recover + interval constants)
\`\`\`

Production code distributed by concern, 16-320 lines per file.
mod.rs's production code drops to ~220 lines; the remaining ~660
lines is the in-file \`mod tests\`, kept whole in this PR so the
test mod's \`use super::*;\` keeps working via re-exports at the
top of mod.rs.

A follow-up could split the tests into a \`scheduler/tests/\`
directory — that's a separate PR.

## Test plan
- [x] \`cargo test -p assistant-runtime --lib scheduler::\` — 18 passing
- [x] \`cargo test -p assistant-runtime --lib\` — 220 passing
- [x] \`make lint\` — clean
- [x] \`cargo fmt --all --check\` — clean