### PR TITLE
refactor(storage): extract AgentStore trait + InMemory impl (Phase 5.I)

### DIFF
--- a/crates/runtime/src/orchestrator/subagent.rs
+++ b/crates/runtime/src/orchestrator/subagent.rs
@@ -11,7 +11,7 @@ use assistant_core::{
     types::conversation::ExecutionContext, types::conversation::Interface,
     types::conversation::Message,
 };
-use assistant_storage::ConversationStore;
+use assistant_storage::{AgentStore, ConversationStore};
 use async_trait::async_trait;
 use opentelemetry::{
     Context as OtelContext, KeyValue, global,

--- a/crates/runtime/src/orchestrator/tests/subagent.rs
+++ b/crates/runtime/src/orchestrator/tests/subagent.rs
@@ -2,7 +2,7 @@
 //! `run_subagent`, conversation delegation, depth limit, tool filtering,
 //! cancellation, LLM-error reporting.
 
-use assistant_storage::ConversationStore;
+use assistant_storage::{AgentStore, ConversationStore};
 use std::time::Duration;
 
 use serde_json::{Value, json};

--- a/crates/storage/src/agents.rs
+++ b/crates/storage/src/agents.rs
@@ -1,9 +1,11 @@
 //! Subagent lifecycle persistence.
 
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use assistant_core::clock::{Clock, SystemClock};
+use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use sqlx::{Row, SqlitePool};
 
@@ -52,13 +54,45 @@ pub struct AgentRecord {
 }
 
 /// SQLite-backed store for subagent lifecycle records.
-pub struct AgentStore {
+/// Trait-based interface for subagent process persistence.
+#[async_trait]
+pub trait AgentStore: Send + Sync {
+    /// Insert a new agent record in `running` status.
+    async fn create(
+        &self,
+        id: &str,
+        parent_agent_id: Option<&str>,
+        parent_conversation_id: &str,
+        conversation_id: &str,
+        task: &str,
+        depth: u32,
+    ) -> Result<()>;
+
+    /// Mark an agent as completed/failed/cancelled.
+    async fn complete(
+        &self,
+        id: &str,
+        status: AgentStatus,
+        result_summary: Option<&str>,
+    ) -> Result<()>;
+
+    /// Fetch a single agent record by ID.
+    async fn get(&self, id: &str) -> Result<Option<AgentRecord>>;
+
+    /// List all subagents spawned within a parent conversation.
+    async fn list_by_parent_conversation(
+        &self,
+        parent_conversation_id: &str,
+    ) -> Result<Vec<AgentRecord>>;
+}
+
+pub struct SqliteAgentStore {
     pool: SqlitePool,
     /// Clock for row timestamps. Default `Arc::new(SystemClock)`.
     clock: Arc<dyn Clock>,
 }
 
-impl AgentStore {
+impl SqliteAgentStore {
     pub fn new(pool: SqlitePool) -> Self {
         Self {
             pool,
@@ -71,9 +105,12 @@ impl AgentStore {
         self.clock = clock;
         self
     }
+}
 
+#[async_trait]
+impl AgentStore for SqliteAgentStore {
     /// Insert a new agent record in `running` status.
-    pub async fn create(
+    async fn create(
         &self,
         id: &str,
         parent_agent_id: Option<&str>,
@@ -102,7 +139,7 @@ impl AgentStore {
     }
 
     /// Mark an agent as completed or failed and record a result summary.
-    pub async fn complete(
+    async fn complete(
         &self,
         id: &str,
         status: AgentStatus,
@@ -123,7 +160,7 @@ impl AgentStore {
     }
 
     /// Fetch a single agent by ID.
-    pub async fn get(&self, id: &str) -> Result<Option<AgentRecord>> {
+    async fn get(&self, id: &str) -> Result<Option<AgentRecord>> {
         let row = sqlx::query(
             "SELECT id, parent_agent_id, parent_conversation_id, conversation_id, \
                     task, status, depth, created_at, completed_at, result_summary \
@@ -140,7 +177,7 @@ impl AgentStore {
     }
 
     /// List agents spawned within a given parent conversation.
-    pub async fn list_by_parent_conversation(
+    async fn list_by_parent_conversation(
         &self,
         parent_conversation_id: &str,
     ) -> Result<Vec<AgentRecord>> {
@@ -173,6 +210,110 @@ fn parse_row(row: sqlx::sqlite::SqliteRow) -> Result<AgentRecord> {
     })
 }
 
+// ---------------------------------------------------------------------------
+// In-memory implementation
+// ---------------------------------------------------------------------------
+
+/// In-memory [`AgentStore`]. HashMap<id, AgentRecord>.
+pub struct InMemoryAgentStore {
+    state: Arc<Mutex<HashMap<String, AgentRecord>>>,
+    clock: Arc<dyn Clock>,
+}
+
+impl InMemoryAgentStore {
+    pub fn new() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(HashMap::new())),
+            clock: Arc::new(SystemClock),
+        }
+    }
+
+    pub fn with_clock(mut self, clock: Arc<dyn Clock>) -> Self {
+        self.clock = clock;
+        self
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<String, AgentRecord>> {
+        match self.state.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        }
+    }
+}
+
+impl Default for InMemoryAgentStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl AgentStore for InMemoryAgentStore {
+    async fn create(
+        &self,
+        id: &str,
+        parent_agent_id: Option<&str>,
+        parent_conversation_id: &str,
+        conversation_id: &str,
+        task: &str,
+        depth: u32,
+    ) -> Result<()> {
+        let now = self.clock.now();
+        let mut state = self.lock();
+        state.insert(
+            id.to_string(),
+            AgentRecord {
+                id: id.to_string(),
+                parent_agent_id: parent_agent_id.map(str::to_string),
+                parent_conversation_id: parent_conversation_id.to_string(),
+                conversation_id: conversation_id.to_string(),
+                task: task.to_string(),
+                status: AgentStatus::Running,
+                depth: depth as i64,
+                created_at: now,
+                completed_at: None,
+                result_summary: None,
+            },
+        );
+        Ok(())
+    }
+
+    async fn complete(
+        &self,
+        id: &str,
+        status: AgentStatus,
+        result_summary: Option<&str>,
+    ) -> Result<()> {
+        let now = self.clock.now();
+        let mut state = self.lock();
+        if let Some(a) = state.get_mut(id) {
+            a.status = status;
+            a.completed_at = Some(now);
+            a.result_summary = result_summary.map(str::to_string);
+        }
+        Ok(())
+    }
+
+    async fn get(&self, id: &str) -> Result<Option<AgentRecord>> {
+        let state = self.lock();
+        Ok(state.get(id).cloned())
+    }
+
+    async fn list_by_parent_conversation(
+        &self,
+        parent_conversation_id: &str,
+    ) -> Result<Vec<AgentRecord>> {
+        let state = self.lock();
+        let mut out: Vec<AgentRecord> = state
+            .values()
+            .filter(|a| a.parent_conversation_id == parent_conversation_id)
+            .cloned()
+            .collect();
+        out.sort_by_key(|a| a.created_at);
+        Ok(out)
+    }
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -180,9 +321,9 @@ mod tests {
     use super::*;
     use crate::StorageLayer;
 
-    async fn store() -> AgentStore {
+    async fn store() -> SqliteAgentStore {
         let storage = StorageLayer::new_in_memory().await.unwrap();
-        AgentStore::new(storage.pool)
+        SqliteAgentStore::new(storage.pool)
     }
 
     #[tokio::test]

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -58,7 +58,7 @@ pub mod user_store;
 pub mod webhooks;
 pub mod workflows;
 
-pub use agents::{AgentRecord, AgentStatus, AgentStore};
+pub use agents::{AgentRecord, AgentStatus, AgentStore, InMemoryAgentStore, SqliteAgentStore};
 pub use api_key_store::SqliteApiKeyStore;
 pub use attachments::{AttachmentStore, InMemoryAttachmentStore, SqliteAttachmentStore};
 pub use auth_state_store::{
@@ -213,8 +213,8 @@ impl StorageLayer {
     }
 
     /// Convenience: build an [`AgentStore`] backed by this pool.
-    pub fn agent_store(&self) -> AgentStore {
-        AgentStore::new(self.pool.clone())
+    pub fn agent_store(&self) -> SqliteAgentStore {
+        SqliteAgentStore::new(self.pool.clone())
     }
 
     /// Convenience: build a [`PersonaSkillAccessStore`] backed by this pool.

--- a/crates/storage/tests/contract.rs
+++ b/crates/storage/tests/contract.rs
@@ -5,6 +5,7 @@
 //! impls fails CI.
 
 mod contract {
+    pub mod agent_store;
     pub mod attachment_store;
     pub mod command_event_store;
     pub mod conversation_store;

--- a/crates/storage/tests/contract/agent_store.rs
+++ b/crates/storage/tests/contract/agent_store.rs
@@ -1,0 +1,93 @@
+//! Contract tests for [`AgentStore`].
+
+use assistant_storage::{
+    AgentRecord, AgentStatus, AgentStore, InMemoryAgentStore, SqliteAgentStore, StorageLayer,
+};
+
+async fn sqlite() -> Box<dyn AgentStore> {
+    let storage = StorageLayer::new_in_memory().await.unwrap();
+    Box::new(SqliteAgentStore::new(storage.pool))
+}
+
+fn memory() -> Box<dyn AgentStore> {
+    Box::new(InMemoryAgentStore::new())
+}
+
+async fn create_and_get(store: Box<dyn AgentStore>) {
+    store
+        .create("a1", None, "parent-conv", "child-conv", "do thing", 1)
+        .await
+        .unwrap();
+    let got: AgentRecord = store.get("a1").await.unwrap().unwrap();
+    assert_eq!(got.id, "a1");
+    assert_eq!(got.status, AgentStatus::Running);
+    assert_eq!(got.depth, 1);
+}
+
+async fn complete_sets_status(store: Box<dyn AgentStore>) {
+    store
+        .create("a1", None, "parent-conv", "child-conv", "task", 0)
+        .await
+        .unwrap();
+    store
+        .complete("a1", AgentStatus::Completed, Some("done"))
+        .await
+        .unwrap();
+    let got = store.get("a1").await.unwrap().unwrap();
+    assert_eq!(got.status, AgentStatus::Completed);
+    assert_eq!(got.result_summary.as_deref(), Some("done"));
+    assert!(got.completed_at.is_some());
+}
+
+async fn list_by_parent_conversation(store: Box<dyn AgentStore>) {
+    store
+        .create("a1", None, "conv-A", "c1", "t", 0)
+        .await
+        .unwrap();
+    store
+        .create("a2", None, "conv-A", "c2", "t", 0)
+        .await
+        .unwrap();
+    store
+        .create("a3", None, "conv-B", "c3", "t", 0)
+        .await
+        .unwrap();
+    let list = store.list_by_parent_conversation("conv-A").await.unwrap();
+    assert_eq!(list.len(), 2);
+    assert!(list.iter().all(|a| a.parent_conversation_id == "conv-A"));
+}
+
+async fn get_missing_returns_none(store: Box<dyn AgentStore>) {
+    assert!(store.get("nope").await.unwrap().is_none());
+}
+
+macro_rules! contract_tests {
+    ($name:ident, $ctor:expr) => {
+        mod $name {
+            use super::*;
+
+            #[tokio::test]
+            async fn t_create_and_get() {
+                create_and_get($ctor).await;
+            }
+
+            #[tokio::test]
+            async fn t_complete_sets_status() {
+                complete_sets_status($ctor).await;
+            }
+
+            #[tokio::test]
+            async fn t_list_by_parent_conversation() {
+                list_by_parent_conversation($ctor).await;
+            }
+
+            #[tokio::test]
+            async fn t_get_missing_returns_none() {
+                get_missing_returns_none($ctor).await;
+            }
+        }
+    };
+}
+
+contract_tests!(sqlite_impl, sqlite().await);
+contract_tests!(memory_impl, memory());

--- a/crates/test-support/src/prelude.rs
+++ b/crates/test-support/src/prelude.rs
@@ -19,11 +19,11 @@
 
 pub use assistant_core::clock::{Clock, FakeClock, SystemClock};
 pub use assistant_storage::{
-    AttachmentStore, CommandEventStore, ConversationStore, InMemoryAttachmentStore,
-    InMemoryCommandEventStore, InMemoryConversationStore, InMemoryLogStore,
-    InMemoryPushSubscriptionStore, InMemorySlackActiveThreadStore, InMemoryTraceStore,
-    InMemoryWebhookStore, LogStore, PushSubscriptionStore, SlackActiveThreadStore, TraceStore,
-    WebhookStore,
+    AgentStore, AttachmentStore, CommandEventStore, ConversationStore, InMemoryAgentStore,
+    InMemoryAttachmentStore, InMemoryCommandEventStore, InMemoryConversationStore,
+    InMemoryLogStore, InMemoryPushSubscriptionStore, InMemorySlackActiveThreadStore,
+    InMemoryTraceStore, InMemoryWebhookStore, LogStore, PushSubscriptionStore,
+    SlackActiveThreadStore, TraceStore, WebhookStore,
 };
 
 pub use crate::fixture::{Fixture, FixtureBuilder};

--- a/crates/tool-executor/src/builtins/agent_status.rs
+++ b/crates/tool-executor/src/builtins/agent_status.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use assistant_core::types::conversation::ExecutionContext;
 use assistant_core::{ToolHandler, ToolOutput};
-use assistant_storage::StorageLayer;
+use assistant_storage::{AgentStore, StorageLayer};
 use async_trait::async_trait;
 use serde_json::json;
 
@@ -144,7 +144,7 @@ impl ToolHandler for AgentStatusHandler {
 mod tests {
     use super::*;
     use assistant_core::types::conversation::Interface;
-    use assistant_storage::{AgentStore, StorageLayer};
+    use assistant_storage::{AgentStore, SqliteAgentStore, StorageLayer};
     use uuid::Uuid;
 
     fn ctx_with_conversation(conversation_id: Uuid) -> ExecutionContext {
@@ -162,7 +162,7 @@ mod tests {
         }
     }
 
-    async fn setup() -> (Arc<StorageLayer>, AgentStatusHandler, AgentStore) {
+    async fn setup() -> (Arc<StorageLayer>, AgentStatusHandler, SqliteAgentStore) {
         let storage = Arc::new(StorageLayer::new_in_memory().await.unwrap());
         let handler = AgentStatusHandler::new(storage.clone());
         let agent_store = storage.agent_store();


### PR DESCRIPTION
AgentStore trait + Sqlite/InMemory + 8 contract tests. Consumers in tool-executor and runtime/orchestrator/subagent import the trait.