### PR TITLE
feat(test-support): scaffold assistant-test-support composition crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -705,6 +705,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "assistant-test-support"
+version = "0.1.160"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "assistant-tool-executor"
 version = "0.1.160"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "crates/opentelemetry-exporter-iceberg",
     "crates/bus-nats",
     "crates/backup",
+    "crates/test-support",
 ]
 default-members = [
     "crates/interface-cli",

--- a/coverage.toml
+++ b/coverage.toml
@@ -60,7 +60,7 @@ crates = [
     "workflow-http",
     "opentelemetry-exporter-iceberg",
     "opentelemetry-exporter-sqlite",
-    # test-support — added when the crate is scaffolded in Phase 2.
+    "test-support",
 ]
 
 # File path regex patterns excluded from coverage measurement.

--- a/crates/test-support/Cargo.toml
+++ b/crates/test-support/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "assistant-test-support"
+version = "0.1.160"
+edition.workspace = true
+license.workspace = true
+description = "Composition layer for assistant workspace test fixtures. Hosts FixtureBuilder + prelude re-exports of in-memory persistence impls, ScriptedLlmProvider, and orchestration stubs."
+publish = false
+
+[dependencies]
+# Kept minimal at the scaffold stage. Re-export targets are added in later
+# phases of openspec/changes/workspace-test-coverage-floor/ as their owning
+# crates land their fakes: Clock (Phase 3), persistence stores (Phase 5),
+# orchestration stubs (Phase 7), ScriptedLlmProvider (Phase 5.H).
+
+[dev-dependencies]
+tokio = { workspace = true }
+
+# Inherit the workspace lint baseline. This crate is library code (its
+# src/lib.rs is compiled like any other crate), so it must respect the
+# panic-free contract — keep .unwrap() / .expect() / panic!() out of
+# fixture composition logic. Tests inside crates/test-support/tests/
+# are exempt from clippy by default and may use .unwrap() freely.
+[lints]
+workspace = true

--- a/crates/test-support/src/fixture.rs
+++ b/crates/test-support/src/fixture.rs
@@ -1,0 +1,47 @@
+//! Fixture composition for `assistant` workspace tests.
+//!
+//! [`FixtureBuilder`] is a scaffold at this stage. Methods that wire `Clock`,
+//! `LlmProvider`, `MessageBus`, and the persistence trait fakes land in later
+//! phases of `openspec/changes/workspace-test-coverage-floor/` as their owning
+//! crates land their in-memory implementations:
+//!
+//! - Phase 3 — `with_clock(FakeClock)`
+//! - Phase 5 — `with_canned_llm_responses`, in-memory store wiring
+//! - Phase 7 — `Arc<dyn OrchestrationEngine>` wired to `StubOrchestrationEngine`
+//!
+//! The public shape is fixed now so consumers can begin migrating to
+//! `FixtureBuilder::new().build().await` calls and grow naturally.
+
+/// Builder for a composed [`Fixture`]. Defaults wire every fake to a
+/// sensible no-op initial state; per-field overrides come from `with_*`
+/// methods that land in later phases.
+#[derive(Default)]
+pub struct FixtureBuilder {
+    // Fields fill in as fakes land in later phases of
+    // workspace-test-coverage-floor.
+    _private: (),
+}
+
+impl FixtureBuilder {
+    /// Start a new builder with all defaults.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Materialise the [`Fixture`].
+    ///
+    /// At Phase 2 this is a no-op composition; later phases wire in real
+    /// fakes (in-memory stores, scripted LLM provider, message bus, etc.).
+    pub async fn build(self) -> Fixture {
+        Fixture { _private: () }
+    }
+}
+
+/// Composed test fixture. Carries the configured fakes once they land in
+/// later phases of `workspace-test-coverage-floor`. At Phase 2 the type is
+/// inhabited but carries no fields; tests construct it through
+/// [`FixtureBuilder::build`].
+pub struct Fixture {
+    // Fields fill in as fakes land in later phases.
+    _private: (),
+}

--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -1,0 +1,29 @@
+//! Composition layer for the `assistant` workspace's test fixtures.
+//!
+//! This crate is a thin re-export and composition layer. The actual fakes —
+//! `InMemoryConversationStore`, `ScriptedLlmProvider`, `StubOrchestrationEngine`,
+//! `FakeClock`, `InMemoryMessageBus`, and so on — live in their owning crates
+//! next to their SQLite/production counterparts. The job of this crate is to:
+//!
+//! 1. Re-export those fakes through [`prelude`] so test files have one
+//!    `use assistant_test_support::prelude::*;` line.
+//! 2. Compose them via [`FixtureBuilder`] so tests can spin up a wired-up
+//!    [`Fixture`] in a single chained call.
+//!
+//! ## Crate boundary rules
+//!
+//! - `assistant-test-support` MUST NOT appear in any crate's `[dependencies]`
+//!   section. Only `[dev-dependencies]`. Enforced by
+//!   `tests/workspace_test_support_lint.rs` at the repo root.
+//! - Test-only types whose name starts with `InMemory`, `Scripted`, or `Stub`
+//!   MUST NOT be constructed in non-test production code. Enforced by
+//!   `tests/workspace_test_impls_in_prod.rs` at the repo root, with an explicit
+//!   exempt list for documented production fallbacks
+//!   (e.g. `InMemoryConversationBroadcaster`).
+//!
+//! See `openspec/changes/workspace-test-coverage-floor/specs/persistence-trait-symmetry/`.
+
+pub mod fixture;
+pub mod prelude;
+
+pub use fixture::{Fixture, FixtureBuilder};

--- a/crates/test-support/src/prelude.rs
+++ b/crates/test-support/src/prelude.rs
@@ -1,0 +1,20 @@
+//! Prelude — single-import re-exports for the most-used fixture types and
+//! workspace fakes.
+//!
+//! Test code should prefer
+//!
+//! ```ignore
+//! use assistant_test_support::prelude::*;
+//! ```
+//!
+//! over individual imports. As fakes land in their owning crates in later
+//! phases of `openspec/changes/workspace-test-coverage-floor/`, they are
+//! re-exported here:
+//!
+//! - Phase 3 — `FakeClock` from `assistant_core::clock`
+//! - Phase 5 — `InMemory*Store` types from `assistant_storage` and
+//!   `ScriptedLlmProvider` from `assistant_llm_provider`
+//! - Phase 7 — `StubOrchestrationEngine`, `StubToolDispatcher`,
+//!   `InMemorySkillCatalog`
+
+pub use crate::fixture::{Fixture, FixtureBuilder};

--- a/crates/test-support/tests/smoke.rs
+++ b/crates/test-support/tests/smoke.rs
@@ -1,0 +1,18 @@
+//! Smoke test for `assistant-test-support`.
+//!
+//! Asserts that the crate compiles, the `prelude` module exists, and
+//! `FixtureBuilder::new().build().await` returns a `Fixture`. As fakes
+//! land in later phases of `workspace-test-coverage-floor`, this test
+//! grows to assert their presence on the prelude.
+
+use assistant_test_support::prelude::*;
+
+#[tokio::test]
+async fn fixture_builder_smoke() {
+    let _fixture: Fixture = FixtureBuilder::new().build().await;
+}
+
+#[tokio::test]
+async fn fixture_builder_default_smoke() {
+    let _fixture = FixtureBuilder::default().build().await;
+}

--- a/openspec/changes/workspace-test-coverage-floor/tasks.md
+++ b/openspec/changes/workspace-test-coverage-floor/tasks.md
@@ -7,19 +7,19 @@
 - [x] 1.5 Add `tools/check_coverage.sh` (or `tools/check_coverage.rs`) that parses `coverage.json`, computes per-crate line coverage, and exits non-zero when any crate not in the report-only allowlist falls below 80%.
 - [x] 1.6 Seed the report-only allowlist with **every** crate; the gate prints but does not fail.
 - [x] 1.7 Document `cargo llvm-cov` usage in `AGENTS.md` and link to the gate script.
-- [ ] 1.8 Run `make lint && make format`; commit as `feat(ci): add cargo-llvm-cov coverage measurement (report-only)`.
+- [x] 1.8 Run `make lint && make format`; commit as `feat(ci): add cargo-llvm-cov coverage measurement (report-only)`.
 
 ## 2. Phase 2 — `assistant-test-support` crate scaffold (composition only)
 
 `assistant-test-support` is a thin composition layer. It hosts `FixtureBuilder` + a `prelude` module that re-exports the in-memory impls from their owning crates. The in-memory impls themselves do NOT live here — they live next to their SQLite peers in their owning crates and are plain `pub`, NOT feature-gated.
 
-- [ ] 2.1 Add failing test under `crates/test-support/tests/smoke.rs` that imports `assistant_test_support::FixtureBuilder` and constructs an empty fixture; should fail to compile (crate does not exist yet).
-- [ ] 2.2 Create `crates/test-support/` with `Cargo.toml`, `src/lib.rs`, and module stubs (`prelude`, `fixture`). Package name `assistant-test-support`. Empty `[dependencies]` initially (re-exports get added as their source crates land their fakes).
-- [ ] 2.3 Register `crates/test-support` in the root `Cargo.toml` workspace members list.
-- [ ] 2.4 Configure `[lints]\nworkspace = true` in `crates/test-support/Cargo.toml` — keep panic-free contract at workspace baseline (`warn`, not `deny`); `.unwrap()` is ergonomic in test helpers.
-- [ ] 2.5 Document the crate's purpose: it composes existing fakes, it does NOT host the fakes themselves. Document the rule that `assistant-test-support` MUST NOT appear in any crate's `[dependencies]` section (only `[dev-dependencies]`).
-- [ ] 2.6 Add `tests/workspace_test_support_lint.rs` at the repo root that fails when `assistant-test-support` appears in any crate's `[dependencies]` table (only `[dev-dependencies]` is allowed).
-- [ ] 2.7 Add `tests/workspace_test_impls_in_prod.rs` at the repo root that fails when types matching `InMemory*`, `Scripted*`, or `Stub*` are constructed in non-test production code paths (exempt: the defining module itself, `#[cfg(test)]` modules, `tests/` directories, the `assistant-test-support` crate, and the documented production-fallback construction sites for `InMemoryConversationBroadcaster`).
+- [x] 2.1 Add failing test under `crates/test-support/tests/smoke.rs` that imports `assistant_test_support::FixtureBuilder` and constructs an empty fixture; should fail to compile (crate does not exist yet).
+- [x] 2.2 Create `crates/test-support/` with `Cargo.toml`, `src/lib.rs`, and module stubs (`prelude`, `fixture`). Package name `assistant-test-support`. Empty `[dependencies]` initially (re-exports get added as their source crates land their fakes).
+- [x] 2.3 Register `crates/test-support` in the root `Cargo.toml` workspace members list.
+- [x] 2.4 Configure `[lints]\nworkspace = true` in `crates/test-support/Cargo.toml` — keep panic-free contract at workspace baseline (`warn`, not `deny`); `.unwrap()` is ergonomic in test helpers.
+- [x] 2.5 Document the crate's purpose: it composes existing fakes, it does NOT host the fakes themselves. Document the rule that `assistant-test-support` MUST NOT appear in any crate's `[dependencies]` section (only `[dev-dependencies]`).
+- [x] 2.6 Add `tests/workspace_test_support_lint.rs` at the repo root that fails when `assistant-test-support` appears in any crate's `[dependencies]` table (only `[dev-dependencies]` is allowed).
+- [x] 2.7 Add `tests/workspace_test_impls_in_prod.rs` at the repo root that fails when types matching `InMemory*`, `Scripted*`, or `Stub*` are constructed in non-test production code paths (exempt: the defining module itself, `#[cfg(test)]` modules, `tests/` directories, the `assistant-test-support` crate, and the documented production-fallback construction sites for `InMemoryConversationBroadcaster`).
 - [ ] 2.8 Run `make lint && make format`; commit as `feat(test-support): scaffold assistant-test-support composition crate`.
 
 ## 3. Phase 3 — `Clock` trait

--- a/tests/workspace_test_impls_in_prod.rs
+++ b/tests/workspace_test_impls_in_prod.rs
@@ -1,0 +1,190 @@
+//! Workspace lint: test-only types must not appear in production code.
+//!
+//! Asserts the contract introduced by the `workspace-test-coverage-floor`
+//! OpenSpec change (specs/persistence-trait-symmetry):
+//!
+//! Types whose name starts with `InMemory`, `Scripted`, or `Stub` are
+//! considered test-only stand-ins. They MUST NOT be constructed in
+//! non-test production code, with the following exemptions:
+//!
+//! - The file that defines the type (where `impl Default` / `impl <Type>`
+//!   blocks construct it as part of the impl surface).
+//! - Files in `crates/test-support/` — the test composition layer.
+//! - Files under any `tests/` directory.
+//! - Lines inside `#[cfg(test)] mod tests { ... }` blocks (heuristic:
+//!   any line whose number is greater than the first `#[cfg(test)]`
+//!   attribute in the file).
+//! - The documented `EXEMPT_TYPE_NAMES` list below (production fallbacks
+//!   that happen to share the `InMemory` naming convention because they
+//!   are legitimately non-persistent).
+//!
+//! As more in-memory impls land in later phases (Phase 5 persistence,
+//! Phase 7 orchestration stubs), contributors keep this lint passing by
+//! keeping their construction inside test code or by adding documented
+//! production fallbacks to `EXEMPT_TYPE_NAMES`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Types whose construction is allowed in production code despite the
+/// `InMemory*` / `Scripted*` / `Stub*` prefix. Each entry is a documented
+/// production fallback or compatibility shim.
+const EXEMPT_TYPE_NAMES: &[&str] = &[
+    // Used as the default `ConversationBroadcast` impl when no external
+    // broadcaster (NATS, web-ui SSE multiplexer) is configured. Defined in
+    // `crates/storage/src/conversation_broadcaster.rs`; constructed in
+    // `crates/web-ui/src/api/mod.rs::ApiState::new` and analogous locations.
+    "InMemoryConversationBroadcaster",
+];
+
+/// Crate directories under `crates/` exempt from the scan.
+const EXEMPT_CRATES: &[&str] = &[
+    // The test composition layer is allowed to construct any fake.
+    "test-support",
+];
+
+#[test]
+fn no_test_only_impls_in_production_code() {
+    let root = workspace_root().join("crates");
+    let mut violations: Vec<String> = Vec::new();
+
+    for entry in fs::read_dir(&root).expect("read crates/") {
+        let entry = entry.expect("dir entry");
+        if !entry.path().is_dir() {
+            continue;
+        }
+        let crate_dir_name = entry.file_name().to_string_lossy().into_owned();
+        if EXEMPT_CRATES.contains(&crate_dir_name.as_str()) {
+            continue;
+        }
+        let src_dir = entry.path().join("src");
+        if !src_dir.is_dir() {
+            continue;
+        }
+        scan_dir(&src_dir, &mut violations);
+    }
+
+    assert!(
+        violations.is_empty(),
+        "test-only impls constructed in production code:\n  {}",
+        violations.join("\n  ")
+    );
+}
+
+fn scan_dir(dir: &Path, violations: &mut Vec<String>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            // Skip in-tree `tests/` directories (some crates colocate them).
+            if path.file_name().and_then(|n| n.to_str()) == Some("tests") {
+                continue;
+            }
+            scan_dir(&path, violations);
+            continue;
+        }
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        scan_file(&path, violations);
+    }
+}
+
+fn scan_file(path: &Path, violations: &mut Vec<String>) {
+    let Ok(content) = fs::read_to_string(path) else {
+        return;
+    };
+
+    // Compute the line number of the first `#[cfg(test)]` attribute, if any.
+    // Lines at or after this number are treated as test code by the
+    // heuristic. This is an approximation: it works for the common pattern
+    // of `#[cfg(test)] mod tests { ... }` at the bottom of a file, but
+    // would over-exempt files that gate a single `use` statement with
+    // `#[cfg(test)]` near the top. Refine if false negatives appear.
+    let first_cfg_test_line: Option<usize> = content.lines().enumerate().find_map(|(idx, line)| {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("#[cfg(test)]") {
+            Some(idx + 1)
+        } else {
+            None
+        }
+    });
+
+    // The file is permitted to construct types it defines.
+    let defines_type = |type_name: &str| -> bool {
+        let needle = format!("pub struct {type_name}");
+        content.contains(&needle)
+    };
+
+    for (idx, line) in content.lines().enumerate() {
+        let line_no = idx + 1;
+        if let Some(cfg_test_line) = first_cfg_test_line
+            && line_no >= cfg_test_line
+        {
+            continue;
+        }
+
+        for type_name in find_test_only_constructions(line) {
+            if EXEMPT_TYPE_NAMES.contains(&type_name.as_str()) {
+                continue;
+            }
+            if defines_type(&type_name) {
+                continue;
+            }
+            violations.push(format!(
+                "{}:{} constructs test-only type `{type_name}`",
+                path.display(),
+                line_no,
+            ));
+        }
+    }
+}
+
+/// Find type names of the form `(InMemory|Scripted|Stub)<PascalCase>`
+/// followed by `::` on the given line.
+fn find_test_only_constructions(line: &str) -> Vec<String> {
+    let mut hits: Vec<String> = Vec::new();
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        for prefix in ["InMemory", "Scripted", "Stub"] {
+            let p = prefix.as_bytes();
+            if i + p.len() < bytes.len() && bytes[i..i + p.len()].eq_ignore_ascii_case(p) {
+                // Must be at a word boundary on the left.
+                if i > 0 && (bytes[i - 1].is_ascii_alphanumeric() || bytes[i - 1] == b'_') {
+                    continue;
+                }
+                let start = i;
+                let mut end = i + p.len();
+                // Continue across PascalCase identifier characters.
+                while end < bytes.len()
+                    && (bytes[end].is_ascii_alphanumeric() || bytes[end] == b'_')
+                {
+                    end += 1;
+                }
+                // The match must be followed by `::` to count as a
+                // constructor / associated-item reference. This avoids
+                // false positives on type-name mentions in comments,
+                // docstrings, or `dyn TraitName` references.
+                if end + 1 < bytes.len() && &bytes[end..end + 2] == b"::" {
+                    // Require at least one extra character after the
+                    // prefix so we don't match the bare prefix word.
+                    if end > i + p.len() {
+                        let name = String::from_utf8_lossy(&bytes[start..end]).to_string();
+                        hits.push(name);
+                    }
+                }
+                i = end;
+                break;
+            }
+        }
+        i += 1;
+    }
+    hits
+}

--- a/tests/workspace_test_support_lint.rs
+++ b/tests/workspace_test_support_lint.rs
@@ -1,0 +1,74 @@
+//! Workspace lint: `assistant-test-support` is dev-deps only.
+//!
+//! Asserts the contract introduced by the `workspace-test-coverage-floor`
+//! OpenSpec change (specs/persistence-trait-symmetry): the
+//! `assistant-test-support` crate MUST appear only in `[dev-dependencies]`,
+//! never `[dependencies]`. Production binaries must not link the test
+//! composition layer.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use toml::Value;
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn read_toml(path: &Path) -> Value {
+    let raw = fs::read_to_string(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    toml::from_str::<Value>(&raw).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
+}
+
+fn workspace_members() -> Vec<String> {
+    let root = read_toml(&workspace_root().join("Cargo.toml"));
+    root.get("workspace")
+        .and_then(|w| w.get("members"))
+        .and_then(|m| m.as_array())
+        .expect("[workspace.members] missing")
+        .iter()
+        .map(|v| v.as_str().expect("member must be a string").to_string())
+        .collect()
+}
+
+const TEST_SUPPORT_CRATE: &str = "assistant-test-support";
+
+#[test]
+fn test_support_not_in_normal_dependencies() {
+    let root = workspace_root();
+    let mut violations: Vec<String> = Vec::new();
+
+    for member in workspace_members() {
+        let manifest_path = root.join(&member).join("Cargo.toml");
+        if !manifest_path.exists() {
+            continue;
+        }
+        let toml = read_toml(&manifest_path);
+        if let Some(deps) = toml.get("dependencies").and_then(|d| d.as_table())
+            && deps.contains_key(TEST_SUPPORT_CRATE)
+        {
+            violations.push(format!(
+                "{}: lists {TEST_SUPPORT_CRATE} in [dependencies]; \
+                 it MUST be in [dev-dependencies] only",
+                member,
+            ));
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "assistant-test-support appears in normal dependencies:\n  {}",
+        violations.join("\n  ")
+    );
+}
+
+#[test]
+fn test_support_crate_is_registered() {
+    // Sanity check: the test-support crate itself is a workspace member.
+    let members = workspace_members();
+    assert!(
+        members.iter().any(|m| m == "crates/test-support"),
+        "crates/test-support missing from [workspace.members]; \
+         members = {members:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Phase 2 of [`workspace-test-coverage-floor`](openspec/changes/workspace-test-coverage-floor/) — the test composition layer scaffold + workspace lints that defend it.

- `crates/test-support/` — new workspace member, `[dev-dependencies]`-only edges from consumers. Hosts `FixtureBuilder` + `prelude` re-exports. **The actual fakes do NOT live here** — they will live next to their SQLite/production peers in their owning crates (Phase 3 `FakeClock`, Phase 5 stores + `ScriptedLlmProvider`, Phase 7 `Stub*`) and be re-exported through `prelude`.
- `FixtureBuilder::new().build().await` is wired today as a no-op scaffold so consumers can start writing the call shape. Builder methods (`with_clock`, `with_canned_llm_responses`, etc.) land in later phases.
- `tests/workspace_test_support_lint.rs` — fails CI when any crate lists `assistant-test-support` in `[dependencies]` (only `[dev-dependencies]` allowed).
- `tests/workspace_test_impls_in_prod.rs` — fails CI when types prefixed `InMemory*` / `Scripted*` / `Stub*` are constructed in non-test production code, with `EXEMPT_TYPE_NAMES` carrying the one current production fallback (`InMemoryConversationBroadcaster`).
- `coverage.toml` — adds `test-support` to the report-only allowlist.

Test-code detection in the prod-impls lint uses a heuristic: the first `#[cfg(test)]` attribute in a file marks the start of the test region. This works for the common pattern (test mod at the bottom of the file). It would over-exempt a file that gates a single `use` at the top, but at this phase no `InMemory*` / `Scripted*` / `Stub*` types exist outside the exempt list, so the lint catches zero false negatives today. Refine if/when false negatives appear.

## Test plan

- [x] `cargo check -p assistant-test-support` clean
- [x] `cargo test -p assistant-test-support` — 2/2 smoke tests pass
- [x] `cargo test -p assistant --tests` — all 7 workspace lint tests pass (4 existing `workspace_lint_policy` + 1 new `workspace_test_impls_in_prod` + 2 new `workspace_test_support_lint`)
- [x] `make lint` clean
- [x] `make format` clean
- [x] Pre-commit hooks pass