### PR TITLE
feat(app): migrate chat_screen onto barrel + Adaptive wrappers

### DIFF
--- a/app/lib/features/chat/chat_screen.dart
+++ b/app/lib/features/chat/chat_screen.dart
@@ -6,8 +6,6 @@ import 'package:assistant_api/assistant_api.dart' hide ServerCapabilities;
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:desktop_drop/desktop_drop.dart';
 import 'package:file_picker/file_picker.dart';
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_smooth_markdown/flutter_smooth_markdown.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -15,8 +13,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'svg_builder.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../shared/platform/adaptive_context_menu.dart';
-import '../../shared/platform/platform.dart';
+import '../../shared/platform/widgets.dart';
 import '../../services/share_service.dart';
 import '../../api/api_client.dart';
 import '../../api/attachment_service.dart';
@@ -365,34 +362,21 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     ];
 
     return Scaffold(
-      appBar: isAppleTouch
-          ? CupertinoNavigationBar(
-              middle: Text(activePersonaName),
-              leading: isWide
-                  ? null
-                  : Builder(
-                      builder: (ctx) => GestureDetector(
-                        onTap: () => Scaffold.of(ctx).openDrawer(),
-                        child: const Icon(CupertinoIcons.line_horizontal_3),
-                      ),
-                    ),
-              trailing: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: chatActions,
+      appBar: AdaptiveNavBar(
+        title: activePersonaName,
+        leading: isWide
+            ? null
+            : Builder(
+                builder: (ctx) => IconButton(
+                  icon: const AdaptiveIcon(
+                    cupertino: CupertinoIcons.line_horizontal_3,
+                    material: Icons.menu,
+                  ),
+                  onPressed: () => Scaffold.of(ctx).openDrawer(),
+                ),
               ),
-            )
-          : AppBar(
-              title: Text(activePersonaName),
-              leading: isWide
-                  ? null
-                  : Builder(
-                      builder: (ctx) => IconButton(
-                        icon: const Icon(Icons.menu),
-                        onPressed: () => Scaffold.of(ctx).openDrawer(),
-                      ),
-                    ),
-              actions: chatActions,
-            ),
+        actions: chatActions,
+      ),
 
       // Drawer on narrow screens.
       drawer: isWide
@@ -1985,45 +1969,23 @@ class _InputRowState extends State<_InputRow> {
                       });
                     }
                   },
-                  child: isAppleTouch
-                      ? CupertinoTextField(
-                          key: const Key('message_input'),
-                          controller: widget.controller,
-                          focusNode: widget.focusNode,
-                          placeholder: widget.pendingAttachments.isNotEmpty
-                              ? 'Add a caption...'
-                              : 'Type a message...',
-                          cursorColor: colorScheme.primary,
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 14,
-                            vertical: 10,
-                          ),
-                          minLines: 1,
-                          maxLines: 6,
-                          textInputAction: TextInputAction.send,
-                          onSubmitted: (_) => widget.onSend(),
-                        )
-                      : TextField(
-                          key: const Key('message_input'),
-                          controller: widget.controller,
-                          focusNode: widget.focusNode,
-                          cursorColor: colorScheme.primary,
-                          decoration: InputDecoration(
-                            hintText: widget.pendingAttachments.isNotEmpty
-                                ? 'Add a caption...'
-                                : 'Type a message...',
-                            border: const OutlineInputBorder(),
-                            contentPadding: const EdgeInsets.symmetric(
-                              horizontal: 14,
-                              vertical: 10,
-                            ),
-                            isDense: true,
-                          ),
-                          minLines: 1,
-                          maxLines: 6,
-                          textInputAction: TextInputAction.send,
-                          onSubmitted: (_) => widget.onSend(),
-                        ),
+                  child: AdaptiveTextField(
+                    key: const Key('message_input'),
+                    controller: widget.controller,
+                    focusNode: widget.focusNode,
+                    placeholder: widget.pendingAttachments.isNotEmpty
+                        ? 'Add a caption...'
+                        : 'Type a message...',
+                    cursorColor: colorScheme.primary,
+                    contentPadding: const EdgeInsets.symmetric(
+                      horizontal: 14,
+                      vertical: 10,
+                    ),
+                    minLines: 1,
+                    maxLines: 6,
+                    textInputAction: TextInputAction.send,
+                    onSubmitted: (_) => widget.onSend(),
+                  ),
                 ),
               ),
               const SizedBox(width: 8),

--- a/app/lib/shared/platform/adaptive_text_field.dart
+++ b/app/lib/shared/platform/adaptive_text_field.dart
@@ -14,6 +14,7 @@ class AdaptiveTextField extends StatelessWidget {
   const AdaptiveTextField({
     super.key,
     this.controller,
+    this.focusNode,
     this.placeholder,
     this.onChanged,
     this.onSubmitted,
@@ -22,9 +23,15 @@ class AdaptiveTextField extends StatelessWidget {
     this.autofocus = false,
     this.textInputAction,
     this.prefix,
+    this.minLines,
+    this.maxLines = 1,
+    this.cursorColor,
+    this.contentPadding,
+    this.enabled,
   });
 
   final TextEditingController? controller;
+  final FocusNode? focusNode;
   final String? placeholder;
   final ValueChanged<String>? onChanged;
   final ValueChanged<String>? onSubmitted;
@@ -38,11 +45,27 @@ class AdaptiveTextField extends StatelessWidget {
   /// on Material. Commonly an [Icon] used for search affordances.
   final Widget? prefix;
 
+  /// Multi-line support. `maxLines = 1` (the default) renders a single
+  /// line; pass `null` for unbounded growth.
+  final int? minLines;
+  final int? maxLines;
+
+  /// Caret colour. Maps directly on both platforms.
+  final Color? cursorColor;
+
+  /// Inner padding. Maps to `CupertinoTextField.padding` on iOS and to
+  /// `InputDecoration.contentPadding` on Material.
+  final EdgeInsetsGeometry? contentPadding;
+
+  /// Whether the field accepts input. `null` (the default) means enabled.
+  final bool? enabled;
+
   @override
   Widget build(BuildContext context) {
     if (isAppleTouch) {
       return CupertinoTextField(
         controller: controller,
+        focusNode: focusNode,
         placeholder: placeholder,
         onChanged: onChanged,
         onSubmitted: onSubmitted,
@@ -51,12 +74,25 @@ class AdaptiveTextField extends StatelessWidget {
         autofocus: autofocus,
         textInputAction: textInputAction,
         prefix: prefix,
+        minLines: minLines,
+        maxLines: maxLines,
+        cursorColor: cursorColor,
+        enabled: enabled ?? true,
+        padding:
+            contentPadding ??
+            const EdgeInsets.symmetric(horizontal: 6, vertical: 7),
       );
     }
     return TextField(
       controller: controller,
-      decoration: (placeholder != null || prefix != null)
-          ? InputDecoration(hintText: placeholder, prefixIcon: prefix)
+      focusNode: focusNode,
+      decoration:
+          (placeholder != null || prefix != null || contentPadding != null)
+          ? InputDecoration(
+              hintText: placeholder,
+              prefixIcon: prefix,
+              contentPadding: contentPadding,
+            )
           : null,
       onChanged: onChanged,
       onSubmitted: onSubmitted,
@@ -64,6 +100,10 @@ class AdaptiveTextField extends StatelessWidget {
       obscureText: obscureText,
       autofocus: autofocus,
       textInputAction: textInputAction,
+      minLines: minLines,
+      maxLines: maxLines,
+      cursorColor: cursorColor,
+      enabled: enabled,
     );
   }
 }

--- a/app/lib/shared/platform/widgets.dart
+++ b/app/lib/shared/platform/widgets.dart
@@ -131,8 +131,45 @@ export 'package:flutter/material.dart'
         // inputs are configured.
         TextFormField,
         InputDecoration,
+        InputBorder,
+        OutlineInputBorder,
+        UnderlineInputBorder,
         TextInputAction,
         TextInputType,
+        // Structural widgets needed by hybrid screens (chat, nav_shell)
+        // that combine a Material Scaffold with adaptive top chrome.
+        // Pure-list screens should still prefer AdaptiveScaffold +
+        // AdaptiveNavBar / AdaptiveSliverNavBar.
+        Scaffold,
+        ScaffoldState,
+        AppBar,
+        // SnackBar configuration types — `ScaffoldMessenger.showSnackBar`
+        // accepts a SnackBar; the wrapper-only path via showAdaptiveSnackBar
+        // covers simple cases, but custom SnackBars are sometimes needed.
+        SnackBar,
+        SnackBarBehavior,
+        // Linear progress indicator — used by chat for in-flight stream
+        // progress; no Cupertino equivalent.
+        LinearProgressIndicator,
+        // Selectable text (long-press to copy) — Material-only.
+        SelectableText,
+        AdaptiveTextSelectionToolbar,
+        // Generic dialog widget — used for custom modals (e.g. image preview)
+        // that aren't a two-button confirmation.
+        Dialog,
+        // Slider + theming for custom voice-message playback slider.
+        // AdaptiveSlider is the wrapper for general 0..1 sliders; this
+        // re-export covers cases that need custom SliderTheme.
+        Slider,
+        SliderTheme,
+        SliderThemeData,
+        RoundSliderThumbShape,
+        SliderComponentShape,
+        // Colors class — Material's named colour catalog. The
+        // check_no_raw_colors.sh gate still fires on every Colors.X usage
+        // outside lib/shared/theme/ (except Colors.transparent), so re-exporting
+        // the class is safe — direct usage is enforced at a different layer.
+        Colors,
         // Material localisations (used in date/time pickers).
         DefaultMaterialLocalizations;
 

--- a/app/test/widget/features/chat/chat_screen_test.dart
+++ b/app/test/widget/features/chat/chat_screen_test.dart
@@ -12,6 +12,7 @@ import 'package:assistant_app/features/chat/chat_screen.dart';
 import 'package:assistant_app/features/chat/streaming_timeline_entry.dart';
 import 'package:assistant_app/features/connection/connection_provider.dart';
 import 'package:assistant_app/features/personas/personas_provider.dart';
+import 'package:assistant_app/shared/platform/adaptive_text_field.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -114,7 +115,7 @@ void main() {
       await tester.pump();
 
       // Verify focus before sending.
-      final textField = tester.widget<TextField>(inputFinder);
+      final textField = tester.widget<AdaptiveTextField>(inputFinder);
       expect(
         textField.focusNode?.hasFocus,
         isTrue,
@@ -129,7 +130,7 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 400));
 
-      final afterSend = tester.widget<TextField>(inputFinder);
+      final afterSend = tester.widget<AdaptiveTextField>(inputFinder);
       expect(
         afterSend.focusNode?.hasFocus,
         isTrue,
@@ -158,7 +159,7 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 400));
 
-      final afterSubmit = tester.widget<TextField>(inputFinder);
+      final afterSubmit = tester.widget<AdaptiveTextField>(inputFinder);
       expect(
         afterSubmit.focusNode?.hasFocus,
         isTrue,
@@ -181,7 +182,7 @@ void main() {
       );
       await tester.pump();
 
-      final textField = tester.widget<TextField>(
+      final textField = tester.widget<AdaptiveTextField>(
         find.byKey(const Key('message_input')),
       );
       expect(

--- a/app/test/widget/features/chat/command_autocomplete_test.dart
+++ b/app/test/widget/features/chat/command_autocomplete_test.dart
@@ -4,6 +4,7 @@ import 'package:assistant_app/features/chat/chat_screen.dart';
 import 'package:assistant_app/features/chat/commands_provider.dart';
 import 'package:assistant_app/features/connection/connection_provider.dart';
 import 'package:assistant_app/features/personas/personas_provider.dart';
+import 'package:assistant_app/shared/platform/adaptive_text_field.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -211,7 +212,7 @@ void main() {
         await tester.pump(const Duration(milliseconds: 400));
 
         // Input should be filled with "/model " and popup should dismiss.
-        final controller = tester.widget<TextField>(
+        final controller = tester.widget<AdaptiveTextField>(
           find.byKey(const Key('message_input')),
         );
         expect(

--- a/openspec/changes/adaptive-ui-consolidation/tasks.md
+++ b/openspec/changes/adaptive-ui-consolidation/tasks.md
@@ -55,14 +55,12 @@
 
 ## 5. Phase 2.4 — Chat screen (likely small stack inside one PR)
 
-- [ ] 5.1 Spike: read `chat_screen.dart` (2229 LOC) and decide whether to extract composer + message list into separate files before the import sweep; record decision in PR description
-- [ ] 5.2 If extracted: move composer to `app/lib/features/chat/chat_composer.dart` with widget test; verify chat screen still renders identically
-- [ ] 5.3 If extracted: move message list to `app/lib/features/chat/chat_messages_view.dart` with widget test
-- [ ] 5.4 Replace `CupertinoTextField` with `AdaptiveTextField`
-- [ ] 5.5 Replace `CupertinoNavigationBar` with `AdaptiveNavBar` (regular, non-large-title — per `cupertino-chrome` REQ-4)
-- [ ] 5.6 Replace Material `Switch`, `Slider`, `SnackBar` with `AdaptiveSwitch`/`AdaptiveSlider`/`AdaptiveSnackBar`
-- [ ] 5.7 Drop both `package:flutter/cupertino.dart` and any unnecessary `package:flutter/material.dart` imports
-- [ ] 5.8 Update widget tests; update Playwright baselines if visual diff is non-zero on web
+- [x] 5.1 Spike outcome: kept chat_screen as a single 2229 LOC file rather than extracting composer/message list. The migration touches imports + a handful of structural sites, not internal composition; an extraction would balloon the diff.
+- [x] 5.4 Replaced `CupertinoTextField` + `TextField` (the dual chat input) with a single `AdaptiveTextField`. Extended the wrapper with `focusNode`, `minLines`/`maxLines`, `cursorColor`, `contentPadding`, and `enabled` parameters to cover the chat-composer feature surface.
+- [x] 5.5 Replaced the inline `CupertinoNavigationBar` / `AppBar` conditional in the chat top bar with a single `AdaptiveNavBar`. Burger menu icon now uses `AdaptiveIcon(cupertino: CupertinoIcons.line_horizontal_3, material: Icons.menu)`.
+- [x] 5.6 SnackBar usages kept as raw `SnackBar` (re-exported via barrel) — six call sites use custom action / behaviour configurations that don't fit `showAdaptiveSnackBar`'s simple-string API. The voice-message custom-themed Slider stays as raw Slider (re-exported via barrel) — has a custom `SliderThemeData` (track height, thumb shape, overlay shape) that `AdaptiveSlider` doesn't expose.
+- [x] 5.7 Dropped both `package:flutter/cupertino.dart` and `package:flutter/material.dart` imports from `chat_screen.dart`. Replaced with single `import '../../shared/platform/widgets.dart';`. Also dropped the now-redundant `adaptive_context_menu.dart` direct import (covered by barrel).
+- [x] 5.8 Updated `chat_screen_test.dart` and `command_autocomplete_test.dart` to cast to `AdaptiveTextField` instead of `TextField` (four sites). All chat tests (64) and full suite (951) green.
 
 ## 6. Phase 2.5 — Nav shell (1 PR, last in Phase 2)
 


### PR DESCRIPTION
Phase 2.4 — Pattern C, the 2229 LOC chat screen. Migrates to the barrel, drops both cupertino.dart and material.dart imports, swaps CupertinoNavigationBar/AppBar -> AdaptiveNavBar and CupertinoTextField/TextField -> AdaptiveTextField.

Extended AdaptiveTextField with focusNode/minLines/maxLines/cursorColor/contentPadding/enabled to cover the chat composer surface.

Barrel additions: Scaffold/AppBar/ScaffoldState (chat needs Drawer support, keeps Material Scaffold), SnackBar/SnackBarBehavior (6 custom-config sites), LinearProgressIndicator, SelectableText, AdaptiveTextSelectionToolbar, Dialog, Slider+theme classes (custom voice-player theming), Colors (for Colors.transparent on image preview).

Updated 5 test sites to cast AdaptiveTextField instead of TextField. 951/951 tests green.

## Stack
- ✅ Phase 1 + 2.0 + 2.2 + 2.3 (merged)
- 👉 **This PR** — Phase 2.4 chat
- Next — nav_shell (Phase 2.5, the last migration)