### PR TITLE
feat(app): Phase B — TurnProgressCard widget above the chat composer

### DIFF
--- a/app/lib/features/chat/chat_screen.dart
+++ b/app/lib/features/chat/chat_screen.dart
@@ -35,6 +35,7 @@ import '../../shared/theme/assistant_spacing.dart';
 import 'image_utils.dart';
 import 'markdown_link_handler.dart';
 import 'streaming_timeline_entry.dart';
+import 'turn_progress_card.dart';
 import 'theme_aware_mermaid.dart';
 import 'voice_recorder_button.dart';
 
@@ -572,6 +573,11 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                         ],
                       ),
                     ),
+
+                    // In-flight turn progress card — renders nothing when no
+                    // turn is active, an activity label otherwise, a stall
+                    // label after 30s of silence.
+                    const TurnProgressCard(),
 
                     // Input row.
                     _InputRow(

--- a/app/lib/features/chat/turn_progress_card.dart
+++ b/app/lib/features/chat/turn_progress_card.dart
@@ -1,0 +1,117 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../shared/platform/widgets.dart';
+import 'chat_provider.dart';
+import 'turn_status_label.dart';
+
+/// Stall threshold — once the in-flight turn has been silent for this
+/// long, the card transitions from its activity label to a stall label
+/// with an elapsed-time indicator. Tuneable; documented in design.md
+/// Decision 3 ("30 seconds is longer than the average human attention
+/// span, shorter than most enterprise web tool calls").
+const Duration kTurnStallThreshold = Duration(seconds: 30);
+
+/// Compact, persistent indicator of the active turn's most recent
+/// activity. Renders nothing when no turn is in flight.
+///
+/// Driven by [ChatState.currentTurnStatus]. The label flips per SSE
+/// event kind via [turnStatusLabel]; after [kTurnStallThreshold] of
+/// silence, the card surfaces a stall message with elapsed-seconds via
+/// a 1-second [Timer.periodic].
+class TurnProgressCard extends ConsumerStatefulWidget {
+  const TurnProgressCard({super.key});
+
+  @override
+  ConsumerState<TurnProgressCard> createState() => _TurnProgressCardState();
+}
+
+class _TurnProgressCardState extends ConsumerState<TurnProgressCard> {
+  Timer? _ticker;
+  DateTime _now = DateTime.now();
+
+  @override
+  void dispose() {
+    _ticker?.cancel();
+    super.dispose();
+  }
+
+  void _ensureTicker(TurnStatusSnapshot? snap) {
+    if (snap == null) {
+      _ticker?.cancel();
+      _ticker = null;
+      return;
+    }
+    _ticker ??= Timer.periodic(const Duration(seconds: 1), (_) {
+      if (!mounted) return;
+      setState(() => _now = DateTime.now());
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final snap = ref.watch(
+      chatProvider.select((s) => s.value?.currentTurnStatus),
+    );
+    _ensureTicker(snap);
+
+    if (snap == null) {
+      return const SizedBox.shrink();
+    }
+
+    final elapsed = _now.difference(snap.lastEventAt);
+    final stalled = elapsed >= kTurnStallThreshold;
+    final label = stalled
+        ? stalledTurnStatusLabel(elapsed)
+        : turnStatusLabel(snap);
+
+    final colorScheme = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: BoxDecoration(
+          color: stalled
+              ? colorScheme.errorContainer.withValues(alpha: 0.35)
+              : colorScheme.surfaceContainerHigh,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(
+            color: stalled
+                ? colorScheme.error.withValues(alpha: 0.4)
+                : colorScheme.outlineVariant,
+          ),
+        ),
+        child: Row(
+          children: [
+            SizedBox(
+              width: 16,
+              height: 16,
+              child: CircularProgressIndicator.adaptive(
+                strokeWidth: 2,
+                valueColor: AlwaysStoppedAnimation<Color>(
+                  stalled ? colorScheme.error : colorScheme.primary,
+                ),
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                label,
+                key: const Key('turn_progress_card_label'),
+                style: TextStyle(
+                  fontSize: 13,
+                  color: stalled
+                      ? colorScheme.onErrorContainer
+                      : colorScheme.onSurface,
+                ),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/features/chat/turn_status_label.dart
+++ b/app/lib/features/chat/turn_status_label.dart
@@ -1,0 +1,51 @@
+import 'chat_provider.dart' show TurnEventKind, TurnStatusSnapshot;
+
+/// Returns a plain-language label describing the active turn's current
+/// activity, derived from the most recent SSE event.
+///
+/// Pure function — no `BuildContext`, no localisation hooks (yet). Returns
+/// the English copy expected by the in-flight progress card. When i18n is
+/// added later, the lookup moves through `AppLocalizations`.
+///
+/// Specified by `openspec/changes/chat-stream-progress-ux/specs/...`
+/// "In-flight turn progress card" requirement.
+String turnStatusLabel(TurnStatusSnapshot snapshot) {
+  switch (snapshot.lastEventKind) {
+    case TurnEventKind.runStarted:
+      return 'Starting…';
+    case TurnEventKind.thinking:
+      return 'Thinking…';
+    case TurnEventKind.token:
+      return 'Generating response…';
+    case TurnEventKind.status:
+      return 'Working…';
+    case TurnEventKind.toolResult:
+      final name = snapshot.currentToolName;
+      if (name != null && name.isNotEmpty) {
+        return 'Calling $name…';
+      }
+      return 'Running tool…';
+    case TurnEventKind.subagentStarted:
+      final task = snapshot.currentToolName;
+      if (task != null && task.isNotEmpty) {
+        return 'Subagent: $task…';
+      }
+      return 'Running subagent…';
+    case TurnEventKind.subagentCompleted:
+      return 'Subagent finished — generating…';
+    case TurnEventKind.audioReady:
+      return 'Audio ready';
+  }
+}
+
+/// Returns the stall-state label rendered when the active turn has been
+/// silent for longer than the stall threshold. Includes a compact elapsed-
+/// time string in the form `0:34`.
+///
+/// Callers pass the elapsed-seconds count from a [Ticker] in the widget.
+String stalledTurnStatusLabel(Duration elapsed) {
+  final minutes = elapsed.inMinutes;
+  final seconds = elapsed.inSeconds % 60;
+  final compact = '$minutes:${seconds.toString().padLeft(2, '0')}';
+  return 'Server is taking longer than expected — $compact';
+}

--- a/app/test/unit/chat/turn_status_label_test.dart
+++ b/app/test/unit/chat/turn_status_label_test.dart
@@ -1,0 +1,115 @@
+// Pure unit tests for the `turnStatusLabel` and `stalledTurnStatusLabel`
+// helpers. Locks the user-facing copy per `TurnEventKind`, the tool-name
+// interpolation, and the stalled elapsed-time format.
+//
+// Specified by: openspec/changes/chat-stream-progress-ux/specs/...
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/features/chat/chat_provider.dart';
+import 'package:assistant_app/features/chat/turn_status_label.dart';
+
+TurnStatusSnapshot _snap(TurnEventKind kind, {String? toolName}) =>
+    TurnStatusSnapshot(
+      runId: 'run-1',
+      lastEventKind: kind,
+      lastEventAt: DateTime(2026, 5, 17, 12, 0, 0),
+      currentToolName: toolName,
+    );
+
+void main() {
+  group('turnStatusLabel', () {
+    test('runStarted → "Starting…"', () {
+      expect(turnStatusLabel(_snap(TurnEventKind.runStarted)), 'Starting…');
+    });
+
+    test('thinking → "Thinking…"', () {
+      expect(turnStatusLabel(_snap(TurnEventKind.thinking)), 'Thinking…');
+    });
+
+    test('token → "Generating response…"', () {
+      expect(
+        turnStatusLabel(_snap(TurnEventKind.token)),
+        'Generating response…',
+      );
+    });
+
+    test('status → "Working…"', () {
+      expect(turnStatusLabel(_snap(TurnEventKind.status)), 'Working…');
+    });
+
+    test('toolResult with tool name → "Calling {name}…"', () {
+      expect(
+        turnStatusLabel(_snap(TurnEventKind.toolResult, toolName: 'fetch_url')),
+        'Calling fetch_url…',
+      );
+    });
+
+    test('toolResult without tool name → generic fallback', () {
+      expect(
+        turnStatusLabel(_snap(TurnEventKind.toolResult)),
+        'Running tool…',
+        reason:
+            'When the server omits the tool name, the label should still be '
+            'meaningful — not just "Calling …"',
+      );
+    });
+
+    test('subagentStarted with task → "Subagent: {task}…"', () {
+      expect(
+        turnStatusLabel(
+          _snap(TurnEventKind.subagentStarted, toolName: 'analyze data'),
+        ),
+        'Subagent: analyze data…',
+      );
+    });
+
+    test('subagentStarted without task → generic fallback', () {
+      expect(
+        turnStatusLabel(_snap(TurnEventKind.subagentStarted)),
+        'Running subagent…',
+      );
+    });
+
+    test('subagentCompleted → "Subagent finished — generating…"', () {
+      expect(
+        turnStatusLabel(_snap(TurnEventKind.subagentCompleted)),
+        'Subagent finished — generating…',
+      );
+    });
+
+    test('audioReady → "Audio ready"', () {
+      expect(turnStatusLabel(_snap(TurnEventKind.audioReady)), 'Audio ready');
+    });
+  });
+
+  group('stalledTurnStatusLabel', () {
+    test('formats sub-minute elapsed as "0:SS"', () {
+      expect(
+        stalledTurnStatusLabel(const Duration(seconds: 34)),
+        'Server is taking longer than expected — 0:34',
+      );
+    });
+
+    test('formats elapsed past 1 minute as "M:SS"', () {
+      expect(
+        stalledTurnStatusLabel(const Duration(seconds: 95)),
+        'Server is taking longer than expected — 1:35',
+      );
+    });
+
+    test('pads single-digit seconds with a leading zero', () {
+      expect(
+        stalledTurnStatusLabel(const Duration(seconds: 9)),
+        'Server is taking longer than expected — 0:09',
+      );
+    });
+
+    test('handles exactly N minutes (00 seconds)', () {
+      expect(
+        stalledTurnStatusLabel(const Duration(minutes: 2)),
+        'Server is taking longer than expected — 2:00',
+      );
+    });
+  });
+}

--- a/app/test/widget/features/chat/turn_progress_card_test.dart
+++ b/app/test/widget/features/chat/turn_progress_card_test.dart
@@ -1,0 +1,239 @@
+// Widget tests for [TurnProgressCard]. Pins:
+//   - rendering nothing when no turn is in flight
+//   - rendering the correct label for each event kind
+//   - transitioning to the stalled label after kTurnStallThreshold
+//   - cleaning up the ticker on disposal
+//
+// Specified by: openspec/changes/chat-stream-progress-ux/specs/...
+//   "In-flight turn progress card"
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/features/chat/chat_provider.dart';
+import 'package:assistant_app/features/chat/turn_progress_card.dart';
+
+class _FakeChatNotifier extends ChatNotifier {
+  @override
+  Future<ChatState> build() async => const ChatState();
+
+  void push(ChatState s) => state = AsyncData(s);
+}
+
+Future<_FakeChatNotifier> _pumpCard(WidgetTester tester) async {
+  final notifier = _FakeChatNotifier();
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [chatProvider.overrideWith(() => notifier)],
+      child: const MaterialApp(home: Scaffold(body: TurnProgressCard())),
+    ),
+  );
+  return notifier;
+}
+
+TurnStatusSnapshot _snap(
+  TurnEventKind kind, {
+  String? toolName,
+  DateTime? at,
+}) => TurnStatusSnapshot(
+  runId: 'run-1',
+  lastEventKind: kind,
+  lastEventAt: at ?? DateTime.now(),
+  currentToolName: toolName,
+);
+
+void main() {
+  group('TurnProgressCard', () {
+    testWidgets('renders nothing when no turn is in flight', (tester) async {
+      await _pumpCard(tester);
+      await tester.pump();
+
+      // No label widget — the card collapses to SizedBox.shrink().
+      expect(find.byKey(const Key('turn_progress_card_label')), findsNothing);
+    });
+
+    testWidgets('renders the activity label for a runStarted snapshot', (
+      tester,
+    ) async {
+      final notifier = await _pumpCard(tester);
+      notifier.push(
+        ChatState(currentTurnStatus: _snap(TurnEventKind.runStarted)),
+      );
+      await tester.pump();
+
+      expect(find.text('Starting…'), findsOneWidget);
+    });
+
+    testWidgets('renders a tool-name label for toolResult', (tester) async {
+      final notifier = await _pumpCard(tester);
+      notifier.push(
+        ChatState(
+          currentTurnStatus: _snap(
+            TurnEventKind.toolResult,
+            toolName: 'fetch_url',
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Calling fetch_url…'), findsOneWidget);
+    });
+
+    testWidgets('renders a subagent-task label for subagentStarted', (
+      tester,
+    ) async {
+      final notifier = await _pumpCard(tester);
+      notifier.push(
+        ChatState(
+          currentTurnStatus: _snap(
+            TurnEventKind.subagentStarted,
+            toolName: 'crunch numbers',
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Subagent: crunch numbers…'), findsOneWidget);
+    });
+
+    testWidgets('transitions to stalled label after stall threshold', (
+      tester,
+    ) async {
+      final notifier = await _pumpCard(tester);
+
+      // Push a snapshot whose lastEventAt is 35 s in the past — already
+      // past the 30 s stall threshold.
+      final past = DateTime.now().subtract(const Duration(seconds: 35));
+      notifier.push(
+        ChatState(currentTurnStatus: _snap(TurnEventKind.token, at: past)),
+      );
+      await tester.pump();
+
+      // The card should be showing the stall label, not the activity
+      // label. The exact elapsed seconds depends on wall-clock timing
+      // between push and pump, so match on the stall prefix.
+      expect(
+        find.textContaining('Server is taking longer than expected'),
+        findsOneWidget,
+      );
+      expect(find.text('Generating response…'), findsNothing);
+    });
+
+    testWidgets(
+      'transitions back to activity label when a fresher event arrives',
+      (tester) async {
+        final notifier = await _pumpCard(tester);
+        // Start stalled (35 s old).
+        notifier.push(
+          ChatState(
+            currentTurnStatus: _snap(
+              TurnEventKind.token,
+              at: DateTime.now().subtract(const Duration(seconds: 35)),
+            ),
+          ),
+        );
+        await tester.pump();
+        expect(
+          find.textContaining('Server is taking longer than expected'),
+          findsOneWidget,
+        );
+
+        // A fresh event arrives — lastEventAt updates to now.
+        notifier.push(
+          ChatState(
+            currentTurnStatus: _snap(
+              TurnEventKind.thinking,
+              at: DateTime.now(),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        // Stall label gone; activity label visible.
+        expect(
+          find.textContaining('Server is taking longer than expected'),
+          findsNothing,
+        );
+        expect(find.text('Thinking…'), findsOneWidget);
+      },
+    );
+
+    testWidgets('disappears when currentTurnStatus is cleared', (tester) async {
+      final notifier = await _pumpCard(tester);
+      notifier.push(
+        ChatState(currentTurnStatus: _snap(TurnEventKind.runStarted)),
+      );
+      await tester.pump();
+      expect(find.text('Starting…'), findsOneWidget);
+
+      notifier.push(const ChatState());
+      await tester.pump();
+      expect(find.byKey(const Key('turn_progress_card_label')), findsNothing);
+    });
+
+    testWidgets('ticker fires once per second to update elapsed-time display', (
+      tester,
+    ) async {
+      final notifier = await _pumpCard(tester);
+
+      // Push a snapshot whose lastEventAt is right at the stall
+      // threshold, so the very next tick crosses into stall state.
+      final atThreshold = DateTime.now().subtract(const Duration(seconds: 30));
+      notifier.push(
+        ChatState(
+          currentTurnStatus: _snap(TurnEventKind.token, at: atThreshold),
+        ),
+      );
+      await tester.pump();
+
+      // After one second of real time, the ticker fires setState
+      // and the label updates with the new elapsed-time count. We
+      // verify the card stays in stall state (the label may still
+      // be either pre-30s threshold or post; what we pin is the
+      // periodic Timer keeps it rendering without errors).
+      await tester.pump(const Duration(seconds: 1));
+      await tester.pump(const Duration(seconds: 1));
+      expect(
+        find.byKey(const Key('turn_progress_card_label')),
+        findsOneWidget,
+        reason:
+            'The card must keep rendering across ticker frames — no '
+            'dispose-during-build errors or null-state crashes',
+      );
+    });
+
+    testWidgets('disposes ticker cleanly on widget removal', (tester) async {
+      FakeAsync().run((async) {
+        final notifier = _FakeChatNotifier();
+        runApp(
+          ProviderScope(
+            overrides: [chatProvider.overrideWith(() => notifier)],
+            child: const MaterialApp(home: Scaffold(body: TurnProgressCard())),
+          ),
+        );
+        notifier.push(
+          ChatState(currentTurnStatus: _snap(TurnEventKind.runStarted)),
+        );
+        async.elapse(const Duration(seconds: 1));
+        // Pump removal — replace with an empty scaffold.
+        runApp(
+          ProviderScope(
+            overrides: [chatProvider.overrideWith(() => notifier)],
+            child: const MaterialApp(home: Scaffold()),
+          ),
+        );
+        async.elapse(const Duration(seconds: 5));
+        // No pending timers means the ticker was cancelled in dispose.
+        expect(
+          async.pendingTimers,
+          isEmpty,
+          reason:
+              'TurnProgressCard.dispose() must cancel its 1-second '
+              'periodic ticker',
+        );
+      });
+    });
+  });
+}

--- a/openspec/changes/chat-stream-progress-ux/tasks.md
+++ b/openspec/changes/chat-stream-progress-ux/tasks.md
@@ -7,13 +7,13 @@
 
 ## 2. Phase B — TurnProgressCard widget + integration
 
-- [ ] 2.1 Spike: build a `turnStatusLabel(TurnStatusSnapshot)` pure function with widget tests for each case (run_started / token / status / thinking / tool_result / subagent_started / stalled / unknown).
-- [ ] 2.2 Write failing widget tests for `TurnProgressCard` rendering each state.
-- [ ] 2.3 Implement `app/lib/features/chat/turn_progress_card.dart`.
-- [ ] 2.4 Wire elapsed-seconds via a `Ticker` inside the card; dispose on widget removal.
-- [ ] 2.5 Integrate into `chat_screen.dart` above the composer.
-- [ ] 2.6 Re-baseline Playwright screenshots for the chat screen.
-- [ ] 2.7 Manual smoke on iPhone Simulator, iPad Simulator, Chrome, `flutter run -d macos`.
+- [x] 2.1 Built `turnStatusLabel(TurnStatusSnapshot)` pure function in `lib/features/chat/turn_status_label.dart`. 14 unit tests cover every TurnEventKind, tool-name interpolation, generic fallbacks, and the stalled elapsed-time format (`0:34`, `1:35`, padded seconds).
+- [x] 2.2 Wrote widget tests for every state (renders-nothing-when-null, per-event-kind labels, stalled-transition at 30 s, recovers-on-fresh-event, disappears-on-clear, ticker fires once per second, ticker disposes cleanly).
+- [x] 2.3 Implemented `app/lib/features/chat/turn_progress_card.dart` — Riverpod-driven, watches `chatProvider.select((s) => s.value?.currentTurnStatus)`.
+- [x] 2.4 Elapsed-seconds wired via a 1-second `Timer.periodic`. Started on first non-null snapshot, cancelled in `dispose()`. Verified via fake_async test.
+- [x] 2.5 Integrated into `chat_screen.dart` above the `_InputRow` composer. Single line: `const TurnProgressCard(),`. Renders to `SizedBox.shrink()` when no turn is in flight.
+- [ ] 2.6 Re-baseline Playwright screenshots for the chat screen. Defer to a follow-up — the visual diff is bounded to the composer area; existing baselines will fail until updated.
+- [ ] 2.7 Manual smoke on iPhone Simulator, iPad Simulator, Chrome, `flutter run -d macos`. Defer to user verification.
 
 ## 3. Phase C — Queued ghost bubbles
 


### PR DESCRIPTION
## Summary

Second phase of [\`chat-stream-progress-ux\`](openspec/changes/chat-stream-progress-ux/). Adds the visible progress indicator users asked for: while a turn is streaming (whether it's emitting tokens, calling a tool, or thinking), a compact card above the composer shows what's happening.

Phase A (#822) exposed \`currentTurnStatus\` as observable state. This PR renders it.

## What's new

\`lib/features/chat/turn_status_label.dart\` — pure function returning the user-facing label for any \`TurnStatusSnapshot\`. Per-event-kind copy:

| Event | Label |
|---|---|
| runStarted | \"Starting…\" |
| thinking | \"Thinking…\" |
| token | \"Generating response…\" |
| status | \"Working…\" |
| toolResult + tool name | \"Calling fetch_url…\" |
| subagentStarted + task | \"Subagent: analyze data…\" |
| subagentCompleted | \"Subagent finished — generating…\" |
| audioReady | \"Audio ready\" |

Plus a stalled-state formatter producing \`Server is taking longer than expected — 0:34\`.

\`lib/features/chat/turn_progress_card.dart\` — Riverpod widget. Watches \`chatProvider.select((s) => s.value?.currentTurnStatus)\`. Renders nothing when null; otherwise an adaptive spinner + label in a rounded container. Transitions to a red-bordered stall variant after 30 s of silence; elapsed-seconds tick once per second via \`Timer.periodic\` (cancelled in \`dispose()\`).

Integration: one line in \`chat_screen.dart\` above \`_InputRow\`.

## Tests

| File | Coverage | Count |
|---|---|---|
| \`turn_status_label_test.dart\` | every event kind, tool-name interpolation, fallbacks, stalled time format | 14 |
| \`turn_progress_card_test.dart\` | nothing-when-null, per-kind labels, stalled transition, recovery, disappearance, ticker frames, ticker disposal | 9 |

## Stack

- ✅ Phase A (#822) merged.
- 👉 **This PR** — Phase B
- Phase C (queued ghost bubbles), D (reconnect banner) follow.

## Deferred

- Playwright re-baseline (visual diff bounded to composer area)
- Manual smoke on physical devices

## Test plan

- [x] \`flutter test\` — 991/991 pass (was 968; +23 new)
- [x] \`flutter analyze --fatal-infos\` — 0 issues
- [x] Pre-commit hook — passed (first attempt flaked on the \`chat_screen retry affordance\` test; second attempt clean)