### PR TITLE
chore(openspec): propose workspace-test-coverage-floor

### DIFF
--- a/openspec/changes/workspace-test-coverage-floor/design.md
+++ b/openspec/changes/workspace-test-coverage-floor/design.md
@@ -1,0 +1,480 @@
+## Context
+
+Workspace audit (2026-05-17, branch `worktree-buzzing-enchanting-flame`) computed
+test-LOC-to-src-LOC ratio per crate as a rough coverage proxy. The distribution
+is heavy-tailed:
+
+| Crate                          | Src LOC | Tests LOC | Ratio | Inline tests |
+| ------------------------------ | ------: | --------: | ----: | -----------: |
+| opentelemetry-exporter-sqlite  |  1 ,918 |    1 ,407 |   73% |           15 |
+| auth                           |  5 ,093 |    2 ,529 |   50% |          106 |
+| storage                        | 14 ,420 |    6 ,306 |   44% |          235 |
+| bus-nats                       |  1 ,105 |       447 |   40% |           22 |
+| web-ui                         | 26 ,160 |    9 ,057 |   35% |          245 |
+| llm-provider                   |  6 ,598 |    2 ,126 |   32% |          103 |
+| core                           |  8 ,584 |    2 ,667 |   31% |          183 |
+| runtime                        | 16 ,983 |    4 ,857 |   29% |          218 |
+| tool-executor                  |  6 ,004 |    1 ,718 |   29% |           73 |
+| workflow                       |     927 |       271 |   29% |            6 |
+| backup                         |  1 ,434 |       408 |   28% |           21 |
+| interfaces                     |  9 ,984 |    2 ,540 |   25% |          128 |
+| transcription                  |  2 ,202 |       529 |   24% |           47 |
+| skills                         |     590 |       132 |   22% |            8 |
+| interface-cli                  |  4 ,987 |       893 |   18% |           59 |
+| mcp-client                     |     995 |       151 |   15% |           11 |
+| a2a-json-schema                |  1 ,378 |       189 |   14% |           10 |
+| opentelemetry-exporter-iceberg |  1 ,752 |       152 |    9% |            7 |
+| workflow-http                  |     232 |         0 |    0% |            0 |
+| mcp-server                     |     530 |         0 |    0% |            0 |
+
+LOC ratio is a noisy proxy. The actual gate uses `cargo llvm-cov --json` line
+coverage, which measures execution rather than file size. The 80% target is
+defined in terms of llvm-cov, not the audit ratio.
+
+The audit also identified seventeen production files >200 LOC with zero inline
+tests, all of which sit behind one of four structural blockers:
+
+1. **Concrete-type DI**: `Arc<Orchestrator>`, `Arc<ToolExecutor>`,
+   `Arc<SkillRegistry>` are taken by callers that cannot construct fakes.
+   `mcp-server::handle_request` and the messenger adapters all suffer from this.
+2. **Constructor-internal `reqwest::Client::new()`**: `workflow-http`,
+   `web-ui/push`, `nextcloud`, `matrix`, `oidc`, `cmd_login` each open their own
+   client. Without a `with_base_url` seam, `wiremock` cannot redirect traffic.
+3. **Direct clock calls**: 92 production sites call `Utc::now()` /
+   `SystemTime::now()`. JWT expiry, device-code TTL, scheduler firing, retry
+   backoff, conversation timestamps — all impossible to assert deterministically.
+4. **Monolithic mixed-concern files**: `interface-cli/main.rs` (1002),
+   `web-ui/backends/iceberg.rs` (984), messenger `runner.rs` files (~116 each).
+   The pure logic is embedded in the I/O glue.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Every crate reaches `>= 80%` line coverage as reported by
+  `cargo llvm-cov --json` per-crate.
+- CI enforces the floor with a fail-fast gate; a regression in any one crate
+  fails the build.
+- Architectural seams are in place to make the floor sustainable:
+  trait facades for `Orchestrator`/`ToolExecutor`/`SkillRegistry`,
+  injected `Clock`, injected `reqwest::Client`, pure dispatch functions
+  in messenger runners.
+
+**Non-Goals:**
+
+- Reaching 100% coverage; cosmetic / unreachable code stays uncovered.
+- Mutation testing.
+- Branch coverage (line coverage only).
+- Removing `StorageLayer::new_in_memory()` — it remains the canonical fixture for `assistant-storage`'s own tests and for contract tests.
+- Splitting `Orchestrator` into smaller types (only its trait facade is added).
+- Splitting the `interfaces` crate.
+- Property-based testing adoption.
+- Reaching 80% on `assistant-integration-tests` (its `src/lib.rs` is a stub).
+- In-memory variants for `migration` and `pool_factory` — SQLite-specific by nature; documented exemption in the spec.
+
+## Decisions
+
+### D1: Use `cargo llvm-cov` as the canonical coverage tool
+
+llvm-cov is the modern standard, ships in stable Rust toolchains via
+`rustup component add llvm-tools-preview`, integrates with `cargo`, and emits
+JSON suitable for per-crate parsing. Tarpaulin is older and macOS-flaky;
+`grcov` is harder to wire to per-crate gates.
+
+The CI gate runs `cargo llvm-cov --workspace --json --output-path coverage.json`,
+then a small `tools/check_coverage.sh` script parses the per-package coverage
+section and asserts `lines.percent >= 80.0` for every crate not in the exclude
+list. The exclude list contains `assistant-integration-tests` (no library code)
+and `assistant-a2a-json-schema` for now (generated types — see D6).
+
+### D2: Trait facades in `assistant-core`, concrete types stay in their crates
+
+Mirror the existing `MessageBus` and `LlmProvider` patterns. For each
+load-bearing concrete type, define a trait in `assistant-core` exposing only
+the methods consumers actually call. The concrete type implements the trait
+without changing its own constructor or fields.
+
+```text
+                    Today                          After
+                    ─────                          ─────
+mcp-server   ─►  Arc<Orchestrator>          mcp-server   ─►  Arc<dyn OrchestrationEngine>
+             ─►  Arc<ToolExecutor>                       ─►  Arc<dyn ToolDispatcher>
+             ─►  Arc<SkillRegistry>                      ─►  Arc<dyn SkillCatalog>
+
+web-ui       ─►  Arc<Orchestrator>          web-ui       ─►  Arc<dyn OrchestrationEngine>
+interfaces   ─►  Arc<Orchestrator>          interfaces   ─►  Arc<dyn OrchestrationEngine>
+```
+
+Method surfaces (initial cut, refined during implementation):
+
+- `OrchestrationEngine`: `submit_turn`, `run_turn_streaming`,
+  `register_extension_tools`, `cancel_turn`.
+- `ToolDispatcher`: `execute`, `to_specs`, `register_handler`, `is_mutating`.
+- `SkillCatalog`: `list`, `get`, `reload`.
+
+Callers depend on the trait; tests inject a hand-rolled stub. The trait is
+deliberately small — anything callers need that isn't on the trait stays on
+the concrete type (so `Orchestrator`'s own integration tests keep their reach).
+
+### D2.5: Persistence trait symmetry — every persistence component is a trait
+
+The same trait-facade pattern applies to every persistence component, not
+just the orchestration triad. Today, ~19 stores are still exposed as
+concrete structs (`ConversationStore`, `TraceStore`, `AttachmentStore`,
+`WebhookStore`, etc.). They become trait + SQLite impl + in-memory impl,
+following the pattern already established for `ApiKeyStore`, `OrgStore`,
+`MessageBus`, and the 14 other already-trait-shaped stores.
+
+```text
+                BEFORE                            AFTER
+                ──────                            ─────
+core           ApiKeyStore (trait) ✓           ConversationStore (trait)
+               MessageBus (trait) ✓            TraceStore (trait)
+                                                AttachmentStore (trait)
+                                                ... ~19 more
+
+storage        ConversationStore (struct)      SqliteConversationStore
+               TraceStore (struct)             SqliteTraceStore
+               AttachmentStore (struct)        SqliteAttachmentStore
+                                                InMemoryConversationBroadcaster (prod)
+
+test-support   (does not exist)                 InMemoryConversationStore
+                                                InMemoryTraceStore
+                                                InMemoryAttachmentStore
+                                                ... matching every trait
+```
+
+The trait surface contains the methods consumers actually call. Some methods
+specific to SQLite (raw pool access, FTS-ranked queries) stay on the concrete
+`Sqlite<Name>` type, not on the trait. The contract test for each trait
+asserts the trait surface is honored consistently across impls.
+
+#### Why this is worth doing now
+
+Three reinforcing reasons:
+
+1. **Layer purity.** Today every test in `runtime`, `web-ui`, `interfaces`,
+   and `interface-cli` transitively depends on `assistant-storage`'s
+   migrations being current. With trait-based access, only `storage`'s
+   own tests do. Refactoring a SQL query no longer cascades into 200 test
+   files across the workspace.
+
+2. **Coverage gate is reachable.** The 80% floor on `runtime`/`web-ui`
+   today demands either booting `StorageLayer::new_in_memory()` (real
+   SQLite, real migrations) per test or skipping coverage on
+   persistence-touching paths. With in-memory impls, the test setup is
+   3 lines and microseconds.
+
+3. **Refactor safety.** Contract tests assert that any new persistence
+   backend (e.g., a Postgres variant later, or a per-org sharded
+   storage) honors the same contract as SQLite. Today there is no such
+   gate; the only "contract" is "tests still pass against whichever
+   impl is wired in."
+
+#### Edge cases the contract test must handle
+
+- **FTS ranking** (`MemoryChunkStore::search_fts`): InMemory impl does a
+  naive substring scan that satisfies the trait but does not match
+  SQLite's BM25 ranking. The contract test gates ranking-specific
+  scenarios with a `// EXEMPT: FTS ranking is SQLite-specific` annotation.
+- **Cascading FKs**: InMemory impls SHALL enforce the obvious cascades
+  (delete conversation → delete messages, delete persona → null persona
+  references) in code. Contract test covers them.
+- **JSON column queries**: InMemory impls use `serde_json` to evaluate
+  `json_extract`-equivalent paths. Contract test covers null/missing
+  divergence.
+- **Atomicity**: InMemory impls wrap state in `Mutex<HashMap<...>>`;
+  multi-step operations (enqueue + ack on `MessageBus`) acquire the
+  mutex for the whole sequence.
+- **Migrations / `pool_factory` / SQLite-only OrgStorageLayer methods**:
+  exempt; contract test does not run against an in-memory variant
+  because none exists.
+
+### D2.6: In-memory impls co-locate with SQLite impls; no feature gates
+
+In-memory impls live in the same crate as their SQLite peers, as plain
+`pub` types. No `#[cfg(test)]`. No `[features] test-support` flag.
+They are alternative implementations of the trait — the same status as
+`SqliteConversationStore` or `OllamaProvider` — and follow the existing
+pattern set by `InMemoryConversationBroadcaster`, which has lived as
+plain `pub` in `assistant-storage::conversation_broadcaster` since the
+crate was created.
+
+```text
+crates/storage/src/conversations.rs
+   pub trait ConversationStore         // moved to assistant-core
+   pub struct SqliteConversationStore
+   pub struct InMemoryConversationStore  ← plain pub, no gate
+
+crates/storage/src/message_bus.rs
+   pub struct SqliteMessageBus
+   pub struct InMemoryMessageBus       ← plain pub
+
+crates/llm-provider/src/scripted.rs
+   pub struct ScriptedLlmProvider      ← plain pub, queue-driven
+
+crates/runtime/src/orchestrator/stub.rs
+   pub struct StubOrchestrationEngine  ← plain pub
+   pub struct StubToolDispatcher
+
+crates/core/src/clock.rs
+   pub struct SystemClock
+   pub struct FakeClock                 ← plain pub, alongside SystemClock
+
+crates/test-support/src/
+   prelude.rs    — re-exports of every InMemory/Scripted/Stub/Fake type
+   fixture.rs    — FixtureBuilder + Fixture (~200 LOC)
+```
+
+Why no gates?
+
+- **Workspace-internal, not published.** None of these crates ship to
+  crates.io. The "API surface hiding" argument feature gates exist for
+  doesn't apply.
+- **Linker dead-code-elimination.** Production binaries don't construct
+  these types; LLVM's DCE strips them. The binary-size argument is
+  near-zero.
+- **Cargo complexity disappears.** No `features = ["test-support"]`
+  ceremony in dev-deps. No `#[cfg(any(test, feature = "test-support"))]`
+  noise. Crates that publish in-memory impls don't add `[features]`
+  sections.
+- **Discoverability wins.** Reading `crates/storage/src/conversations.rs`
+  shows trait + Sqlite impl + InMemory impl in one file. Adding a method
+  to the trait forces the compiler to fail until both impls update.
+- **Pattern already established.** `InMemoryConversationBroadcaster`,
+  the four real `LlmProvider` impls, all already work this way. The
+  proposal is making the implicit pattern explicit.
+
+The risk — production code accidentally constructing a test-only impl —
+is real but small. It is addressed by a workspace lint
+(`tests/workspace_test_impls_in_prod.rs`) that fails the build when
+`InMemory*`, `Scripted*`, or `Stub*` types appear in non-test production
+code. Same enforcement pattern as the `workspace_clock_lint` and
+`workspace_http_client_lint` tests proposed elsewhere in this change.
+
+#### Naming conventions
+
+| Convention            | Use case                                                                   | Example                                                                              |
+| --------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `Sqlite<TraitName>`   | SQLite-backed production impl                                              | `SqliteConversationStore`                                                            |
+| `InMemory<TraitName>` | In-memory impl; test-only OR production fallback (docs disambiguate)       | `InMemoryConversationStore`, `InMemoryConversationBroadcaster` (production fallback) |
+| `Scripted<TraitName>` | Queue-driven impl; real `LlmProvider` for canned responses                 | `ScriptedLlmProvider`                                                                |
+| `Stub<TraitName>`     | Test-only stand-in for trait facades with no plausible production semantic | `StubOrchestrationEngine`, `StubToolDispatcher`                                      |
+| `Fake<TraitName>`     | Reserved; used sparingly when nothing above fits                           | `FakeClock` (by convention)                                                          |
+
+The convention is intentional about the rename: today's draft used
+`FakeLlmProvider` and `FakeOrchestrationEngine`. The renames
+(`ScriptedLlmProvider`, `StubOrchestrationEngine`) clarify intent:
+`ScriptedLlmProvider` is a legitimate `LlmProvider` impl useful for
+demo mode and offline mode, not just tests; `StubOrchestrationEngine`
+is honestly a test-only stand-in. `FakeClock` stays because the
+"FakeClock" naming is widely understood in the testing community.
+
+### D2.7: `assistant-test-support` is a thin composition layer
+
+With in-memory impls living next to their trait owners, the
+`assistant-test-support` crate becomes much smaller — essentially:
+
+```text
+crates/test-support/
+   src/
+     lib.rs       — re-exports the prelude
+     prelude.rs   — `pub use assistant_storage::InMemoryConversationStore;`
+                     `pub use assistant_runtime::StubOrchestrationEngine;`
+                     `pub use assistant_llm_provider::ScriptedLlmProvider;`
+                     `pub use assistant_core::clock::FakeClock;`
+                     ... (one line per fake)
+     fixture.rs   — FixtureBuilder + Fixture
+   Cargo.toml     — depends on assistant-core, assistant-storage,
+                    assistant-runtime, assistant-llm-provider,
+                    assistant-tool-executor (for StubToolDispatcher)
+                    — these are normal [dependencies], NOT features.
+```
+
+The crate has **only `[dev-dependencies]` edges from consumers**
+(`assistant-web-ui`, `assistant-runtime` tests, `assistant-interfaces`
+tests, etc.). Production binaries never link `assistant-test-support`
+because no production code path imports it.
+
+Total size: roughly 200–300 LOC of `FixtureBuilder` + a `prelude.rs`
+that's almost entirely re-exports.
+
+### D2.8: Contract tests run every implementation of a trait
+
+Each persistence trait has a contract test under
+`crates/storage/tests/contract/<trait>.rs`. The test is parameterized
+over implementations using `test_case` or a hand-rolled
+`#[tokio::test]` matrix:
+
+```rust
+async fn create_and_load<S: ConversationStore + 'static>(store: S) {
+    let conv = store.create("Hi").await.unwrap();
+    let loaded = store.get(conv.id).await.unwrap().unwrap();
+    assert_eq!(loaded.title, Some("Hi".into()));
+}
+
+#[tokio::test]
+async fn sqlite_create_and_load() {
+    let storage = StorageLayer::new_in_memory().await.unwrap();
+    create_and_load(SqliteConversationStore::new(storage.pool)).await;
+}
+
+#[tokio::test]
+async fn memory_create_and_load() {
+    create_and_load(InMemoryConversationStore::new()).await;
+}
+```
+
+Adding a new impl requires only registering it in the matrix; no
+contract scenario is duplicated. Both impls live in `assistant-storage`,
+so the contract test does not need to import `assistant-test-support`.
+
+### D3: `Clock` trait with `SystemClock` and `FakeClock`
+
+```rust
+// assistant-core::clock
+pub trait Clock: Send + Sync {
+    fn now(&self) -> DateTime<Utc>;
+    fn now_instant(&self) -> Instant;
+}
+
+pub struct SystemClock;       // wraps Utc::now() / Instant::now()
+pub struct FakeClock { /* RwLock<DateTime<Utc>> */ }  // test-only seam
+```
+
+Adoption is gradual. Production code threads `Arc<dyn Clock>` through
+constructors. The `FakeClock` lives behind `#[cfg(test)]` re-exports so
+non-test code cannot accidentally use it.
+
+The 92 call sites are rolled forward in order of safety impact:
+JWT expiry → device-code TTL → scheduler firing → retry backoff → everything
+else. Each rollout PR converts one crate at a time so reviews stay small.
+
+### D4: HTTP client injection contract
+
+Any type that issues outbound HTTP MUST:
+
+- accept a `reqwest::Client` (or a thin abstraction over it) at construction;
+- expose a `with_base_url(...)` builder so tests can point it at a
+  `wiremock::MockServer`;
+- never call `reqwest::Client::new()` inside method bodies.
+
+The constructor-injection rule applies to `workflow-http::HttpRequestActionExecutor`,
+`assistant-web-ui::push::WebPushClient`, `assistant-interfaces::nextcloud::{adapter,tools}`,
+`assistant-interfaces::matrix::client::MatrixClient`, `assistant-auth::oidc::OidcProvider`,
+`assistant-interface-cli::cmd_login` flow types.
+
+### D5: Pure dispatch functions in messenger `runner.rs`
+
+Each messenger runner currently looks like:
+
+```rust
+loop {
+    let msg = ws.next().await?;
+    match decode(msg) {
+        Event::Message { channel, text, .. } => {
+            // 50 lines of orchestrator + storage + reaction dispatch
+        }
+        Event::Reaction { .. } => { /* ... */ }
+    }
+}
+```
+
+The refactor extracts the inner match arms into:
+
+```rust
+async fn handle_event(
+    event: SlackEvent,
+    deps: &SlackRunnerDeps,  // bundles orchestrator, storage, api client, clock
+) -> Result<RunnerAction>;
+```
+
+`handle_event` is pure given its dependencies — it takes serde-deserialized
+events, returns either a side-effect description (`RunnerAction::ReplyInThread`,
+`AddReaction`, `NoOp`) or executes through the injected trait facades. Unit
+tests construct fixture events with `serde_json::json!` and assert the
+returned action; the WebSocket loop itself stays untested by design.
+
+### D6: `a2a-json-schema` excluded from the floor
+
+The crate is largely `serde`-derived structs mirroring the A2A JSON schema.
+Coverage targets on generated/typed code are meaningless. Exclude it from
+the gate; if hand-written logic grows there, re-evaluate.
+
+### D7: Phased rollout, ratchet by crate dependency order
+
+Coverage debt is paid in dependency order so each crate's tests cover the
+trait facades the next crate up depends on:
+
+```
+core            ┐
+auth            ├── infrastructure
+storage         │
+clock+http      ┘
+───────────────────────────────────
+llm-provider    ┐
+tool-executor   ├── platform
+skills          │
+runtime         ┘
+───────────────────────────────────
+mcp-server      ┐
+mcp-client      │
+interfaces      ├── edge
+web-ui          │
+interface-cli   ┘
+```
+
+The gate is added in **report-only mode** first (CI prints coverage but does
+not fail). It flips to **enforce** only after each crate is independently
+green. This lets crates be promoted one at a time without a flag-day.
+
+### D8: Coverage measurement excludes generated code
+
+`build.rs`-generated files, `#[derive(...)]`-expanded code, and `*.pb.rs`
+artifacts are excluded via `coverage.toml`. Hand-written code remains in scope.
+
+## Risks / Trade-offs
+
+- **R1: Trait facades add indirection.** Mitigated by keeping facades small
+  and `pub(crate)` consumption paths intact. Concrete types keep their
+  full surface.
+- **R2: Clock injection threads a parameter through many constructors.**
+  Mitigated by phased rollout (one crate at a time) and by defaulting
+  `Clock` to `SystemClock` via `Default` on builder types when possible.
+- **R3: 80% is a hard line; some crates may need /\* coverage: off \*/ pragmas
+  for genuinely unreachable code.** llvm-cov supports `#[coverage(off)]`
+  attributes; allowed sparingly and reviewed in PR.
+- **R4: CI time grows.** Coverage runs `cargo test` under instrumentation
+  which is ~2× slower. Run only on PRs to `main` and nightly, not on every
+  push. Cache `~/.cargo` aggressively.
+- **R5: Per-crate gate may pin floor at 80% and discourage further gains.**
+  Document that the gate is a floor, not a target. Track median and 90th
+  percentile in the coverage badge.
+
+## Migration Plan
+
+See `tasks.md` for the full task breakdown. The high-level order:
+
+1. Land coverage infra (`make coverage`, CI in report-only mode).
+2. Land `Clock` trait + `SystemClock` + `FakeClock`. Roll into `assistant-auth`
+   first (highest correctness leverage on JWT/device-code TTL).
+3. Land trait facades in `assistant-core`. Adopt in `mcp-server` first
+   (smallest crate, biggest coverage uplift).
+4. Land HTTP client injection. Adopt in `workflow-http` first (smallest crate,
+   trivially testable once injected).
+5. Per-crate coverage-debt sprints, dependency order from D7.
+6. Flip CI gate to enforce, one crate at a time. Each crate becomes a
+   tripwire — a regression below 80% fails the build for that crate.
+
+## Open Questions
+
+- Should `assistant-runtime`'s integration tests at
+  `crates/runtime/src/orchestrator/tests/*.rs` count toward `runtime`'s
+  coverage, or move to `tests/` directory? llvm-cov treats both as
+  `runtime`'s tests, so the answer is mostly cosmetic. Default: leave as-is.
+- Do we want a Flutter coverage gate too? Out of scope here; can be a
+  follow-up with `lcov` from `flutter test --coverage`.
+- Should the gate be 80% on day one, or step up from each crate's current
+  number? Stepping up is more humane but adds long-running state to CI.
+  Default: 80% hard floor, but in **enforce** mode only after the crate
+  is green once.

--- a/openspec/changes/workspace-test-coverage-floor/proposal.md
+++ b/openspec/changes/workspace-test-coverage-floor/proposal.md
@@ -1,0 +1,68 @@
+## Why
+
+A workspace audit (2026-05-17) found test density is uneven and the bottom of the distribution is driven by structural untestability, not absent intent:
+
+- 2 crates with **0% test coverage** (`mcp-server` 530 LOC, `workflow-http` 232 LOC).
+- 17 production files >200 LOC with **zero inline tests**, including `interface-cli/main.rs` (1002), `web-ui/backends/iceberg.rs` (984), `runtime/orchestrator/dispatch.rs` (418), `tool-executor/builtins/bash.rs` (261).
+- Median crate ratio is ~30% (test LOC / src LOC); only 4 crates exceed 40%.
+- Root causes: load-bearing components (`Orchestrator`, `ToolExecutor`, `SkillRegistry`, `StorageLayer`) are exposed as concrete structs with 20–30 fields, not trait facades. `reqwest::Client::new()`, `Utc::now()`, and `std::env::var` appear in constructors and method bodies across the workspace, leaving no test seams.
+
+Establishing an 80% per-crate **line-coverage floor**, measured by `cargo llvm-cov` and enforced in CI, locks in the discipline. Reaching it requires modest trait-facade refactors first.
+
+## What Changes
+
+- **Adopt `cargo llvm-cov` as the workspace coverage tool**; commit a `coverage.toml` configuration and a `make coverage` target.
+- **Add a per-crate 80% line-coverage gate to CI** (`coverage.yml` workflow). Gate fires per-crate, not per-workspace, so a regression in one crate cannot be hidden by gains elsewhere.
+- **Extract traits for every persistence component still exposed as a concrete struct** (`ConversationStore`, `ConversationEventStore`, `CommandEventStore`, `TraceStore`, `LogStore`, `MetricsStore`, `AttachmentStore`, `AudioStore`, `AgentStore`, `MemoryChunkStore`, `PersonaStore`, `PersonaSkillAccess`, `PushSubscriptionStore`, `RefinementStore`, `ScheduledTasksStore`, `SlackThreadStore`, `WebhookStore`, `WorkflowStore`). Traits live in `assistant-core`; SQLite implementations stay in `assistant-storage` (or their owning domain crate). Consumers above storage take `Arc<dyn StoreTrait>`.
+- **Add in-memory implementations alongside the SQLite ones** in the same crate (typically `assistant-storage`), as plain `pub` types. No `#[cfg(test)]`. No `[features] test-support` gate. They are alternative `Trait` impls — same status as `SqliteConversationStore` or `OllamaProvider` — following the existing pattern set by `InMemoryConversationBroadcaster`.
+- **Add a thin `assistant-test-support` crate** under `[dev-dependencies]` of every consumer. It hosts only `FixtureBuilder` and a `prelude` module that re-exports the in-memory impls + the orchestration stubs + `ScriptedLlmProvider`. The actual fakes live in their owning crates. Production binaries do not link `assistant-test-support`.
+- **Add a workspace lint test** (`tests/workspace_test_impls_in_prod.rs`) that fails the build when types matching `InMemory*`, `Scripted*`, or `Stub*` are constructed in non-test production code paths, with an exempt list for the defining module, `#[cfg(test)]` modules, `tests/` dirs, the `assistant-test-support` crate, and documented production-fallback sites (e.g., `InMemoryConversationBroadcaster`).
+- **Run contract tests per persistence trait**: a single test script under `crates/storage/tests/contract/<trait>.rs` exercises every implementation of the trait (SQLite + in-memory). Drift between impls fails CI.
+- **Introduce trait facades in `assistant-core`** for the load-bearing runtime types currently exposed concretely:
+  - `OrchestrationEngine` (subset of `Orchestrator` actually consumed by `mcp-server`, `web-ui`, `interfaces`)
+  - `ToolDispatcher` (subset of `ToolExecutor`)
+  - `SkillCatalog` (subset of `SkillRegistry`)
+- **Introduce `Clock` trait in `assistant-core`** with `SystemClock` and `FakeClock` implementations. Replace all 92 non-test `Utc::now()` / `SystemTime::now()` calls with injected clocks.
+- **Inject `reqwest::Client` at constructor seams** in `workflow-http`, `web-ui/push`, `nextcloud`, `matrix`, `oidc`, `cmd_login`. Always honor `with_base_url(...)` so `wiremock` can be wired.
+- **Extract pure dispatch functions in each messenger `runner.rs`** (Slack, Mattermost, Matrix, Nextcloud, Signal). The WebSocket / long-poll loop stays I/O-only; payload-to-action logic moves to a pure function unit-testable with `serde_json::json!` fixtures.
+- **Split `interface-cli/main.rs`**: extract subcommand bodies into `cmd_*.rs` files so `main()` is just argument parsing + dispatch. Existing untested subcommands (`cmd_login`, `cmd_account`, `bootstrap`) get inline test modules.
+- **Split `web-ui/backends/iceberg.rs` and `opentelemetry-exporter-iceberg/{span,log,metric}.rs`** to make filtering/aggregation pure functions over `RecordBatch` slices, then add a tiny parquet fixture corpus under `tests/fixtures/warehouse/`.
+
+## Capabilities
+
+### New Capabilities
+
+- `test-coverage-floor` — defines the 80% per-crate line-coverage rule, the `cargo llvm-cov` measurement contract, and the CI enforcement gate.
+- `persistence-trait-symmetry` — defines the rule that every persistence component is exposed as a trait, has at least one in-memory implementation co-located with its SQLite peer as plain `pub` (no feature gate), is reachable to tests via a thin `assistant-test-support` composition crate, and is covered by per-trait contract tests; production misuse is caught by a workspace lint.
+- `orchestration-trait-seams` — defines the `OrchestrationEngine`, `ToolDispatcher`, `SkillCatalog` traits in `assistant-core` and the rule that consumers MUST take the trait, not the concrete type.
+- `clock-abstraction` — defines the `Clock` trait, `SystemClock` + `FakeClock` implementations, and the rule banning direct `Utc::now()` in non-test production code.
+- `http-client-injection` — defines the rule that any type making outbound HTTP calls MUST accept an injected client and a configurable base URL.
+- `messenger-runner-dispatch` — defines the pure-function dispatch contract for messenger runners.
+
+### Modified Capabilities
+
+None. Existing user-facing specs are unchanged.
+
+## Impact
+
+- **Code**: every crate (the floor applies workspace-wide); concrete refactors in `assistant-core` (new trait definitions), `assistant-storage` (each concrete store gets a `Sqlite<Name>` wrapper around the existing struct), `runtime/orchestrator/`, `mcp-server`, `workflow-http`, `interfaces/*/runner.rs`, `interface-cli/main.rs`, `web-ui/backends/iceberg.rs`, `web-ui/oauth/`, `web-ui/a2a/handlers.rs`, all `llm-provider/*`, `auth/jwt.rs`, `auth/oauth2/device.rs`.
+- **New crate**: `assistant-test-support` under `crates/test-support/` (dev-dependency only).
+- **Build**: `cargo llvm-cov` adds ~30 s to local `make test` when run with coverage; CI gains a coverage job (~3–5 min on cold cache). `assistant-test-support` adds compile time only to test builds.
+- **Runtime**: no behavior changes. Trait facades and store traits are added alongside existing concrete types and adopted incrementally.
+- **Tests**: thousands of new LOC. See `tasks.md` for per-crate sequencing; the lowest-coverage crates ship first because they unblock the gate.
+- **Dependencies**: `cargo-llvm-cov` as a dev tool (installed via `cargo install` in CI; not a workspace dependency).
+
+## Non-goals
+
+- Mutation testing or branch-coverage targets (line coverage only for now).
+- Property-based testing adoption (a possible follow-up).
+- Removing `StorageLayer::new_in_memory()` — it stays as the SQLite-backed bootstrap path for `assistant-storage`'s own tests and contract tests; consumers above storage migrate to per-trait in-memory impls but `new_in_memory()` itself is not deleted.
+- Splitting the `interfaces` crate into per-messenger crates (separate change; out of scope here).
+- Splitting `Orchestrator` itself; only its trait facade is added.
+- Splitting `web-ui/api/messages.rs` (2124 LOC) — already passes the 80% bar via test_helpers.
+- Backfilling coverage on `assistant-integration-tests` (it is the integration harness, not a production library).
+- Migrations and pool factory get no in-memory variant; documented as exemptions in the `persistence-trait-symmetry` spec.
+
+## User-facing documentation
+
+**Not required.** This is an internal engineering-discipline change. The only externally visible artifact is a coverage badge in the README; the CI gate is invisible to users.

--- a/openspec/changes/workspace-test-coverage-floor/specs/clock-abstraction/spec.md
+++ b/openspec/changes/workspace-test-coverage-floor/specs/clock-abstraction/spec.md
@@ -1,0 +1,101 @@
+## ADDED Requirements
+
+### Requirement: `Clock` trait in `assistant-core`
+
+`assistant-core` SHALL define a `Clock` trait abstracting wall-clock and
+monotonic time access:
+
+```rust
+pub trait Clock: Send + Sync {
+    fn now(&self) -> chrono::DateTime<chrono::Utc>;
+    fn now_instant(&self) -> std::time::Instant;
+}
+```
+
+`assistant-core` SHALL also export a `SystemClock` implementation that
+wraps `chrono::Utc::now()` and `std::time::Instant::now()` for
+production use.
+
+#### Scenario: production code receives `SystemClock`
+
+- **WHEN** a production binary (CLI, web-ui, MCP server) constructs a
+  component that needs the current time
+- **THEN** it passes `Arc::new(SystemClock) as Arc<dyn Clock>` (or
+  defaults to it via a builder)
+
+### Requirement: `FakeClock` for tests
+
+`assistant-core` SHALL expose a `FakeClock` test helper that allows
+seeding and advancing a virtual time. `FakeClock` SHALL live behind
+`#[cfg(any(test, feature = "test-support"))]` so production binaries
+cannot accidentally depend on it.
+
+`FakeClock` SHALL support:
+
+- construction with a seed `DateTime<Utc>`
+- `advance(Duration)` to move time forward
+- thread-safe read access (interior mutability)
+
+#### Scenario: test seeds and advances time
+
+- **WHEN** a test constructs `FakeClock::new(seed)` and later calls
+  `fake.advance(Duration::from_secs(60))`
+- **THEN** subsequent calls to `fake.now()` return `seed + 60s`
+
+### Requirement: direct `Utc::now()` is banned in non-test production code
+
+Non-test production code under `crates/*/src/` SHALL NOT call
+`chrono::Utc::now()`, `chrono::Local::now()`, or
+`std::time::SystemTime::now()` directly. All current-time reads MUST go
+through an injected `Arc<dyn Clock>`.
+
+Exemptions:
+
+- `assistant-core::clock::SystemClock` — the canonical wrapper.
+- Top-level binary entry points (`main.rs`) when constructing the root
+  `SystemClock` instance.
+
+#### Scenario: workspace lint test enforces the ban
+
+- **WHEN** `cargo test -p assistant tests::workspace_clock_lint` runs
+- **THEN** the test greps all non-test `.rs` files in `crates/*/src/`
+  for `Utc::now\(\)` / `SystemTime::now\(\)` and fails if any match
+  occurs outside the exempt paths
+
+#### Scenario: test code is allowed to call `Utc::now()`
+
+- **WHEN** a `#[cfg(test)] mod tests` or a `tests/*.rs` file calls
+  `Utc::now()` directly
+- **THEN** the workspace lint test ignores the call (test code is
+  exempt)
+
+### Requirement: time-sensitive components accept `Arc<dyn Clock>`
+
+The following components SHALL accept `Arc<dyn Clock>` at construction:
+
+- `assistant_auth::jwt::JwtManager` (token issuance + expiry checks).
+- `assistant_auth::oauth2::device::DeviceCodeManager` (device-code TTL).
+- `assistant_auth::api_keys` lifecycle (`expires_at`, `last_used_at`).
+- `assistant_runtime::scheduler::Scheduler` (firing decisions).
+- `assistant_runtime::title_generator::TitleGeneratorWorker` (debounce).
+- `assistant_runtime::memory_indexer` (indexing cadence).
+- `assistant_runtime::compaction` (eviction timestamps).
+- `assistant_llm_provider::retry` (backoff between attempts).
+- `assistant_storage::conversation_events`, `traces`, `metrics` (row
+  timestamps).
+- `assistant_bus_nats` (heartbeat / TTL).
+
+Each component SHALL provide a constructor that defaults to
+`SystemClock` so production call sites do not need to change.
+
+#### Scenario: JWT expiry verification under FakeClock
+
+- **WHEN** a JWT is issued with `JwtManager::new_with_clock(fake_clock, ...)`
+  at `t = 0` with expiry `60s`, and `fake_clock.advance(Duration::from_secs(61))`
+- **THEN** verification of that JWT fails with the expired-token error
+
+#### Scenario: scheduler fires under FakeClock
+
+- **WHEN** a scheduler is configured with a task at `t = 60s` and the
+  test advances the fake clock to `t = 60s`
+- **THEN** the scheduler dispatches the task on its next tick

--- a/openspec/changes/workspace-test-coverage-floor/specs/http-client-injection/spec.md
+++ b/openspec/changes/workspace-test-coverage-floor/specs/http-client-injection/spec.md
@@ -1,0 +1,82 @@
+## ADDED Requirements
+
+### Requirement: outbound HTTP types accept an injected `reqwest::Client`
+
+Any type that issues outbound HTTP requests SHALL accept a
+`reqwest::Client` at construction time. The type MUST NOT call
+`reqwest::Client::new()` (or `reqwest::Client::builder().build()`)
+inside method bodies or trait-method implementations.
+
+In-scope types include but are not limited to:
+
+- `assistant_workflow_http::HttpRequestActionExecutor`
+- `assistant_web_ui::push::WebPushClient`
+- `assistant_interfaces::nextcloud::adapter::NextcloudAdapter` and
+  `assistant_interfaces::nextcloud::tools::*`
+- `assistant_interfaces::matrix::client::MatrixClient`
+- `assistant_interfaces::slack::client::SlackApiClient`
+- `assistant_interfaces::mattermost::client::*`
+- `assistant_interfaces::signal::client::*`
+- `assistant_auth::oidc::OidcProvider`
+- `assistant_llm_provider::*` providers
+- `assistant_interface_cli::cmd_login` flow types
+
+#### Scenario: constructor accepts a client
+
+- **WHEN** an in-scope type is constructed
+- **THEN** its primary constructor accepts a `reqwest::Client` (or a
+  thin abstraction over it) as a parameter, or provides a
+  `with_client(client, ...)` builder alongside any zero-argument
+  convenience constructor
+
+#### Scenario: method bodies do not construct clients
+
+- **WHEN** any method on an in-scope type is invoked
+- **THEN** the method uses `self.client` (or equivalent injected
+  field) and does not instantiate a new `reqwest::Client`
+
+### Requirement: configurable base URL for `wiremock` redirection
+
+Any type that issues outbound HTTP to a fixed third-party host SHALL
+expose a `with_base_url(...)` (or equivalent) builder so tests can
+redirect traffic to a `wiremock::MockServer`. Hard-coded host strings
+inside method bodies are forbidden.
+
+#### Scenario: test redirects traffic to wiremock
+
+- **WHEN** a test constructs an in-scope HTTP client with
+  `Type::with_base_url(mock_server.uri())`
+- **THEN** all subsequent HTTP calls from that instance target the
+  mock server, allowing the test to assert request shape and inject
+  mock responses
+
+### Requirement: workspace lint enforces no in-method client construction
+
+A `tests/workspace_http_client_lint.rs` integration test SHALL fail
+the build when `reqwest::Client::new()` or
+`reqwest::Client::builder()` appears in non-test code outside of:
+
+- a constructor / `Default` impl
+- a top-level binary entry point (`main.rs`)
+- a documented `new_with_default_client(...)` helper
+
+#### Scenario: lint catches in-method construction
+
+- **WHEN** a contributor adds `let client = reqwest::Client::new();`
+  to a method body in `crates/*/src/`
+- **THEN** `cargo test -p assistant tests::workspace_http_client_lint`
+  fails with a message naming the file and line
+
+### Requirement: existing constructors remain back-compatible
+
+The injection refactor SHALL preserve existing zero-argument
+constructors via convenience wrappers that build a default
+`reqwest::Client` internally. Production call sites do not need
+to change unless they explicitly want to inject a custom client.
+
+#### Scenario: existing `new()` still works
+
+- **WHEN** existing production code calls `Type::new(...)` without
+  passing a client
+- **THEN** the call compiles and uses a default `reqwest::Client`
+  internally

--- a/openspec/changes/workspace-test-coverage-floor/specs/messenger-runner-dispatch/spec.md
+++ b/openspec/changes/workspace-test-coverage-floor/specs/messenger-runner-dispatch/spec.md
@@ -1,0 +1,94 @@
+## ADDED Requirements
+
+### Requirement: messenger runners separate I/O from dispatch
+
+Messenger interface adapters SHALL separate their WebSocket / long-poll I/O loop from their per-event dispatch logic. This applies to every messenger under `crates/interfaces/src/{slack, mattermost, matrix, nextcloud, signal}/`.
+
+The I/O loop (`runner.rs`) SHALL be limited to:
+
+- opening and maintaining the transport (WebSocket, long-poll cursor).
+- decoding raw frames into typed event enums.
+- forwarding each event to the dispatch function.
+- handling reconnect / backoff.
+
+The dispatch function (`dispatch.rs`, or a sibling module) SHALL be a
+pure-ish async function with the shape:
+
+```rust
+pub async fn handle_event(
+    event: <Messenger>Event,
+    deps: &<Messenger>RunnerDeps,
+) -> anyhow::Result<RunnerAction>;
+```
+
+where `<Messenger>RunnerDeps` bundles the trait-typed dependencies
+(`Arc<dyn OrchestrationEngine>`, `Arc<dyn Clock>`, the messenger's
+HTTP client, storage handles, etc.).
+
+#### Scenario: dispatch function is unit-testable
+
+- **WHEN** a test fixture constructs `<Messenger>Event` from a
+  `serde_json::json!` payload, builds a `<Messenger>RunnerDeps`
+  carrying hand-rolled fakes, and calls `handle_event`
+- **THEN** the function returns a `RunnerAction` (or executes
+  through the fakes) that the test can assert without opening a
+  real WebSocket
+
+#### Scenario: I/O loop stays slim
+
+- **WHEN** the runner's WebSocket loop is inspected
+- **THEN** all decoded events are dispatched via the `handle_event`
+  function; per-event business logic (orchestrator invocation,
+  reaction posting, attachment upload) does not appear inline in
+  the loop
+
+### Requirement: `RunnerAction` describes side effects declaratively
+
+Each messenger module SHALL define a `RunnerAction` enum that
+describes the side effects produced by a single dispatch invocation:
+
+- `NoOp` — the event was ignored (e.g., bot author, channel not allowed).
+- `Reply { ... }` — post a message in a channel/thread.
+- `Reaction { ... }` — add or remove an emoji reaction.
+- `UploadAttachment { ... }` — upload bytes to the messenger.
+- platform-specific variants as needed.
+
+Dispatch tests SHALL assert on `RunnerAction` rather than on the
+side effect's HTTP request. Side-effect execution itself MAY be
+exercised by a separate, smaller set of integration tests that use
+`wiremock`.
+
+#### Scenario: dispatch test asserts on action
+
+- **WHEN** a unit test runs `handle_event(SlackEvent::Message { ... })`
+- **THEN** it asserts `result == RunnerAction::Reply { channel, text, ... }`
+  rather than asserting on an outbound HTTP request
+
+### Requirement: bot-author filter and channel allowlist are unit-tested
+
+The dispatch function SHALL exercise the following guards inside
+`handle_event` and SHALL be unit-tested for each:
+
+- the event author is the bot itself → `RunnerAction::NoOp`.
+- the channel is not on the per-messenger allowlist → `NoOp`.
+- the event is a thread reply to a thread the assistant did not
+  initiate → `NoOp` (or platform-specific behavior).
+- the event is a duplicate (already-seen `event_id`) → `NoOp`.
+
+#### Scenario: bot loop is prevented
+
+- **WHEN** a test constructs an event whose author equals the bot
+  user id stored in `RunnerDeps`
+- **THEN** `handle_event` returns `RunnerAction::NoOp` and does not
+  invoke the orchestrator fake
+
+### Requirement: CLI REPL applies the same pattern
+
+The CLI REPL SHALL separate its input loop from its per-command dispatch. A `dispatch_command(cmd, deps)` function SHALL handle each command's logic in `crates/interface-cli/src/main.rs` and SHALL be unit-tested for each `Command` variant.
+
+#### Scenario: CLI subcommand is unit-testable
+
+- **WHEN** a test calls `dispatch_command(Command::Persona { ... },
+deps)`
+- **THEN** the test can assert on the resulting state without
+  spawning a child process or reading from stdin

--- a/openspec/changes/workspace-test-coverage-floor/specs/orchestration-trait-seams/spec.md
+++ b/openspec/changes/workspace-test-coverage-floor/specs/orchestration-trait-seams/spec.md
@@ -1,0 +1,79 @@
+## ADDED Requirements
+
+### Requirement: trait facades for load-bearing types live in `assistant-core`
+
+The `assistant-core` crate SHALL define trait facades for the workspace's
+load-bearing concrete types:
+
+- `OrchestrationEngine` — the subset of `assistant_runtime::Orchestrator`
+  consumed by external callers (`assistant-mcp-server`, `assistant-web-ui`,
+  `assistant-interfaces`).
+- `ToolDispatcher` — the subset of `assistant_tool_executor::ToolExecutor`
+  consumed by external callers.
+- `SkillCatalog` — the subset of `assistant_storage::SkillRegistry`
+  consumed by external callers.
+
+The trait surface SHALL contain only the methods external callers
+actually use. New trait methods MUST be added when a new consumer
+requires them; the concrete struct surface is not the source of truth.
+
+#### Scenario: trait facade method surface
+
+- **WHEN** an external caller (`mcp-server`, `web-ui`, `interfaces`)
+  needs a method on `Orchestrator`/`ToolExecutor`/`SkillRegistry`
+- **THEN** the method is exposed on the corresponding trait in
+  `assistant-core`, and the consumer takes `Arc<dyn Trait>` rather
+  than `Arc<Concrete>`
+
+#### Scenario: trait facade lives in core
+
+- **WHEN** a developer searches for the `OrchestrationEngine` definition
+- **THEN** it is found in `crates/core/src/orchestration.rs` (or
+  similar), not in `crates/runtime/`
+
+### Requirement: consumers depend on the trait, not the concrete type
+
+Consumers of orchestration, tool dispatch, or skill catalog functionality SHALL declare dependencies in terms of the `assistant-core` traits, not the concrete types. The exception is `assistant-runtime` itself (which defines and owns the concrete `Orchestrator`).
+
+#### Scenario: mcp-server takes the trait
+
+- **WHEN** `assistant-mcp-server` exposes `handle_request`
+- **THEN** its signature accepts `Arc<dyn OrchestrationEngine>`,
+  `Arc<dyn ToolDispatcher>`, `Arc<dyn SkillCatalog>` — never the
+  concrete types
+
+#### Scenario: web-ui takes the trait
+
+- **WHEN** `assistant-web-ui::ApiState` is constructed
+- **THEN** its orchestrator field is typed `Arc<dyn OrchestrationEngine>`
+
+#### Scenario: messenger adapter takes the trait
+
+- **WHEN** an adapter in `assistant-interfaces` is constructed
+- **THEN** its orchestrator handle is typed `Arc<dyn OrchestrationEngine>`
+
+### Requirement: concrete types still implement the trait
+
+Concrete types `Orchestrator`, `ToolExecutor`, and `SkillRegistry` SHALL implement their respective trait facades. Adoption is additive — the concrete struct fields and method surface are not changed by this spec.
+
+#### Scenario: Orchestrator implements OrchestrationEngine
+
+- **WHEN** `crates/runtime/src/orchestrator/mod.rs` is inspected
+- **THEN** an `impl OrchestrationEngine for Orchestrator { ... }` block
+  exists alongside the existing `impl Orchestrator { ... }` blocks
+
+### Requirement: tests use hand-rolled fakes against the trait
+
+Unit tests for code that consumes the trait facades SHALL construct
+hand-rolled fakes (test-only structs implementing the trait) rather
+than booting a real `Orchestrator`/`ToolExecutor`/`SkillRegistry`.
+This rule unblocks coverage for `mcp-server`, messenger runner
+dispatch, and `web-ui` handlers without dragging the full runtime
+into each test.
+
+#### Scenario: mcp-server unit test
+
+- **WHEN** `crates/mcp-server/tests/dispatch.rs` runs `handle_request`
+- **THEN** the test constructs `FakeOrchestrationEngine`,
+  `FakeToolDispatcher`, `FakeSkillCatalog` instances; it MUST NOT
+  construct a real `Orchestrator`

--- a/openspec/changes/workspace-test-coverage-floor/specs/persistence-trait-symmetry/spec.md
+++ b/openspec/changes/workspace-test-coverage-floor/specs/persistence-trait-symmetry/spec.md
@@ -1,0 +1,185 @@
+## ADDED Requirements
+
+### Requirement: persistence components are defined as traits
+
+Persistence components SHALL be exposed as traits owned by `assistant-core` (or, when domain-specific, by the domain crate). Concrete backend implementations SHALL live in the implementing crate. Consumers SHALL depend on the trait, never on the concrete struct.
+
+In-scope persistence components include the following stores currently exposed as concrete structs:
+
+- `ConversationStore`
+- `ConversationEventStore`
+- `CommandEventStore`
+- `TraceStore`
+- `LogStore`
+- `MetricsStore`
+- `AttachmentStore`
+- `AudioStore`
+- `AgentStore`
+- `MemoryChunkStore`
+- `PersonaStore`
+- `PersonaSkillAccess`
+- `PushSubscriptionStore`
+- `RefinementStore`
+- `ScheduledTasksStore`
+- `SlackThreadStore`
+- `WebhookStore`
+- `WorkflowStore`
+- `SkillRegistry` (read-side; `SkillCatalog` trait already proposed in `orchestration-trait-seams`)
+
+#### Scenario: trait extraction for ConversationStore
+
+- **WHEN** `assistant-core` is inspected
+- **THEN** a `pub trait ConversationStore: Send + Sync` exists defining the methods consumers use (`create`, `get`, `list`, `update_title`, `mark_locked`, etc.)
+- **AND** `crates/storage/src/conversations.rs` provides `pub struct SqliteConversationStore` implementing the trait
+- **AND** consumers in `assistant-runtime`, `assistant-web-ui`, and `assistant-interfaces` accept `Arc<dyn ConversationStore>`, not the concrete struct
+
+#### Scenario: consumer signature uses the trait
+
+- **WHEN** a public function or struct field in any crate above `assistant-storage` holds a reference to a persistence component
+- **THEN** the type is `Arc<dyn StoreTrait>` (or `&dyn StoreTrait`), never `Arc<SqliteConcreteStore>`
+
+### Requirement: every persistence trait has an in-memory implementation
+
+Each persistence trait listed above SHALL have an in-memory implementation living in the same crate as the SQLite implementation, typically as a sibling module or in the same file. The in-memory implementations SHALL be plain `pub` types, NOT gated behind `#[cfg(test)]` or a Cargo feature. They are alternative implementations of the trait — the same status as `SqliteConversationStore` — and follow the existing pattern set by `InMemoryConversationBroadcaster`, `OllamaProvider`, `AnthropicProvider`, etc.
+
+The in-memory implementation SHALL:
+
+- honor the trait contract for all non-exempt scenarios (see "Documented exemptions" below)
+- enforce obvious referential cascades in code (e.g., deleting a conversation deletes its messages)
+- preserve atomicity guarantees the trait requires (via internal `Mutex` / `RwLock`)
+- avoid disk I/O entirely (no `tempfile`, no `std::fs`)
+- live next to the SQLite implementation: `crates/storage/src/conversations.rs` holds both `SqliteConversationStore` and `InMemoryConversationStore`
+
+#### Scenario: InMemoryConversationStore satisfies the contract
+
+- **WHEN** a test constructs `assistant_storage::InMemoryConversationStore::new()`
+- **THEN** the value implements `assistant_core::ConversationStore`
+- **AND** all `ConversationStore` contract test scenarios pass against it
+
+#### Scenario: in-memory impl ships ungated
+
+- **WHEN** `crates/storage/Cargo.toml` is inspected
+- **THEN** there is no `[features] test-support = []` entry covering the in-memory impls
+- **AND** consumers MAY import `InMemoryConversationStore` from `assistant_storage` directly without enabling any feature
+
+#### Scenario: upstream consumer test uses the in-memory impl
+
+- **WHEN** a `crates/runtime` or `crates/web-ui` unit test needs persistence
+- **THEN** it MAY use `Arc::new(InMemoryConversationStore::new())` instead of booting `StorageLayer::new_in_memory()`
+- **AND** the test does not depend on SQLite migrations being current
+
+### Requirement: workspace lint forbids test-only impls in production code
+
+A `tests/workspace_test_impls_in_prod.rs` integration test SHALL fail compilation when test-only implementations (types named `InMemory*Store`, `InMemoryMessageBus`, `InMemorySkillCatalog`, `ScriptedLlmProvider`, `StubOrchestrationEngine`, `StubToolDispatcher`) are constructed in non-test production code paths.
+
+Exempt paths:
+
+- the defining module itself (the file containing the type's `impl` block)
+- `#[cfg(test)]` modules anywhere in the workspace
+- files under any `tests/` directory
+- the `assistant-test-support` crate's `FixtureBuilder`
+- top-level production fallback constructions documented in module-level docs (e.g., `InMemoryConversationBroadcaster` used when no external broadcaster is configured)
+
+#### Scenario: lint catches accidental production use
+
+- **WHEN** a contributor adds `let store = InMemoryConversationStore::new();` to a production `fn main()` or to a non-test method on a production struct
+- **THEN** `cargo test -p assistant tests::workspace_test_impls_in_prod` fails with a message naming the file and line
+
+#### Scenario: lint allows fixture builder
+
+- **WHEN** `assistant-test-support::FixtureBuilder` constructs `InMemoryConversationStore`
+- **THEN** the lint passes — the test-support crate is on the exempt list
+
+### Requirement: `assistant-test-support` crate hosts composition helpers
+
+A workspace crate `assistant-test-support` SHALL host cross-cutting test helpers that compose pieces from multiple crates:
+
+- `FixtureBuilder` — wires `Arc<dyn OrchestrationEngine>` (from `assistant-runtime`'s stub), `Arc<dyn LlmProvider>` (from `assistant-llm-provider`'s `ScriptedLlmProvider`), in-memory stores (from `assistant-storage`), `Arc<dyn Clock>` (from `assistant-core::FakeClock`), and default config.
+- `prelude` module — single-import re-exports of the most-used fakes and in-memory impls so test files have one `use` line.
+- helper macros for common assertion patterns (`assert_recorded_llm_call!`, `assert_persisted_message!`).
+
+The crate SHALL be added as a `[dev-dependencies]` of every crate that uses `FixtureBuilder` in tests; it SHALL NOT appear in any crate's `[dependencies]` section. The in-memory impls and fakes themselves do NOT live in this crate — they live next to their trait implementations in the owning crates.
+
+The crate's `Cargo.toml` SHALL declare panic-free lint policy at the workspace baseline (`warn`), not `deny` — `.unwrap()` is ergonomic in test helpers.
+
+#### Scenario: production binary excludes test-support
+
+- **WHEN** `cargo build --release -p assistant-cli` is run
+- **THEN** `assistant-test-support` does not appear in the resulting binary's dependency closure
+
+#### Scenario: test depends on test-support as dev-dep
+
+- **WHEN** `crates/web-ui/Cargo.toml` is inspected
+- **THEN** `assistant-test-support` appears under `[dev-dependencies]`, not `[dependencies]`
+
+#### Scenario: prelude consolidates imports
+
+- **WHEN** a test file imports `use assistant_test_support::prelude::*;`
+- **THEN** `InMemoryConversationStore`, `InMemoryMessageBus`, `ScriptedLlmProvider`, `StubOrchestrationEngine`, `FakeClock`, `FixtureBuilder` are all in scope
+
+### Requirement: contract tests run every implementation of a trait
+
+For every persistence trait covered by this spec, a contract test SHALL exist under `crates/storage/tests/contract/<trait_name>.rs` that runs the same test script against every implementation of the trait (SQLite-backed and in-memory). The contract test SHALL be parameterized so that adding a new implementation requires only registering it in the matrix.
+
+#### Scenario: contract test matrix runs both impls
+
+- **WHEN** `cargo test -p assistant-storage --test contract` is run
+- **THEN** each contract scenario executes against `SqliteConversationStore` and `InMemoryConversationStore`
+- **AND** any divergence in observable behavior (return values, error variants, ordering) fails the test
+
+#### Scenario: new impl joins the matrix
+
+- **WHEN** a contributor adds a third implementation of `ConversationStore`
+- **THEN** registering it in the contract test matrix is the only edit needed; no contract scenario is duplicated
+
+### Requirement: documented exemptions
+
+Some persistence concerns SHALL be exempt from the in-memory-variant requirement because they are SQLite-specific by nature:
+
+- `crates/storage/src/migration.rs` — schema migration logic.
+- `crates/storage/src/pool_factory.rs` — SQLite connection pool factory.
+- `OrgStorageLayer` SQLite-coupled bootstrap methods (e.g., schema initialization).
+- FTS-specific query paths on `MemoryChunkStore` — the trait's `search_fts` method's _ranking_ behavior is SQLite-specific. The in-memory impl SHALL provide a naive substring scan that satisfies the trait contract but is not expected to match SQLite's BM25 ranking.
+
+Each exemption SHALL be documented in module-level docs of the exempt code and noted in the contract test as a `// EXEMPT: ...` annotation.
+
+#### Scenario: contract test annotates an exemption
+
+- **WHEN** a contract test scenario does not apply to the in-memory impl
+- **THEN** the scenario is annotated `// EXEMPT: <reason>` and the in-memory impl is skipped for that scenario only — not the entire trait
+
+### Requirement: naming conventions distinguish impl roles
+
+Implementation names SHALL follow these conventions:
+
+- `Sqlite<TraitName>` — SQLite-backed production impl.
+- `InMemory<TraitName>` — in-memory impl. Applies whether the impl is test-only or also serves as a production fallback. Disambiguation comes from module docs, not naming.
+- `Scripted<TraitName>` — for non-persistence traits where the in-memory variant is driven by a pre-loaded queue (e.g., `ScriptedLlmProvider`).
+- `Stub<TraitName>` — for trait facades where there is no plausible production semantic, only a test-only stand-in (e.g., `StubOrchestrationEngine`, `StubToolDispatcher`).
+- `Fake<TraitName>` — reserved for cases where neither "InMemory", "Scripted", nor "Stub" fits, used sparingly. `FakeClock` falls in this category by convention.
+
+#### Scenario: ScriptedLlmProvider naming
+
+- **WHEN** `crates/llm-provider/src/scripted.rs` is inspected
+- **THEN** it defines `pub struct ScriptedLlmProvider` with a queue-driven `chat` and `chat_stream` impl
+- **AND** the type is not named `FakeLlmProvider` — it is a legitimate `LlmProvider` impl with real use cases (demo mode, offline mode, contract tests)
+
+#### Scenario: StubOrchestrationEngine naming
+
+- **WHEN** `crates/runtime/src/orchestrator/stub.rs` is inspected
+- **THEN** it defines `pub struct StubOrchestrationEngine` whose `submit_turn` returns canned `TurnResult` values and records inputs
+- **AND** the naming signals "test-only stand-in", distinct from a real orchestrator
+
+### Requirement: `FixtureBuilder` composes the common test scaffold
+
+`assistant-test-support` SHALL expose a `FixtureBuilder` that wires the common test scaffold — in-memory stores, `ScriptedLlmProvider`, `InMemoryMessageBus`, `FakeClock`, default config — with sensible defaults and per-field overrides. Tests SHALL be able to construct a complete test environment in a single chained-builder expression.
+
+#### Scenario: minimal fixture construction
+
+- **WHEN** a test calls `assistant_test_support::FixtureBuilder::new().build().await`
+- **THEN** the returned `Fixture` carries an `Arc<dyn OrchestrationEngine>` wired to a `ScriptedLlmProvider`, an `InMemoryMessageBus`, in-memory store implementations, and a `FakeClock` seeded to a deterministic timestamp
+
+#### Scenario: per-field override
+
+- **WHEN** a test calls `FixtureBuilder::new().with_clock(custom_fake_clock).with_canned_llm_responses(vec![...]).build().await`
+- **THEN** the returned fixture uses the supplied clock and LLM response queue, with all other fields defaulted

--- a/openspec/changes/workspace-test-coverage-floor/specs/test-coverage-floor/spec.md
+++ b/openspec/changes/workspace-test-coverage-floor/specs/test-coverage-floor/spec.md
@@ -1,0 +1,91 @@
+## ADDED Requirements
+
+### Requirement: per-crate line-coverage floor
+
+Every crate in the workspace SHALL maintain `>= 80%` line coverage as
+measured by `cargo llvm-cov --workspace --json` per-package. The floor
+applies to all production crates; the exclusions are documented in
+`coverage.toml`.
+
+Excluded crates (initial set):
+
+- `assistant-integration-tests` — contains no production library code
+  (its `src/lib.rs` is a stub for shared test helpers).
+- `assistant-a2a-json-schema` — generated `serde` types mirror the A2A
+  JSON schema; coverage targets on typed data are not meaningful.
+
+#### Scenario: workspace coverage CI gate is configured
+
+- **WHEN** the GitHub Actions `coverage.yml` workflow runs on a PR
+- **THEN** it executes `cargo llvm-cov --workspace --json --output-path coverage.json`
+  and invokes `tools/check_coverage.sh` to assert per-crate coverage
+
+#### Scenario: a crate falls below 80%
+
+- **WHEN** any non-excluded crate's `lines.percent` in `coverage.json`
+  is below `80.0`
+- **THEN** the CI gate exits non-zero with a message listing the crate,
+  its current coverage, and the delta to 80%
+
+#### Scenario: an excluded crate is added or removed
+
+- **WHEN** a contributor proposes adding or removing a crate from the
+  exclusion list
+- **THEN** the change MUST justify the exclusion in the PR description
+  (generated code, harness-only, or equivalent rationale)
+
+### Requirement: report-only mode during rollout
+
+The CI gate SHALL support a per-crate report-only allowlist. Crates on
+the allowlist SHALL print their coverage delta in the CI log but MUST NOT
+fail the build for falling below the floor.
+
+#### Scenario: crate on the report-only allowlist
+
+- **WHEN** a crate listed in the allowlist measures below 80%
+- **THEN** the gate prints the coverage and the delta but exits 0
+
+#### Scenario: a crate is promoted to enforced
+
+- **WHEN** a contributor removes a crate from the report-only allowlist
+- **THEN** the gate enforces 80% for that crate on all subsequent PRs;
+  the removal is permanent — re-adding a crate to the allowlist requires
+  a separate OpenSpec change
+
+### Requirement: coverage measurement excludes generated code
+
+The `coverage.toml` configuration SHALL exclude `build.rs`-generated
+files, `*.pb.rs` artifacts, and macro-expanded `#[derive(...)]`
+boilerplate from the line-coverage calculation.
+
+#### Scenario: hand-written code remains in scope
+
+- **WHEN** `cargo llvm-cov` runs against the workspace
+- **THEN** all hand-written `.rs` files under `crates/*/src/**` count
+  toward coverage, while generated files identified in `coverage.toml`
+  are excluded
+
+### Requirement: `make coverage` reproduces CI locally
+
+The root `Makefile` SHALL expose a `coverage` target that runs the same
+`cargo llvm-cov` invocation as CI and prints a per-crate table of
+current coverage percentages.
+
+#### Scenario: developer runs `make coverage`
+
+- **WHEN** a developer runs `make coverage` after editing code
+- **THEN** the output table lists every crate with its current coverage,
+  the floor (80%), the delta, and the report-only status, sorted by
+  delta ascending
+
+### Requirement: contributor guidance is documented
+
+The `AGENTS.md` testing section SHALL document the 80% floor, link to
+the `make coverage` workflow, and reference this spec.
+
+#### Scenario: new crate is added to the workspace
+
+- **WHEN** a contributor adds a new crate under `crates/`
+- **THEN** the crate inherits the 80% floor immediately; if the initial
+  PR cannot reach the floor, the crate MUST be added to the report-only
+  allowlist with a follow-up task to reach the floor

--- a/openspec/changes/workspace-test-coverage-floor/tasks.md
+++ b/openspec/changes/workspace-test-coverage-floor/tasks.md
@@ -1,0 +1,208 @@
+## 1. Phase 1 — Coverage infrastructure
+
+- [ ] 1.1 Add failing CI smoke job that runs `cargo llvm-cov --workspace --json --output-path coverage.json` and uploads the artifact; assert exit code 0 (no parsing yet).
+- [ ] 1.2 Install `cargo-llvm-cov` in `.github/workflows/coverage.yml` (Linux runner, cached toolchain).
+- [ ] 1.3 Add `make coverage` target to root `Makefile` that runs the same command locally and prints a per-crate summary table.
+- [ ] 1.4 Commit `coverage.toml` with the exclude list (generated code globs, `build.rs`).
+- [ ] 1.5 Add `tools/check_coverage.sh` (or `tools/check_coverage.rs`) that parses `coverage.json`, computes per-crate line coverage, and exits non-zero when any crate not in the report-only allowlist falls below 80%.
+- [ ] 1.6 Seed the report-only allowlist with **every** crate; the gate prints but does not fail.
+- [ ] 1.7 Document `cargo llvm-cov` usage in `AGENTS.md` and link to the gate script.
+- [ ] 1.8 Run `make lint && make format`; commit as `feat(ci): add cargo-llvm-cov coverage measurement (report-only)`.
+
+## 2. Phase 2 — `assistant-test-support` crate scaffold (composition only)
+
+`assistant-test-support` is a thin composition layer. It hosts `FixtureBuilder` + a `prelude` module that re-exports the in-memory impls from their owning crates. The in-memory impls themselves do NOT live here — they live next to their SQLite peers in their owning crates and are plain `pub`, NOT feature-gated.
+
+- [ ] 2.1 Add failing test under `crates/test-support/tests/smoke.rs` that imports `assistant_test_support::FixtureBuilder` and constructs an empty fixture; should fail to compile (crate does not exist yet).
+- [ ] 2.2 Create `crates/test-support/` with `Cargo.toml`, `src/lib.rs`, and module stubs (`prelude`, `fixture`). Package name `assistant-test-support`. Empty `[dependencies]` initially (re-exports get added as their source crates land their fakes).
+- [ ] 2.3 Register `crates/test-support` in the root `Cargo.toml` workspace members list.
+- [ ] 2.4 Configure `[lints]\nworkspace = true` in `crates/test-support/Cargo.toml` — keep panic-free contract at workspace baseline (`warn`, not `deny`); `.unwrap()` is ergonomic in test helpers.
+- [ ] 2.5 Document the crate's purpose: it composes existing fakes, it does NOT host the fakes themselves. Document the rule that `assistant-test-support` MUST NOT appear in any crate's `[dependencies]` section (only `[dev-dependencies]`).
+- [ ] 2.6 Add `tests/workspace_test_support_lint.rs` at the repo root that fails when `assistant-test-support` appears in any crate's `[dependencies]` table (only `[dev-dependencies]` is allowed).
+- [ ] 2.7 Add `tests/workspace_test_impls_in_prod.rs` at the repo root that fails when types matching `InMemory*`, `Scripted*`, or `Stub*` are constructed in non-test production code paths (exempt: the defining module itself, `#[cfg(test)]` modules, `tests/` directories, the `assistant-test-support` crate, and the documented production-fallback construction sites for `InMemoryConversationBroadcaster`).
+- [ ] 2.8 Run `make lint && make format`; commit as `feat(test-support): scaffold assistant-test-support composition crate`.
+
+## 3. Phase 3 — `Clock` trait
+
+- [ ] 3.1 Add failing test in `crates/core/src/clock.rs` that asserts `FakeClock` returns the seeded `DateTime<Utc>` and advances on `tick()`.
+- [ ] 3.2 Implement `pub trait Clock: Send + Sync` with `now() -> DateTime<Utc>` and `now_instant() -> Instant`. Implement `SystemClock` and `FakeClock` both as plain `pub` types in `assistant-core::clock` — no `#[cfg(test)]`, no feature flag. `FakeClock` is just another `Clock` impl, available wherever the `Clock` trait is.
+- [ ] 3.3 Re-export `Clock`, `SystemClock`, `FakeClock` from `assistant_core`'s lib root.
+- [ ] 3.4 Add `assistant_core::FakeClock` to the `assistant-test-support` prelude re-exports.
+- [ ] 3.5 Add failing test in `crates/auth/tests/jwt_clock.rs` asserting a JWT issued by a `FakeClock`-backed `JwtManager` reports `exp` relative to the fake clock.
+- [ ] 3.6 Thread `Arc<dyn Clock>` into `assistant_auth::jwt::JwtManager`; default to `Arc::new(SystemClock)` via a `Default` impl or `new()` builder.
+- [ ] 3.7 Replace `Utc::now()` calls in `crates/auth/src/{jwt,oauth2/device,api_keys,providers,middleware,oidc}.rs` with the injected clock.
+- [ ] 3.8 Update auth tests to use `FakeClock` for time-sensitive assertions; remove ad-hoc `tokio::time::pause()` workarounds.
+- [ ] 3.9 Repeat 3.5–3.8 for `assistant-runtime` (`scheduler`, `title_generator`, `memory_indexer`, `compaction`, `orchestrator/worker`).
+- [ ] 3.10 Repeat for `assistant-bus-nats`, `assistant-storage` (event timestamps in `conversation_events`, `traces`, `metrics`), and `assistant-llm-provider` (retry backoff via `crates/llm-provider/src/retry.rs`).
+- [ ] 3.11 Add `tests/workspace_clock_lint.rs` that fails compilation if `Utc::now\(\)` or `SystemTime::now\(\)` appears in any non-test `.rs` file outside `assistant_core::clock`.
+- [ ] 3.12 Run `make lint && make format`; commit as `feat(core): introduce Clock trait and migrate workspace`.
+
+## 4. Phase 4 — HTTP client injection
+
+- [ ] 4.1 Add failing test in `crates/workflow-http/tests/http_action.rs` that mounts a `wiremock::MockServer`, constructs `HttpRequestActionExecutor::with_client(client, base_url)`, and asserts a 200 path through `execute`.
+- [ ] 4.2 Refactor `HttpRequestActionExecutor::new` to accept `reqwest::Client`. Add `HttpRequestActionExecutor::with_client(client, default_timeout)` constructor. Keep `new(default_timeout)` as a thin wrapper that builds a default client.
+- [ ] 4.3 Write the remaining `workflow-http` unit tests (host policy enforcement, retry/backoff with `FakeClock`, response mapping, timeout). Target: 80%+ on `crates/workflow-http`.
+- [ ] 4.4 Repeat 4.1–4.3 for `assistant-web-ui::push::WebPushClient`.
+- [ ] 4.5 Repeat for `assistant-interfaces::nextcloud::{adapter,tools}`.
+- [ ] 4.6 Repeat for `assistant-interfaces::matrix::client::MatrixClient`.
+- [ ] 4.7 Repeat for `assistant-auth::oidc::OidcProvider`.
+- [ ] 4.8 Audit remaining `reqwest::Client::new()` call sites; refactor each to accept the client.
+- [ ] 4.9 Add `tests/workspace_http_client_lint.rs` that fails when `reqwest::Client::new\(\)` appears outside of a `new_with_default_client` helper or top-level binary.
+- [ ] 4.10 Run `make lint && make format`; commit as `refactor(workspace): inject reqwest::Client at constructor seams`.
+
+## 5. Phase 5 — Persistence trait extraction (Wave A: high-traffic stores)
+
+Each store: failing test → trait in `assistant-core` → `Sqlite*` impl + `InMemory*` impl both as plain `pub` in the owning crate → contract test → consumer migration → re-export to test-support prelude. One sub-phase per store; each shippable as its own PR.
+
+### 5.A — `ConversationStore`
+
+- [ ] 5.A.1 Add failing test in `crates/storage/tests/contract/conversation_store.rs` that runs `create → get → list → update_title → mark_locked` against both `SqliteConversationStore` and `InMemoryConversationStore`. Neither type exists yet — test will not compile.
+- [ ] 5.A.2 Define `pub trait ConversationStore: Send + Sync` in `crates/core/src/store.rs` (or a new `crates/core/src/persistence.rs`) with the methods consumers call today.
+- [ ] 5.A.3 Rename the existing `crates/storage/src/conversations.rs::ConversationStore` struct to `SqliteConversationStore` and `impl ConversationStore for SqliteConversationStore`.
+- [ ] 5.A.4 Add `pub struct InMemoryConversationStore` in the same file (`crates/storage/src/conversations.rs`) as plain `pub`. HashMap-backed, `Mutex`-protected, enforces obvious cascades. `impl ConversationStore for InMemoryConversationStore`.
+- [ ] 5.A.5 Confirm contract test from 5.A.1 passes for both impls.
+- [ ] 5.A.6 Add `pub use assistant_storage::InMemoryConversationStore;` to `assistant-test-support`'s prelude.
+- [ ] 5.A.7 Migrate consumers in `assistant-runtime`, `assistant-web-ui`, `assistant-interfaces` to `Arc<dyn ConversationStore>`. Existing call sites change `Arc<ConversationStore>` → `Arc<dyn ConversationStore>`.
+- [ ] 5.A.8 Update consumer tests to use `InMemoryConversationStore` (via the test-support prelude) where they were using `StorageLayer::new_in_memory()` solely for conversation access.
+- [ ] 5.A.9 Run `make lint && make format`; commit as `refactor(storage): extract ConversationStore trait + add InMemory impl`.
+
+### 5.B — `TraceStore`
+
+- [ ] 5.B.1 Failing contract test in `crates/storage/tests/contract/trace_store.rs`.
+- [ ] 5.B.2 `trait TraceStore` in `assistant-core`; `SqliteTraceStore` + `InMemoryTraceStore` both in `crates/storage/src/traces.rs` as plain `pub`.
+- [ ] 5.B.3 Contract test green for both impls.
+- [ ] 5.B.4 Re-export `InMemoryTraceStore` from the test-support prelude.
+- [ ] 5.B.5 Migrate consumers (`runtime/otel_spans`, `runtime/telemetry`, `web-ui/backends/sqlite`, `web-ui/api/traces` if it exists).
+- [ ] 5.B.6 Commit as `refactor(storage): extract TraceStore trait + add InMemory impl`.
+
+### 5.C — `LogStore`
+
+- [ ] 5.C.1–5.C.6 Same pattern. Both impls in `crates/storage/src/logs.rs` as plain `pub`. Re-export from test-support prelude.
+
+### 5.D — `AttachmentStore`
+
+- [ ] 5.D.1–5.D.6 Same pattern. Both impls in `crates/storage/src/attachments.rs`. `InMemoryAttachmentStore` stores bytes in `HashMap<Uuid, Vec<u8>>` rather than on disk.
+
+### 5.E — `AudioStore` (lives in `assistant-transcription`)
+
+- [ ] 5.E.1–5.E.6 Same pattern; trait lives in `assistant-core` (or `assistant-transcription`'s root if multimodal-specific). Both impls in `crates/transcription/src/audio_store.rs` as plain `pub`.
+
+### 5.F — `ConversationEventStore` + `RunBroadcaster`
+
+- [ ] 5.F.1–5.F.6 Same pattern. Both impls in `crates/storage/src/conversation_events.rs`. Note: this is distinct from the existing production `InMemoryConversationBroadcaster` in `conversation_broadcaster.rs` — that one remains a production fallback. The new `InMemoryConversationEventStore` is also `pub` (no gate) but is exempt-listed in the `workspace_test_impls_in_prod.rs` lint when accessed from `FixtureBuilder`.
+
+### 5.G — `InMemoryMessageBus` (MessageBus already a trait)
+
+- [ ] 5.G.1 Failing contract test asserting enqueue/dequeue/ack/redeliver behavior across `SqliteMessageBus` and a new `InMemoryMessageBus`.
+- [ ] 5.G.2 Add `pub struct InMemoryMessageBus` in `crates/storage/src/message_bus.rs` as plain `pub` (channels + `Mutex<HashMap>` for inflight leases).
+- [ ] 5.G.3 Contract test green for both impls.
+- [ ] 5.G.4 Re-export `InMemoryMessageBus` from the test-support prelude.
+- [ ] 5.G.5 Migrate runtime worker tests to `InMemoryMessageBus`. The 218 runtime tests benefit most here.
+- [ ] 5.G.6 Commit as `feat(storage): add InMemoryMessageBus + contract tests`.
+
+### 5.H — `ScriptedLlmProvider` (LlmProvider already a trait)
+
+- [ ] 5.H.1 Failing test in `crates/llm-provider/tests/scripted.rs` asserting `ScriptedLlmProvider` returns canned responses in queue order and records calls.
+- [ ] 5.H.2 Add `pub struct ScriptedLlmProvider` in `crates/llm-provider/src/scripted.rs` as plain `pub`. Builder methods `with_canned_responses(Vec<LlmResponse>)`, `with_streaming_script(Vec<StreamChunk>)`, and inspection method `recorded_calls() -> Vec<ChatHistory>`. The naming signals real intent — it's a legitimate `LlmProvider` impl usable for demo mode, offline mode, and contract tests, not solely a unit-test stub.
+- [ ] 5.H.3 Add the LlmProvider contract test — runs `chat`, `chat_stream`, and capability negotiation against `ScriptedLlmProvider` (plus the existing wiremock-backed Ollama tests as the SQLite analogue).
+- [ ] 5.H.4 Re-export `ScriptedLlmProvider` from the test-support prelude.
+- [ ] 5.H.5 Migrate the highest-volume `wiremock`-based runtime/web-ui tests to `ScriptedLlmProvider`. Wiremock stays for `llm-provider` crate's own protocol tests.
+- [ ] 5.H.6 Commit as `feat(llm-provider): add ScriptedLlmProvider for canned/scripted responses`.
+
+### 5.I — `FixtureBuilder`
+
+- [ ] 5.I.1 Failing test in `crates/test-support/tests/fixture.rs` asserting `FixtureBuilder::new().build().await` returns a `Fixture` with wired-up `Arc<dyn OrchestrationEngine>`, in-memory stores, `FakeClock`, `ScriptedLlmProvider`, `InMemoryMessageBus`.
+- [ ] 5.I.2 Implement `assistant_test_support::fixture::{FixtureBuilder, Fixture}` composing the re-exports from storage, llm-provider, runtime, core. Builder methods: `with_clock`, `with_canned_llm_responses`, `with_storage`, `with_extension_tool`.
+- [ ] 5.I.3 Document `FixtureBuilder` in the crate-level docs and add a usage example to `AGENTS.md` testing section.
+- [ ] 5.I.4 Commit as `feat(test-support): add FixtureBuilder for composed test scaffolding`.
+
+## 6. Phase 6 — Persistence trait extraction (Wave B: lower-traffic stores)
+
+One sub-phase per store; same `failing test → trait + impls → consumer migration → commit` pattern. Smaller PRs since each store is less central.
+
+- [ ] 6.A `CommandEventStore` (consumed by interface adapters)
+- [ ] 6.B `MetricsStore`
+- [ ] 6.C `AgentStore`
+- [ ] 6.D `MemoryChunkStore` (FTS-specific scenarios annotated EXEMPT in contract test)
+- [ ] 6.E `PersonaStore`
+- [ ] 6.F `PersonaSkillAccess`
+- [ ] 6.G `PushSubscriptionStore`
+- [ ] 6.H `RefinementStore`
+- [ ] 6.I `ScheduledTasksStore`
+- [ ] 6.J `SlackThreadStore`
+- [ ] 6.K `WebhookStore`
+- [ ] 6.L `WorkflowStore`
+- [ ] 6.M `SkillRegistry` read-side (`SkillCatalog` trait — overlaps with Phase 7)
+
+## 7. Phase 7 — Orchestration trait facades
+
+- [ ] 7.1 Add failing test in `crates/runtime/src/orchestrator/stub.rs` that constructs a `StubOrchestrationEngine` and verifies the trait surface compiles with `Arc<dyn OrchestrationEngine>`.
+- [ ] 7.2 Define `OrchestrationEngine` trait in `assistant_core::orchestration` with the minimum methods consumed by `mcp-server`, `web-ui`, `interfaces`: `submit_turn`, `run_turn_streaming`, `register_extension_tools`, `cancel_turn`.
+- [ ] 7.3 `impl OrchestrationEngine for Orchestrator` in `crates/runtime/src/orchestrator/mod.rs`; do not change the struct fields. Add `pub struct StubOrchestrationEngine` in `crates/runtime/src/orchestrator/stub.rs` as plain `pub` (records calls, returns canned `TurnResult` values).
+- [ ] 7.4 Define `ToolDispatcher` trait in `assistant_core::tool` with `execute`, `to_specs`, `register_handler`, `is_mutating`. `impl ToolDispatcher for ToolExecutor` in `crates/tool-executor/src/executor.rs`. Add `pub struct StubToolDispatcher` in `crates/tool-executor/src/stub.rs` as plain `pub`.
+- [ ] 7.5 Define `SkillCatalog` trait in `assistant_core::skill` (or `assistant_core::catalog`) with `list`, `get`, `reload`. `impl SkillCatalog for SkillRegistry` in `crates/storage/src/registry.rs`. Add `pub struct InMemorySkillCatalog` in the same file as plain `pub`.
+- [ ] 7.6 Re-export `StubOrchestrationEngine`, `StubToolDispatcher`, `InMemorySkillCatalog` from the `assistant-test-support` prelude.
+- [ ] 7.7 Migrate `crates/mcp-server/src/server.rs` to accept `Arc<dyn OrchestrationEngine>`, `Arc<dyn ToolDispatcher>`, `Arc<dyn SkillCatalog>` instead of the concrete types.
+- [ ] 7.8 Add `crates/mcp-server/tests/dispatch.rs` that builds the stubs from the test-support prelude and walks `handle_request` through every JSON-RPC method (`initialize`, `tools/list`, `tools/call`, `resources/list`, `resources/read`, plus error paths). Target: 80%+ on `crates/mcp-server`.
+- [ ] 7.9 Migrate `crates/web-ui/src/lib.rs::ApiState` to hold `Arc<dyn OrchestrationEngine>` instead of `Arc<Orchestrator>`. Existing tests should compile unchanged; add new tests for paths previously untestable.
+- [ ] 7.10 Migrate `crates/interfaces/src/{slack,mattermost,matrix,nextcloud,signal}/adapter.rs` to take `Arc<dyn OrchestrationEngine>`.
+- [ ] 7.11 Run `make lint && make format`; commit as `feat(core): add OrchestrationEngine/ToolDispatcher/SkillCatalog trait facades`.
+
+## 8. Phase 8 — Messenger `runner.rs` pure-dispatch extraction + CLI REPL split
+
+- [ ] 8.1 Add failing test in `crates/interfaces/src/slack/dispatch.rs` asserting `handle_event(SlackEvent::Message { ... })` returns the expected `RunnerAction` given a `StubOrchestrationEngine` from the test-support prelude.
+- [ ] 8.2 Extract Slack runner inner loop into `pub async fn handle_event(event: SlackEvent, deps: &SlackRunnerDeps) -> Result<RunnerAction>`. Keep the WebSocket loop in `runner.rs`; move dispatch logic to `dispatch.rs`.
+- [ ] 8.3 Write Slack `dispatch.rs` unit tests for: plain message, threaded reply, reaction-add, attachment upload trigger, bot-author skip, channel-not-allowed skip, duplicate `event_id` skip. Target: 80%+ on `crates/interfaces/src/slack/`.
+- [ ] 8.4 Repeat 8.1–8.3 for Mattermost (`crates/interfaces/src/mattermost/`).
+- [ ] 8.5 Repeat for Matrix (`crates/interfaces/src/matrix/`).
+- [ ] 8.6 Repeat for Nextcloud (`crates/interfaces/src/nextcloud/`).
+- [ ] 8.7 Repeat for Signal (`crates/interfaces/src/signal/`).
+- [ ] 8.8 Extract `dispatch_command(cmd, deps)` from `crates/interface-cli/src/main.rs`. Write per-subcommand tests using the `FixtureBuilder`.
+- [ ] 8.9 Run `make lint && make format`; commit as `refactor(interfaces): extract pure handle_event from each messenger runner`.
+
+## 9. Phase 9 — Per-crate coverage backfill (dependency order)
+
+Each sub-phase: add failing tests for the lowest-covered files first, then implement. Target `>= 80%` line coverage per crate. With the test-support infrastructure in place, every test setup is `FixtureBuilder::new()` + per-test customization.
+
+- [ ] 9.1 `assistant-core` → 80%. Files: `bus.rs` (388 LOC, no tests), `subagent.rs`, `auth.rs` trait surface.
+- [ ] 9.2 `assistant-skills` → 80%.
+- [ ] 9.3 `assistant-storage` → 80%. Files: `memory_chunks.rs` (253, 0 tests), backend-of-record edge cases. Most coverage comes from contract tests added in Phases 5–6.
+- [ ] 9.4 `assistant-llm-provider` → 80%.
+- [ ] 9.5 `assistant-tool-executor` → 80%. Files: `builtins/bash.rs` (261, 0 tests — security-critical), `builtins/web_search.rs`, `builtins/web_fetch.rs`, `builtins/self_analyze.rs`, `installer.rs`.
+- [ ] 9.6 `assistant-runtime` → 80%. Files: `orchestrator/dispatch.rs` (418), `orchestrator/turn_control.rs` (233), `metrics.rs` (274), `scheduler/tasks.rs` (320).
+- [ ] 9.7 `assistant-mcp-client` → 80%.
+- [ ] 9.8 `assistant-mcp-server` → 80% (covered in Phase 7.7).
+- [ ] 9.9 `assistant-interfaces` → 80% (after Phase 8 should be close).
+- [ ] 9.10 `assistant-web-ui` → 80%. Files: `backends/iceberg.rs` (984), `a2a/handlers.rs` (658), `oauth/{token,authorize,device}.rs`, `backends/sqlite.rs` (235).
+- [ ] 9.11 `assistant-interface-cli` → 80%. Files: `cmd_login.rs` (446), `cmd_account.rs` (255), `bootstrap.rs` (289), the dispatch logic split out in 8.8.
+- [ ] 9.12 `opentelemetry-exporter-iceberg` → 80%. Files: `metric.rs`, `span.rs`, `log.rs`, `catalog.rs`. Add tests using a tiny on-disk warehouse fixture in `tests/fixtures/warehouse/` (Phase 10).
+- [ ] 9.13 `assistant-transcription` → 80%.
+- [ ] 9.14 `assistant-backup` → 80%.
+- [ ] 9.15 `assistant-workflow` → 80%.
+- [ ] 9.16 `assistant-bus-nats` → 80%.
+- [ ] 9.17 `assistant-auth` → 80% (current 50%, close).
+- [ ] 9.18 `assistant-test-support` → 80%. Yes, the test-support crate itself is in the gate: every fake gets unit tests asserting it honors the trait contract beyond what the cross-crate contract tests already cover.
+
+## 10. Phase 10 — Iceberg-backed analytics fixtures
+
+- [ ] 10.1 Add failing test in `crates/web-ui/tests/iceberg_backend.rs` that scans a hand-built parquet warehouse fixture and asserts the expected `TraceSummary` list.
+- [ ] 10.2 Build `tests/fixtures/warehouse/` containing minimal parquet files: 3 spans, 5 logs, 2 metrics. Commit the bytes (small enough; document the build script).
+- [ ] 10.3 Extract pure aggregation functions in `iceberg.rs` (`aggregate_traces(batches: &[RecordBatch], filter: &TraceFilter) -> Vec<TraceSummary>`); the I/O path stays in the impl methods.
+- [ ] 10.4 Write unit tests against the aggregation functions; cover filtering, time-window selection, empty corpus, malformed timestamps.
+- [ ] 10.5 Repeat in `crates/opentelemetry-exporter-iceberg/` for span/log/metric write paths.
+
+## 11. Phase 11 — Flip CI gate to enforce
+
+- [ ] 11.1 Once `assistant-core` is at `>= 80%`, remove it from the report-only allowlist; the gate now enforces 80% on core.
+- [ ] 11.2 Repeat per crate as each one becomes green (storage → test-support → auth → llm-provider → tool-executor → runtime → mcp-server → mcp-client → interfaces → web-ui → interface-cli → exporters → transcription → backup → workflow → workflow-http → bus-nats).
+- [ ] 11.3 After all crates are enforcing, delete the allowlist mechanism entirely from `tools/check_coverage.sh`.
+- [ ] 11.4 Add a coverage badge to the README.
+- [ ] 11.5 Document the floor in `AGENTS.md` under the existing "Testing Patterns" section so new crates inherit the rule; add a "Choosing fakes" subsection covering when to use `InMemoryFooStore` vs `StorageLayer::new_in_memory()` vs wiremock.
+- [ ] 11.6 Run `make lint && make format && make test`; commit as `feat(ci): enforce 80% per-crate coverage floor`.
+
+## 12. Phase 12 — Closeout
+
+- [ ] 12.1 Update `openapi.json` only if any of the trait-facade refactors touched a route (none expected). Run `make dump-openapi && make generate-flutter-client` if so.
+- [ ] 12.2 Add an ADR under `docs/adr/` documenting the persistence-trait-symmetry pattern, the `assistant-test-support` crate boundary, and the trait-facade pattern for `OrchestrationEngine`/`ToolDispatcher`/`SkillCatalog`.
+- [ ] 12.3 Add an ADR (or extend 12.2) documenting the `Clock` injection rule and the HTTP-client injection rule.
+- [ ] 12.4 Archive this change with `openspec archive workspace-test-coverage-floor` once all phases are green on `main`.


### PR DESCRIPTION
## Summary

- Establishes an 80% per-crate **line-coverage floor** measured by `cargo llvm-cov` and enforced in CI.
- Captures the architectural seams needed to reach it: persistence trait symmetry, orchestration trait facades (`OrchestrationEngine`, `ToolDispatcher`, `SkillCatalog`), `Clock` injection, HTTP client injection, pure-function dispatch in messenger runners.
- Adds a thin `assistant-test-support` crate as a composition layer (FixtureBuilder + prelude). In-memory impls live next to their SQLite peers as plain `pub`, gated only by a workspace lint that forbids their use in production code.

No production code changes in this PR — only OpenSpec design + phased task plan under `openspec/changes/workspace-test-coverage-floor/`.

## Test plan

- [x] `openspec validate workspace-test-coverage-floor --strict` passes
- [x] Pre-commit hooks pass (fmt, clippy, machete)
- Future PRs will land Phase 1 (coverage infra) → Phase 12 (closeout)