### PR TITLE
refactor(storage): extract PushSubscriptionStore trait + InMemory impl (Phase 5.E)

### DIFF
--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -88,7 +88,10 @@ pub use org_store::SqliteOrgStore;
 pub use persona_skill_access::PersonaSkillAccessStore;
 pub use personas::{PersonaRecord, PersonaStore};
 pub use pool_factory::OrgPoolFactory;
-pub use push_subscriptions::{PushSubscription, PushSubscriptionStore};
+pub use push_subscriptions::{
+    InMemoryPushSubscriptionStore, PushSubscription, PushSubscriptionStore,
+    SqlitePushSubscriptionStore,
+};
 pub use refinements::{RefinementStatus, RefinementsStore, SkillRefinement};
 pub use registry::SkillRegistry;
 pub use scheduled_tasks::{ScheduledTask, ScheduledTaskStore};
@@ -236,8 +239,8 @@ impl StorageLayer {
     }
 
     /// Convenience: build a [`PushSubscriptionStore`] backed by this pool.
-    pub fn push_subscription_store(&self) -> PushSubscriptionStore {
-        PushSubscriptionStore::new(self.pool.clone())
+    pub fn push_subscription_store(&self) -> SqlitePushSubscriptionStore {
+        SqlitePushSubscriptionStore::new(self.pool.clone())
     }
 
     /// Convenience: build a [`WorkflowStore`] backed by this pool.

--- a/crates/storage/src/push_subscriptions.rs
+++ b/crates/storage/src/push_subscriptions.rs
@@ -1,13 +1,11 @@
 //! PWA Web Push subscription persistence.
-//!
-//! Each row represents one browser push subscription endpoint.  Subscriptions
-//! are upserted by endpoint URL (unique) and deleted automatically when the
-//! push service returns `410 Gone`.
 
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use assistant_core::clock::{Clock, SystemClock};
+use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use sqlx::{Row, SqlitePool};
 
@@ -21,15 +19,27 @@ pub struct PushSubscription {
     pub created_at: DateTime<Utc>,
 }
 
+/// Trait-based interface for PWA push subscription persistence.
+#[async_trait]
+pub trait PushSubscriptionStore: Send + Sync {
+    /// Insert or update a subscription by `endpoint` (unique key).
+    async fn upsert(&self, endpoint: &str, p256dh: &str, auth: &str) -> Result<()>;
+
+    /// Delete a subscription by its push endpoint URL.
+    async fn delete(&self, endpoint: &str) -> Result<()>;
+
+    /// Return every stored subscription (used by the push dispatcher).
+    async fn list_all(&self) -> Result<Vec<PushSubscription>>;
+}
+
 /// SQLite-backed store for PWA push subscriptions.
 #[derive(Clone)]
-pub struct PushSubscriptionStore {
+pub struct SqlitePushSubscriptionStore {
     pool: SqlitePool,
-    /// Clock for row timestamps. Default `Arc::new(SystemClock)`.
     clock: Arc<dyn Clock>,
 }
 
-impl PushSubscriptionStore {
+impl SqlitePushSubscriptionStore {
     pub fn new(pool: SqlitePool) -> Self {
         Self {
             pool,
@@ -37,14 +47,15 @@ impl PushSubscriptionStore {
         }
     }
 
-    /// Inject a [`Clock`] implementation.
     pub fn with_clock(mut self, clock: Arc<dyn Clock>) -> Self {
         self.clock = clock;
         self
     }
+}
 
-    /// Insert or update a subscription by `endpoint` (unique key).
-    pub async fn upsert(&self, endpoint: &str, p256dh: &str, auth: &str) -> Result<()> {
+#[async_trait]
+impl PushSubscriptionStore for SqlitePushSubscriptionStore {
+    async fn upsert(&self, endpoint: &str, p256dh: &str, auth: &str) -> Result<()> {
         let now = self.clock.now();
         sqlx::query(
             "INSERT INTO push_subscriptions (endpoint, p256dh, auth, created_at) \
@@ -61,7 +72,7 @@ impl PushSubscriptionStore {
     }
 
     /// Delete a subscription by its push endpoint URL.
-    pub async fn delete(&self, endpoint: &str) -> Result<()> {
+    async fn delete(&self, endpoint: &str) -> Result<()> {
         sqlx::query("DELETE FROM push_subscriptions WHERE endpoint = ?1")
             .bind(endpoint)
             .execute(&self.pool)
@@ -70,7 +81,7 @@ impl PushSubscriptionStore {
     }
 
     /// Return every stored subscription (used by the push dispatcher).
-    pub async fn list_all(&self) -> Result<Vec<PushSubscription>> {
+    async fn list_all(&self) -> Result<Vec<PushSubscription>> {
         let rows = sqlx::query(
             "SELECT id, endpoint, p256dh, auth, created_at FROM push_subscriptions ORDER BY id",
         )
@@ -92,6 +103,90 @@ impl PushSubscriptionStore {
     }
 }
 
+// ---------------------------------------------------------------------------
+// In-memory implementation
+// ---------------------------------------------------------------------------
+
+/// In-memory [`PushSubscriptionStore`]. Vec-backed.
+pub struct InMemoryPushSubscriptionStore {
+    state: Arc<Mutex<InMemoryPushState>>,
+    clock: Arc<dyn Clock>,
+}
+
+#[derive(Default)]
+struct InMemoryPushState {
+    next_id: i64,
+    by_endpoint: HashMap<String, PushSubscription>,
+}
+
+impl InMemoryPushSubscriptionStore {
+    pub fn new() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(InMemoryPushState::default())),
+            clock: Arc::new(SystemClock),
+        }
+    }
+
+    pub fn with_clock(mut self, clock: Arc<dyn Clock>) -> Self {
+        self.clock = clock;
+        self
+    }
+}
+
+impl Default for InMemoryPushSubscriptionStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl PushSubscriptionStore for InMemoryPushSubscriptionStore {
+    async fn upsert(&self, endpoint: &str, p256dh: &str, auth: &str) -> Result<()> {
+        let now = self.clock.now();
+        let mut state = match self.state.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        if let Some(sub) = state.by_endpoint.get_mut(endpoint) {
+            sub.p256dh = p256dh.to_string();
+            sub.auth = auth.to_string();
+        } else {
+            state.next_id += 1;
+            let id = state.next_id;
+            state.by_endpoint.insert(
+                endpoint.to_string(),
+                PushSubscription {
+                    id,
+                    endpoint: endpoint.to_string(),
+                    p256dh: p256dh.to_string(),
+                    auth: auth.to_string(),
+                    created_at: now,
+                },
+            );
+        }
+        Ok(())
+    }
+
+    async fn delete(&self, endpoint: &str) -> Result<()> {
+        let mut state = match self.state.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        state.by_endpoint.remove(endpoint);
+        Ok(())
+    }
+
+    async fn list_all(&self) -> Result<Vec<PushSubscription>> {
+        let state = match self.state.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let mut subs: Vec<PushSubscription> = state.by_endpoint.values().cloned().collect();
+        subs.sort_by_key(|s| s.id);
+        Ok(subs)
+    }
+}
+
 // -- Tests -------------------------------------------------------------------
 
 #[cfg(test)]
@@ -99,9 +194,9 @@ mod tests {
     use super::*;
     use crate::StorageLayer;
 
-    async fn store() -> PushSubscriptionStore {
+    async fn store() -> SqlitePushSubscriptionStore {
         let storage = StorageLayer::new_in_memory().await.unwrap();
-        PushSubscriptionStore::new(storage.pool)
+        SqlitePushSubscriptionStore::new(storage.pool)
     }
 
     #[tokio::test]

--- a/crates/storage/tests/contract.rs
+++ b/crates/storage/tests/contract.rs
@@ -8,5 +8,6 @@ mod contract {
     pub mod attachment_store;
     pub mod conversation_store;
     pub mod log_store;
+    pub mod push_subscription_store;
     pub mod trace_store;
 }

--- a/crates/storage/tests/contract/push_subscription_store.rs
+++ b/crates/storage/tests/contract/push_subscription_store.rs
@@ -1,0 +1,86 @@
+//! Contract tests for the [`PushSubscriptionStore`] trait.
+
+use assistant_storage::{
+    InMemoryPushSubscriptionStore, PushSubscriptionStore, SqlitePushSubscriptionStore, StorageLayer,
+};
+
+async fn sqlite_store() -> Box<dyn PushSubscriptionStore> {
+    let storage = StorageLayer::new_in_memory().await.unwrap();
+    Box::new(SqlitePushSubscriptionStore::new(storage.pool))
+}
+
+fn memory_store() -> Box<dyn PushSubscriptionStore> {
+    Box::new(InMemoryPushSubscriptionStore::new())
+}
+
+async fn upsert_and_list(store: Box<dyn PushSubscriptionStore>) {
+    store
+        .upsert("https://push.example.com/abc", "p256", "auth")
+        .await
+        .unwrap();
+    let subs = store.list_all().await.unwrap();
+    assert_eq!(subs.len(), 1);
+    assert_eq!(subs[0].endpoint, "https://push.example.com/abc");
+}
+
+async fn upsert_replaces_existing(store: Box<dyn PushSubscriptionStore>) {
+    store
+        .upsert("https://push.example.com/dup", "k1", "a1")
+        .await
+        .unwrap();
+    store
+        .upsert("https://push.example.com/dup", "k2", "a2")
+        .await
+        .unwrap();
+    let subs = store.list_all().await.unwrap();
+    assert_eq!(subs.len(), 1);
+    assert_eq!(subs[0].p256dh, "k2");
+}
+
+async fn delete_removes_subscription(store: Box<dyn PushSubscriptionStore>) {
+    store
+        .upsert("https://push.example.com/del", "k", "a")
+        .await
+        .unwrap();
+    store.delete("https://push.example.com/del").await.unwrap();
+    let subs = store.list_all().await.unwrap();
+    assert!(subs.is_empty());
+}
+
+async fn delete_missing_endpoint_is_ok(store: Box<dyn PushSubscriptionStore>) {
+    store
+        .delete("https://push.example.com/never-existed")
+        .await
+        .unwrap();
+}
+
+macro_rules! contract_tests {
+    ($name:ident, $ctor:expr) => {
+        mod $name {
+            use super::*;
+
+            #[tokio::test]
+            async fn t_upsert_and_list() {
+                upsert_and_list($ctor).await;
+            }
+
+            #[tokio::test]
+            async fn t_upsert_replaces_existing() {
+                upsert_replaces_existing($ctor).await;
+            }
+
+            #[tokio::test]
+            async fn t_delete_removes_subscription() {
+                delete_removes_subscription($ctor).await;
+            }
+
+            #[tokio::test]
+            async fn t_delete_missing_endpoint_is_ok() {
+                delete_missing_endpoint_is_ok($ctor).await;
+            }
+        }
+    };
+}
+
+contract_tests!(sqlite, sqlite_store().await);
+contract_tests!(memory, memory_store());

--- a/crates/test-support/src/prelude.rs
+++ b/crates/test-support/src/prelude.rs
@@ -20,7 +20,8 @@
 pub use assistant_core::clock::{Clock, FakeClock, SystemClock};
 pub use assistant_storage::{
     AttachmentStore, ConversationStore, InMemoryAttachmentStore, InMemoryConversationStore,
-    InMemoryLogStore, InMemoryTraceStore, LogStore, TraceStore,
+    InMemoryLogStore, InMemoryPushSubscriptionStore, InMemoryTraceStore, LogStore,
+    PushSubscriptionStore, TraceStore,
 };
 
 pub use crate::fixture::{Fixture, FixtureBuilder};

--- a/crates/web-ui/src/api/push.rs
+++ b/crates/web-ui/src/api/push.rs
@@ -23,7 +23,7 @@ use crate::api::internal_error;
 
 #[derive(Clone)]
 pub struct PushApiState {
-    pub store: Arc<PushSubscriptionStore>,
+    pub store: Arc<dyn PushSubscriptionStore>,
     /// Base64url-encoded VAPID public key (uncompressed P-256 point).
     pub vapid_public_key: Arc<String>,
 }

--- a/crates/web-ui/src/push.rs
+++ b/crates/web-ui/src/push.rs
@@ -119,14 +119,14 @@ async fn persist_vapid_keys(
 pub struct PushDispatcher {
     /// base64url-encoded PEM bytes of the P-256 ECDSA signing key.
     vapid_private_key_b64: Arc<String>,
-    store: Arc<PushSubscriptionStore>,
+    store: Arc<dyn PushSubscriptionStore>,
     /// HTTP client used for outbound push delivery. Default `Client::new()`;
     /// tests inject a client built against a `wiremock::MockServer`.
     client: reqwest::Client,
 }
 
 impl PushDispatcher {
-    pub fn new(vapid_private_key_b64: String, store: Arc<PushSubscriptionStore>) -> Self {
+    pub fn new(vapid_private_key_b64: String, store: Arc<dyn PushSubscriptionStore>) -> Self {
         Self::with_client(vapid_private_key_b64, store, reqwest::Client::new())
     }
 
@@ -134,7 +134,7 @@ impl PushDispatcher {
     /// built against a `wiremock::MockServer`.
     pub fn with_client(
         vapid_private_key_b64: String,
-        store: Arc<PushSubscriptionStore>,
+        store: Arc<dyn PushSubscriptionStore>,
         client: reqwest::Client,
     ) -> Self {
         Self {
@@ -430,7 +430,7 @@ mod tests {
         let storage = assistant_storage::StorageLayer::new_in_memory()
             .await
             .unwrap();
-        let store = Arc::new(PushSubscriptionStore::new(storage.pool.clone()));
+        let store = Arc::new(SqlitePushSubscriptionStore::new(storage.pool.clone()));
         let dispatcher = PushDispatcher::with_client(
             "AA".repeat(40), // not a valid key, but not parsed in the empty path
             store,
@@ -459,7 +459,7 @@ mod tests {
         let storage = assistant_storage::StorageLayer::new_in_memory()
             .await
             .unwrap();
-        let store = Arc::new(PushSubscriptionStore::new(storage.pool.clone()));
+        let store = Arc::new(SqlitePushSubscriptionStore::new(storage.pool.clone()));
         let dispatcher = PushDispatcher::with_client("fakekey".to_string(), store, custom_client);
 
         // Construct OK + empty send_to_all returns Ok.


### PR DESCRIPTION
Phase 5.E. PushSubscriptionStore trait + Sqlite/InMemory impls + 4 contract scenarios. web-ui::PushDispatcher + PushApiState hold Arc<dyn PushSubscriptionStore>.