### PR TITLE
feat(app): route initial-stall watchdog through turn-status probe

### DIFF
--- a/app/lib/api/api_client.dart
+++ b/app/lib/api/api_client.dart
@@ -223,6 +223,29 @@ class ApiClient {
     }
   }
 
+  /// Probe the authoritative server-side state of a turn.
+  ///
+  /// Returns the [TurnState] from `GET .../turns/{turnId}/status`, or `null`
+  /// if the call failed for any reason (network error, deserialization
+  /// failure, etc.). Callers treat `null` as "probe inconclusive" and fall
+  /// back to whatever they were going to do anyway.
+  ///
+  /// Used by `ChatNotifier`'s initial-stall watchdog: when the SSE stream
+  /// has been quiet for ~12 s but we already have a run id, the probe
+  /// disambiguates a slow server (state == running, keep waiting) from
+  /// a dead one (completed/errored/unknown, recover).
+  Future<TurnState?> turnStatus(String conversationId, String turnId) async {
+    try {
+      final resp = await conversations.getTurnStatus(
+        conversationId: conversationId,
+        turnId: turnId,
+      );
+      return resp.data?.state;
+    } catch (_) {
+      return null;
+    }
+  }
+
   /// Stream assistant tokens for a conversation message.
   ///
   /// Yields [RunStartedEvent] first (from the `X-Run-Id` response header),

--- a/app/lib/features/chat/chat_provider.dart
+++ b/app/lib/features/chat/chat_provider.dart
@@ -1454,8 +1454,8 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
     // Arm the same initial-stall watchdog used by the text path. The voice
     // SSE response carries TranscriptEvent + token/status events; any event
     // counts as progress. Until the first event arrives, a quiet interval
-    // of [_initialStallTimeout] triggers a fallback to a direct
-    // conversation fetch (iOS Dio buffering safety net).
+    // of [_initialStallTimeout] probes the server: a `running` reply keeps
+    // the sink open (iOS Dio buffering safety net), anything else recovers.
     var sawProgress = false;
     final source = api
         .sendVoiceMessage(conversationId, audioBytes, mimeType)
@@ -1463,8 +1463,14 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
           _initialStallTimeout,
           onTimeout: (sink) {
             if (sawProgress) return;
-            unawaited(_recoverStalledStream(conversationId, userMsgId));
-            sink.close();
+            unawaited(
+              _probeOrRecover(
+                conversationId: conversationId,
+                userMsgId: userMsgId,
+                sink: sink,
+                sawProgress: () => sawProgress,
+              ),
+            );
           },
         );
 
@@ -1687,9 +1693,11 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
     // Arm the initial-stall watchdog as a per-event timeout on the SSE
     // stream. Until we see a UI-visible event (anything other than
     // [RunStartedEvent]), a quiet interval of [_initialStallTimeout]
-    // triggers a fallback to a direct conversation fetch. After progress
-    // has been observed, the byte-level heartbeat (90 s) handles longer
-    // silences that may legitimately occur during tool execution.
+    // probes the server to disambiguate iOS Dio buffering (server still
+    // running — keep the sink open) from a dead turn (recover via
+    // [_recoverStalledStream]). After progress has been observed, the
+    // byte-level heartbeat (90 s) handles longer silences that may
+    // legitimately occur during tool execution.
     var sawProgress = false;
     final source = api
         .streamMessages(
@@ -1701,12 +1709,14 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
           _initialStallTimeout,
           onTimeout: (sink) {
             if (sawProgress) return;
-            // Recover synchronously so the placeholder clears immediately
-            // (the synchronous prefix of [_recoverStalledStream] runs
-            // before its first await), then close the stream so the
-            // await-for loop exits cleanly.
-            unawaited(_recoverStalledStream(conversationId, userMsgId));
-            sink.close();
+            unawaited(
+              _probeOrRecover(
+                conversationId: conversationId,
+                userMsgId: userMsgId,
+                sink: sink,
+                sawProgress: () => sawProgress,
+              ),
+            );
           },
         );
 
@@ -1954,6 +1964,47 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
         ),
       );
     }
+  }
+
+  /// Called from the initial-stall watchdog's `onTimeout`. Probes the
+  /// server-side turn state to decide whether to keep the SSE sink open
+  /// (server still working — most often iOS Dio buffering the chunked
+  /// body) or to fall back to [_recoverStalledStream] for terminal /
+  /// unknown turns.
+  ///
+  /// `sawProgress` is a closure-captured getter — the same flag the
+  /// caller sets to `true` on the first UI-visible event. We re-check
+  /// it after the probe completes because the stream may have woken up
+  /// while we were awaiting the server.
+  Future<void> _probeOrRecover({
+    required String conversationId,
+    required String userMsgId,
+    required EventSink<StreamEvent> sink,
+    required bool Function() sawProgress,
+  }) async {
+    if (sawProgress() || _cancelled) return;
+    final api = _api;
+    final runId = _currentRunId;
+    if (api == null || runId == null) {
+      // RunStarted hasn't fired yet (or no client) — no run id to probe.
+      // Fall back to the legacy recovery path so the dots state still
+      // resolves within the watchdog window.
+      await _recoverStalledStream(conversationId, userMsgId);
+      if (!_cancelled) sink.close();
+      return;
+    }
+    final state = await api.turnStatus(conversationId, runId);
+    if (sawProgress() || _cancelled) return;
+    if (state == TurnState.running) {
+      // Server says the turn is still in flight — leave the sink open.
+      // The chat-stream-progress-ux card already shows a stalled UI past
+      // `kTurnStallThreshold`; the 90 s byte-watchdog is the final
+      // safety net for genuinely dead connections.
+      return;
+    }
+    // completed / errored / unknown / null (probe failed) → recover.
+    await _recoverStalledStream(conversationId, userMsgId);
+    if (!_cancelled) sink.close();
   }
 
   /// Recover from a stalled SSE stream by fetching the conversation

--- a/app/test/unit/chat/chat_provider_test.dart
+++ b/app/test/unit/chat/chat_provider_test.dart
@@ -101,6 +101,26 @@ class _FakeApiClient extends ApiClient {
       }
     }
   }
+
+  // -- Turn-status probe stub ------------------------------------------------
+  //
+  // Configure [nextTurnStatus] to drive `ChatNotifier`'s initial-stall
+  // watchdog. `null` (default) means "probe failed" → notifier falls back
+  // to its recovery path.
+
+  /// Value returned by the next [turnStatus] call. `null` means the probe
+  /// throws or the server returns no body — both paths fall back to the
+  /// legacy recovery in the notifier.
+  TurnState? nextTurnStatus;
+
+  /// Captures each `(conversationId, runId)` the notifier probes for.
+  final List<({String conversationId, String runId})> turnStatusCalls = [];
+
+  @override
+  Future<TurnState?> turnStatus(String conversationId, String runId) async {
+    turnStatusCalls.add((conversationId: conversationId, runId: runId));
+    return nextTurnStatus;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -1725,6 +1745,254 @@ void main() {
             'messages=${after.messages.map((m) => '(${m.id}, streaming=${m.isStreaming}, content="${m.content}")').toList()}',
       );
     });
+  });
+
+  // -- Turn-status probe routes the initial-stall watchdog ------------------
+  //
+  // When `_initialStallTimeout` fires before any UI-visible event, the
+  // notifier now consults `api.turnStatus` instead of unconditionally
+  // recovering. The decision matrix:
+  //
+  //   server says `running`       → keep the sink open (don't clear dots)
+  //   server says `completed`     → recover (clear placeholder, refetch)
+  //   server says `errored`       → recover (clear placeholder, refetch)
+  //   server says `unknown`       → recover (server doesn't recognise turn)
+  //   probe fails / returns null  → recover (fallback to legacy behaviour)
+
+  group('ChatNotifier — stall probe routing', () {
+    testWidgets('probe=running keeps the placeholder in the dots state', (
+      tester,
+    ) async {
+      final fakeApi = _FakeApiClient();
+      fakeApi.nextTurnStatus = TurnState.running;
+      final ctrl = fakeApi.enqueueStream();
+      addTearDown(() async {
+        if (!ctrl.isClosed) await ctrl.close();
+      });
+
+      final notifier = await _pumpTestApp(tester, fakeApi);
+
+      unawaited(notifier.sendMessage('hello'));
+      await tester.pump();
+
+      // RunStarted gives the notifier a run id to probe with — without it
+      // the probe path is bypassed and the legacy recovery runs instead.
+      ctrl.add(const RunStartedEvent('run-1'));
+      await tester.pump();
+
+      await tester.pump(const Duration(seconds: 15));
+      await tester.pumpAndSettle();
+
+      final after = notifier.state.value!;
+      final placeholder = after.messages.firstWhere(
+        (m) => m.id == 'assistant-streaming',
+        orElse: () =>
+            ChatMessage(id: 'missing', role: 'assistant', content: ''),
+      );
+      expect(
+        placeholder.id == 'assistant-streaming' &&
+            placeholder.isStreaming &&
+            placeholder.content.isEmpty,
+        isTrue,
+        reason:
+            'probe=running must leave the streaming placeholder in place '
+            'so the 90 s byte-watchdog (not the 12 s app watchdog) decides '
+            'whether to recover. Current: '
+            'isSending=${after.isSending}, error=${after.error}, '
+            'messages=${after.messages.map((m) => '(${m.id}, streaming=${m.isStreaming})').toList()}',
+      );
+      expect(
+        after.error,
+        isNull,
+        reason: 'no error surfaced on a healthy turn',
+      );
+      expect(after.isSending, isTrue, reason: 'still sending');
+      expect(
+        fakeApi.turnStatusCalls,
+        isNotEmpty,
+        reason: 'probe must have been invoked',
+      );
+      expect(fakeApi.turnStatusCalls.first.runId, 'run-1');
+
+      // Drain the controller before teardown so the await-for completes.
+      ctrl.add(const DoneEvent(role: 'assistant', content: ''));
+      await ctrl.close();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets(
+      'probe=completed triggers recovery and clears the placeholder',
+      (tester) async {
+        final fakeApi = _FakeApiClient();
+        fakeApi.nextTurnStatus = TurnState.completed;
+        final ctrl = fakeApi.enqueueStream();
+        addTearDown(() async {
+          if (!ctrl.isClosed) await ctrl.close();
+        });
+
+        final notifier = await _pumpTestApp(tester, fakeApi);
+
+        unawaited(notifier.sendMessage('hello'));
+        await tester.pump();
+        ctrl.add(const RunStartedEvent('run-1'));
+        await tester.pump();
+
+        await tester.pump(const Duration(seconds: 15));
+        await tester.pumpAndSettle();
+
+        final after = notifier.state.value!;
+        final stillInDots = after.messages.any(
+          (m) =>
+              m.id == 'assistant-streaming' &&
+              m.isStreaming &&
+              m.content.isEmpty,
+        );
+        expect(
+          stillInDots,
+          isFalse,
+          reason: 'probe=completed must clear the dots placeholder',
+        );
+        expect(fakeApi.turnStatusCalls, isNotEmpty);
+      },
+    );
+
+    testWidgets('probe=errored triggers recovery and clears the placeholder', (
+      tester,
+    ) async {
+      final fakeApi = _FakeApiClient();
+      fakeApi.nextTurnStatus = TurnState.errored;
+      final ctrl = fakeApi.enqueueStream();
+      addTearDown(() async {
+        if (!ctrl.isClosed) await ctrl.close();
+      });
+
+      final notifier = await _pumpTestApp(tester, fakeApi);
+
+      unawaited(notifier.sendMessage('hello'));
+      await tester.pump();
+      ctrl.add(const RunStartedEvent('run-1'));
+      await tester.pump();
+
+      await tester.pump(const Duration(seconds: 15));
+      await tester.pumpAndSettle();
+
+      final after = notifier.state.value!;
+      final stillInDots = after.messages.any(
+        (m) =>
+            m.id == 'assistant-streaming' && m.isStreaming && m.content.isEmpty,
+      );
+      expect(
+        stillInDots,
+        isFalse,
+        reason: 'probe=errored must clear the dots placeholder',
+      );
+    });
+
+    testWidgets(
+      'probe=unknown triggers recovery (server no longer has the turn)',
+      (tester) async {
+        final fakeApi = _FakeApiClient();
+        fakeApi.nextTurnStatus = TurnState.unknown;
+        final ctrl = fakeApi.enqueueStream();
+        addTearDown(() async {
+          if (!ctrl.isClosed) await ctrl.close();
+        });
+
+        final notifier = await _pumpTestApp(tester, fakeApi);
+
+        unawaited(notifier.sendMessage('hello'));
+        await tester.pump();
+        ctrl.add(const RunStartedEvent('run-1'));
+        await tester.pump();
+
+        await tester.pump(const Duration(seconds: 15));
+        await tester.pumpAndSettle();
+
+        final after = notifier.state.value!;
+        final stillInDots = after.messages.any(
+          (m) =>
+              m.id == 'assistant-streaming' &&
+              m.isStreaming &&
+              m.content.isEmpty,
+        );
+        expect(
+          stillInDots,
+          isFalse,
+          reason: 'probe=unknown must clear the dots placeholder',
+        );
+      },
+    );
+
+    testWidgets('probe failure (null return) falls back to legacy recovery', (
+      tester,
+    ) async {
+      final fakeApi = _FakeApiClient();
+      fakeApi.nextTurnStatus = null; // simulate probe failing
+      final ctrl = fakeApi.enqueueStream();
+      addTearDown(() async {
+        if (!ctrl.isClosed) await ctrl.close();
+      });
+
+      final notifier = await _pumpTestApp(tester, fakeApi);
+
+      unawaited(notifier.sendMessage('hello'));
+      await tester.pump();
+      ctrl.add(const RunStartedEvent('run-1'));
+      await tester.pump();
+
+      await tester.pump(const Duration(seconds: 15));
+      await tester.pumpAndSettle();
+
+      final after = notifier.state.value!;
+      final stillInDots = after.messages.any(
+        (m) =>
+            m.id == 'assistant-streaming' && m.isStreaming && m.content.isEmpty,
+      );
+      expect(
+        stillInDots,
+        isFalse,
+        reason:
+            'probe failure must not leave the UI in dots — fall back to '
+            'legacy recovery so the user gets out of the wait state',
+      );
+    });
+
+    testWidgets(
+      'stream without RunStarted (no run id) bypasses probe, runs recovery',
+      (tester) async {
+        // No RunStartedEvent ever fires → `_currentRunId` stays null and the
+        // probe is skipped. The watchdog must still resolve via recovery.
+        final fakeApi = _FakeApiClient();
+        // nextTurnStatus left null; should not be consulted anyway.
+        final ctrl = fakeApi.enqueueStream();
+        addTearDown(() async {
+          if (!ctrl.isClosed) await ctrl.close();
+        });
+
+        final notifier = await _pumpTestApp(tester, fakeApi);
+
+        unawaited(notifier.sendMessage('hello'));
+        await tester.pump();
+        // Intentionally no RunStartedEvent.
+
+        await tester.pump(const Duration(seconds: 15));
+        await tester.pumpAndSettle();
+
+        final after = notifier.state.value!;
+        final stillInDots = after.messages.any(
+          (m) =>
+              m.id == 'assistant-streaming' &&
+              m.isStreaming &&
+              m.content.isEmpty,
+        );
+        expect(stillInDots, isFalse);
+        expect(
+          fakeApi.turnStatusCalls,
+          isEmpty,
+          reason: 'no run id → probe must not be called',
+        );
+      },
+    );
   });
 
   // -- Salvaged from PR #809 fix (2): stalled recovery vs concurrent stream --


### PR DESCRIPTION
## Summary

Builds on #836. The 12 s `_initialStallTimeout` no longer cancels the SSE stream on a heuristic — it probes `GET .../turns/{run_id}/status` and decides:

| Probe says   | Action                                                             |
|--------------|--------------------------------------------------------------------|
| `running`    | Keep sink open; 90 s byte-watchdog handles dead connections        |
| `completed`  | Recover (server has the reply — refetch conversation)              |
| `errored`    | Recover (server marked the turn failed)                            |
| `unknown`    | Recover (server doesn't recognise the turn — likely GC'd)          |
| Probe fails  | Recover (legacy fallback)                                          |

This preserves in-flight work whenever the symptom is iOS Dio buffering rather than a dead server.

## Changes

- `ApiClient.turnStatus(conversationId, runId) -> Future<TurnState?>` — thin wrapper, returns null on any error so callers don't handle DioException
- `ChatNotifier._probeOrRecover` — shared timeout handler for text + voice paths
- 6 new tests in `stall probe routing` group covering every state plus the no-run-id-yet bypass
- Legacy `_recoverStalledStream` is unchanged and still used as the fallback

## Compatibility

When `RunStarted` hasn't fired yet (`_currentRunId == null`), the probe is skipped and the legacy recovery runs. This preserves the safety net for cases where the body is buffered before the `X-Run-Id` header reaches the parser.

## Test plan

- [x] `flutter analyze --fatal-infos` clean
- [x] `flutter test` — 1007/1007 pass
- [x] `chat_provider_test.dart` — 68/68 pass (62 existing + 6 new)
- [x] Pre-commit hooks green

Refs: `openspec/changes/turn-status-endpoint/` § 3.2-3.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stall detection for streaming conversations. The app now intelligently verifies with the server whether your message is still being processed before treating an unexpected delay as a stall error, reducing false timeout notifications during slower operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cedricziel/assistant/pull/842?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->