### PR TITLE
feat(app): Phase D — reconnect banner during attemptReconnect

### DIFF
--- a/app/lib/features/chat/chat_provider.dart
+++ b/app/lib/features/chat/chat_provider.dart
@@ -557,6 +557,7 @@ class ChatState {
     this.messages = const [],
     this.isSending = false,
     this.isLoadingHistory = false,
+    this.isReconnecting = false,
     this.streamingContent = '',
     this.statusMessage,
     this.lastToolResult,
@@ -569,6 +570,12 @@ class ChatState {
   final List<ChatMessage> messages;
   final bool isSending;
   final bool isLoadingHistory;
+
+  /// True while [ChatNotifier.attemptReconnect] is actively recovering an
+  /// interrupted stream — drives the "Reconnecting…" banner.
+  /// Distinct from [isSending]: reconnect happens after the original
+  /// stream terminated, before its replay reaches DoneEvent.
+  final bool isReconnecting;
 
   /// Accumulated token content during streaming (before DoneEvent).
   final String streamingContent;
@@ -598,6 +605,7 @@ class ChatState {
     List<ChatMessage>? messages,
     bool? isSending,
     bool? isLoadingHistory,
+    bool? isReconnecting,
     String? streamingContent,
     String? statusMessage,
     ChatToolResult? lastToolResult,
@@ -616,6 +624,7 @@ class ChatState {
       messages: messages ?? this.messages,
       isSending: isSending ?? this.isSending,
       isLoadingHistory: isLoadingHistory ?? this.isLoadingHistory,
+      isReconnecting: isReconnecting ?? this.isReconnecting,
       streamingContent: streamingContent ?? this.streamingContent,
       statusMessage: clearStatusMessage
           ? null
@@ -2071,45 +2080,62 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
 
     if (api == null || conversationId == null) return;
 
-    // Strategy 1: Replay from last event sequence.
-    if (runId != null && userMsgId != null) {
-      try {
-        final replayed = await _replayRun(
-          api,
-          conversationId,
-          userMsgId,
-          runId,
-          _lastSeq,
-        );
-        if (replayed) return;
-      } catch (_) {
-        // Replay failed — fall through to history fetch.
+    // Surface the recovery work as a banner — set BEFORE any await so
+    // the UI shows "Reconnecting…" promptly. Cleared in every exit path.
+    final current = state.value ?? const ChatState();
+    state = AsyncData(current.copyWith(isReconnecting: true));
+
+    try {
+      // Strategy 1: Replay from last event sequence.
+      if (runId != null && userMsgId != null) {
+        try {
+          final replayed = await _replayRun(
+            api,
+            conversationId,
+            userMsgId,
+            runId,
+            _lastSeq,
+          );
+          if (replayed) return;
+        } catch (_) {
+          // Replay failed — fall through to history fetch.
+        }
+      }
+
+      // Strategy 2: Fetch full conversation history.
+      // Save current messages in case loadConversation fails and wipes
+      // them.
+      final preLoadMessages = List<ChatMessage>.from(
+        state.value?.messages ?? [],
+      );
+      await loadConversation(conversationId);
+      // loadConversation catches errors internally — check if it
+      // succeeded.
+      final afterLoad = state.value;
+      if (afterLoad != null && afterLoad.error == null) return;
+
+      // Both strategies failed: restore messages and show friendly error.
+      final msgs = List<ChatMessage>.from(preLoadMessages);
+      if (userMsgId != null) {
+        final userIdx = msgs.indexWhere((m) => m.id == userMsgId);
+        if (userIdx != -1) {
+          msgs[userIdx] = msgs[userIdx].copyWith(status: MessageStatus.failed);
+        }
+      }
+      state = AsyncData(
+        ChatState(
+          conversationId: conversationId,
+          messages: msgs,
+          error: 'Connection lost — tap retry to resend',
+        ),
+      );
+    } finally {
+      // Clear the banner regardless of which branch terminated us.
+      final s = state.value;
+      if (s != null && s.isReconnecting) {
+        state = AsyncData(s.copyWith(isReconnecting: false));
       }
     }
-
-    // Strategy 2: Fetch full conversation history.
-    // Save current messages in case loadConversation fails and wipes them.
-    final preLoadMessages = List<ChatMessage>.from(state.value?.messages ?? []);
-    await loadConversation(conversationId);
-    // loadConversation catches errors internally — check if it succeeded.
-    final afterLoad = state.value;
-    if (afterLoad != null && afterLoad.error == null) return;
-
-    // Both strategies failed: restore messages and show friendly error.
-    final msgs = List<ChatMessage>.from(preLoadMessages);
-    if (userMsgId != null) {
-      final userIdx = msgs.indexWhere((m) => m.id == userMsgId);
-      if (userIdx != -1) {
-        msgs[userIdx] = msgs[userIdx].copyWith(status: MessageStatus.failed);
-      }
-    }
-    state = AsyncData(
-      ChatState(
-        conversationId: conversationId,
-        messages: msgs,
-        error: 'Connection lost — tap retry to resend',
-      ),
-    );
   }
 
   /// Clears deferred reconnection state.

--- a/app/lib/features/chat/chat_screen.dart
+++ b/app/lib/features/chat/chat_screen.dart
@@ -35,6 +35,7 @@ import '../../shared/theme/assistant_spacing.dart';
 import 'image_utils.dart';
 import 'markdown_link_handler.dart';
 import 'queued_message_bubble.dart';
+import 'reconnect_banner.dart';
 import 'streaming_timeline_entry.dart';
 import 'turn_progress_card.dart';
 import 'theme_aware_mermaid.dart';
@@ -595,6 +596,11 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                         ],
                       ),
                     ),
+
+                    // Brief banner shown while attemptReconnect is
+                    // recovering an interrupted stream after a resume.
+                    // Renders nothing on routine foreground transitions.
+                    const ReconnectBanner(),
 
                     // In-flight turn progress card — renders nothing when no
                     // turn is active, an activity label otherwise, a stall

--- a/app/lib/features/chat/reconnect_banner.dart
+++ b/app/lib/features/chat/reconnect_banner.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../shared/platform/widgets.dart';
+import 'chat_provider.dart';
+
+/// Slim, transient banner shown while [ChatNotifier.attemptReconnect] is
+/// recovering an interrupted stream (typically after
+/// `AppLifecycleState.resumed`).
+///
+/// Renders nothing when `isReconnecting` is false — i.e. on routine
+/// app-resume transitions where there's no interrupted stream to
+/// recover. Only the recovery path that does network work (replay +
+/// loadConversation) flips the flag, so the banner doesn't flash on
+/// every foreground.
+class ReconnectBanner extends ConsumerWidget {
+  const ReconnectBanner({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isReconnecting = ref.watch(
+      chatProvider.select((s) => s.value?.isReconnecting ?? false),
+    );
+
+    if (!isReconnecting) return const SizedBox.shrink();
+
+    final colorScheme = Theme.of(context).colorScheme;
+    return Material(
+      color: colorScheme.secondaryContainer,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: Row(
+          key: const Key('reconnect_banner'),
+          children: [
+            SizedBox(
+              width: 14,
+              height: 14,
+              child: CircularProgressIndicator.adaptive(
+                strokeWidth: 2,
+                valueColor: AlwaysStoppedAnimation<Color>(
+                  colorScheme.onSecondaryContainer,
+                ),
+              ),
+            ),
+            const SizedBox(width: 10),
+            Text(
+              'Reconnecting…',
+              style: TextStyle(
+                fontSize: 13,
+                color: colorScheme.onSecondaryContainer,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/test/unit/chat/chat_provider_test.dart
+++ b/app/test/unit/chat/chat_provider_test.dart
@@ -2375,4 +2375,41 @@ void main() {
       expect(notifier.state.value!.pendingQueue, isEmpty);
     });
   });
+
+  // -- Phase D of chat-stream-progress-ux: isReconnecting flag --------------
+  //
+  // The full "flag flips true during recovery, false on completion" path
+  // is implicitly verified by the widget test (which renders the banner
+  // against a forced isReconnecting=true state) and by inspection of the
+  // try/finally block in `attemptReconnect`. The during-recovery
+  // assertion requires mocking `api.conversations.getConversation` —
+  // the current _FakeApiClient does not, so the integration test hangs
+  // on Dio's 15 s connectTimeout. Same limitation as PR #818's fix-2
+  // positive case. Source-documented; defer the integration test to
+  // the deeper-mock follow-up.
+
+  group('ChatNotifier.attemptReconnect — isReconnecting flag', () {
+    testWidgets(
+      'routine resume (no needsReconnect, no queue) keeps isReconnecting false',
+      (tester) async {
+        final fakeApi = _FakeApiClient();
+        final notifier = await _pumpTestApp(tester, fakeApi);
+        await tester.pumpAndSettle();
+
+        expect(notifier.needsReconnect, isFalse);
+        expect(notifier.state.value!.isReconnecting, isFalse);
+
+        await notifier.attemptReconnect();
+        await tester.pumpAndSettle();
+
+        expect(
+          notifier.state.value!.isReconnecting,
+          isFalse,
+          reason:
+              'no interrupted stream → no banner; the early-return branch '
+              'must not flip the flag',
+        );
+      },
+    );
+  });
 }

--- a/app/test/widget/features/chat/reconnect_banner_test.dart
+++ b/app/test/widget/features/chat/reconnect_banner_test.dart
@@ -1,0 +1,87 @@
+// Widget tests for [ReconnectBanner]. Pins:
+//   - renders nothing when isReconnecting is false (the routine-resume
+//     case must not flash a banner)
+//   - renders the "Reconnecting…" label + spinner when true
+//   - disappears as soon as the flag flips back to false
+//
+// Specified by: openspec/changes/chat-stream-progress-ux/specs/.../
+//   "Reconnect banner during attemptReconnect"
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:assistant_app/features/chat/chat_provider.dart';
+import 'package:assistant_app/features/chat/reconnect_banner.dart';
+
+class _FakeChatNotifier extends ChatNotifier {
+  @override
+  Future<ChatState> build() async => const ChatState();
+
+  void push(ChatState s) => state = AsyncData(s);
+}
+
+Future<_FakeChatNotifier> _pumpBanner(WidgetTester tester) async {
+  final notifier = _FakeChatNotifier();
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [chatProvider.overrideWith(() => notifier)],
+      child: const MaterialApp(home: Scaffold(body: ReconnectBanner())),
+    ),
+  );
+  await tester.pump();
+  return notifier;
+}
+
+void main() {
+  group('ReconnectBanner', () {
+    testWidgets('renders nothing when isReconnecting is false', (tester) async {
+      await _pumpBanner(tester);
+
+      expect(find.byKey(const Key('reconnect_banner')), findsNothing);
+      expect(find.text('Reconnecting…'), findsNothing);
+    });
+
+    testWidgets('renders the banner when isReconnecting is true', (
+      tester,
+    ) async {
+      final notifier = await _pumpBanner(tester);
+
+      notifier.push(const ChatState(isReconnecting: true));
+      await tester.pump();
+
+      expect(find.byKey(const Key('reconnect_banner')), findsOneWidget);
+      expect(find.text('Reconnecting…'), findsOneWidget);
+    });
+
+    testWidgets('disappears when isReconnecting flips back to false', (
+      tester,
+    ) async {
+      final notifier = await _pumpBanner(tester);
+
+      notifier.push(const ChatState(isReconnecting: true));
+      await tester.pump();
+      expect(find.byKey(const Key('reconnect_banner')), findsOneWidget);
+
+      notifier.push(const ChatState(isReconnecting: false));
+      await tester.pump();
+      expect(find.byKey(const Key('reconnect_banner')), findsNothing);
+    });
+
+    testWidgets(
+      'no spurious flash on routine resume (no isReconnecting flip)',
+      (tester) async {
+        final notifier = await _pumpBanner(tester);
+
+        // Routine resume — state mutates without ever setting
+        // isReconnecting. Banner stays hidden.
+        notifier.push(const ChatState(isSending: true));
+        await tester.pump();
+        notifier.push(const ChatState(messages: [], pendingQueue: []));
+        await tester.pump();
+
+        expect(find.byKey(const Key('reconnect_banner')), findsNothing);
+      },
+    );
+  });
+}

--- a/openspec/changes/chat-stream-progress-ux/tasks.md
+++ b/openspec/changes/chat-stream-progress-ux/tasks.md
@@ -26,20 +26,21 @@
 
 ## 4. Phase D — Reconnect banner
 
-- [ ] 4.1 Write failing widget test for the reconnect banner appearance during an `attemptReconnect()` call and its disappearance on resolution.
-- [ ] 4.2 Implement the banner. Reuse the `update_banner.dart` pattern if it fits; otherwise build a sibling overlay.
-- [ ] 4.3 Integrate into `chat_screen.dart` (or `nav_shell.dart` if the banner should be app-wide).
-- [ ] 4.4 Confirm the banner does NOT fire on routine `AppLifecycleState.resumed` events with no interrupted stream (regression test).
+- [x] 4.1 Wrote `test/widget/features/chat/reconnect_banner_test.dart` — 4 tests covering renders-nothing-when-false, renders-when-true, disappearance, and no-spurious-flash on routine resume.
+- [x] 4.2 Implemented `lib/features/chat/reconnect_banner.dart`. Material banner using `colorScheme.secondaryContainer` with an adaptive spinner + "Reconnecting…" label. Built sibling-overlay pattern (consumes Riverpod selector); did not reuse update_banner because its wrapper structure doesn't fit a per-screen overlay.
+- [x] 4.3 Integrated into `chat_screen.dart` above `TurnProgressCard`. Single line: `const ReconnectBanner(),`.
+- [x] 4.4 Added `isReconnecting: bool` to ChatState. `attemptReconnect` sets it true before any await and clears it in a `finally` block. Verified by a provider test that the routine-resume path (no `_needsReconnect`) does NOT flip the flag.
+- [ ] 4.5 ~~Provider test for "flag is true during recovery"~~ deferred — requires mocking `api.conversations.getConversation` deterministically. Same untestable surface as PR #818's fix-2 positive case; documented in source.
 
 ## 5. Telemetry
 
-- [ ] 5.1 Emit OpenTelemetry events for turn-state transitions: `turn.started`, `turn.stalled`, `turn.recovered`, `turn.completed`, `turn.errored`, `turn.queue.dropped` (via remove-from-queue).
-- [ ] 5.2 Add a brief docs section to `docs/operations/` describing how to query the new events in the SQLite trace store.
+- [ ] 5.1 ~~Emit OpenTelemetry events for turn-state transitions~~ **Deferred to a follow-up change.** The OpenTelemetry SQLite exporter integration on the client side requires touching the OTel SDK wiring and the existing trace pipeline. Out of scope for the UX-rendering change. The proposal's spec doesn't require telemetry to land in lockstep with the UX; logging hooks can be added cleanly later via a small follow-up PR once the UX itself is stable on main.
+- [ ] 5.2 Docs section for telemetry queries — defer with 5.1.
 
 ## 6. Final verification
 
-- [ ] 6.1 `make lint-flutter && make test-flutter` — green.
-- [ ] 6.2 `flutter analyze --fatal-infos` — zero issues.
-- [ ] 6.3 Manual visual QA across iPhone 26, iPad 26, Apple Silicon Mac (Designed for iPad), Chrome browser, `flutter run -d macos`.
-- [ ] 6.4 Visual regression baselines re-captured and reviewed.
-- [ ] 6.5 Confirm telemetry surfaces in the dev SQLite trace store after exercising each transition.
+- [x] 6.1 `make lint-flutter && make test-flutter` — green (1001/1001 + dart_pre_commit clean).
+- [x] 6.2 `flutter analyze --fatal-infos` — zero issues.
+- [ ] 6.3 Manual visual QA across iPhone 26, iPad 26, Apple Silicon Mac (Designed for iPad), Chrome browser, `flutter run -d macos`. **User verification required** (cannot drive headlessly).
+- [ ] 6.4 Visual regression baselines re-captured and reviewed. **Deferred** to a follow-up PR — the diffs are bounded to the composer area and the message list (banner + card + ghost bubbles); landing the implementation first lets the baseline PR be a single mechanical re-capture.
+- [ ] 6.5 Confirm telemetry surfaces — deferred with 5.1.


### PR DESCRIPTION
Fourth and final UX phase of chat-stream-progress-ux. Surfaces the silent recovery work that runs on AppLifecycleState.resumed so users know the system is trying to recover.

## What's new

- `ChatState.isReconnecting: bool` flag.
- `attemptReconnect` sets it true before the first await and clears it in a try/finally. Routine resume (no _needsReconnect) never flips the flag.
- `lib/features/chat/reconnect_banner.dart` — Material banner with adaptive spinner + "Reconnecting…" label. Renders SizedBox.shrink() when the flag is false.
- One-line drop-in above TurnProgressCard in chat_screen.dart.

## Tests

- 4 widget tests (renders-nothing-when-false, renders-when-true, disappearance, no-spurious-flash on routine resume)
- 1 provider test (routine-resume keeps flag false)

1001 tests passing (was 996; +5 new).

## Stack

- ✅ Phase A (#822), B (#826), C (#828) merged.
- 👉 **This PR** — Phase D
- All UX-rendering phases on main with this merge.

## Deferred to follow-ups

- Provider test for "flag is true during recovery" — needs deeper Dio mock (same untestable surface as PR #818's fix-2 positive case).
- Telemetry (Phase 5 of the change) — touches OTel SDK wiring; small follow-up.
- Playwright re-baseline — batched.
- Manual smoke on physical devices.