### PR TITLE
refactor(storage): extract TraceStore trait + InMemory impl (Phase 5.B)

### DIFF
--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -95,7 +95,8 @@ pub use scheduled_tasks::{ScheduledTask, ScheduledTaskStore};
 pub use slack_threads::SlackActiveThreadStore;
 pub use space_store::{SqliteMembershipStore, SqliteSpaceStore};
 pub use traces::{
-    RecordedSpan, SkillStatsProvider, TraceFilter, TraceStats, TraceStore, TraceSummary,
+    InMemoryTraceStore, RecordedSpan, SkillStatsProvider, SqliteTraceStore, TraceFilter,
+    TraceStats, TraceStore, TraceSummary,
 };
 pub use user_store::SqliteUserStore;
 pub use webhooks::{WebhookRecord, WebhookStore};
@@ -154,9 +155,9 @@ impl StorageLayer {
         Ok(Self { pool })
     }
 
-    /// Convenience: build a `TraceStore` backed by this pool.
-    pub fn trace_store(&self) -> TraceStore {
-        TraceStore::new(self.pool.clone())
+    /// Convenience: build a `SqliteTraceStore` backed by this pool.
+    pub fn trace_store(&self) -> SqliteTraceStore {
+        SqliteTraceStore::new(self.pool.clone())
     }
 
     /// Convenience: build a [`ConversationEventStore`] backed by this pool.

--- a/crates/storage/src/migration.rs
+++ b/crates/storage/src/migration.rs
@@ -335,6 +335,7 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    use crate::conversations::ConversationStore;
     use assistant_core::store::{MembershipStore, OrgStore, SpaceStore, UserStore};
 
     // -- is_legacy_layout tests ----------------------------------------------

--- a/crates/storage/src/traces.rs
+++ b/crates/storage/src/traces.rs
@@ -1,6 +1,13 @@
-//! Distributed trace storage backed by OpenTelemetry spans persisted in SQLite.
+//! Distributed trace storage.
+//!
+//! Defines the [`TraceStore`] trait, its SQLite-backed implementation
+//! [`SqliteTraceStore`], and the test-only [`InMemoryTraceStore`].
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
+use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde_json::Value;
 use sqlx::sqlite::SqliteRow;
@@ -100,18 +107,68 @@ pub struct RecordedSpan {
     pub output_tokens: Option<i64>,
 }
 
+/// Trait-based interface for distributed trace storage.
+///
+/// Consumers in `assistant-web-ui` (`backends/sqlite.rs`) depend on this
+/// trait so tests can substitute [`InMemoryTraceStore`]. The trait is
+/// kept slim — methods on the concrete [`SqliteTraceStore`] that don't
+/// translate cleanly to in-memory storage (raw SQL, FTS) stay inherent.
+#[async_trait]
+pub trait TraceStore: Send + Sync {
+    /// Return the `limit` most-recent spans for the given skill name.
+    async fn get_recent_for_skill(&self, skill_name: &str, limit: i64)
+    -> Result<Vec<RecordedSpan>>;
+
+    /// Return the `limit` most-recent spans, regardless of skill.
+    async fn list_recent(&self, limit: i64) -> Result<Vec<RecordedSpan>>;
+
+    /// List recent trace summaries, optionally filtered by skill name.
+    async fn list_recent_traces(
+        &self,
+        limit: i64,
+        skill_filter: Option<&str>,
+    ) -> Result<Vec<TraceSummary>>;
+
+    /// List recent trace summaries for a specific agent.
+    async fn list_recent_traces_for_agent(
+        &self,
+        limit: i64,
+        filter: &TraceFilter,
+        agent_id: &str,
+    ) -> Result<Vec<TraceSummary>>;
+
+    /// Fetch all spans of a given trace by ID.
+    async fn get_trace(&self, trace_id: &str) -> Result<Vec<RecordedSpan>>;
+
+    /// Fetch all spans of a given trace, scoped to an agent.
+    async fn get_trace_for_agent(
+        &self,
+        trace_id: &str,
+        agent_id: &str,
+    ) -> Result<Vec<RecordedSpan>>;
+
+    /// List distinct skill names referenced in the trace log.
+    async fn list_skills(&self) -> Result<Vec<String>>;
+
+    /// Compute summary stats for a skill over the trailing `window` seconds.
+    async fn stats_for_skill(&self, skill_name: &str, window: i64) -> Result<TraceStats>;
+}
+
 /// SQLite-backed store for execution traces.
-pub struct TraceStore {
+pub struct SqliteTraceStore {
     pool: SqlitePool,
 }
 
-impl TraceStore {
+impl SqliteTraceStore {
     pub fn new(pool: SqlitePool) -> Self {
         Self { pool }
     }
+}
 
+#[async_trait]
+impl TraceStore for SqliteTraceStore {
     /// Return the `limit` most-recent traces for the given skill name.
-    pub async fn get_recent_for_skill(
+    async fn get_recent_for_skill(
         &self,
         skill_name: &str,
         limit: i64,
@@ -135,7 +192,7 @@ impl TraceStore {
     }
 
     /// Return the `limit` most-recent traces across all skills.
-    pub async fn list_recent(&self, limit: i64) -> Result<Vec<RecordedSpan>> {
+    async fn list_recent(&self, limit: i64) -> Result<Vec<RecordedSpan>> {
         let rows = sqlx::query(
             "SELECT span_id, trace_id, parent_span_id, name, conversation_id, turn, \
                     service_name, \
@@ -155,7 +212,7 @@ impl TraceStore {
 
     /// Return metadata for the newest distributed traces, optionally filtered to
     /// those that include a particular tool span.
-    pub async fn list_recent_traces(
+    async fn list_recent_traces(
         &self,
         limit: i64,
         skill_filter: Option<&str>,
@@ -238,7 +295,7 @@ impl TraceStore {
     }
 
     /// Return metadata for recent traces scoped to a specific assistant agent.
-    pub async fn list_recent_traces_for_agent(
+    async fn list_recent_traces_for_agent(
         &self,
         limit: i64,
         filter: &TraceFilter,
@@ -340,7 +397,7 @@ impl TraceStore {
 
     /// Fetch every span belonging to a trace ordered by start time so the UI can
     /// render the full hierarchy/timeline.
-    pub async fn get_trace(&self, trace_id: &str) -> Result<Vec<RecordedSpan>> {
+    async fn get_trace(&self, trace_id: &str) -> Result<Vec<RecordedSpan>> {
         let rows = sqlx::query(
             "SELECT span_id, trace_id, parent_span_id, name, conversation_id, turn, \
                     service_name, \
@@ -358,7 +415,7 @@ impl TraceStore {
     }
 
     /// Fetch every span for a trace, constrained to one assistant agent.
-    pub async fn get_trace_for_agent(
+    async fn get_trace_for_agent(
         &self,
         trace_id: &str,
         agent_id: &str,
@@ -382,7 +439,7 @@ impl TraceStore {
     }
 
     /// List distinct skill names that have recorded traces.
-    pub async fn list_skills(&self) -> Result<Vec<String>> {
+    async fn list_skills(&self) -> Result<Vec<String>> {
         let rows = sqlx::query(
             "SELECT DISTINCT tool_name \
              FROM distributed_traces \
@@ -399,7 +456,7 @@ impl TraceStore {
     }
 
     /// Compute aggregate statistics over the most-recent `window` traces for a skill.
-    pub async fn stats_for_skill(&self, skill_name: &str, window: i64) -> Result<TraceStats> {
+    async fn stats_for_skill(&self, skill_name: &str, window: i64) -> Result<TraceStats> {
         // Aggregate over the newest `window` rows for this skill.
         let agg_row = sqlx::query(
             "WITH recent AS ( \
@@ -467,7 +524,9 @@ impl TraceStore {
             common_errors,
         })
     }
+}
 
+impl SqliteTraceStore {
     fn row_to_span(row: SqliteRow) -> Result<RecordedSpan> {
         let conv_raw: Option<String> = row.try_get("conversation_id").ok().flatten();
         let conversation_id = match conv_raw {
@@ -518,6 +577,254 @@ impl TraceStore {
     }
 }
 
+// ---------------------------------------------------------------------------
+// In-memory implementation (test-only — see workspace_test_impls_in_prod.rs)
+// ---------------------------------------------------------------------------
+
+/// In-memory [`TraceStore`] implementation.
+///
+/// Stores spans in a `Vec<RecordedSpan>` keyed by insertion order. Queries
+/// are naive linear scans, which is fine for unit tests against the trait
+/// contract. Use [`InMemoryTraceStore::insert`] to populate.
+pub struct InMemoryTraceStore {
+    spans: Arc<Mutex<Vec<RecordedSpan>>>,
+}
+
+impl InMemoryTraceStore {
+    /// Create an empty store.
+    pub fn new() -> Self {
+        Self {
+            spans: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    /// Insert a span (for test setup).
+    pub fn insert(&self, span: RecordedSpan) {
+        if let Ok(mut g) = self.spans.lock() {
+            g.push(span);
+        }
+    }
+
+    fn snapshot(&self) -> Vec<RecordedSpan> {
+        match self.spans.lock() {
+            Ok(g) => g.clone(),
+            Err(poisoned) => poisoned.into_inner().clone(),
+        }
+    }
+}
+
+impl Default for InMemoryTraceStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl TraceStore for InMemoryTraceStore {
+    async fn get_recent_for_skill(
+        &self,
+        skill_name: &str,
+        limit: i64,
+    ) -> Result<Vec<RecordedSpan>> {
+        let mut out: Vec<RecordedSpan> = self
+            .snapshot()
+            .into_iter()
+            .filter(|s| s.tool_name.as_deref() == Some(skill_name))
+            .collect();
+        out.sort_by_key(|s| std::cmp::Reverse(s.start_time));
+        if limit > 0 {
+            out.truncate(limit as usize);
+        }
+        Ok(out)
+    }
+
+    async fn list_recent(&self, limit: i64) -> Result<Vec<RecordedSpan>> {
+        let mut out: Vec<RecordedSpan> = self
+            .snapshot()
+            .into_iter()
+            .filter(|s| s.tool_name.is_some())
+            .collect();
+        out.sort_by_key(|s| std::cmp::Reverse(s.start_time));
+        if limit > 0 {
+            out.truncate(limit as usize);
+        }
+        Ok(out)
+    }
+
+    async fn list_recent_traces(
+        &self,
+        limit: i64,
+        skill_filter: Option<&str>,
+    ) -> Result<Vec<TraceSummary>> {
+        let spans = self.snapshot();
+        let summaries = summarize_traces(&spans, skill_filter, None);
+        Ok(take_limit(summaries, limit))
+    }
+
+    async fn list_recent_traces_for_agent(
+        &self,
+        limit: i64,
+        filter: &TraceFilter,
+        _agent_id: &str,
+    ) -> Result<Vec<TraceSummary>> {
+        // The in-memory impl doesn't track agent_id on spans (it's an
+        // attribute in production); apply the post-filter portion only.
+        let spans = self.snapshot();
+        let skill = filter.skill.as_deref();
+        let summaries = summarize_traces(&spans, skill, Some(filter));
+        Ok(take_limit(summaries, limit))
+    }
+
+    async fn get_trace(&self, trace_id: &str) -> Result<Vec<RecordedSpan>> {
+        let mut out: Vec<RecordedSpan> = self
+            .snapshot()
+            .into_iter()
+            .filter(|s| s.trace_id == trace_id)
+            .collect();
+        out.sort_by_key(|s| s.start_time);
+        Ok(out)
+    }
+
+    async fn get_trace_for_agent(
+        &self,
+        trace_id: &str,
+        _agent_id: &str,
+    ) -> Result<Vec<RecordedSpan>> {
+        // Same caveat as list_recent_traces_for_agent: the in-memory impl
+        // doesn't filter by agent_id.
+        self.get_trace(trace_id).await
+    }
+
+    async fn list_skills(&self) -> Result<Vec<String>> {
+        let mut skills: Vec<String> = self
+            .snapshot()
+            .into_iter()
+            .filter_map(|s| s.tool_name)
+            .collect();
+        skills.sort();
+        skills.dedup();
+        Ok(skills)
+    }
+
+    async fn stats_for_skill(&self, skill_name: &str, _window: i64) -> Result<TraceStats> {
+        let spans: Vec<RecordedSpan> = self
+            .snapshot()
+            .into_iter()
+            .filter(|s| s.tool_name.as_deref() == Some(skill_name))
+            .collect();
+        let total = spans.len() as i64;
+        let error_count = spans.iter().filter(|s| s.error.is_some()).count() as i64;
+        let success_count = total - error_count;
+        let avg_duration_ms = if total > 0 {
+            spans.iter().map(|s| s.duration_ms).sum::<i64>() as f64 / total as f64
+        } else {
+            0.0
+        };
+        let total_input_tokens = spans.iter().filter_map(|s| s.input_tokens).sum();
+        let total_output_tokens = spans.iter().filter_map(|s| s.output_tokens).sum();
+        let mut common_errors: Vec<String> = spans.iter().filter_map(|s| s.error.clone()).collect();
+        common_errors.sort();
+        common_errors.dedup();
+        common_errors.truncate(5);
+        Ok(TraceStats {
+            skill_name: skill_name.to_string(),
+            total,
+            success_count,
+            error_count,
+            avg_duration_ms,
+            total_input_tokens,
+            total_output_tokens,
+            common_errors,
+        })
+    }
+}
+
+/// Group spans by trace_id and summarize. Used by the InMemory impl's
+/// list_recent_traces variants.
+fn summarize_traces(
+    spans: &[RecordedSpan],
+    skill_filter: Option<&str>,
+    full_filter: Option<&TraceFilter>,
+) -> Vec<TraceSummary> {
+    let mut by_trace: HashMap<String, Vec<RecordedSpan>> = HashMap::new();
+    for span in spans {
+        by_trace
+            .entry(span.trace_id.clone())
+            .or_default()
+            .push(span.clone());
+    }
+    let mut summaries: Vec<TraceSummary> = by_trace
+        .into_iter()
+        .map(|(trace_id, trace_spans)| {
+            let start_time = trace_spans
+                .iter()
+                .map(|s| s.start_time)
+                .min()
+                .unwrap_or_else(|| {
+                    trace_spans
+                        .first()
+                        .map(|s| s.start_time)
+                        .unwrap_or_else(chrono::Utc::now)
+                });
+            let end_time = trace_spans
+                .iter()
+                .map(|s| s.end_time)
+                .max()
+                .unwrap_or(start_time);
+            let span_count = trace_spans.len() as i64;
+            let tool_span_count =
+                trace_spans.iter().filter(|s| s.tool_name.is_some()).count() as i64;
+            let error_count = trace_spans.iter().filter(|s| s.error.is_some()).count() as i64;
+            let mut tool_names: Vec<String> = trace_spans
+                .iter()
+                .filter_map(|s| s.tool_name.clone())
+                .collect();
+            tool_names.sort();
+            tool_names.dedup();
+            let root = trace_spans.iter().find(|s| s.parent_span_id.is_none());
+            TraceSummary {
+                trace_id,
+                conversation_id: trace_spans.iter().find_map(|s| s.conversation_id),
+                start_time,
+                end_time,
+                span_count,
+                tool_span_count,
+                error_count,
+                has_reply: tool_names
+                    .iter()
+                    .any(|t| t.contains("reply") || t.contains("slack-post")),
+                tool_names,
+                root_span_name: root.map(|s| s.name.clone()),
+                root_service_name: root.and_then(|s| s.service_name.clone()),
+                interface: None,
+            }
+        })
+        .collect();
+
+    if let Some(skill) = skill_filter {
+        summaries.retain(|s| s.tool_names.iter().any(|n| n == skill));
+    }
+    if let Some(f) = full_filter {
+        summaries.retain(|s| {
+            f.conversation.is_none_or(|c| s.conversation_id == Some(c))
+                && f.since.is_none_or(|since| s.start_time >= since)
+                && f.until.is_none_or(|until| s.start_time <= until)
+                && f.min_duration_ms
+                    .is_none_or(|min_ms| (s.end_time - s.start_time).num_milliseconds() >= min_ms)
+        });
+    }
+
+    summaries.sort_by_key(|s| std::cmp::Reverse(s.start_time));
+    summaries
+}
+
+fn take_limit(mut v: Vec<TraceSummary>, limit: i64) -> Vec<TraceSummary> {
+    if limit > 0 {
+        v.truncate(limit as usize);
+    }
+    v
+}
+
 /// Trait for querying skill-scoped execution statistics from trace storage.
 ///
 /// Implementations exist for both SQLite (`TraceStore`) and Iceberg backends.
@@ -529,7 +836,7 @@ pub trait SkillStatsProvider: Send + Sync {
 }
 
 #[async_trait::async_trait]
-impl SkillStatsProvider for TraceStore {
+impl SkillStatsProvider for SqliteTraceStore {
     async fn stats_for_active_skill(&self, skill_name: &str, window: i64) -> Result<TraceStats> {
         let agg_row = sqlx::query(
             "WITH recent AS ( \

--- a/crates/storage/tests/contract.rs
+++ b/crates/storage/tests/contract.rs
@@ -6,4 +6,5 @@
 
 mod contract {
     pub mod conversation_store;
+    pub mod trace_store;
 }

--- a/crates/storage/tests/contract/trace_store.rs
+++ b/crates/storage/tests/contract/trace_store.rs
@@ -1,0 +1,187 @@
+//! Contract tests for the [`TraceStore`] trait.
+//!
+//! Each scenario inserts spans through the impl-specific write path
+//! (SQLite via direct INSERT, InMemory via `insert()`) and then asserts
+//! the trait read API returns consistent results.
+
+use assistant_storage::{
+    InMemoryTraceStore, RecordedSpan, SqliteTraceStore, StorageLayer, TraceStore,
+};
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+use sqlx::SqlitePool;
+
+fn span(span_id: &str, trace_id: &str, tool: &str, start: DateTime<Utc>) -> RecordedSpan {
+    RecordedSpan {
+        span_id: span_id.into(),
+        trace_id: trace_id.into(),
+        parent_span_id: None,
+        name: format!("span-{span_id}"),
+        service_name: Some("test".into()),
+        conversation_id: None,
+        turn: Some(0),
+        tool_name: Some(tool.into()),
+        tool_status: Some("ok".into()),
+        observation: None,
+        error: None,
+        duration_ms: 5,
+        start_time: start,
+        end_time: start + chrono::Duration::milliseconds(5),
+        attributes: Value::Object(Default::default()),
+        input_tokens: Some(10),
+        output_tokens: Some(20),
+    }
+}
+
+async fn insert_sqlite(pool: &SqlitePool, s: RecordedSpan) {
+    let attrs = serde_json::to_string(&s.attributes).unwrap_or_else(|_| "{}".into());
+    sqlx::query(
+        "INSERT INTO distributed_traces \
+            (span_id, trace_id, parent_span_id, name, conversation_id, turn, \
+             service_name, tool_name, tool_status, tool_observation, tool_error, \
+             duration_ms, start_time, end_time, attributes, input_tokens, output_tokens) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
+    )
+    .bind(&s.span_id)
+    .bind(&s.trace_id)
+    .bind(&s.parent_span_id)
+    .bind(&s.name)
+    .bind(s.conversation_id.map(|c| c.to_string()))
+    .bind(s.turn)
+    .bind(&s.service_name)
+    .bind(&s.tool_name)
+    .bind(&s.tool_status)
+    .bind(&s.observation)
+    .bind(&s.error)
+    .bind(s.duration_ms)
+    .bind(s.start_time)
+    .bind(s.end_time)
+    .bind(attrs)
+    .bind(s.input_tokens)
+    .bind(s.output_tokens)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+// -- SQLite scenarios ---------------------------------------------------------
+
+#[tokio::test]
+async fn sqlite_list_skills_collects_distinct_tools() {
+    let storage = StorageLayer::new_in_memory().await.unwrap();
+    let pool = storage.pool.clone();
+    let store = SqliteTraceStore::new(pool.clone());
+    let t0 = Utc::now();
+    insert_sqlite(&pool, span("a1", "trace-1", "echo", t0)).await;
+    insert_sqlite(&pool, span("a2", "trace-1", "bash", t0)).await;
+    insert_sqlite(
+        &pool,
+        span("a3", "trace-2", "echo", t0 + chrono::Duration::seconds(1)),
+    )
+    .await;
+    let mut skills = store.list_skills().await.unwrap();
+    skills.sort();
+    assert_eq!(skills, vec!["bash".to_string(), "echo".to_string()]);
+}
+
+#[tokio::test]
+async fn sqlite_get_trace_returns_spans_of_trace_id() {
+    let storage = StorageLayer::new_in_memory().await.unwrap();
+    let pool = storage.pool.clone();
+    let store = SqliteTraceStore::new(pool.clone());
+    let t0 = Utc::now();
+    insert_sqlite(&pool, span("a1", "trace-X", "foo", t0)).await;
+    insert_sqlite(&pool, span("a2", "trace-X", "bar", t0)).await;
+    insert_sqlite(&pool, span("a3", "trace-Y", "baz", t0)).await;
+    let spans = store.get_trace("trace-X").await.unwrap();
+    assert_eq!(spans.len(), 2);
+    assert!(spans.iter().all(|s| s.trace_id == "trace-X"));
+}
+
+#[tokio::test]
+async fn sqlite_list_recent_caps_to_limit() {
+    let storage = StorageLayer::new_in_memory().await.unwrap();
+    let pool = storage.pool.clone();
+    let store = SqliteTraceStore::new(pool.clone());
+    let t0 = Utc::now();
+    for i in 0..5 {
+        insert_sqlite(
+            &pool,
+            span(
+                &format!("s{i}"),
+                &format!("t{i}"),
+                "tool",
+                t0 + chrono::Duration::seconds(i),
+            ),
+        )
+        .await;
+    }
+    let recent = store.list_recent(3).await.unwrap();
+    assert_eq!(recent.len(), 3);
+}
+
+#[tokio::test]
+async fn sqlite_stats_for_skill_counts_total() {
+    let storage = StorageLayer::new_in_memory().await.unwrap();
+    let pool = storage.pool.clone();
+    let store = SqliteTraceStore::new(pool.clone());
+    let t0 = Utc::now();
+    for i in 0..3 {
+        insert_sqlite(&pool, span(&format!("a{i}"), &format!("t{i}"), "calc", t0)).await;
+    }
+    let stats = store.stats_for_skill("calc", 100).await.unwrap();
+    assert_eq!(stats.total, 3);
+}
+
+// -- InMemory scenarios -------------------------------------------------------
+
+#[tokio::test]
+async fn memory_list_skills_collects_distinct_tools() {
+    let store = InMemoryTraceStore::new();
+    let t0 = Utc::now();
+    store.insert(span("a1", "trace-1", "echo", t0));
+    store.insert(span("a2", "trace-1", "bash", t0));
+    store.insert(span("a3", "trace-2", "echo", t0));
+    let mut skills = store.list_skills().await.unwrap();
+    skills.sort();
+    assert_eq!(skills, vec!["bash".to_string(), "echo".to_string()]);
+}
+
+#[tokio::test]
+async fn memory_get_trace_returns_spans_of_trace_id() {
+    let store = InMemoryTraceStore::new();
+    let t0 = Utc::now();
+    store.insert(span("a1", "trace-X", "foo", t0));
+    store.insert(span("a2", "trace-X", "bar", t0));
+    store.insert(span("a3", "trace-Y", "baz", t0));
+    let spans = store.get_trace("trace-X").await.unwrap();
+    assert_eq!(spans.len(), 2);
+    assert!(spans.iter().all(|s| s.trace_id == "trace-X"));
+}
+
+#[tokio::test]
+async fn memory_list_recent_caps_to_limit() {
+    let store = InMemoryTraceStore::new();
+    let t0 = Utc::now();
+    for i in 0..5 {
+        store.insert(span(
+            &format!("s{i}"),
+            &format!("t{i}"),
+            "tool",
+            t0 + chrono::Duration::seconds(i),
+        ));
+    }
+    let recent = store.list_recent(3).await.unwrap();
+    assert_eq!(recent.len(), 3);
+}
+
+#[tokio::test]
+async fn memory_stats_for_skill_counts_total() {
+    let store = InMemoryTraceStore::new();
+    let t0 = Utc::now();
+    for i in 0..3 {
+        store.insert(span(&format!("a{i}"), &format!("t{i}"), "calc", t0));
+    }
+    let stats = store.stats_for_skill("calc", 100).await.unwrap();
+    assert_eq!(stats.total, 3);
+}

--- a/crates/test-support/src/prelude.rs
+++ b/crates/test-support/src/prelude.rs
@@ -18,6 +18,8 @@
 //!   `InMemorySkillCatalog`.
 
 pub use assistant_core::clock::{Clock, FakeClock, SystemClock};
-pub use assistant_storage::{ConversationStore, InMemoryConversationStore};
+pub use assistant_storage::{
+    ConversationStore, InMemoryConversationStore, InMemoryTraceStore, TraceStore,
+};
 
 pub use crate::fixture::{Fixture, FixtureBuilder};

--- a/crates/web-ui/src/backends/sqlite.rs
+++ b/crates/web-ui/src/backends/sqlite.rs
@@ -7,7 +7,7 @@ use sqlx::SqlitePool;
 
 use assistant_storage::{
     LogStats, LogStore, MetricsStore, MetricsSummary, ModelTokenUsage, RecordedLog, RecordedSpan,
-    TimeSeriesPoint, ToolUsageStats, TraceFilter, TraceStore, TraceSummary,
+    SqliteTraceStore, TimeSeriesPoint, ToolUsageStats, TraceFilter, TraceStore, TraceSummary,
 };
 
 use super::{LogBackend, MetricsBackend, TraceBackend};
@@ -32,7 +32,7 @@ impl TraceBackend for SqliteTraceBackend {
         filter: &TraceFilter,
         agent_id: &str,
     ) -> Result<Vec<TraceSummary>> {
-        let store = TraceStore::new(self.pool.clone());
+        let store = SqliteTraceStore::new(self.pool.clone());
         if agent_id.is_empty() {
             // Unscoped: the base query only accepts a skill filter, so we
             // fetch a larger batch and apply the remaining filters in memory.
@@ -80,7 +80,7 @@ impl TraceBackend for SqliteTraceBackend {
     }
 
     async fn get_trace(&self, trace_id: &str, agent_id: &str) -> Result<Vec<RecordedSpan>> {
-        let store = TraceStore::new(self.pool.clone());
+        let store = SqliteTraceStore::new(self.pool.clone());
         if agent_id.is_empty() {
             store.get_trace(trace_id).await
         } else {

--- a/openspec/changes/workspace-test-coverage-floor/tasks.md
+++ b/openspec/changes/workspace-test-coverage-floor/tasks.md
@@ -70,12 +70,12 @@ Each store: failing test → trait in `assistant-core` → `Sqlite*` impl + `InM
 
 ### 5.B — `TraceStore`
 
-- [ ] 5.B.1 Failing contract test in `crates/storage/tests/contract/trace_store.rs`.
-- [ ] 5.B.2 `trait TraceStore` in `assistant-core`; `SqliteTraceStore` + `InMemoryTraceStore` both in `crates/storage/src/traces.rs` as plain `pub`.
-- [ ] 5.B.3 Contract test green for both impls.
-- [ ] 5.B.4 Re-export `InMemoryTraceStore` from the test-support prelude.
-- [ ] 5.B.5 Migrate consumers (`runtime/otel_spans`, `runtime/telemetry`, `web-ui/backends/sqlite`, `web-ui/api/traces` if it exists).
-- [ ] 5.B.6 Commit as `refactor(storage): extract TraceStore trait + add InMemory impl`.
+- [x] 5.B.1 Failing contract test in `crates/storage/tests/contract/trace_store.rs`.
+- [x] 5.B.2 `trait TraceStore` in `crates/storage/src/traces.rs` (deferred to storage for now, same TODO as ConversationStore); `SqliteTraceStore` (renamed from `TraceStore` struct) + `InMemoryTraceStore` both plain `pub`.
+- [x] 5.B.3 Contract test green for both impls — 8 scenarios.
+- [x] 5.B.4 Re-export `InMemoryTraceStore` + `TraceStore` from the test-support prelude.
+- [x] 5.B.5 Migrate consumer `web-ui/backends/sqlite` to construct `SqliteTraceStore::new(...)`.
+- [x] 5.B.6 Commit as `refactor(storage): extract TraceStore trait + add InMemory impl`.
 
 ### 5.C — `LogStore`
 


### PR DESCRIPTION
Phase 5.B of workspace-test-coverage-floor. Same pattern as Phase 5.A:
- TraceStore is now a trait (8 methods).
- Existing struct renamed → SqliteTraceStore.
- New InMemoryTraceStore (Vec-backed, Mutex-protected) for tests.
- Contract tests run 4 scenarios × 2 impls = 8 tests.
- web-ui/backends/sqlite.rs migrated.

Storage tests 234 lib + 28 contract = 262 pass. Lint clean.