### PR TITLE
feat(ci): add cargo-llvm-cov coverage measurement (report-only)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,71 @@
+name: Coverage
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  coverage:
+    name: Workspace coverage (report-only)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        run: rustup show
+
+      - name: Install llvm-tools-preview
+        run: rustup component add llvm-tools-preview
+
+      - name: Install mold linker
+        uses: rui314/setup-mold@v1
+
+      - name: Install system dependencies
+        run: sudo apt-get update -y && sudo apt-get install -y protobuf-compiler ffmpeg jq
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "coverage"
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Run cargo llvm-cov
+        # The --ignore-filename-regex value is kept in sync with
+        # coverage.toml's [file_excludes] section. When updating one,
+        # update the other.
+        run: |
+          cargo llvm-cov \
+            --workspace \
+            --json \
+            --output-path coverage.json \
+            --ignore-filename-regex '/build\.rs$|/target/|\.pb\.rs$|/app/packages/assistant_api/'
+
+      - name: Upload coverage.json
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-json
+          path: coverage.json
+          retention-days: 14
+
+      - name: Run per-crate coverage gate
+        # During rollout the gate is report-only for every crate
+        # (seeded in coverage.toml). It prints the per-crate table
+        # but does not fail the build. As crates reach 80% they are
+        # promoted to enforcing by removing them from the report_only
+        # list in coverage.toml.
+        run: ./tools/check_coverage.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ make lint-flutter     # dart_pre_commit (format, analyze, deps, OSV)
 make test-flutter     # flutter test
 make precommit        # run all pre-commit checks manually
 make test-integration # cargo test -p assistant-integration-tests --test smoke -- --ignored --nocapture
+make coverage         # cargo llvm-cov --workspace --json + per-crate gate (report-only during rollout)
 ```
 
 Run a single test in a specific crate:
@@ -318,8 +319,34 @@ Prefixes: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `perf`.
 - Helper functions for fixtures: `make_skill()`, `build()`, `mount_answer()`.
 - Use `assert_eq!` with descriptive messages as the third argument.
 
+## Test Coverage Floor
+
+The workspace targets `>= 80%` line coverage per crate, measured by
+`cargo llvm-cov` and gated in CI via `.github/workflows/coverage.yml`.
+
+```sh
+# Local: produce coverage.json and run the per-crate gate.
+make coverage
+
+# Inputs:
+#   coverage.toml          — floor, excluded crates, report-only allowlist, file excludes
+#   tools/check_coverage.sh — gate script (parses coverage.toml + coverage.json)
+```
+
+During rollout (tracked by openspec/changes/workspace-test-coverage-floor/),
+every crate sits on the `[report_only]` list in `coverage.toml`. The gate
+prints each crate's coverage delta but does not fail CI. As a crate reaches
+the floor sustainably, remove it from `report_only` — that flips the gate
+to enforcing for that crate, and any subsequent PR that drops it below 80%
+fails the build. Promotion is a one-way ratchet; re-adding a crate requires
+a separate OpenSpec change.
+
+Permanently excluded crates (no production library code or generated types)
+live in `[excluded_crates]` and never gate CI.
+
 ## CI
 
-GitHub Actions runs on push to `main` and PRs: check, test, lint (clippy), format.
+GitHub Actions runs on push to `main` and PRs: check, test, lint (clippy), format, coverage.
 All messenger interfaces compile unconditionally as part of the `assistant-interfaces` crate.
 Integration tests run with `continue-on-error: true` (require Ollama).
+The coverage job is report-only during the rollout; see the section above.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build test lint lint-signal lint-flutter format clean check install-hooks run run-mcp run-slack run-mattermost run-matrix run-nextcloud run-signal run-webui run-worker build-signal build-macos-binary build-macos-bundle test-flutter precommit icons
+.PHONY: all build test lint lint-signal lint-flutter format clean check install-hooks run run-mcp run-slack run-mattermost run-matrix run-nextcloud run-signal run-webui run-worker build-signal build-macos-binary build-macos-bundle test-flutter precommit icons coverage
 
 all: build
 
@@ -13,6 +13,20 @@ test:
 
 test-integration:
 	cargo test -p assistant-integration-tests --test smoke -- --ignored --nocapture --test-threads=1
+
+# Run cargo-llvm-cov over the workspace and apply the per-crate coverage
+# gate from coverage.toml. Requires `cargo install cargo-llvm-cov` and
+# the `llvm-tools-preview` rustup component. The gate is currently
+# report-only for every crate during the rollout to the 80% floor;
+# crates promote to enforcing by being removed from coverage.toml's
+# [report_only].crates list. See openspec/changes/workspace-test-coverage-floor/.
+coverage:
+	cargo llvm-cov \
+		--workspace \
+		--json \
+		--output-path coverage.json \
+		--ignore-filename-regex '/build\.rs$$|/target/|\.pb\.rs$$|/app/packages/assistant_api/'
+	./tools/check_coverage.sh
 
 lint:
 	cargo clippy --workspace -- -D warnings

--- a/coverage.toml
+++ b/coverage.toml
@@ -1,0 +1,79 @@
+# Workspace coverage configuration consumed by `make coverage` and
+# `tools/check_coverage.sh`. Specified by the openspec change
+# `workspace-test-coverage-floor` (see openspec/changes/).
+
+# Per-crate line-coverage floor (percent). Crates not in `excluded_crates`
+# or `report_only` must meet or exceed this number on every PR.
+floor = 80.0
+
+# Crates permanently excluded from the coverage gate.
+# They may appear in coverage.json but never gate CI.
+#
+# Identifiers are workspace directory names under `crates/`, NOT Cargo
+# package names. (e.g. `mcp-server`, not `assistant-mcp-server`.) The
+# directory name is what cargo-llvm-cov emits in coverage.json file paths.
+#
+# Each exclusion must have a documented reason here.
+[excluded_crates]
+crates = [
+    # No production library code; src/lib.rs is a stub for shared
+    # test helpers used by the integration suite.
+    "integration-tests",
+
+    # Generated serde types mirroring the A2A JSON schema; coverage
+    # on typed data is not meaningful.
+    "a2a-json-schema",
+]
+
+# Crates in report-only mode during the rollout to the 80% floor.
+# The gate prints these crates' coverage and delta but does not fail
+# CI on them.
+#
+# Promotion to enforcing mode is a one-way ratchet: remove a crate from
+# this list once it sustainably reaches 80%, and the next PR that drops
+# it below 80% will fail.
+#
+# Seeded with every non-excluded workspace member. As crates clear the
+# floor (tracked in openspec/changes/workspace-test-coverage-floor/tasks.md
+# Phase 11), they are removed from this list.
+#
+# Identifiers are workspace directory names under `crates/`, NOT Cargo
+# package names. (e.g. `runtime` not `assistant-runtime`.)
+[report_only]
+crates = [
+    "auth",
+    "backup",
+    "bus-nats",
+    "core",
+    "interface-cli",
+    "interfaces",
+    "llm-provider",
+    "mcp-client",
+    "mcp-server",
+    "runtime",
+    "skills",
+    "storage",
+    "tool-executor",
+    "transcription",
+    "web-ui",
+    "workflow",
+    "workflow-http",
+    "opentelemetry-exporter-iceberg",
+    "opentelemetry-exporter-sqlite",
+    # test-support — added when the crate is scaffolded in Phase 2.
+]
+
+# File path regex patterns excluded from coverage measurement.
+# Passed to `cargo llvm-cov --ignore-filename-regex` as a joined alternation.
+[file_excludes]
+patterns = [
+    # Build scripts — run at compile time, not at test time.
+    "/build\\.rs$",
+    # Cargo build output.
+    "/target/",
+    # Protobuf-generated code (none today; reserved for future).
+    "\\.pb\\.rs$",
+    # Generated OpenAPI bindings inside Flutter dart code — out of scope
+    # for Rust coverage anyway, but listed for safety.
+    "/app/packages/assistant_api/",
+]

--- a/openspec/changes/workspace-test-coverage-floor/tasks.md
+++ b/openspec/changes/workspace-test-coverage-floor/tasks.md
@@ -1,12 +1,12 @@
 ## 1. Phase 1 — Coverage infrastructure
 
-- [ ] 1.1 Add failing CI smoke job that runs `cargo llvm-cov --workspace --json --output-path coverage.json` and uploads the artifact; assert exit code 0 (no parsing yet).
-- [ ] 1.2 Install `cargo-llvm-cov` in `.github/workflows/coverage.yml` (Linux runner, cached toolchain).
-- [ ] 1.3 Add `make coverage` target to root `Makefile` that runs the same command locally and prints a per-crate summary table.
-- [ ] 1.4 Commit `coverage.toml` with the exclude list (generated code globs, `build.rs`).
-- [ ] 1.5 Add `tools/check_coverage.sh` (or `tools/check_coverage.rs`) that parses `coverage.json`, computes per-crate line coverage, and exits non-zero when any crate not in the report-only allowlist falls below 80%.
-- [ ] 1.6 Seed the report-only allowlist with **every** crate; the gate prints but does not fail.
-- [ ] 1.7 Document `cargo llvm-cov` usage in `AGENTS.md` and link to the gate script.
+- [x] 1.1 Add failing CI smoke job that runs `cargo llvm-cov --workspace --json --output-path coverage.json` and uploads the artifact; assert exit code 0 (no parsing yet).
+- [x] 1.2 Install `cargo-llvm-cov` in `.github/workflows/coverage.yml` (Linux runner, cached toolchain).
+- [x] 1.3 Add `make coverage` target to root `Makefile` that runs the same command locally and prints a per-crate summary table.
+- [x] 1.4 Commit `coverage.toml` with the exclude list (generated code globs, `build.rs`).
+- [x] 1.5 Add `tools/check_coverage.sh` (or `tools/check_coverage.rs`) that parses `coverage.json`, computes per-crate line coverage, and exits non-zero when any crate not in the report-only allowlist falls below 80%.
+- [x] 1.6 Seed the report-only allowlist with **every** crate; the gate prints but does not fail.
+- [x] 1.7 Document `cargo llvm-cov` usage in `AGENTS.md` and link to the gate script.
 - [ ] 1.8 Run `make lint && make format`; commit as `feat(ci): add cargo-llvm-cov coverage measurement (report-only)`.
 
 ## 2. Phase 2 — `assistant-test-support` crate scaffold (composition only)

--- a/tools/check_coverage.sh
+++ b/tools/check_coverage.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# tools/check_coverage.sh
+#
+# Reads coverage.json (produced by `cargo llvm-cov --workspace --json`)
+# and coverage.toml; computes per-crate line coverage; prints a sorted
+# table; exits non-zero when any crate not in the report-only allowlist
+# falls below the floor.
+#
+# Dependencies: bash 3.2+, jq, awk (POSIX), grep, sed.
+#
+# Specified by openspec/changes/workspace-test-coverage-floor/.
+
+set -euo pipefail
+
+# --- Locate inputs ----------------------------------------------------------
+
+ROOT="${ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+COVERAGE_JSON="${COVERAGE_JSON:-$ROOT/coverage.json}"
+COVERAGE_TOML="${COVERAGE_TOML:-$ROOT/coverage.toml}"
+
+if [[ ! -f "$COVERAGE_JSON" ]]; then
+    echo "error: $COVERAGE_JSON not found." >&2
+    echo "       run 'make coverage' (or 'cargo llvm-cov --workspace --json --output-path coverage.json') first." >&2
+    exit 2
+fi
+
+if [[ ! -f "$COVERAGE_TOML" ]]; then
+    echo "error: $COVERAGE_TOML not found." >&2
+    exit 2
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "error: jq is required but not installed." >&2
+    exit 2
+fi
+
+# --- Parse coverage.toml ----------------------------------------------------
+#
+# POSIX awk only — no gawk `match(...,arr)` extensions, no bash mapfile.
+# Tracks the active [section] header and extracts double-quoted strings
+# inside a `key = [ ... ]` array spanning one or more lines.
+
+extract_array() {
+    local section="$1"
+    local key="$2"
+    awk -v sect="[$section]" -v target_key="$key" '
+        BEGIN { in_section = 0; in_array = 0 }
+        /^\[.+\]$/ {
+            in_section = ($0 == sect) ? 1 : 0
+            in_array = 0
+            next
+        }
+        {
+            line = $0
+        }
+        in_section && !in_array && line ~ /^[[:space:]]*[a-zA-Z_]+[[:space:]]*=[[:space:]]*\[/ {
+            k = line
+            sub(/^[[:space:]]+/, "", k)
+            sub(/[[:space:]]*=.*$/, "", k)
+            if (k == target_key) {
+                in_array = 1
+                sub(/^[^\[]*\[/, "", line)
+            }
+        }
+        in_array {
+            # Pull every "..." occurrence on this line.
+            while (match(line, /"[^"]*"/)) {
+                s = substr(line, RSTART + 1, RLENGTH - 2)
+                print s
+                line = substr(line, RSTART + RLENGTH)
+            }
+            if (index(line, "]") > 0) { in_array = 0 }
+        }
+    ' "$COVERAGE_TOML"
+}
+
+FLOOR="$(awk '
+    /^[[:space:]]*floor[[:space:]]*=/ {
+        gsub(/[^0-9.]/, "")
+        print
+        exit
+    }
+' "$COVERAGE_TOML")"
+
+if [[ -z "$FLOOR" ]]; then
+    echo "error: 'floor' not set in $COVERAGE_TOML" >&2
+    exit 2
+fi
+
+# Portable replacement for `mapfile -t`: read into bash 3.2-compatible array.
+EXCLUDED=()
+while IFS= read -r line; do
+    [[ -n "$line" ]] && EXCLUDED+=("$line")
+done < <(extract_array excluded_crates crates)
+
+REPORT_ONLY=()
+while IFS= read -r line; do
+    [[ -n "$line" ]] && REPORT_ONLY+=("$line")
+done < <(extract_array report_only crates)
+
+is_in_list() {
+    local needle="$1"
+    shift
+    local item
+    for item in "$@"; do
+        [[ "$item" == "$needle" ]] && return 0
+    done
+    return 1
+}
+
+# --- Compute per-crate coverage from coverage.json --------------------------
+#
+# llvm-cov's `--json` output places file-level coverage under
+# `.data[0].files[].summary.lines.{count,covered}`. We group by the
+# `crates/<name>/` segment of the filename, sum count and covered per
+# crate, and compute percent.
+#
+# Files outside `crates/<name>/` are ignored.
+
+CRATE_DATA="$(jq -r '
+    .data[0].files
+    | map(select(.filename | test("/crates/[^/]+/")))
+    | group_by(.filename | capture("/crates/(?<c>[^/]+)/") | .c)
+    | map({
+        crate: (.[0].filename | capture("/crates/(?<c>[^/]+)/") | .c),
+        covered: (map(.summary.lines.covered) | add // 0),
+        count:   (map(.summary.lines.count)   | add // 0)
+      })
+    | map(. + { percent: (if .count > 0 then (.covered * 100 / .count) else 100 end) })
+    | sort_by(.percent)
+    | .[] | "\(.crate)\t\(.covered)\t\(.count)\t\(.percent)"
+' "$COVERAGE_JSON")"
+
+# --- Print the table --------------------------------------------------------
+
+printf "\n%-36s %10s %10s %8s %s\n" "CRATE" "COVERED" "TOTAL" "PERCENT" "STATUS"
+printf -- "----------------------------------------------------------------------------------\n"
+
+FAILED=0
+ANY_REPORTED=0
+
+# Portable array-empty checks (set -u trips on ${arr[@]} with empty arrays in bash 3.2).
+excluded_args=()
+if [[ "${#EXCLUDED[@]}" -gt 0 ]]; then
+    excluded_args=("${EXCLUDED[@]}")
+fi
+report_only_args=()
+if [[ "${#REPORT_ONLY[@]}" -gt 0 ]]; then
+    report_only_args=("${REPORT_ONLY[@]}")
+fi
+
+while IFS=$'\t' read -r crate covered count percent; do
+    [[ -z "$crate" ]] && continue
+    ANY_REPORTED=1
+    delta="$(awk -v p="$percent" -v f="$FLOOR" 'BEGIN { printf "%+.1f", (p - f) }')"
+
+    if is_in_list "$crate" "${excluded_args[@]+"${excluded_args[@]}"}"; then
+        status="excluded"
+    elif [[ "$(awk -v p="$percent" -v f="$FLOOR" 'BEGIN { print (p + 0.0001 >= f) }')" == "1" ]]; then
+        status="ok"
+    elif is_in_list "$crate" "${report_only_args[@]+"${report_only_args[@]}"}"; then
+        status="report-only (delta ${delta}%)"
+    else
+        status="FAIL (delta ${delta}%)"
+        FAILED=1
+    fi
+
+    printf "%-36s %10d %10d %7.1f%% %s\n" "$crate" "$covered" "$count" "$percent" "$status"
+done <<EOF
+$CRATE_DATA
+EOF
+
+if [[ "$ANY_REPORTED" -eq 0 ]]; then
+    echo
+    echo "warning: no crates matched the 'crates/<name>/' pattern in coverage.json." >&2
+    echo "         coverage.json may be empty or malformed." >&2
+fi
+
+echo
+echo "floor: ${FLOOR}%   excluded: ${#EXCLUDED[@]}   report-only: ${#REPORT_ONLY[@]}"
+
+if [[ "$FAILED" -eq 1 ]]; then
+    echo
+    echo "Coverage gate FAILED: one or more enforcing crates fell below the floor." >&2
+    exit 1
+fi
+
+echo "Coverage gate passed."


### PR DESCRIPTION
## Summary

Phase 1 of [`workspace-test-coverage-floor`](openspec/changes/workspace-test-coverage-floor/) — the coverage infrastructure. The gate is **report-only** for every crate during rollout; no crate gates CI on this PR.

- `.github/workflows/coverage.yml` — runs `cargo llvm-cov --workspace --json` on every PR/push, uploads `coverage.json` as an artifact, invokes the gate.
- `coverage.toml` — declarative config: `floor = 80.0`, `excluded_crates` (integration-tests, a2a-json-schema), `report_only` seeded with every other workspace crate, file path excludes.
- `tools/check_coverage.sh` — portable POSIX-awk + jq script that parses both files and prints a per-crate table sorted by percent. Exits non-zero only for crates not in `excluded_crates` and not in `report_only` that fall below the floor.
- `make coverage` — local equivalent.
- AGENTS.md — documents the discipline, the one-way ratchet, and the rollout pattern.

Crates promote to enforcing by being removed from `coverage.toml`'s `[report_only].crates` list. That's the only edit needed to flip the gate to fail-fast for that crate.

## Test plan

- [x] Local smoke-test of `tools/check_coverage.sh` against a hand-built `coverage.json` fixture confirms:
  - Crates above floor → `ok`
  - Crates below floor on `report_only` → `report-only (delta -X.X%)`, exit 0
  - Crates below floor NOT on `report_only` → `FAIL (delta -X.X%)`, exit 1
- [x] `make lint` clean
- [x] `make format` clean
- [x] Pre-commit hooks pass
- CI run on this PR will be the first real `cargo llvm-cov` invocation; if it falls over for any reason, no other CI job is affected (separate workflow).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automated code coverage tracking and reporting to CI pipelines with an 80% per-crate line coverage target.

* **Chores**
  * Configured a phased coverage enforcement rollout, initially in report-only mode to allow teams to meet standards before enforcement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cedricziel/assistant/pull/821?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->