### PR TITLE
refactor(app): migrate logs_screen onto AdaptiveSliverNavBar + barrel

### DIFF
--- a/app/lib/features/logs/logs_screen.dart
+++ b/app/lib/features/logs/logs_screen.dart
@@ -1,13 +1,11 @@
 import 'dart:async';
 
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 
 import 'package:assistant_api/assistant_api.dart';
 
-import '../../shared/platform/platform.dart';
+import '../../shared/platform/widgets.dart';
+import '../../shared/theme/log_severity_colors.dart';
 import 'logs_provider.dart';
 
 /// Observability screen that lists recent structured log entries.
@@ -48,143 +46,60 @@ class _LogsScreenState extends ConsumerState<LogsScreen> {
 
     final searchField = Padding(
       padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
-      child: TextField(
+      child: AdaptiveTextField(
         key: const Key('log_search_field'),
         controller: _searchController,
-        decoration: InputDecoration(
-          hintText: 'Filter by keyword...',
-          prefixIcon: const Icon(Icons.search, size: 20),
-          suffixIcon: _searching
-              ? const Padding(
-                  padding: EdgeInsets.all(12),
-                  child: SizedBox(
-                    width: 16,
-                    height: 16,
-                    child: CircularProgressIndicator.adaptive(strokeWidth: 2),
-                  ),
-                )
-              : null,
-          border: const OutlineInputBorder(),
-          contentPadding: const EdgeInsets.symmetric(vertical: 8),
-          isDense: true,
-        ),
+        placeholder: 'Filter by keyword...',
         onChanged: _onSearchChanged,
       ),
     );
 
-    if (isAppleTouch) {
-      return Scaffold(
-        body: GestureDetector(
-          onTap: () => FocusScope.of(context).unfocus(),
-          child: CustomScrollView(
-            slivers: [
-              CupertinoSliverNavigationBar(
-                largeTitle: const Text('Logs'),
-                trailing: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    IconButton(
-                      icon: const Icon(Icons.refresh),
-                      onPressed: () =>
-                          ref.read(logsProvider.notifier).refresh(),
-                    ),
-                  ],
-                ),
-              ),
-              SliverToBoxAdapter(child: searchField),
-              logsAsync.when(
-                loading: () => const SliverFillRemaining(
-                  child: Center(child: CircularProgressIndicator.adaptive()),
-                ),
-                error: (err, _) => SliverFillRemaining(
-                  child: _ErrorView(
-                    error: err.toString(),
-                    onRetry: () => ref.read(logsProvider.notifier).refresh(),
-                  ),
-                ),
-                data: (state) {
-                  if (state.error != null) {
-                    return SliverFillRemaining(
-                      child: _ErrorView(
-                        error: state.error!,
-                        onRetry: () =>
-                            ref.read(logsProvider.notifier).refresh(),
-                      ),
-                    );
-                  }
-                  if (state.logs.isEmpty) {
-                    return SliverFillRemaining(
-                      child: Center(
-                        child: state.searchQuery.isNotEmpty
-                            ? Text(
-                                'No logs matching "${state.searchQuery}"',
-                                style: TextStyle(
-                                  color: Theme.of(
-                                    context,
-                                  ).colorScheme.onSurfaceVariant,
-                                ),
-                              )
-                            : const _EmptyView(),
-                      ),
-                    );
-                  }
-                  return SliverList(
-                    delegate: SliverChildBuilderDelegate((context, index) {
-                      if (index.isOdd) {
-                        return const Divider(
-                          height: 1,
-                          indent: 12,
-                          endIndent: 12,
-                        );
-                      }
-                      return _LogRow(entry: state.logs[index ~/ 2]);
-                    }, childCount: state.logs.length * 2 - 1),
-                  );
-                },
-              ),
-            ],
-          ),
-        ),
-      );
-    }
-
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Logs'),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () => context.go('/chat'),
-        ),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.refresh),
-            onPressed: () => ref.read(logsProvider.notifier).refresh(),
-          ),
-        ],
-      ),
+    return AdaptiveScaffold(
       body: GestureDetector(
         onTap: () => FocusScope.of(context).unfocus(),
-        child: Column(
-          children: [
-            searchField,
-            // Log list
-            Expanded(
-              child: logsAsync.when(
-                loading: () =>
-                    const Center(child: CircularProgressIndicator.adaptive()),
-                error: (err, _) => _ErrorView(
+        child: CustomScrollView(
+          slivers: [
+            AdaptiveSliverNavBar(
+              title: 'Logs',
+              actions: [
+                if (_searching)
+                  const Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 8),
+                    child: SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator.adaptive(strokeWidth: 2),
+                    ),
+                  ),
+                IconButton(
+                  icon: const Icon(Icons.refresh),
+                  onPressed: () => ref.read(logsProvider.notifier).refresh(),
+                ),
+              ],
+            ),
+            SliverToBoxAdapter(child: searchField),
+            logsAsync.when(
+              loading: () => const SliverFillRemaining(
+                child: Center(child: CircularProgressIndicator.adaptive()),
+              ),
+              error: (err, _) => SliverFillRemaining(
+                child: _ErrorView(
                   error: err.toString(),
                   onRetry: () => ref.read(logsProvider.notifier).refresh(),
                 ),
-                data: (state) {
-                  if (state.error != null) {
-                    return _ErrorView(
+              ),
+              data: (state) {
+                if (state.error != null) {
+                  return SliverFillRemaining(
+                    child: _ErrorView(
                       error: state.error!,
                       onRetry: () => ref.read(logsProvider.notifier).refresh(),
-                    );
-                  }
-                  if (state.logs.isEmpty) {
-                    return Center(
+                    ),
+                  );
+                }
+                if (state.logs.isEmpty) {
+                  return SliverFillRemaining(
+                    child: Center(
                       child: state.searchQuery.isNotEmpty
                           ? Text(
                               'No logs matching "${state.searchQuery}"',
@@ -195,22 +110,26 @@ class _LogsScreenState extends ConsumerState<LogsScreen> {
                               ),
                             )
                           : const _EmptyView(),
-                    );
-                  }
-                  return ListView.separated(
-                    itemCount: state.logs.length,
-                    separatorBuilder: (context, index) =>
-                        const Divider(height: 1, indent: 12, endIndent: 12),
-                    itemBuilder: (context, index) {
-                      return _LogRow(entry: state.logs[index]);
-                    },
+                    ),
                   );
-                },
-              ),
+                }
+                return SliverList(
+                  delegate: SliverChildBuilderDelegate((context, index) {
+                    if (index.isOdd) {
+                      return const Divider(
+                        height: 1,
+                        indent: 12,
+                        endIndent: 12,
+                      );
+                    }
+                    return _LogRow(entry: state.logs[index ~/ 2]);
+                  }, childCount: state.logs.length * 2 - 1),
+                );
+              },
             ),
           ],
         ),
-      ), // GestureDetector
+      ),
     );
   }
 }
@@ -305,13 +224,14 @@ class _SeverityChip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
-    final (bgColor, textColor) = switch (severity.toUpperCase()) {
-      'ERROR' => (colorScheme.errorContainer, colorScheme.error),
-      'WARN' => (Colors.orange.shade100, Colors.orange.shade800),
-      'INFO' => (Colors.blue.shade100, Colors.blue.shade800),
-      'DEBUG' => (Colors.grey.shade200, Colors.grey.shade700),
-      _ => (Colors.purple.shade50, Colors.purple.shade700),
-    };
+    // ERROR maps to the standard Material 3 error roles; everything else
+    // pulls from the design-token helper in lib/shared/theme/.
+    final (bgColor, textColor) = severity.toUpperCase() == 'ERROR'
+        ? (colorScheme.errorContainer, colorScheme.error)
+        : () {
+            final swatch = logSeverityColors(severity);
+            return (swatch.bg, swatch.fg);
+          }();
 
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
@@ -382,7 +302,7 @@ class _ErrorView extends StatelessWidget {
           const SizedBox(height: 12),
           Text(error, textAlign: TextAlign.center),
           const SizedBox(height: 12),
-          FilledButton(onPressed: onRetry, child: const Text('Retry')),
+          AdaptiveButton.filled(onPressed: onRetry, child: const Text('Retry')),
         ],
       ),
     );

--- a/app/lib/shared/theme/log_severity_colors.dart
+++ b/app/lib/shared/theme/log_severity_colors.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+/// Background + foreground colour pair for a log-level chip.
+typedef LogSeverityColors = ({Color bg, Color fg});
+
+/// Returns the chip colour pair for a given log severity string.
+///
+/// Material 3's ColorScheme has no semantic slot for warn/info/debug, so
+/// the swatches are kept here as design tokens. This file is inside
+/// `lib/shared/theme/` so it is exempt from the no-raw-colours gate; do
+/// not move these constants to a feature file.
+///
+/// `ERROR` is the only level that maps to a ColorScheme equivalent —
+/// callers should prefer `Theme.of(context).colorScheme.errorContainer /
+/// error` directly. The entry here exists for completeness so the helper
+/// covers every value the API may return.
+LogSeverityColors logSeverityColors(String severity) {
+  switch (severity.toUpperCase()) {
+    case 'ERROR':
+      // Approximates Material 3 errorContainer / error. Prefer the
+      // ColorScheme values at call sites when a BuildContext is in scope.
+      return (bg: const Color(0xFFFFDAD6), fg: const Color(0xFFBA1A1A));
+    case 'WARN':
+      return (bg: Colors.orange.shade100, fg: Colors.orange.shade800);
+    case 'INFO':
+      return (bg: Colors.blue.shade100, fg: Colors.blue.shade800);
+    case 'DEBUG':
+      return (bg: Colors.grey.shade200, fg: Colors.grey.shade700);
+    default:
+      // TRACE and any other value.
+      return (bg: Colors.purple.shade50, fg: Colors.purple.shade700);
+  }
+}

--- a/openspec/changes/adaptive-ui-consolidation/tasks.md
+++ b/openspec/changes/adaptive-ui-consolidation/tasks.md
@@ -40,7 +40,7 @@
 ## 3. Phase 2.2 — Sliver-nav list screens (9 stacked PRs, one per screen)
 
 - [x] 3.1 `traces_screen.dart`: replace inline `if (isAppleTouch) CupertinoSliverNavigationBar` with `AdaptiveSliverNavBar`; drop `package:flutter/cupertino.dart` import; existing tests stay green. Unified both platform paths into a single CustomScrollView with the wrapper. Material visual change: SliverAppBar.large (collapsing) replaces fixed AppBar, and the explicit `IconButton(arrow_back) → /chat` is dropped (top-level nav screen — sidebar/tab bar already provides home access; matches the existing iOS path which had no back button).
-- [ ] 3.2 `logs_screen.dart`: same treatment
+- [x] 3.2 `logs_screen.dart`: same treatment. Switched to the barrel and `AdaptiveSliverNavBar`. Surfaced `Colors.{orange,blue,grey,purple}.shade*` for the severity chip — extracted into `lib/shared/theme/log_severity_colors.dart` as a design token helper (inside the theme dir so it's exempt from `check_no_raw_colors.sh`). Also `Scaffold` → `AdaptiveScaffold`, `TextField` → `AdaptiveTextField` (with the inline progress spinner moved from `suffixIcon` to the nav-bar actions), `FilledButton` → `AdaptiveButton.filled`. Same Material visual change as traces: fixed AppBar → SliverAppBar.large, explicit back button dropped.
 - [ ] 3.3 `agents_screen.dart`: same treatment + replace `CupertinoButton`/`CupertinoIcons` with `AdaptiveButton`/`AdaptiveIcons`
 - [ ] 3.4 `workflows_screen.dart`: same as 3.3
 - [ ] 3.5 `personas_screen.dart`: same treatment


### PR DESCRIPTION
## Summary

Phase 2.2.2 — third Phase-2 migration in the [`adaptive-ui-consolidation`](openspec/changes/adaptive-ui-consolidation/) series. Replaces the inline `if (isAppleTouch) CupertinoSliverNavigationBar else AppBar` branch in `logs_screen.dart` with `AdaptiveSliverNavBar` from the façade (#789), routes the file through the barrel (#797), and unifies both platform paths into one `CustomScrollView`. Net diff: ~-95 LOC.

## What the barrel surfaced

Switching the import to the barrel revealed four direct-Material usages this file had besides the obvious Cupertino branch:

| Direct usage | Migrated to |
|---|---|
| `Scaffold(body: …)` | `AdaptiveScaffold(body: …)` |
| `TextField` (search field) | `AdaptiveTextField` |
| `FilledButton(onPressed, child)` | `AdaptiveButton.filled(onPressed, child)` |
| `Colors.{orange,blue,grey,purple}.shade*` for the severity chip | `logSeverityColors()` helper in `lib/shared/theme/log_severity_colors.dart` (returns `(bg, fg)` record) |

The severity-colour helper is a new file inside `lib/shared/theme/` so it's exempt from `scripts/check_no_raw_colors.sh`. `ERROR` keeps mapping to `colorScheme.errorContainer/error` directly since it has a semantic ColorScheme slot.

## Behavioural notes

- **iOS path: unchanged** — `CupertinoSliverNavigationBar` (large-title-collapses) inside a `CustomScrollView` is exactly what `AdaptiveSliverNavBar` produces.
- **Material path: AppBar → SliverAppBar.large** via the wrapper — same as the traces migration. Large title collapses on scroll.
- **Material path: explicit `IconButton(arrow_back) → /chat` dropped** — Logs is a top-level nav destination; iOS path never had one. Consistent with the precedent set in #793.
- **Search progress spinner moved** — was inside `TextField`'s `suffixIcon`; now lives next to the refresh action in the nav-bar `actions` slot. Same indication, different placement (the `AdaptiveTextField` API doesn't expose `suffixIcon`).

## Stack

- ✅ #789 (merged) — Phase 1 façade wrappers
- ✅ #793 (merged) — Phase 2.2.1 traces migration
- ✅ #797 (merged) — Phase 2.0 barrel shim
- 👉 **This PR** — Phase 2.2.2 logs migration
- Phase 2.2.3+ (next) — `agents_screen`, `workflows_screen`, `personas_screen`, `skills_screen`, `webhooks_screen`, `analytics_screen`, `context_switcher_screen`

## Test plan

- [x] `flutter test test/widget/features/logs/logs_screen_test.dart` — 8/8 pass
- [x] `flutter test` — 949/949 pass
- [x] `flutter analyze --fatal-infos` — 0 issues
- [x] `scripts/check_no_raw_colors.sh` — clean (raw `Colors.X.shadeY` moved inside `lib/shared/theme/`)
- [x] Pre-commit hook — passed (first attempt flaked on an unrelated `chat_screen` test; second attempt clean)

## Refs

OpenSpec: `openspec/changes/adaptive-ui-consolidation/` (Phase 2.2, task 3.2 complete).