### PR TITLE
feat(app): migrate analytics_screen onto AdaptiveSliverNavBar + barrel

### DIFF
--- a/app/lib/features/analytics/analytics_screen.dart
+++ b/app/lib/features/analytics/analytics_screen.dart
@@ -1,9 +1,7 @@
 import 'package:assistant_api/assistant_api.dart';
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../shared/platform/platform.dart';
+import '../../shared/platform/widgets.dart';
 import 'analytics_provider.dart';
 
 /// Screen showing aggregated assistant usage analytics.
@@ -14,72 +12,42 @@ class AnalyticsScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final analyticsAsync = ref.watch(analyticsProvider);
 
-    if (isAppleTouch) {
-      return Scaffold(
-        body: CustomScrollView(
-          slivers: [
-            CupertinoSliverNavigationBar(
-              largeTitle: const Text('Analytics'),
-              trailing: CupertinoButton(
-                padding: EdgeInsets.zero,
-                child: const Icon(CupertinoIcons.refresh),
+    return AdaptiveScaffold(
+      body: CustomScrollView(
+        slivers: [
+          AdaptiveSliverNavBar(
+            title: 'Analytics',
+            actions: [
+              IconButton(
+                icon: const Icon(Icons.refresh),
                 onPressed: () => ref.read(analyticsProvider.notifier).refresh(),
               ),
+            ],
+          ),
+          analyticsAsync.when(
+            loading: () => const SliverFillRemaining(
+              child: Center(child: CircularProgressIndicator.adaptive()),
             ),
-            analyticsAsync.when(
-              loading: () => const SliverFillRemaining(
-                child: Center(child: CircularProgressIndicator.adaptive()),
+            error: (err, _) => SliverFillRemaining(
+              child: _ErrorView(
+                error: err.toString(),
+                onRetry: () => ref.read(analyticsProvider.notifier).refresh(),
               ),
-              error: (err, _) => SliverFillRemaining(
-                child: _ErrorView(
-                  error: err.toString(),
-                  onRetry: () => ref.read(analyticsProvider.notifier).refresh(),
-                ),
-              ),
-              data: (state) {
-                if (state.error != null) {
-                  return SliverFillRemaining(
-                    child: _ErrorView(
-                      error: state.error!,
-                      onRetry: () =>
-                          ref.read(analyticsProvider.notifier).refresh(),
-                    ),
-                  );
-                }
-                return SliverFillRemaining(child: _AnalyticsBody(state: state));
-              },
             ),
-          ],
-        ),
-      );
-    }
-
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Analytics'),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.refresh),
-            onPressed: () => ref.read(analyticsProvider.notifier).refresh(),
+            data: (state) {
+              if (state.error != null) {
+                return SliverFillRemaining(
+                  child: _ErrorView(
+                    error: state.error!,
+                    onRetry: () =>
+                        ref.read(analyticsProvider.notifier).refresh(),
+                  ),
+                );
+              }
+              return SliverFillRemaining(child: _AnalyticsBody(state: state));
+            },
           ),
         ],
-      ),
-      body: analyticsAsync.when(
-        loading: () =>
-            const Center(child: CircularProgressIndicator.adaptive()),
-        error: (err, _) => _ErrorView(
-          error: err.toString(),
-          onRetry: () => ref.read(analyticsProvider.notifier).refresh(),
-        ),
-        data: (state) {
-          if (state.error != null) {
-            return _ErrorView(
-              error: state.error!,
-              onRetry: () => ref.read(analyticsProvider.notifier).refresh(),
-            );
-          }
-          return _AnalyticsBody(state: state);
-        },
       ),
     );
   }
@@ -416,7 +384,7 @@ class _ErrorView extends StatelessWidget {
           const SizedBox(height: 12),
           Text(error, textAlign: TextAlign.center),
           const SizedBox(height: 12),
-          FilledButton(onPressed: onRetry, child: const Text('Retry')),
+          AdaptiveButton.filled(onPressed: onRetry, child: const Text('Retry')),
         ],
       ),
     );

--- a/app/lib/shared/platform/widgets.dart
+++ b/app/lib/shared/platform/widgets.dart
@@ -97,8 +97,15 @@ export 'package:flutter/material.dart'
         DefaultTabController,
         // Chip / Badge / Avatar style widgets — no iOS equivalent.
         Chip,
+        ChoiceChip,
+        InputChip,
         Badge,
         CircleAvatar,
+        // DataTable family — Material-only tabular layout.
+        DataTable,
+        DataColumn,
+        DataRow,
+        DataCell,
         // Form-aware list tile, occasionally used in settings.
         // (Settings will migrate to AdaptiveSwitchTile, but `CheckboxListTile`
         // is occasionally useful and has no Cupertino equivalent.)

--- a/openspec/changes/adaptive-ui-consolidation/tasks.md
+++ b/openspec/changes/adaptive-ui-consolidation/tasks.md
@@ -46,7 +46,7 @@
 - [x] 3.5 `personas_screen.dart`: switched to barrel + AdaptiveSliverNavBar + AdaptiveScaffold + AdaptiveListTile + AdaptiveButton.filled. Extended `AdaptiveTextField` with a `prefix` parameter (maps to `CupertinoTextField.prefix` on iOS, `InputDecoration.prefixIcon` on Material) to preserve the leading search icon. Two new tests verify the prefix on both platforms.
 - [x] 3.6 `skills_screen.dart`: switched to barrel + AdaptiveSliverNavBar / AdaptiveScaffold / AdaptiveButton.filled. Enabled/disabled badge colours migrated from `Colors.green.shade*` / `Colors.grey.shade*` to `colorScheme.tertiary` / `colorScheme.onSurfaceVariant` (matches workflows). Added `VisualDensity` to the barrel show-list (Material-only). Fixed one test assertion (`findsOneWidget` → `findsAtLeastNWidgets(1)`) because `SliverAppBar.large` renders both a collapsed and expanded title.
 - [x] 3.7 `webhooks_screen.dart`: same treatment. Active/inactive badge migrated to colorScheme tokens (tertiary / onSurfaceVariant + tertiaryContainer / surfaceContainerHighest). The verified-checkmark icon's `Colors.blue.shade600` → `colorScheme.primary`. Cupertino's `CupertinoButton + CupertinoIcons.refresh` collapsed to `IconButton + Icons.refresh`.
-- [ ] 3.8 `analytics_screen.dart`: same as 3.3
+- [x] 3.8 `analytics_screen.dart`: same treatment. Added `ChoiceChip`, `InputChip`, `DataTable`, `DataColumn`, `DataRow`, `DataCell` to the barrel show-list (all Material-only — no Cupertino equivalents for chip-based selectors or tabular layouts). No raw colours to migrate.
 - [ ] 3.9 `contexts/screens/context_switcher_screen.dart`: same treatment + adopt `AdaptiveActionSheet` for delete confirmation
 
 ## 4. Phase 2.3 — Settings screen (1 PR)


### PR DESCRIPTION
Phase 2.2.8. Adds ChoiceChip / InputChip / DataTable family to the barrel show-list (Material-only widgets). 951/951 tests green.

## Stack
- ✅ Phase 1 + 2.0 + 2.2.1–7 (merged)
- 👉 **This PR** — Phase 2.2.8 analytics
- Next — context_switcher, settings, chat, nav_shell