### PR TITLE
fix(storage,web-ui): repair test compilation after Phase 5 store extractions

### DIFF
--- a/crates/storage/src/webhooks.rs
+++ b/crates/storage/src/webhooks.rs
@@ -489,9 +489,9 @@ mod tests {
     use super::*;
     use crate::StorageLayer;
 
-    async fn store() -> WebhookStore {
+    async fn store() -> SqliteWebhookStore {
         let storage = StorageLayer::new_in_memory().await.unwrap();
-        WebhookStore::new(storage.pool)
+        SqliteWebhookStore::new(storage.pool)
     }
 
     #[tokio::test]

--- a/crates/web-ui/src/api/commands.rs
+++ b/crates/web-ui/src/api/commands.rs
@@ -266,7 +266,7 @@ pub async fn list_command_events(
 mod tests {
     use super::*;
     use assistant_runtime::CommandRegistry;
-    use assistant_storage::SqliteCommandEventStore;
+    use assistant_storage::{CommandEventStore, SqliteCommandEventStore};
 
     #[test]
     fn list_commands_returns_all_builtins() {
@@ -308,7 +308,7 @@ mod tests {
         let storage = assistant_storage::StorageLayer::new_in_memory()
             .await
             .unwrap();
-        let store = CommandEventStore::new(storage.pool.clone());
+        let store = SqliteCommandEventStore::new(storage.pool.clone());
         let conv_id = Uuid::new_v4();
 
         // Save an event.
@@ -336,7 +336,7 @@ mod tests {
         let storage = assistant_storage::StorageLayer::new_in_memory()
             .await
             .unwrap();
-        let store = CommandEventStore::new(storage.pool.clone());
+        let store = SqliteCommandEventStore::new(storage.pool.clone());
 
         let events = store.list_events(Uuid::new_v4()).await.unwrap();
         let responses: Vec<CommandEventResponse> =

--- a/crates/web-ui/src/api/messages.rs
+++ b/crates/web-ui/src/api/messages.rs
@@ -1196,7 +1196,8 @@ mod tests {
     use assistant_runtime::CommandRegistry;
     use assistant_storage::{
         CommandEventStore, ConversationStore, InMemoryConversationBroadcaster, RunBroadcaster,
-        SkillRegistry, SqliteCommandEventStore, SqliteConversationStore, StorageLayer,
+        SkillRegistry, SqliteAttachmentStore, SqliteCommandEventStore, SqliteConversationStore,
+        StorageLayer,
     };
 
     use super::super::ApiState;

--- a/crates/web-ui/src/push.rs
+++ b/crates/web-ui/src/push.rs
@@ -40,6 +40,8 @@ use sha2::Sha256;
 use tracing::{debug, info, warn};
 
 use assistant_storage::PushSubscriptionStore;
+#[cfg(test)]
+use assistant_storage::SqlitePushSubscriptionStore;
 
 // -- VAPID key provisioning --------------------------------------------------
 


### PR DESCRIPTION
Phase 5 trait extractions passed make lint (lib-only) but left test code referring to old type names / missing imports. CI on #850 and #853 caught it. This fixes the test compilation across web-ui (commands, messages, push) and storage::webhooks.