### PR TITLE
refactor(storage): extract SlackActiveThreadStore trait + InMemory impl (Phase 5.G)

### DIFF
--- a/crates/interfaces/src/slack/adapter.rs
+++ b/crates/interfaces/src/slack/adapter.rs
@@ -18,7 +18,7 @@ use assistant_core::{
     types::conversation::ChannelType, types::conversation::Message,
     types::conversation::MessageRole,
 };
-use assistant_storage::{ConversationStore, StorageLayer};
+use assistant_storage::{ConversationStore, SlackActiveThreadStore, StorageLayer};
 use assistant_transcription::{TranscriptionProvider, TranscriptionRequest, is_audio_mime};
 use async_trait::async_trait;
 use futures::SinkExt;

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -97,7 +97,9 @@ pub use push_subscriptions::{
 pub use refinements::{RefinementStatus, RefinementsStore, SkillRefinement};
 pub use registry::SkillRegistry;
 pub use scheduled_tasks::{ScheduledTask, ScheduledTaskStore};
-pub use slack_threads::SlackActiveThreadStore;
+pub use slack_threads::{
+    InMemorySlackActiveThreadStore, SlackActiveThreadStore, SqliteSlackActiveThreadStore,
+};
 pub use space_store::{SqliteMembershipStore, SqliteSpaceStore};
 pub use traces::{
     InMemoryTraceStore, RecordedSpan, SkillStatsProvider, SqliteTraceStore, TraceFilter,
@@ -251,8 +253,8 @@ impl StorageLayer {
     }
 
     /// Convenience: build a [`SlackActiveThreadStore`] backed by this pool.
-    pub fn slack_active_thread_store(&self) -> SlackActiveThreadStore {
-        SlackActiveThreadStore::new(self.pool.clone())
+    pub fn slack_active_thread_store(&self) -> SqliteSlackActiveThreadStore {
+        SqliteSlackActiveThreadStore::new(self.pool.clone())
     }
 
     /// Convenience: build a [`SqliteAttachmentStore`] backed by this pool.

--- a/crates/storage/src/slack_threads.rs
+++ b/crates/storage/src/slack_threads.rs
@@ -4,20 +4,37 @@
 //! responding in threads it was previously invited to.  `last_seen_at` is
 //! refreshed on every access so stale threads can be pruned.
 
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use assistant_core::clock::{Clock, SystemClock};
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use sqlx::SqlitePool;
 
+/// Trait-based interface for active Slack thread persistence.
+#[async_trait]
+pub trait SlackActiveThreadStore: Send + Sync {
+    /// Return `true` if `(channel_id, thread_ts)` exists.
+    async fn contains(&self, channel_id: &str, thread_ts: &str) -> Result<bool>;
+
+    /// Insert or refresh `(channel_id, thread_ts)`.
+    async fn upsert(&self, channel_id: &str, thread_ts: &str) -> Result<()>;
+
+    /// Delete rows whose `last_seen_at` is older than `older_than_days`.
+    /// Returns the number of pruned rows.
+    async fn prune(&self, older_than_days: i64) -> Result<u64>;
+}
+
 /// SQLite-backed store for active Slack thread keys.
-pub struct SlackActiveThreadStore {
+pub struct SqliteSlackActiveThreadStore {
     pool: SqlitePool,
     /// Clock for row timestamps. Default `Arc::new(SystemClock)`.
     clock: Arc<dyn Clock>,
 }
 
-impl SlackActiveThreadStore {
+impl SqliteSlackActiveThreadStore {
     pub fn new(pool: SqlitePool) -> Self {
         Self {
             pool,
@@ -30,9 +47,12 @@ impl SlackActiveThreadStore {
         self.clock = clock;
         self
     }
+}
 
+#[async_trait]
+impl SlackActiveThreadStore for SqliteSlackActiveThreadStore {
     /// Return `true` if `(channel_id, thread_ts)` exists in the database.
-    pub async fn contains(&self, channel_id: &str, thread_ts: &str) -> Result<bool> {
+    async fn contains(&self, channel_id: &str, thread_ts: &str) -> Result<bool> {
         let count: i64 = sqlx::query_scalar(
             "SELECT COUNT(*) FROM slack_active_threads \
              WHERE channel_id = ?1 AND thread_ts = ?2",
@@ -45,7 +65,7 @@ impl SlackActiveThreadStore {
     }
 
     /// Insert or update a `(channel_id, thread_ts)` pair, refreshing `last_seen_at`.
-    pub async fn upsert(&self, channel_id: &str, thread_ts: &str) -> Result<()> {
+    async fn upsert(&self, channel_id: &str, thread_ts: &str) -> Result<()> {
         let now = self.clock.now();
         sqlx::query(
             "INSERT INTO slack_active_threads (channel_id, thread_ts, last_seen_at) \
@@ -62,12 +82,75 @@ impl SlackActiveThreadStore {
 
     /// Delete threads that have not been seen for more than `older_than_days` days.
     /// Returns the number of rows deleted.
-    pub async fn prune(&self, older_than_days: i64) -> Result<u64> {
+    async fn prune(&self, older_than_days: i64) -> Result<u64> {
         let cutoff = self.clock.now() - chrono::Duration::days(older_than_days);
         let result = sqlx::query("DELETE FROM slack_active_threads WHERE last_seen_at < ?1")
             .bind(cutoff)
             .execute(&self.pool)
             .await?;
         Ok(result.rows_affected())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// In-memory implementation
+// ---------------------------------------------------------------------------
+
+type ThreadKey = (String, String);
+type ThreadMap = HashMap<ThreadKey, DateTime<Utc>>;
+
+/// In-memory [`SlackActiveThreadStore`]. HashMap-backed.
+pub struct InMemorySlackActiveThreadStore {
+    state: Arc<Mutex<ThreadMap>>,
+    clock: Arc<dyn Clock>,
+}
+
+impl InMemorySlackActiveThreadStore {
+    pub fn new() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(HashMap::new())),
+            clock: Arc::new(SystemClock),
+        }
+    }
+
+    pub fn with_clock(mut self, clock: Arc<dyn Clock>) -> Self {
+        self.clock = clock;
+        self
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, ThreadMap> {
+        match self.state.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        }
+    }
+}
+
+impl Default for InMemorySlackActiveThreadStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl SlackActiveThreadStore for InMemorySlackActiveThreadStore {
+    async fn contains(&self, channel_id: &str, thread_ts: &str) -> Result<bool> {
+        let state = self.lock();
+        Ok(state.contains_key(&(channel_id.to_string(), thread_ts.to_string())))
+    }
+
+    async fn upsert(&self, channel_id: &str, thread_ts: &str) -> Result<()> {
+        let now = self.clock.now();
+        let mut state = self.lock();
+        state.insert((channel_id.to_string(), thread_ts.to_string()), now);
+        Ok(())
+    }
+
+    async fn prune(&self, older_than_days: i64) -> Result<u64> {
+        let cutoff = self.clock.now() - chrono::Duration::days(older_than_days);
+        let mut state = self.lock();
+        let before = state.len();
+        state.retain(|_, last_seen| *last_seen >= cutoff);
+        Ok((before - state.len()) as u64)
     }
 }

--- a/crates/storage/tests/contract.rs
+++ b/crates/storage/tests/contract.rs
@@ -10,5 +10,6 @@ mod contract {
     pub mod conversation_store;
     pub mod log_store;
     pub mod push_subscription_store;
+    pub mod slack_active_thread_store;
     pub mod trace_store;
 }

--- a/crates/storage/tests/contract/slack_active_thread_store.rs
+++ b/crates/storage/tests/contract/slack_active_thread_store.rs
@@ -1,0 +1,62 @@
+//! Contract tests for [`SlackActiveThreadStore`].
+
+use assistant_storage::{
+    InMemorySlackActiveThreadStore, SlackActiveThreadStore, SqliteSlackActiveThreadStore,
+    StorageLayer,
+};
+
+async fn sqlite() -> Box<dyn SlackActiveThreadStore> {
+    let storage = StorageLayer::new_in_memory().await.unwrap();
+    Box::new(SqliteSlackActiveThreadStore::new(storage.pool))
+}
+
+fn memory() -> Box<dyn SlackActiveThreadStore> {
+    Box::new(InMemorySlackActiveThreadStore::new())
+}
+
+async fn upsert_and_contains(store: Box<dyn SlackActiveThreadStore>) {
+    assert!(!store.contains("C123", "1.2").await.unwrap());
+    store.upsert("C123", "1.2").await.unwrap();
+    assert!(store.contains("C123", "1.2").await.unwrap());
+}
+
+async fn upsert_idempotent(store: Box<dyn SlackActiveThreadStore>) {
+    store.upsert("C1", "t1").await.unwrap();
+    store.upsert("C1", "t1").await.unwrap();
+    assert!(store.contains("C1", "t1").await.unwrap());
+}
+
+async fn prune_preserves_recent_rows(store: Box<dyn SlackActiveThreadStore>) {
+    // With older_than_days = 7, a just-upserted row's last_seen_at is well
+    // within the window and must be preserved.
+    store.upsert("C1", "t1").await.unwrap();
+    let pruned = store.prune(7).await.unwrap();
+    assert_eq!(pruned, 0);
+    assert!(store.contains("C1", "t1").await.unwrap());
+}
+
+macro_rules! contract_tests {
+    ($name:ident, $ctor:expr) => {
+        mod $name {
+            use super::*;
+
+            #[tokio::test]
+            async fn t_upsert_and_contains() {
+                upsert_and_contains($ctor).await;
+            }
+
+            #[tokio::test]
+            async fn t_upsert_idempotent() {
+                upsert_idempotent($ctor).await;
+            }
+
+            #[tokio::test]
+            async fn t_prune_preserves_recent_rows() {
+                prune_preserves_recent_rows($ctor).await;
+            }
+        }
+    };
+}
+
+contract_tests!(sqlite_impl, sqlite().await);
+contract_tests!(memory_impl, memory());

--- a/crates/test-support/src/prelude.rs
+++ b/crates/test-support/src/prelude.rs
@@ -21,7 +21,8 @@ pub use assistant_core::clock::{Clock, FakeClock, SystemClock};
 pub use assistant_storage::{
     AttachmentStore, CommandEventStore, ConversationStore, InMemoryAttachmentStore,
     InMemoryCommandEventStore, InMemoryConversationStore, InMemoryLogStore,
-    InMemoryPushSubscriptionStore, InMemoryTraceStore, LogStore, PushSubscriptionStore, TraceStore,
+    InMemoryPushSubscriptionStore, InMemorySlackActiveThreadStore, InMemoryTraceStore, LogStore,
+    PushSubscriptionStore, SlackActiveThreadStore, TraceStore,
 };
 
 pub use crate::fixture::{Fixture, FixtureBuilder};


### PR DESCRIPTION
SlackActiveThreadStore trait + Sqlite/InMemory + 6 contract tests.