### PR TITLE
feat(core): add Clock trait + SystemClock + FakeClock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,6 +708,7 @@ dependencies = [
 name = "assistant-test-support"
 version = "0.1.160"
 dependencies = [
+ "assistant-core",
  "tokio",
 ]
 

--- a/crates/core/src/clock.rs
+++ b/crates/core/src/clock.rs
@@ -1,0 +1,277 @@
+//! Workspace clock abstraction.
+//!
+//! Provides the [`Clock`] trait abstracting wall-clock and monotonic time
+//! access, the production [`SystemClock`] implementation, and the test-only
+//! [`FakeClock`] implementation. The trait + impls live in `assistant-core`
+//! alongside other shared workspace primitives.
+//!
+//! ## Adoption
+//!
+//! Production code that needs the current time SHALL accept
+//! `Arc<dyn Clock>` at construction and default to
+//! `Arc::new(SystemClock)` via a builder. Direct calls to
+//! [`chrono::Utc::now`] / [`std::time::SystemTime::now`] / [`std::time::Instant::now`]
+//! are forbidden in non-test production code; the workspace lint
+//! `tests/workspace_clock_lint.rs` (added in a later phase of
+//! `workspace-test-coverage-floor`) will enforce this once every crate has
+//! migrated.
+//!
+//! Tests use [`FakeClock`] to seed and advance virtual time:
+//!
+//! ```
+//! use assistant_core::clock::{Clock, FakeClock};
+//! use std::sync::Arc;
+//! use std::time::Duration;
+//!
+//! let fake = Arc::new(FakeClock::new_at_seed());
+//! let t0 = fake.now();
+//! fake.advance(Duration::from_secs(60));
+//! let t1 = fake.now();
+//! assert_eq!((t1 - t0).num_seconds(), 60);
+//! ```
+
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use chrono::{DateTime, TimeZone, Utc};
+
+/// Abstract access to wall-clock and monotonic time.
+///
+/// Production: `SystemClock` (wraps `chrono::Utc::now` and `std::time::Instant::now`).
+/// Tests: `FakeClock` (seedable + advanceable virtual time).
+pub trait Clock: Send + Sync {
+    /// The current wall-clock time as a `DateTime<Utc>`.
+    fn now(&self) -> DateTime<Utc>;
+
+    /// A monotonic instant. For `SystemClock`, the underlying
+    /// `std::time::Instant`. For `FakeClock`, derived from the seeded
+    /// wall-clock time so that `now_instant` advances in lockstep with
+    /// `now`.
+    fn now_instant(&self) -> Instant;
+}
+
+/// Production [`Clock`] implementation. Wraps `chrono::Utc::now` and
+/// `std::time::Instant::now`.
+///
+/// `SystemClock` is the only call site of the underlying system clocks
+/// permitted by the workspace lint policy; every other production site
+/// MUST route through `Arc<dyn Clock>`.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now(&self) -> DateTime<Utc> {
+        Utc::now()
+    }
+
+    fn now_instant(&self) -> Instant {
+        Instant::now()
+    }
+}
+
+/// Test-only [`Clock`] implementation backed by a seeded `DateTime<Utc>`.
+///
+/// `FakeClock` is interior-mutable: cloned handles share the same
+/// underlying time, so a test can hold an `Arc<dyn Clock>` referring to
+/// a `FakeClock` *and* hold the concrete `FakeClock` to advance it.
+///
+/// Despite its name and intended use, `FakeClock` is plain `pub` (not
+/// `#[cfg(test)]`-gated) — the workspace's testability policy mandates
+/// that in-memory / fake implementations live next to their production
+/// peers and are usable from any crate's tests via the test-support
+/// prelude. Production code that constructs `FakeClock` is flagged by
+/// `tests/workspace_test_impls_in_prod.rs`.
+#[derive(Debug, Clone)]
+pub struct FakeClock {
+    inner: Arc<FakeClockInner>,
+}
+
+#[derive(Debug)]
+struct FakeClockInner {
+    state: Mutex<FakeClockState>,
+}
+
+#[derive(Debug)]
+struct FakeClockState {
+    wall: DateTime<Utc>,
+    /// Origin `Instant` recorded at construction. `now_instant()` returns
+    /// `origin + (wall - wall_origin)`.
+    origin_instant: Instant,
+    wall_origin: DateTime<Utc>,
+}
+
+impl FakeClock {
+    /// Construct a [`FakeClock`] seeded at the given wall-clock time.
+    pub fn new(seed: DateTime<Utc>) -> Self {
+        let origin_instant = Instant::now();
+        Self {
+            inner: Arc::new(FakeClockInner {
+                state: Mutex::new(FakeClockState {
+                    wall: seed,
+                    origin_instant,
+                    wall_origin: seed,
+                }),
+            }),
+        }
+    }
+
+    /// Construct a [`FakeClock`] seeded at a deterministic, well-known
+    /// epoch (`2026-01-01T00:00:00Z`). Convenient for test fixtures.
+    pub fn new_at_seed() -> Self {
+        let seed = Utc
+            .with_ymd_and_hms(2026, 1, 1, 0, 0, 0)
+            .single()
+            .unwrap_or_else(|| {
+                // Fallback chain in the extremely unlikely event chrono
+                // rejects the seed literal — keep this code panic-free.
+                Utc.timestamp_opt(0, 0)
+                    .single()
+                    .unwrap_or_else(|| DateTime::<Utc>::from_timestamp(0, 0).unwrap_or_default())
+            });
+        Self::new(seed)
+    }
+
+    /// Advance virtual time by the given duration.
+    pub fn advance(&self, by: Duration) {
+        if let Ok(mut state) = self.inner.state.lock() {
+            state.wall += chrono::Duration::from_std(by).unwrap_or(chrono::Duration::zero());
+        }
+    }
+
+    /// Set virtual time to a specific wall-clock instant.
+    pub fn set(&self, to: DateTime<Utc>) {
+        if let Ok(mut state) = self.inner.state.lock() {
+            state.wall = to;
+            // Re-anchor the Instant origin so monotonic time stays in
+            // sync with the new wall-clock value.
+            state.origin_instant = Instant::now();
+            state.wall_origin = to;
+        }
+    }
+}
+
+impl Default for FakeClock {
+    fn default() -> Self {
+        Self::new_at_seed()
+    }
+}
+
+impl Clock for FakeClock {
+    fn now(&self) -> DateTime<Utc> {
+        match self.inner.state.lock() {
+            Ok(state) => state.wall,
+            Err(poisoned) => poisoned.into_inner().wall,
+        }
+    }
+
+    fn now_instant(&self) -> Instant {
+        match self.inner.state.lock() {
+            Ok(state) => {
+                let delta_chrono = state.wall - state.wall_origin;
+                let delta = delta_chrono
+                    .to_std()
+                    .unwrap_or(std::time::Duration::from_secs(0));
+                state.origin_instant + delta
+            }
+            Err(poisoned) => {
+                let state = poisoned.into_inner();
+                let delta_chrono = state.wall - state.wall_origin;
+                let delta = delta_chrono
+                    .to_std()
+                    .unwrap_or(std::time::Duration::from_secs(0));
+                state.origin_instant + delta
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn seed_time() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 5, 17, 8, 30, 0)
+            .single()
+            .unwrap()
+    }
+
+    #[test]
+    fn system_clock_returns_recent_wall_clock_time() {
+        let clock = SystemClock;
+        let before = Utc::now();
+        let now = clock.now();
+        let after = Utc::now();
+        assert!(
+            now >= before && now <= after,
+            "SystemClock::now() must return a time within [before, after]"
+        );
+    }
+
+    #[test]
+    fn fake_clock_returns_seeded_time() {
+        let clock = FakeClock::new(seed_time());
+        assert_eq!(clock.now(), seed_time(), "FakeClock must return the seed");
+    }
+
+    #[test]
+    fn fake_clock_advance_moves_wall_clock() {
+        let clock = FakeClock::new(seed_time());
+        clock.advance(Duration::from_secs(90));
+        let expected = seed_time() + chrono::Duration::seconds(90);
+        assert_eq!(
+            clock.now(),
+            expected,
+            "advance(90s) must move wall clock by 90s"
+        );
+    }
+
+    #[test]
+    fn fake_clock_set_overrides_time() {
+        let clock = FakeClock::new(seed_time());
+        let new_time = seed_time() + chrono::Duration::hours(2);
+        clock.set(new_time);
+        assert_eq!(clock.now(), new_time, "set(x) must replace the wall clock");
+    }
+
+    #[test]
+    fn fake_clock_instant_advances_with_wall_clock() {
+        let clock = FakeClock::new(seed_time());
+        let t0 = clock.now_instant();
+        clock.advance(Duration::from_secs(30));
+        let t1 = clock.now_instant();
+        assert!(
+            t1 >= t0 + Duration::from_secs(29),
+            "now_instant must advance with the wall clock"
+        );
+    }
+
+    #[test]
+    fn fake_clock_is_clonable_and_shared() {
+        let a = FakeClock::new(seed_time());
+        let b = a.clone();
+        a.advance(Duration::from_secs(45));
+        assert_eq!(
+            b.now(),
+            seed_time() + chrono::Duration::seconds(45),
+            "cloned FakeClock handles must share state"
+        );
+    }
+
+    #[test]
+    fn clock_trait_is_object_safe() {
+        // Compile-time assertion that Clock is dyn-compatible.
+        let _: Arc<dyn Clock> = Arc::new(SystemClock);
+        let _: Arc<dyn Clock> = Arc::new(FakeClock::new_at_seed());
+    }
+
+    #[test]
+    fn fake_clock_default_uses_well_known_seed() {
+        let a = FakeClock::default();
+        let b = FakeClock::new_at_seed();
+        assert_eq!(
+            a.now(),
+            b.now(),
+            "Default::default() must equal new_at_seed()"
+        );
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod bus;
 pub mod bus_messages;
 pub mod catalog;
 pub mod channel;
+pub mod clock;
 pub mod command;
 pub mod config;
 pub mod context;
@@ -39,6 +40,7 @@ pub use bus_messages::{
 };
 pub use catalog::{CatalogEntry, CatalogResolver, CatalogResourceType};
 pub use channel::{ChannelAdapter, ChannelContent, ChannelMessage, ChannelUser};
+pub use clock::{Clock, FakeClock, SystemClock};
 pub use command::{CommandArg, CommandDef, CommandResult, ConversationConfig};
 pub use config::{default_config_path, load_config};
 pub use context::{

--- a/crates/test-support/Cargo.toml
+++ b/crates/test-support/Cargo.toml
@@ -7,10 +7,11 @@ description = "Composition layer for assistant workspace test fixtures. Hosts Fi
 publish = false
 
 [dependencies]
-# Kept minimal at the scaffold stage. Re-export targets are added in later
-# phases of openspec/changes/workspace-test-coverage-floor/ as their owning
-# crates land their fakes: Clock (Phase 3), persistence stores (Phase 5),
-# orchestration stubs (Phase 7), ScriptedLlmProvider (Phase 5.H).
+# Re-export targets land in later phases of
+# openspec/changes/workspace-test-coverage-floor/ as their owning crates
+# add their fakes: Clock (Phase 3 — present), persistence stores
+# (Phase 5), orchestration stubs (Phase 7), ScriptedLlmProvider (Phase 5.H).
+assistant-core = { path = "../core" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/test-support/src/prelude.rs
+++ b/crates/test-support/src/prelude.rs
@@ -11,10 +11,12 @@
 //! phases of `openspec/changes/workspace-test-coverage-floor/`, they are
 //! re-exported here:
 //!
-//! - Phase 3 — `FakeClock` from `assistant_core::clock`
+//! - Phase 3 — `FakeClock` from `assistant_core::clock` (present).
 //! - Phase 5 — `InMemory*Store` types from `assistant_storage` and
-//!   `ScriptedLlmProvider` from `assistant_llm_provider`
+//!   `ScriptedLlmProvider` from `assistant_llm_provider`.
 //! - Phase 7 — `StubOrchestrationEngine`, `StubToolDispatcher`,
-//!   `InMemorySkillCatalog`
+//!   `InMemorySkillCatalog`.
+
+pub use assistant_core::clock::{Clock, FakeClock, SystemClock};
 
 pub use crate::fixture::{Fixture, FixtureBuilder};

--- a/crates/test-support/tests/smoke.rs
+++ b/crates/test-support/tests/smoke.rs
@@ -5,6 +5,9 @@
 //! land in later phases of `workspace-test-coverage-floor`, this test
 //! grows to assert their presence on the prelude.
 
+use std::sync::Arc;
+use std::time::Duration;
+
 use assistant_test_support::prelude::*;
 
 #[tokio::test]
@@ -15,4 +18,20 @@ async fn fixture_builder_smoke() {
 #[tokio::test]
 async fn fixture_builder_default_smoke() {
     let _fixture = FixtureBuilder::default().build().await;
+}
+
+#[test]
+fn prelude_exports_fake_clock() {
+    // The prelude must surface FakeClock + Clock + SystemClock so test
+    // code anywhere in the workspace can `use assistant_test_support::prelude::*;`
+    // and immediately work with the time abstraction.
+    let fake = FakeClock::new_at_seed();
+    let t0 = fake.now();
+    fake.advance(Duration::from_secs(30));
+    let t1 = fake.now();
+    assert_eq!((t1 - t0).num_seconds(), 30);
+
+    // Clock is dyn-compatible — both impls coerce to Arc<dyn Clock>.
+    let _system: Arc<dyn Clock> = Arc::new(SystemClock);
+    let _fake_dyn: Arc<dyn Clock> = Arc::new(fake);
 }

--- a/openspec/changes/workspace-test-coverage-floor/tasks.md
+++ b/openspec/changes/workspace-test-coverage-floor/tasks.md
@@ -24,10 +24,10 @@
 
 ## 3. Phase 3 — `Clock` trait
 
-- [ ] 3.1 Add failing test in `crates/core/src/clock.rs` that asserts `FakeClock` returns the seeded `DateTime<Utc>` and advances on `tick()`.
-- [ ] 3.2 Implement `pub trait Clock: Send + Sync` with `now() -> DateTime<Utc>` and `now_instant() -> Instant`. Implement `SystemClock` and `FakeClock` both as plain `pub` types in `assistant-core::clock` — no `#[cfg(test)]`, no feature flag. `FakeClock` is just another `Clock` impl, available wherever the `Clock` trait is.
-- [ ] 3.3 Re-export `Clock`, `SystemClock`, `FakeClock` from `assistant_core`'s lib root.
-- [ ] 3.4 Add `assistant_core::FakeClock` to the `assistant-test-support` prelude re-exports.
+- [x] 3.1 Add failing test in `crates/core/src/clock.rs` that asserts `FakeClock` returns the seeded `DateTime<Utc>` and advances on `tick()`.
+- [x] 3.2 Implement `pub trait Clock: Send + Sync` with `now() -> DateTime<Utc>` and `now_instant() -> Instant`. Implement `SystemClock` and `FakeClock` both as plain `pub` types in `assistant-core::clock` — no `#[cfg(test)]`, no feature flag. `FakeClock` is just another `Clock` impl, available wherever the `Clock` trait is.
+- [x] 3.3 Re-export `Clock`, `SystemClock`, `FakeClock` from `assistant_core`'s lib root.
+- [x] 3.4 Add `assistant_core::FakeClock` to the `assistant-test-support` prelude re-exports.
 - [ ] 3.5 Add failing test in `crates/auth/tests/jwt_clock.rs` asserting a JWT issued by a `FakeClock`-backed `JwtManager` reports `exp` relative to the fake clock.
 - [ ] 3.6 Thread `Arc<dyn Clock>` into `assistant_auth::jwt::JwtManager`; default to `Arc::new(SystemClock)` via a `Default` impl or `new()` builder.
 - [ ] 3.7 Replace `Utc::now()` calls in `crates/auth/src/{jwt,oauth2/device,api_keys,providers,middleware,oidc}.rs` with the injected clock.


### PR DESCRIPTION
## Summary

Phase 3.1–3.4 of [`workspace-test-coverage-floor`](openspec/changes/workspace-test-coverage-floor/) — the Clock foundation. **No consumer migration yet**; the 92 production `Utc::now()` call sites stay as-is for now. Migration lands one or two crates at a time in follow-up PRs.

- `crates/core/src/clock.rs` — `pub trait Clock` + `SystemClock` (production) + `FakeClock` (seedable / advanceable / shareable). Both impls plain `pub`, no `#[cfg(test)]`, no feature gate. `FakeClock::new_at_seed()` returns a deterministic `2026-01-01T00:00:00Z` for fixture convenience.
- `crates/core/src/lib.rs` — re-exports `Clock`, `SystemClock`, `FakeClock` at the crate root.
- `crates/test-support/` — first re-export target landed: prelude now surfaces `Clock`, `SystemClock`, `FakeClock`. Smoke test grew to assert the prelude works and that `Clock` is dyn-compatible.

### What's deferred (the 92 call sites)

| Slice | Target | Files |
|-|-|-|
| 3.5–3.8 | `assistant-auth` | `jwt.rs`, `oauth2/device.rs`, `api_keys.rs`, `providers.rs`, `middleware.rs`, `oidc.rs` |
| 3.9 | `assistant-runtime` | `scheduler/`, `title_generator.rs`, `memory_indexer/`, `compaction.rs`, `orchestrator/worker.rs` |
| 3.10 | `assistant-bus-nats`, `assistant-storage`, `assistant-llm-provider` | event timestamps, retry backoff |
| 3.11 | workspace `tests/workspace_clock_lint.rs` — flips on after all crates migrated |

## Test plan

- [x] `cargo test -p assistant-core clock::` — 8/8 pass (system clock, fake clock seed / advance / set / instant / clone / dyn-safety / default)
- [x] `cargo test -p assistant-test-support` — 3/3 (prelude exports FakeClock, dyn-compatibility, existing fixture smoke)
- [x] `make lint` clean
- [x] `make format` clean
- [x] Pre-commit hooks pass