### PR TITLE
refactor(storage): extract CommandEventStore trait + InMemory impl (Phase 5.F)

### DIFF
--- a/crates/runtime/src/channel_runner.rs
+++ b/crates/runtime/src/channel_runner.rs
@@ -24,7 +24,7 @@ use assistant_core::{
     ChannelAdapter, ChannelContent, ChannelMessage, ContentBlock, ConversationConfig,
     IdentityResolver,
 };
-use assistant_storage::CommandEventStore;
+use assistant_storage::{CommandEventStore, SqliteCommandEventStore};
 use base64::Engine as _;
 use futures::StreamExt;
 use lru::LruCache;
@@ -63,7 +63,7 @@ pub struct ChannelRunner {
     /// Active turns: conv_id → request_id (for `/stop`).
     active_turns: Arc<RwLock<HashMap<Uuid, Uuid>>>,
     /// Store for persisting command events.
-    command_event_store: CommandEventStore,
+    command_event_store: Arc<dyn CommandEventStore>,
     /// Optional resolver that maps platform user IDs to assistant user IDs.
     identity_resolver: Option<Arc<dyn IdentityResolver>>,
 }
@@ -71,7 +71,9 @@ pub struct ChannelRunner {
 impl ChannelRunner {
     /// Create a new runner for `adapter`.
     pub fn new(adapter: Arc<dyn ChannelAdapter>, orchestrator: Arc<Orchestrator>) -> Self {
-        let command_event_store = CommandEventStore::new(orchestrator.storage.pool.clone());
+        let command_event_store: Arc<dyn CommandEventStore> = Arc::new(
+            SqliteCommandEventStore::new(orchestrator.storage.pool.clone()),
+        );
         Self {
             adapter,
             orchestrator,

--- a/crates/storage/src/command_events.rs
+++ b/crates/storage/src/command_events.rs
@@ -4,10 +4,12 @@
 //! timeline.  These records are never included in LLM context — the
 //! orchestrator only loads the `messages` table.
 
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use assistant_core::clock::{Clock, SystemClock};
+use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sqlx::{Row, SqlitePool};
@@ -27,15 +29,30 @@ pub struct CommandEventRow {
     pub created_at: DateTime<Utc>,
 }
 
-/// SQLite-backed store for slash-command events.
-#[derive(Clone)]
-pub struct CommandEventStore {
+/// Trait-based interface for command event persistence.
+#[async_trait]
+pub trait CommandEventStore: Send + Sync {
+    /// Persist a command event.
+    async fn save_event(
+        &self,
+        conversation_id: Uuid,
+        command: &str,
+        payload: Option<&serde_json::Value>,
+        ack_text: &str,
+    ) -> Result<CommandEventRow>;
+
+    /// List all command events for a conversation, ordered by `created_at` ascending.
+    async fn list_events(&self, conversation_id: Uuid) -> Result<Vec<CommandEventRow>>;
+}
+
+/// SQLite-backed command event store.
+pub struct SqliteCommandEventStore {
     pool: SqlitePool,
     /// Clock for row timestamps. Default `Arc::new(SystemClock)`.
     clock: Arc<dyn Clock>,
 }
 
-impl CommandEventStore {
+impl SqliteCommandEventStore {
     pub fn new(pool: SqlitePool) -> Self {
         Self {
             pool,
@@ -48,9 +65,12 @@ impl CommandEventStore {
         self.clock = clock;
         self
     }
+}
 
+#[async_trait]
+impl CommandEventStore for SqliteCommandEventStore {
     /// Persist a command event.
-    pub async fn save_event(
+    async fn save_event(
         &self,
         conversation_id: Uuid,
         command: &str,
@@ -89,7 +109,7 @@ impl CommandEventStore {
     }
 
     /// List all command events for a conversation, ordered by `created_at` ascending.
-    pub async fn list_events(&self, conversation_id: Uuid) -> Result<Vec<CommandEventRow>> {
+    async fn list_events(&self, conversation_id: Uuid) -> Result<Vec<CommandEventRow>> {
         let conv_str = conversation_id.to_string();
         let rows = sqlx::query(
             "SELECT id, conversation_id, event_type, command, payload, ack_text, created_at \
@@ -125,6 +145,75 @@ impl CommandEventStore {
     }
 }
 
+// ---------------------------------------------------------------------------
+// In-memory implementation
+// ---------------------------------------------------------------------------
+
+/// In-memory [`CommandEventStore`]. HashMap<conversation_id, Vec<CommandEventRow>>.
+pub struct InMemoryCommandEventStore {
+    state: Arc<Mutex<HashMap<Uuid, Vec<CommandEventRow>>>>,
+    clock: Arc<dyn Clock>,
+}
+
+impl InMemoryCommandEventStore {
+    pub fn new() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(HashMap::new())),
+            clock: Arc::new(SystemClock),
+        }
+    }
+
+    pub fn with_clock(mut self, clock: Arc<dyn Clock>) -> Self {
+        self.clock = clock;
+        self
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<Uuid, Vec<CommandEventRow>>> {
+        match self.state.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        }
+    }
+}
+
+impl Default for InMemoryCommandEventStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl CommandEventStore for InMemoryCommandEventStore {
+    async fn save_event(
+        &self,
+        conversation_id: Uuid,
+        command: &str,
+        payload: Option<&serde_json::Value>,
+        ack_text: &str,
+    ) -> Result<CommandEventRow> {
+        let now = self.clock.now();
+        let row = CommandEventRow {
+            id: Uuid::new_v4(),
+            conversation_id,
+            event_type: "command".into(),
+            command: command.into(),
+            payload: payload.cloned(),
+            ack_text: Some(ack_text.into()),
+            created_at: now,
+        };
+        let mut state = self.lock();
+        state.entry(conversation_id).or_default().push(row.clone());
+        Ok(row)
+    }
+
+    async fn list_events(&self, conversation_id: Uuid) -> Result<Vec<CommandEventRow>> {
+        let state = self.lock();
+        let mut out = state.get(&conversation_id).cloned().unwrap_or_default();
+        out.sort_by_key(|r| r.created_at);
+        Ok(out)
+    }
+}
+
 // -- Tests --
 
 #[cfg(test)]
@@ -135,7 +224,7 @@ mod tests {
     #[tokio::test]
     async fn save_and_list_events() {
         let storage = StorageLayer::new_in_memory().await.unwrap();
-        let store = CommandEventStore::new(storage.pool.clone());
+        let store = SqliteCommandEventStore::new(storage.pool.clone());
 
         let conv_id = Uuid::new_v4();
         let payload = serde_json::json!({"model_name": "claude-opus-4"});
@@ -173,7 +262,7 @@ mod tests {
     #[tokio::test]
     async fn list_events_empty_for_unknown_conversation() {
         let storage = StorageLayer::new_in_memory().await.unwrap();
-        let store = CommandEventStore::new(storage.pool.clone());
+        let store = SqliteCommandEventStore::new(storage.pool.clone());
 
         let events = store.list_events(Uuid::new_v4()).await.unwrap();
         assert!(events.is_empty());
@@ -182,7 +271,7 @@ mod tests {
     #[tokio::test]
     async fn events_ordered_by_created_at() {
         let storage = StorageLayer::new_in_memory().await.unwrap();
-        let store = CommandEventStore::new(storage.pool.clone());
+        let store = SqliteCommandEventStore::new(storage.pool.clone());
         let conv_id = Uuid::new_v4();
 
         store

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -66,7 +66,9 @@ pub use auth_state_store::{
 };
 pub use binding_store::SqliteBindingStore;
 pub use catalog_item_store::{SqliteCatalogItemStore, SqliteCatalogSubscriptionStore};
-pub use command_events::{CommandEventRow, CommandEventStore};
+pub use command_events::{
+    CommandEventRow, CommandEventStore, InMemoryCommandEventStore, SqliteCommandEventStore,
+};
 pub use conversation_broadcaster::{
     ConversationBroadcast, ConversationEvent, InMemoryConversationBroadcaster,
 };

--- a/crates/storage/tests/contract.rs
+++ b/crates/storage/tests/contract.rs
@@ -6,6 +6,7 @@
 
 mod contract {
     pub mod attachment_store;
+    pub mod command_event_store;
     pub mod conversation_store;
     pub mod log_store;
     pub mod push_subscription_store;

--- a/crates/storage/tests/contract/command_event_store.rs
+++ b/crates/storage/tests/contract/command_event_store.rs
@@ -1,0 +1,71 @@
+//! Contract tests for the [`CommandEventStore`] trait.
+
+use assistant_storage::{
+    CommandEventStore, InMemoryCommandEventStore, SqliteCommandEventStore, StorageLayer,
+};
+use uuid::Uuid;
+
+async fn sqlite() -> Box<dyn CommandEventStore> {
+    let storage = StorageLayer::new_in_memory().await.unwrap();
+    Box::new(SqliteCommandEventStore::new(storage.pool))
+}
+
+fn memory() -> Box<dyn CommandEventStore> {
+    Box::new(InMemoryCommandEventStore::new())
+}
+
+async fn save_and_list(store: Box<dyn CommandEventStore>) {
+    let conv = Uuid::new_v4();
+    let payload = serde_json::json!({"k": "v"});
+    let event = store
+        .save_event(conv, "model", Some(&payload), "ack")
+        .await
+        .unwrap();
+    assert_eq!(event.command, "model");
+    assert_eq!(event.conversation_id, conv);
+    let events = store.list_events(conv).await.unwrap();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].ack_text.as_deref(), Some("ack"));
+}
+
+async fn list_empty_returns_empty(store: Box<dyn CommandEventStore>) {
+    let events = store.list_events(Uuid::new_v4()).await.unwrap();
+    assert!(events.is_empty());
+}
+
+async fn list_orders_by_created_at(store: Box<dyn CommandEventStore>) {
+    let conv = Uuid::new_v4();
+    store.save_event(conv, "first", None, "a1").await.unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+    store.save_event(conv, "second", None, "a2").await.unwrap();
+    let events = store.list_events(conv).await.unwrap();
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0].command, "first");
+    assert_eq!(events[1].command, "second");
+}
+
+macro_rules! contract_tests {
+    ($name:ident, $ctor:expr) => {
+        mod $name {
+            use super::*;
+
+            #[tokio::test]
+            async fn t_save_and_list() {
+                save_and_list($ctor).await;
+            }
+
+            #[tokio::test]
+            async fn t_list_empty() {
+                list_empty_returns_empty($ctor).await;
+            }
+
+            #[tokio::test]
+            async fn t_list_orders_by_created_at() {
+                list_orders_by_created_at($ctor).await;
+            }
+        }
+    };
+}
+
+contract_tests!(sqlite_impl, sqlite().await);
+contract_tests!(memory_impl, memory());

--- a/crates/test-support/src/prelude.rs
+++ b/crates/test-support/src/prelude.rs
@@ -19,9 +19,9 @@
 
 pub use assistant_core::clock::{Clock, FakeClock, SystemClock};
 pub use assistant_storage::{
-    AttachmentStore, ConversationStore, InMemoryAttachmentStore, InMemoryConversationStore,
-    InMemoryLogStore, InMemoryPushSubscriptionStore, InMemoryTraceStore, LogStore,
-    PushSubscriptionStore, TraceStore,
+    AttachmentStore, CommandEventStore, ConversationStore, InMemoryAttachmentStore,
+    InMemoryCommandEventStore, InMemoryConversationStore, InMemoryLogStore,
+    InMemoryPushSubscriptionStore, InMemoryTraceStore, LogStore, PushSubscriptionStore, TraceStore,
 };
 
 pub use crate::fixture::{Fixture, FixtureBuilder};

--- a/crates/web-ui/src/api/commands.rs
+++ b/crates/web-ui/src/api/commands.rs
@@ -266,7 +266,7 @@ pub async fn list_command_events(
 mod tests {
     use super::*;
     use assistant_runtime::CommandRegistry;
-    use assistant_storage::CommandEventStore;
+    use assistant_storage::SqliteCommandEventStore;
 
     #[test]
     fn list_commands_returns_all_builtins() {

--- a/crates/web-ui/src/api/messages.rs
+++ b/crates/web-ui/src/api/messages.rs
@@ -1196,7 +1196,7 @@ mod tests {
     use assistant_runtime::CommandRegistry;
     use assistant_storage::{
         CommandEventStore, ConversationStore, InMemoryConversationBroadcaster, RunBroadcaster,
-        SkillRegistry, SqliteConversationStore, StorageLayer,
+        SkillRegistry, SqliteCommandEventStore, SqliteConversationStore, StorageLayer,
     };
 
     use super::super::ApiState;
@@ -1894,7 +1894,7 @@ mod tests {
             run_broadcaster: RunBroadcaster::new(),
             attachment_store: Arc::new(SqliteAttachmentStore::new(sl.pool.clone())),
             command_registry: Arc::new(CommandRegistry::new()),
-            command_event_store: CommandEventStore::new(sl.pool.clone()),
+            command_event_store: Arc::new(SqliteCommandEventStore::new(sl.pool.clone())),
             conversation_broadcaster: Arc::new(InMemoryConversationBroadcaster::new()),
             conversation_configs: Arc::new(RwLock::new(HashMap::new())),
             orchestrator_ref,

--- a/crates/web-ui/src/api/mod.rs
+++ b/crates/web-ui/src/api/mod.rs
@@ -127,6 +127,7 @@ use assistant_runtime::{AssistantInterface, CommandRegistry, Orchestrator};
 use assistant_storage::{
     AttachmentStore, CommandEventStore, ConversationBroadcast, ConversationEventStore,
     InMemoryConversationBroadcaster, RunBroadcaster, SqliteAttachmentStore,
+    SqliteCommandEventStore,
 };
 use assistant_transcription::{TranscriptionProvider, TtsProvider};
 use axum::{
@@ -170,7 +171,7 @@ pub struct ApiState {
     /// Slash-command registry (shared with all interfaces).
     pub command_registry: Arc<CommandRegistry>,
     /// Durable store for slash-command events.
-    pub command_event_store: CommandEventStore,
+    pub command_event_store: Arc<dyn CommandEventStore>,
     /// Conversation-list broadcaster for reactive SSE streaming.
     pub conversation_broadcaster: Arc<dyn ConversationBroadcast>,
     /// Per-conversation config overrides (model selection, etc.).
@@ -193,7 +194,8 @@ impl ApiState {
         let event_store = ConversationEventStore::new(pool.clone());
         let attachment_store: Arc<dyn AttachmentStore> =
             Arc::new(SqliteAttachmentStore::new(pool.clone()));
-        let command_event_store = CommandEventStore::new(pool.clone());
+        let command_event_store: Arc<dyn CommandEventStore> =
+            Arc::new(SqliteCommandEventStore::new(pool.clone()));
         let default_model = orchestrator_ref.llm.model_name().to_string();
         Self {
             pool,

--- a/crates/web-ui/src/api/test_helpers.rs
+++ b/crates/web-ui/src/api/test_helpers.rs
@@ -22,7 +22,7 @@ use assistant_llm_provider::retry::RetryConfig;
 use assistant_runtime::{CommandRegistry, Orchestrator};
 use assistant_storage::{
     AttachmentStore, CommandEventStore, ConversationEventStore, InMemoryConversationBroadcaster,
-    RunBroadcaster, SkillRegistry, SqliteAttachmentStore, StorageLayer,
+    RunBroadcaster, SkillRegistry, SqliteAttachmentStore, SqliteCommandEventStore, StorageLayer,
 };
 use assistant_tool_executor::ToolExecutor;
 use assistant_transcription::{TranscriptionProvider, TranscriptionRequest, TranscriptionResult};
@@ -122,7 +122,7 @@ pub(crate) async fn test_state(llm_url: &str) -> (ApiState, Arc<StorageLayer>) {
         run_broadcaster: RunBroadcaster::new(),
         attachment_store: Arc::new(SqliteAttachmentStore::new(storage.pool.clone())),
         command_registry: Arc::new(CommandRegistry::new()),
-        command_event_store: CommandEventStore::new(storage.pool.clone()),
+        command_event_store: Arc::new(SqliteCommandEventStore::new(storage.pool.clone())),
         conversation_broadcaster: Arc::new(InMemoryConversationBroadcaster::new()),
         conversation_configs: Arc::new(RwLock::new(HashMap::new())),
         orchestrator_ref,
@@ -180,7 +180,7 @@ pub(crate) async fn event_log_state() -> (ApiState, Arc<StorageLayer>) {
         run_broadcaster: RunBroadcaster::new(),
         attachment_store: Arc::new(SqliteAttachmentStore::new(storage.pool.clone())),
         command_registry: Arc::new(CommandRegistry::new()),
-        command_event_store: CommandEventStore::new(storage.pool.clone()),
+        command_event_store: Arc::new(SqliteCommandEventStore::new(storage.pool.clone())),
         conversation_broadcaster: Arc::new(InMemoryConversationBroadcaster::new()),
         conversation_configs: Arc::new(RwLock::new(HashMap::new())),
         orchestrator_ref,


### PR DESCRIPTION
Same pattern. CommandEventStore trait + Sqlite/InMemory + 6 contract tests. ApiState + channel_runner hold Arc<dyn CommandEventStore>.