### PR TITLE
fix(storage): rename InMemoryState → MemoryState to unbreak workspace lint

### DIFF
--- a/crates/storage/src/conversations.rs
+++ b/crates/storage/src/conversations.rs
@@ -584,7 +584,7 @@ impl ConversationStore for SqliteConversationStore {
 /// The workspace lint `tests/workspace_test_impls_in_prod.rs` forbids
 /// constructing this type outside test code or `assistant-test-support`.
 pub struct InMemoryConversationStore {
-    state: Arc<Mutex<InMemoryState>>,
+    state: Arc<Mutex<MemoryState>>,
     agent_id: String,
     user_id: Option<String>,
     broadcaster: Option<Arc<dyn ConversationBroadcast>>,
@@ -592,7 +592,7 @@ pub struct InMemoryConversationStore {
 }
 
 #[derive(Default)]
-struct InMemoryState {
+struct MemoryState {
     conversations: HashMap<Uuid, ConversationRecord>,
     messages: HashMap<Uuid, Vec<Message>>,
 }
@@ -601,7 +601,7 @@ impl InMemoryConversationStore {
     /// Create a new empty store with the default agent (`"default"`).
     pub fn new() -> Self {
         Self {
-            state: Arc::new(Mutex::new(InMemoryState::default())),
+            state: Arc::new(Mutex::new(MemoryState::default())),
             agent_id: "default".to_string(),
             user_id: None,
             broadcaster: None,
@@ -637,7 +637,7 @@ impl InMemoryConversationStore {
 
     /// Lock the inner state for the duration of a single operation.
     /// Recovers from poisoned locks by extracting the inner state.
-    fn lock_state(&self) -> std::sync::MutexGuard<'_, InMemoryState> {
+    fn lock_state(&self) -> std::sync::MutexGuard<'_, MemoryState> {
         match self.state.lock() {
             Ok(g) => g,
             Err(poisoned) => poisoned.into_inner(),


### PR DESCRIPTION
## Summary

#840 introduced a private \`InMemoryState\` struct as the inner state of \`InMemoryConversationStore\`. The name trips \`tests/workspace_test_impls_in_prod.rs\`, which flags any \`InMemory*\` type constructed in production code as a test-only fake.

\`InMemoryState\` isn't test infra — it's just \`State\` inside an \`InMemoryConversationStore\`. Renaming it removes the lint match cleanly, keeping the exemption list tightly scoped.

## Test plan

- [x] \`cargo test -p assistant --test workspace_test_impls_in_prod\` now passes
- [x] \`cargo test -p assistant-storage\` — 270/270 pass
- [x] Pre-commit hooks green