### PR TITLE
feat(runtime): cancel_turn surface + caller-supplied request_id

### DIFF
--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -26,7 +26,9 @@ pub use command_registry::{CommandContext, CommandRegistry};
 pub use interface_runner::InterfaceRunner;
 pub use interface_trait::AssistantInterface;
 pub use metrics::MetricsRecorder;
-pub use orchestrator::{Orchestrator, OrchestratorEvent, TurnResult};
+pub use orchestrator::{
+    CancelOutcome, Orchestrator, OrchestratorEvent, TURN_CANCELLED_MARKER, TurnResult,
+};
 pub use otel_spans::start_conversation_context;
 pub use scheduler::spawn_scheduler;
 pub use telemetry::{OtelGuard, init_tracing};

--- a/crates/runtime/src/orchestrator/mod.rs
+++ b/crates/runtime/src/orchestrator/mod.rs
@@ -53,6 +53,29 @@ pub trait ConfirmationCallback: Send + Sync {
     fn confirm(&self, tool_name: &str, params: &serde_json::Value) -> bool;
 }
 
+/// Outcome of [`Orchestrator::cancel_turn`].
+///
+/// Distinguishes "we found and triggered a token" from "no in-flight turn
+/// matched the request_id" — the latter is not an error, just an authoritative
+/// signal to the caller that the turn already finished, errored, or was never
+/// registered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CancelOutcome {
+    /// A cancellation token was registered for this `request_id` and has been
+    /// triggered. The turn worker will abort on its next yield point and
+    /// `submit_turn` will return an error containing the cancellation marker.
+    Cancelled,
+    /// No matching turn was registered — either the turn already finished
+    /// (success or error), was never started, or used a different request_id.
+    NotFound,
+}
+
+/// Error message fragment that appears in [`anyhow::Error`] when a turn was
+/// aborted via [`Orchestrator::cancel_turn`]. Callers (e.g. the SSE handler
+/// in `assistant-web-ui`) match on this substring to emit a final
+/// `agent_error` event with the structured cancellation reason.
+pub const TURN_CANCELLED_MARKER: &str = "turn_cancelled";
+
 /// The result of a single orchestrator turn.
 pub struct TurnResult {
     /// The assistant's final answer to the user.
@@ -310,6 +333,45 @@ impl Orchestrator {
     /// Return a reference to the message bus.
     pub fn bus(&self) -> &Arc<dyn MessageBus> {
         &self.bus
+    }
+
+    /// Cancel an in-flight turn by `request_id` (the same UUID `submit_turn`
+    /// assigned, also used as the SSE `run_id` when callers pass it through
+    /// [`Self::submit_turn_with_request_id`]).
+    ///
+    /// Cancellation is propagated via the existing per-turn `CancellationToken`
+    /// stored in [`Self::turn_cancellations`]; the worker's `tokio::select!`
+    /// aborts the in-flight LLM/tool work on the next yield point, and
+    /// `submit_turn` returns an error containing the cancellation marker.
+    ///
+    /// Returns [`CancelOutcome::Cancelled`] if a matching token was found,
+    /// [`CancelOutcome::NotFound`] if the turn has already finished or was
+    /// never registered. The caller is responsible for any side effects
+    /// (e.g. emitting a final SSE `agent_error` event for streaming clients).
+    pub async fn cancel_turn(&self, request_id: Uuid) -> CancelOutcome {
+        let token = self
+            .turn_cancellations
+            .read()
+            .await
+            .get(&request_id)
+            .cloned();
+        match token {
+            Some(t) => {
+                t.cancel();
+                info!(request_id = %request_id, "cancel_turn: cancelled in-flight turn");
+                CancelOutcome::Cancelled
+            }
+            None => CancelOutcome::NotFound,
+        }
+    }
+
+    /// True when `request_id` currently has a registered cancellation token —
+    /// i.e. a turn is in flight under this id. Exposed primarily for tests.
+    pub async fn is_turn_in_flight(&self, request_id: Uuid) -> bool {
+        self.turn_cancellations
+            .read()
+            .await
+            .contains_key(&request_id)
     }
 
     /// Attach an [`AudioStore`] so that audio produced by the `voice-response`

--- a/crates/runtime/src/orchestrator/tests/bus_worker.rs
+++ b/crates/runtime/src/orchestrator/tests/bus_worker.rs
@@ -519,3 +519,136 @@ async fn failed_turn_with_tools_max_iterations_returns_error() {
         ),
     }
 }
+
+// -- Cancellation -------------------------------------------------------------
+
+/// Cancelling an unknown `request_id` is a no-op and reports `NotFound`.
+#[tokio::test]
+async fn cancel_turn_unknown_request_id_returns_not_found() {
+    let server = MockServer::start().await;
+    mount_answer(&server, "unused").await;
+    let (orch, _) = build(&server.uri()).await;
+
+    let outcome = orch.cancel_turn(Uuid::new_v4()).await;
+    assert_eq!(
+        outcome,
+        crate::orchestrator::CancelOutcome::NotFound,
+        "cancelling an unregistered request_id must report NotFound"
+    );
+}
+
+/// Cancelling a turn that's been launched with a caller-supplied request_id
+/// reports `Cancelled`, aborts the in-flight worker future, and unblocks
+/// `submit_turn_with_request_id` promptly with the `turn_cancelled` marker.
+#[tokio::test]
+async fn cancel_turn_aborts_inflight_submit() {
+    // LLM never responds — without cancellation submit_turn would wait the
+    // full configured submit_timeout. We assert the cancel returns it early.
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/chat"))
+        .respond_with(ResponseTemplate::new(200).set_delay(Duration::from_secs(60)))
+        .mount(&server)
+        .await;
+
+    let mut config = AssistantConfig::default();
+    config.memory.enabled = false;
+    let storage = Arc::new(StorageLayer::new_in_memory().await.unwrap());
+    let registry = Arc::new(SkillRegistry::new(storage.pool.clone()).await.unwrap());
+    let llm: Arc<dyn LlmProvider> = Arc::new(
+        LlmClient::new(LlmClientConfig {
+            model: "test".to_string(),
+            base_url: server.uri(),
+            timeout_secs: 120,
+            retry_config: assistant_llm_provider::retry::RetryConfig::disabled(),
+        })
+        .unwrap(),
+    );
+    let executor = Arc::new(ToolExecutor::new(
+        storage.clone(),
+        llm.clone(),
+        registry.clone(),
+        Arc::new(config.clone()),
+    ));
+    let bus: Arc<dyn MessageBus> = Arc::new(storage.message_bus());
+    let orch = Arc::new(
+        Orchestrator::new(
+            llm,
+            storage.clone(),
+            executor.clone(),
+            registry,
+            bus,
+            &config,
+        )
+        .with_submit_timeout(30), // generous; the test must finish well before this
+    );
+    executor.set_subagent_runner(orch.clone());
+
+    // Spawn the worker so the bus message gets picked up and dispatched.
+    let orch_worker = orch.clone();
+    tokio::spawn(async move {
+        orch_worker.run_worker("test-worker").await;
+    });
+
+    let conv_id = Uuid::new_v4();
+    let request_id = Uuid::new_v4();
+
+    // Fire submit_turn_with_request_id in the background — it will block on
+    // the slow LLM call until we cancel.
+    let orch_for_submit = orch.clone();
+    let handle = tokio::spawn(async move {
+        orch_for_submit
+            .submit_turn_with_request_id(
+                request_id,
+                "say hi",
+                conv_id,
+                Interface::Web,
+                None,
+                vec![],
+            )
+            .await
+    });
+
+    // Wait until the orchestrator has registered the cancellation token —
+    // i.e. submit_turn_internal has reached the body. Bounded to keep the
+    // test from hanging if registration ever regresses.
+    let registration_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while !orch.is_turn_in_flight(request_id).await {
+        if tokio::time::Instant::now() > registration_deadline {
+            panic!("turn never registered its cancellation token");
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    // Cancel.
+    let outcome = orch.cancel_turn(request_id).await;
+    assert_eq!(
+        outcome,
+        crate::orchestrator::CancelOutcome::Cancelled,
+        "cancel_turn must report Cancelled when a token is registered"
+    );
+
+    // submit_turn_with_request_id should return promptly with the cancelled
+    // marker — well under the 30 s submit_timeout configured above.
+    let result = tokio::time::timeout(Duration::from_secs(10), handle)
+        .await
+        .expect("submit must return within 10 s of cancel")
+        .expect("join task");
+    let err = match result {
+        Ok(_) => panic!("submit_turn must return Err on cancel"),
+        Err(e) => e,
+    };
+    assert!(
+        err.to_string()
+            .contains(crate::orchestrator::TURN_CANCELLED_MARKER),
+        "cancelled submit must carry the marker; got: {err}"
+    );
+
+    // The token should be deregistered once submit_turn returns, so a
+    // second cancel attempt is a no-op.
+    assert_eq!(
+        orch.cancel_turn(request_id).await,
+        crate::orchestrator::CancelOutcome::NotFound,
+        "request_id should be deregistered after submit_turn returns"
+    );
+}

--- a/crates/runtime/src/orchestrator/worker.rs
+++ b/crates/runtime/src/orchestrator/worker.rs
@@ -614,6 +614,7 @@ impl Orchestrator {
             HashMap::new(),
             vec![],
             TurnIdentity::default(),
+            None,
         )
         .await
     }
@@ -635,6 +636,7 @@ impl Orchestrator {
             HashMap::new(),
             attachment_ids,
             TurnIdentity::default(),
+            None,
         )
         .await
     }
@@ -657,6 +659,36 @@ impl Orchestrator {
             HashMap::new(),
             attachment_ids,
             identity,
+            None,
+        )
+        .await
+    }
+
+    /// Submit a turn using a caller-supplied `request_id`.
+    ///
+    /// Used by streaming HTTP handlers in `assistant-web-ui` so that the SSE
+    /// `run_id` doubles as the orchestrator's `request_id` — letting clients
+    /// invoke [`Self::cancel_turn`] with the same id they already observe in
+    /// the `run_started` event. Behaviour is otherwise identical to
+    /// [`Self::submit_turn_with_attachments`].
+    pub async fn submit_turn_with_request_id(
+        &self,
+        request_id: Uuid,
+        prompt: &str,
+        conversation_id: Uuid,
+        interface: Interface,
+        timestamp: Option<DateTime<Utc>>,
+        attachment_ids: Vec<Uuid>,
+    ) -> Result<TurnResult> {
+        self.submit_turn_internal(
+            prompt,
+            conversation_id,
+            interface,
+            timestamp,
+            HashMap::new(),
+            attachment_ids,
+            TurnIdentity::default(),
+            Some(request_id),
         )
         .await
     }
@@ -673,8 +705,9 @@ impl Orchestrator {
         submit_metadata: HashMap<String, String>,
         attachment_ids: Vec<Uuid>,
         identity: TurnIdentity,
+        request_id_override: Option<Uuid>,
     ) -> Result<TurnResult> {
-        let request_id = Uuid::new_v4();
+        let request_id = request_id_override.unwrap_or_else(Uuid::new_v4);
         // Register a cancellation token so the worker can be interrupted if
         // submit_turn times out before the turn finishes.
         let cancel_token = CancellationToken::new();
@@ -771,6 +804,27 @@ impl Orchestrator {
             .with_conversation_id(conversation_id)
             .with_batch_id(request_id);
         loop {
+            // Honor external cancellation (e.g. POST .../cancel) by short-
+            // circuiting the wait. The worker's own select! already aborts
+            // mid-turn when the same token fires; this branch is what lets
+            // `submit_turn` return promptly instead of waiting for the bus
+            // result that will never arrive.
+            if cancel_token.is_cancelled() {
+                self.turn_cancellations.write().await.remove(&request_id);
+                info!(
+                    conversation_id = %conversation_id,
+                    request_id = %request_id,
+                    interface = %interface_label,
+                    submit_state = "cancelled",
+                    "submit_turn waiter state"
+                );
+                anyhow::bail!(
+                    "{}: submit_turn aborted by cancel_turn \
+                     (conversation_id={conversation_id}, request_id={request_id})",
+                    crate::orchestrator::TURN_CANCELLED_MARKER
+                );
+            }
+
             let now = tokio::time::Instant::now();
             if now > late_result_deadline {
                 self.metrics


### PR DESCRIPTION
## Summary

Adds the public runtime cancellation surface that the upcoming `POST .../turns/{turn_id}/cancel` HTTP endpoint depends on, plus the bridge that lets streaming SSE handlers use the `run_id` they already emit as the orchestrator's `request_id`.

## New on `Orchestrator`

- **`cancel_turn(request_id) -> CancelOutcome`** — looks up the existing per-turn `CancellationToken`, triggers it, returns `Cancelled` / `NotFound`. The worker's `tokio::select!` already aborts in-flight work on this signal; this change just makes the abort externally reachable.
- **`submit_turn_with_request_id(request_id, ...)`** — lets the caller pin the request_id. Without this, HTTP handlers couldn't address the right token from outside.
- **`is_turn_in_flight(request_id)`** — read-only probe (mainly for tests).

## submit_turn poll loop honors external cancellation

When the token fires externally, the wait returns `Err` containing `TURN_CANCELLED_MARKER` ("turn_cancelled") instead of the 3 h late-result timeout. Callers can match on it to emit a final `agent_error` SSE event with a structured cancellation reason.

## Internal change

`submit_turn_internal` gains a `request_id_override: Option<Uuid>` parameter; all three existing public callers pass `None` (unchanged behaviour).

## Test plan

- [x] `cancel_turn_unknown_request_id_returns_not_found` — NotFound when no token
- [x] `cancel_turn_aborts_inflight_submit` — end-to-end: spawn worker, submit slow turn, wait for token registration, cancel, assert submit returns within 10s with the cancellation marker, and token deregisters cleanly
- [x] `cargo test -p assistant-runtime` — 222/222 pass
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] Pre-commit hooks green

Refs: `openspec/changes/turn-status-endpoint/` § 1.2-1.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Orchestrator turns can now be cancelled by request ID, with feedback on cancellation status (cancelled vs. not found).
  * Added support for specifying custom request IDs when submitting turns, enabling better tracking and cancellation management.
  * Added utility method to check if a turn is currently in flight.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cedricziel/assistant/pull/850?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->