### PR TITLE
feat(app): Phase A — currentTurnStatus derived state for in-flight progress

### DIFF
--- a/app/lib/features/chat/chat_provider.dart
+++ b/app/lib/features/chat/chat_provider.dart
@@ -487,6 +487,69 @@ class ChatToolResult {
   bool get isSuccess => status == 'ok';
 }
 
+/// Plain-language summary of which SSE event last drove the in-flight turn.
+/// Drives the UI's progress card. Add a value here if the server protocol
+/// grows a new event kind that the UI should distinguish.
+enum TurnEventKind {
+  runStarted,
+  token,
+  status,
+  thinking,
+  toolResult,
+  subagentStarted,
+  subagentCompleted,
+  audioReady,
+}
+
+/// Snapshot of the in-flight turn's most recent activity, exposed for UI
+/// rendering of progress indicators. `null` on [ChatState.currentTurnStatus]
+/// means no turn is in flight.
+///
+/// Updated by [ChatNotifier] on each SSE event within `_streamMessage`.
+/// Cleared on `DoneEvent`, on the catch block after retries exhaust, and
+/// in `_recoverStalledStream`'s synchronous prefix.
+class TurnStatusSnapshot {
+  const TurnStatusSnapshot({
+    required this.runId,
+    required this.lastEventKind,
+    required this.lastEventAt,
+    this.currentToolName,
+  });
+
+  /// The run ID of the active turn — server-issued, captured from
+  /// `RunStartedEvent`.
+  final String runId;
+
+  /// Which kind of SSE event last fired for this turn.
+  final TurnEventKind lastEventKind;
+
+  /// Wall-clock timestamp of the most recent SSE event. The widget
+  /// derives "seconds since last event" via a [Ticker].
+  final DateTime lastEventAt;
+
+  /// Name of the tool or subagent task currently being executed, if
+  /// the most recent event implied one. Cleared when the assistant
+  /// resumes producing text (`TokenEvent`).
+  final String? currentToolName;
+
+  TurnStatusSnapshot copyWith({
+    String? runId,
+    TurnEventKind? lastEventKind,
+    DateTime? lastEventAt,
+    String? currentToolName,
+    bool clearToolName = false,
+  }) {
+    return TurnStatusSnapshot(
+      runId: runId ?? this.runId,
+      lastEventKind: lastEventKind ?? this.lastEventKind,
+      lastEventAt: lastEventAt ?? this.lastEventAt,
+      currentToolName: clearToolName
+          ? null
+          : (currentToolName ?? this.currentToolName),
+    );
+  }
+}
+
 /// State for the active chat.
 class ChatState {
   const ChatState({
@@ -499,6 +562,7 @@ class ChatState {
     this.lastToolResult,
     this.error,
     this.pendingQueue = const [],
+    this.currentTurnStatus,
   });
 
   final String? conversationId;
@@ -522,6 +586,11 @@ class ChatState {
   /// Messages waiting to be sent after the current in-flight response completes.
   final List<PendingMessage> pendingQueue;
 
+  /// Snapshot of the in-flight turn's most recent activity, exposed for
+  /// rendering progress indicators above the composer. `null` when no
+  /// turn is in flight (between `done` and the next `run_started`).
+  final TurnStatusSnapshot? currentTurnStatus;
+
   bool get isStreaming => isSending && streamingContent.isNotEmpty;
 
   ChatState copyWith({
@@ -537,6 +606,8 @@ class ChatState {
     bool clearConversation = false,
     bool clearStatusMessage = false,
     List<PendingMessage>? pendingQueue,
+    TurnStatusSnapshot? currentTurnStatus,
+    bool clearCurrentTurnStatus = false,
   }) {
     return ChatState(
       conversationId: clearConversation
@@ -552,6 +623,9 @@ class ChatState {
       lastToolResult: lastToolResult ?? this.lastToolResult,
       error: clearError ? null : (error ?? this.error),
       pendingQueue: pendingQueue ?? this.pendingQueue,
+      currentTurnStatus: clearCurrentTurnStatus
+          ? null
+          : (currentTurnStatus ?? this.currentTurnStatus),
     );
   }
 }
@@ -566,6 +640,29 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
     final c = _thinkingController;
     _thinkingController = null;
     if (c != null) unawaited(c.close());
+  }
+
+  /// Update the in-flight turn-status snapshot to reflect a newly-received
+  /// SSE event of [kind]. No-op when no turn is in flight (snapshot null).
+  ///
+  /// [toolName] populates `currentToolName` when relevant (e.g. on
+  /// `tool_result` or `subagent_started`). `TokenEvent` is handled
+  /// inline in `_streamMessage` so the tool name clears alongside the
+  /// streaming-content mutation.
+  void _bumpTurnStatus(TurnEventKind kind, {String? toolName}) {
+    final s = state.value;
+    if (s == null) return;
+    final prev = s.currentTurnStatus;
+    if (prev == null) return;
+    state = AsyncData(
+      s.copyWith(
+        currentTurnStatus: prev.copyWith(
+          lastEventKind: kind,
+          lastEventAt: DateTime.now(),
+          currentToolName: toolName ?? prev.currentToolName,
+        ),
+      ),
+    );
   }
 
   /// Extract a tool name from a [StatusEvent] message.
@@ -1435,6 +1532,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
               isSending: false,
               streamingContent: '',
               error: event.message,
+              clearCurrentTurnStatus: true,
             ),
           );
           return;
@@ -1577,6 +1675,16 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
           // Capture the run ID for potential reconnect; don't change UI.
           _currentRunId = event.runId;
           _lastSeq = (event.sequenceId ?? _lastSeq) + 1;
+          // Open the turn-status snapshot used by the progress card.
+          state = AsyncData(
+            chatState.copyWith(
+              currentTurnStatus: TurnStatusSnapshot(
+                runId: event.runId,
+                lastEventKind: TurnEventKind.runStarted,
+                lastEventAt: DateTime.now(),
+              ),
+            ),
+          );
           continue;
         }
         // Any non-RunStartedEvent counts as progress — the initial-stall
@@ -1601,23 +1709,34 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
               messages: msgs,
               streamingContent: newContent,
               clearStatusMessage: true,
+              // Resuming text generation — clear any active tool name.
+              currentTurnStatus: chatState.currentTurnStatus?.copyWith(
+                lastEventKind: TurnEventKind.token,
+                lastEventAt: DateTime.now(),
+                clearToolName: true,
+              ),
             ),
           );
         } else if (event is StatusEvent) {
           _lastSeq = (event.sequenceId ?? _lastSeq) + 1;
           _onStatusEvent(chatState, event);
+          _bumpTurnStatus(TurnEventKind.status);
         } else if (event is ToolResultEvent) {
           _lastSeq = (event.sequenceId ?? _lastSeq) + 1;
           _onToolResultEvent(chatState, event);
+          _bumpTurnStatus(TurnEventKind.toolResult, toolName: event.toolName);
         } else if (event is ThinkingEvent) {
           _lastSeq = (event.sequenceId ?? _lastSeq) + 1;
           _onThinkingEvent(chatState, event);
+          _bumpTurnStatus(TurnEventKind.thinking);
         } else if (event is SubagentStartedEvent) {
           _lastSeq = (event.sequenceId ?? _lastSeq) + 1;
           _onSubagentStartedEvent(chatState, event);
+          _bumpTurnStatus(TurnEventKind.subagentStarted, toolName: event.task);
         } else if (event is SubagentCompletedEvent) {
           _lastSeq = (event.sequenceId ?? _lastSeq) + 1;
           _onSubagentCompletedEvent(chatState, event);
+          _bumpTurnStatus(TurnEventKind.subagentCompleted);
         } else if (event is DoneEvent) {
           _lastSeq = (event.sequenceId ?? _lastSeq) + 1;
           unawaited(tokenController.close());
@@ -1690,6 +1809,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
               isSending: false,
               streamingContent: '',
               error: event.message,
+              clearCurrentTurnStatus: true,
             ),
           );
           return;
@@ -1765,6 +1885,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
             isSending: false,
             streamingContent: '',
             clearStatusMessage: true,
+            clearCurrentTurnStatus: true,
           ),
         );
         return;
@@ -1784,6 +1905,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
           isSending: false,
           streamingContent: '',
           error: _friendlyErrorMessage(e),
+          clearCurrentTurnStatus: true,
         ),
       );
     }
@@ -1867,6 +1989,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
         isSending: false,
         streamingContent: '',
         error: error,
+        clearCurrentTurnStatus: true,
       ),
     );
   }

--- a/app/test/unit/chat/chat_provider_test.dart
+++ b/app/test/unit/chat/chat_provider_test.dart
@@ -2021,4 +2021,285 @@ void main() {
       );
     },
   );
+
+  // -- Phase A of chat-stream-progress-ux: currentTurnStatus derived state --
+  //
+  // The UI's in-flight progress card consumes a `currentTurnStatus`
+  // snapshot exposed on ChatState. The snapshot tracks the active turn's
+  // runId, the kind of its most recent SSE event, the wall-clock
+  // timestamp of that event, and the name of any currently-active tool.
+  // These tests pin the state-machine transitions per SSE event kind so
+  // the widget layer (Phase B) can rely on a stable observable surface.
+
+  group('ChatNotifier — currentTurnStatus derived state', () {
+    testWidgets('initial state has no currentTurnStatus', (tester) async {
+      final fakeApi = _FakeApiClient();
+      final notifier = await _pumpTestApp(tester, fakeApi);
+      await tester.pump();
+
+      expect(
+        notifier.state.value!.currentTurnStatus,
+        isNull,
+        reason: 'No turn in flight at startup — snapshot should be null',
+      );
+    });
+
+    testWidgets('RunStartedEvent populates currentTurnStatus.runId', (
+      tester,
+    ) async {
+      final fakeApi = _FakeApiClient();
+      final ctrl = fakeApi.enqueueStream();
+      addTearDown(() async {
+        if (!ctrl.isClosed) await ctrl.close();
+      });
+      final notifier = await _pumpTestApp(tester, fakeApi);
+
+      unawaited(notifier.sendMessage('hello'));
+      await tester.pump();
+      ctrl.add(const RunStartedEvent('run-abc'));
+      await tester.pump();
+
+      final snap = notifier.state.value!.currentTurnStatus;
+      expect(snap, isNotNull, reason: 'RunStartedEvent should open a snapshot');
+      expect(snap!.runId, 'run-abc');
+      expect(snap.lastEventKind, TurnEventKind.runStarted);
+      expect(snap.currentToolName, isNull);
+
+      // Close the stream so the source's `.timeout()` watchdog is
+      // cancelled and the test exits without a pending-timer assertion.
+      await ctrl.close();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets(
+      'TokenEvent updates lastEventKind to token and clears tool name',
+      (tester) async {
+        final fakeApi = _FakeApiClient();
+        final ctrl = fakeApi.enqueueStream();
+        addTearDown(() async {
+          if (!ctrl.isClosed) await ctrl.close();
+        });
+        final notifier = await _pumpTestApp(tester, fakeApi);
+
+        unawaited(notifier.sendMessage('hello'));
+        await tester.pump();
+        ctrl.add(const RunStartedEvent('run-1'));
+        await tester.pump();
+        // A tool result first — populates currentToolName.
+        ctrl.add(const ToolResultEvent(toolName: 'fetch_url', status: 'ok'));
+        await tester.pump();
+        expect(
+          notifier.state.value!.currentTurnStatus!.currentToolName,
+          'fetch_url',
+        );
+        // Now the assistant resumes producing tokens — tool name cleared,
+        // lastEventKind transitions to token.
+        ctrl.add(const TokenEvent('hi '));
+        await tester.pump();
+
+        final snap = notifier.state.value!.currentTurnStatus!;
+        expect(snap.lastEventKind, TurnEventKind.token);
+        expect(
+          snap.currentToolName,
+          isNull,
+          reason:
+              'TokenEvent means the assistant resumed text generation; '
+              'the tool name from the previous tool_result should clear',
+        );
+
+        await ctrl.close();
+        await tester.pumpAndSettle();
+      },
+    );
+
+    testWidgets(
+      'ToolResultEvent updates lastEventKind=toolResult and currentToolName',
+      (tester) async {
+        final fakeApi = _FakeApiClient();
+        final ctrl = fakeApi.enqueueStream();
+        addTearDown(() async {
+          if (!ctrl.isClosed) await ctrl.close();
+        });
+        final notifier = await _pumpTestApp(tester, fakeApi);
+
+        unawaited(notifier.sendMessage('hello'));
+        await tester.pump();
+        ctrl.add(const RunStartedEvent('run-1'));
+        await tester.pump();
+        ctrl.add(const ToolResultEvent(toolName: 'fetch_url', status: 'ok'));
+        await tester.pump();
+
+        final snap = notifier.state.value!.currentTurnStatus!;
+        expect(snap.lastEventKind, TurnEventKind.toolResult);
+        expect(snap.currentToolName, 'fetch_url');
+
+        await ctrl.close();
+        await tester.pumpAndSettle();
+      },
+    );
+
+    testWidgets('ThinkingEvent updates lastEventKind=thinking', (tester) async {
+      final fakeApi = _FakeApiClient();
+      final ctrl = fakeApi.enqueueStream();
+      addTearDown(() async {
+        if (!ctrl.isClosed) await ctrl.close();
+      });
+      final notifier = await _pumpTestApp(tester, fakeApi);
+
+      unawaited(notifier.sendMessage('hello'));
+      await tester.pump();
+      ctrl.add(const RunStartedEvent('run-1'));
+      await tester.pump();
+      ctrl.add(const ThinkingEvent('reasoning...'));
+      await tester.pump();
+
+      expect(
+        notifier.state.value!.currentTurnStatus!.lastEventKind,
+        TurnEventKind.thinking,
+      );
+
+      await ctrl.close();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('StatusEvent updates lastEventKind=status', (tester) async {
+      final fakeApi = _FakeApiClient();
+      final ctrl = fakeApi.enqueueStream();
+      addTearDown(() async {
+        if (!ctrl.isClosed) await ctrl.close();
+      });
+      final notifier = await _pumpTestApp(tester, fakeApi);
+
+      unawaited(notifier.sendMessage('hello'));
+      await tester.pump();
+      ctrl.add(const RunStartedEvent('run-1'));
+      await tester.pump();
+      ctrl.add(const StatusEvent('Working...'));
+      await tester.pump();
+
+      expect(
+        notifier.state.value!.currentTurnStatus!.lastEventKind,
+        TurnEventKind.status,
+      );
+
+      await ctrl.close();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets(
+      'SubagentStartedEvent updates lastEventKind=subagentStarted and tool name',
+      (tester) async {
+        final fakeApi = _FakeApiClient();
+        final ctrl = fakeApi.enqueueStream();
+        addTearDown(() async {
+          if (!ctrl.isClosed) await ctrl.close();
+        });
+        final notifier = await _pumpTestApp(tester, fakeApi);
+
+        unawaited(notifier.sendMessage('hello'));
+        await tester.pump();
+        ctrl.add(const RunStartedEvent('run-1'));
+        await tester.pump();
+        ctrl.add(
+          const SubagentStartedEvent(agentId: 'a1', task: 'analyze data'),
+        );
+        await tester.pump();
+
+        final snap = notifier.state.value!.currentTurnStatus!;
+        expect(snap.lastEventKind, TurnEventKind.subagentStarted);
+        expect(snap.currentToolName, 'analyze data');
+
+        await ctrl.close();
+        await tester.pumpAndSettle();
+      },
+    );
+
+    testWidgets('DoneEvent clears currentTurnStatus', (tester) async {
+      final fakeApi = _FakeApiClient();
+      final ctrl = fakeApi.enqueueStream();
+      addTearDown(() async {
+        if (!ctrl.isClosed) await ctrl.close();
+      });
+      final notifier = await _pumpTestApp(tester, fakeApi);
+
+      unawaited(notifier.sendMessage('hello'));
+      await tester.pump();
+      ctrl.add(const RunStartedEvent('run-1'));
+      ctrl.add(const TokenEvent('hi'));
+      ctrl.add(const DoneEvent(role: 'assistant', content: 'hi'));
+      await tester.pumpAndSettle();
+
+      expect(
+        notifier.state.value!.currentTurnStatus,
+        isNull,
+        reason: 'DoneEvent ends the turn — snapshot must be cleared',
+      );
+    });
+
+    testWidgets('transient stream error with run ID clears currentTurnStatus', (
+      tester,
+    ) async {
+      final fakeApi = _FakeApiClient();
+      final ctrl = fakeApi.enqueueStream();
+      final notifier = await _pumpTestApp(tester, fakeApi);
+
+      unawaited(notifier.sendMessage('hello'));
+      await tester.pump();
+      await tester.runAsync(() async {
+        ctrl.add(const RunStartedEvent('run-defer'));
+        await Future<void>.delayed(Duration.zero);
+        ctrl.addError(
+          const HttpException('Connection closed while receiving data'),
+        );
+        await ctrl.close();
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+      });
+      // Pump through 3 retry delays (1+2+4 s).
+      await tester.pump(const Duration(seconds: 2));
+      await tester.pump(const Duration(seconds: 3));
+      await tester.pump(const Duration(seconds: 5));
+      await tester.pumpAndSettle();
+
+      expect(
+        notifier.state.value!.currentTurnStatus,
+        isNull,
+        reason: 'After retries exhaust, the snapshot must be cleared',
+      );
+    });
+
+    testWidgets('lastEventAt is monotonically updated on each event', (
+      tester,
+    ) async {
+      final fakeApi = _FakeApiClient();
+      final ctrl = fakeApi.enqueueStream();
+      addTearDown(() async {
+        if (!ctrl.isClosed) await ctrl.close();
+      });
+      final notifier = await _pumpTestApp(tester, fakeApi);
+
+      unawaited(notifier.sendMessage('hello'));
+      await tester.pump();
+      ctrl.add(const RunStartedEvent('run-1'));
+      await tester.pump();
+      final t1 = notifier.state.value!.currentTurnStatus!.lastEventAt;
+
+      // Real wall-clock delay so the second timestamp differs.
+      await tester.runAsync(() async {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      });
+      ctrl.add(const TokenEvent('hi'));
+      await tester.pump();
+      final t2 = notifier.state.value!.currentTurnStatus!.lastEventAt;
+
+      expect(
+        t2.isAfter(t1) || t2.isAtSameMomentAs(t1),
+        isTrue,
+        reason: 'lastEventAt must not regress between events',
+      );
+
+      await ctrl.close();
+      await tester.pumpAndSettle();
+    });
+  });
 }

--- a/openspec/changes/chat-stream-progress-ux/tasks.md
+++ b/openspec/changes/chat-stream-progress-ux/tasks.md
@@ -1,9 +1,9 @@
 ## 1. Phase A — currentTurnStatus derived state
 
-- [ ] 1.1 Write failing unit tests for the new `currentTurnStatus` accessor on `ChatNotifier` (or sibling selector): covers turnId/lastEventKind/lastEventAt/currentToolName across every SSE event kind.
-- [ ] 1.2 Implement `currentTurnStatus` updates inside `ChatNotifier`'s SSE event handlers — one update per event kind. Cleared on `done` / `agent_error`.
-- [ ] 1.3 Run the new unit tests; confirm green.
-- [ ] 1.4 Run the full `flutter test` suite — must remain green.
+- [x] 1.1 Tests written (10 tests) — runId/lastEventKind/lastEventAt/currentToolName across every SSE event kind, plus initial state, DoneEvent clear, transient-error clear, and lastEventAt monotonicity.
+- [x] 1.2 Implemented: added `TurnEventKind` enum + `TurnStatusSnapshot` class + `ChatState.currentTurnStatus` field. `_streamMessage` opens the snapshot on `RunStartedEvent`, bumps it via a new `_bumpTurnStatus` helper on every subsequent event kind, and clears it on `DoneEvent` / `ErrorEvent` / retries-exhausted / `_clearStalledPlaceholder`. `TokenEvent` clears `currentToolName` inline (the assistant resumed text generation).
+- [x] 1.3 New tests: 10/10 pass.
+- [x] 1.4 Full suite: 968/968 pass. `flutter analyze --fatal-infos` clean.
 
 ## 2. Phase B — TurnProgressCard widget + integration
 


### PR DESCRIPTION
## Summary

First phase of the [`chat-stream-progress-ux`](openspec/changes/chat-stream-progress-ux/) OpenSpec change. Adds the observable surface that the upcoming \`TurnProgressCard\` widget (Phase B) will render. **No UI changes** in this PR — pure state-machine additions.

## What's exposed

\`ChatState\` gains a new field:

\`\`\`dart
final TurnStatusSnapshot? currentTurnStatus;
\`\`\`

- \`null\` when no turn is in flight.
- Otherwise: \`runId\`, \`lastEventKind\` (a closed enum: \`runStarted\` / \`token\` / \`status\` / \`thinking\` / \`toolResult\` / \`subagentStarted\` / \`subagentCompleted\` / \`audioReady\`), \`lastEventAt\` (DateTime), and an optional \`currentToolName\`.

## State-machine wiring

| Event | Effect on snapshot |
|---|---|
| \`RunStartedEvent\` | Opens the snapshot with the run ID. |
| \`TokenEvent\` | Updates \`lastEventKind=token\` and **clears \`currentToolName\`** (assistant resumed text generation; the previously-active tool name should not persist). |
| \`StatusEvent\` / \`ThinkingEvent\` / \`SubagentCompletedEvent\` | Bumps \`lastEventKind\` + \`lastEventAt\`, preserves \`currentToolName\`. |
| \`ToolResultEvent\` | Populates \`currentToolName\` from \`event.toolName\`. |
| \`SubagentStartedEvent\` | Populates \`currentToolName\` from \`event.task\`. |
| \`DoneEvent\` | Clears the snapshot. |
| Catch retries-exhausted, non-transient error, \`_clearStalledPlaceholder\` | Clears via \`clearCurrentTurnStatus: true\`. |

## Tests

10 new tests in group \"ChatNotifier — currentTurnStatus derived state\":

- Initial state has no currentTurnStatus
- RunStartedEvent populates runId
- TokenEvent clears tool name (resumed text generation)
- ToolResultEvent populates currentToolName
- StatusEvent / ThinkingEvent / SubagentStartedEvent transitions
- DoneEvent clears the snapshot
- Transient stream error with run ID clears the snapshot after retries exhaust
- lastEventAt is monotonically updated

## Stack

- ✅ Phase 1 keep-alive (#817) + salvage (#818) + proposals (#816) all merged.
- 👉 **This PR** — Phase A
- Phase B (TurnProgressCard widget), C (queued ghost bubbles), D (reconnect banner) to follow.

## Test plan

- [x] \`flutter test test/unit/chat/chat_provider_test.dart --name \"currentTurnStatus\"\` — 10/10 pass
- [x] \`flutter test\` — 968/968 pass (was 955; +13 new)
- [x] \`flutter analyze --fatal-infos\` — 0 issues
- [x] Pre-commit hook — passed