### PR TITLE
refactor(storage): extract ScheduledTaskStore trait + InMemory impl (Phase 5.J)

### DIFF
--- a/crates/runtime/src/scheduler/tasks.rs
+++ b/crates/runtime/src/scheduler/tasks.rs
@@ -21,7 +21,7 @@ use assistant_core::{
     ChannelContent, ChannelMessage, ChannelUser, PublishRequest, bus_messages, topic,
     types::conversation::ChannelType, types::conversation::Interface,
 };
-use assistant_storage::StorageLayer;
+use assistant_storage::{ScheduledTaskStore, StorageLayer};
 
 use super::SCHEDULER_USER_ID;
 use crate::orchestrator::Orchestrator;

--- a/crates/runtime/src/scheduler/tests/dispatch.rs
+++ b/crates/runtime/src/scheduler/tests/dispatch.rs
@@ -1,6 +1,7 @@
 //! Tests for `run_due_tasks` — cron-driven dispatch into the bus.
 
 use assistant_core::{MessageBus, topic};
+use assistant_storage::ScheduledTaskStore as _;
 use chrono::{Duration, Utc};
 use wiremock::MockServer;
 

--- a/crates/runtime/src/scheduler/tests/home_channel.rs
+++ b/crates/runtime/src/scheduler/tests/home_channel.rs
@@ -2,6 +2,7 @@
 //! path in `run_due_tasks` when no home channel is configured.
 
 use assistant_core::{MessageBus, topic};
+use assistant_storage::ScheduledTaskStore as _;
 use chrono::{Duration, Utc};
 use uuid::Uuid;
 use wiremock::MockServer;

--- a/crates/runtime/src/scheduler/tests/identity.rs
+++ b/crates/runtime/src/scheduler/tests/identity.rs
@@ -1,6 +1,7 @@
 //! Persona-owner identity threading: scheduled tasks must carry the
 //! persona's `owner_user_id` on the resulting `TurnRequest`.
 
+use assistant_storage::ScheduledTaskStore as _;
 use std::sync::Arc;
 
 use assistant_core::{MessageBus, bus_messages, topic};

--- a/crates/runtime/src/skill_improver.rs
+++ b/crates/runtime/src/skill_improver.rs
@@ -9,7 +9,8 @@ use anyhow::Result;
 use assistant_core::types::features::LearningConfig;
 use assistant_core::{ChatHistoryMessage, ChatRole, LlmProvider, LlmResponse};
 use assistant_storage::{
-    RefinementStatus, RefinementsStore, SkillRegistry, SkillStatsProvider, StorageLayer,
+    RefinementStatus, RefinementsStore, ScheduledTaskStore, SkillRegistry, SkillStatsProvider,
+    StorageLayer,
 };
 use chrono::Utc;
 use tracing::{debug, info, warn};

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -96,7 +96,9 @@ pub use push_subscriptions::{
 };
 pub use refinements::{RefinementStatus, RefinementsStore, SkillRefinement};
 pub use registry::SkillRegistry;
-pub use scheduled_tasks::{ScheduledTask, ScheduledTaskStore};
+pub use scheduled_tasks::{
+    InMemoryScheduledTaskStore, ScheduledTask, ScheduledTaskStore, SqliteScheduledTaskStore,
+};
 pub use slack_threads::{
     InMemorySlackActiveThreadStore, SlackActiveThreadStore, SqliteSlackActiveThreadStore,
 };
@@ -198,13 +200,13 @@ impl StorageLayer {
     }
 
     /// Convenience: build a `ScheduledTaskStore` backed by this pool.
-    pub fn scheduled_task_store(&self) -> ScheduledTaskStore {
-        ScheduledTaskStore::new(self.pool.clone())
+    pub fn scheduled_task_store(&self) -> SqliteScheduledTaskStore {
+        SqliteScheduledTaskStore::new(self.pool.clone())
     }
 
     /// Convenience: build a `ScheduledTaskStore` scoped to a Persona.
-    pub fn scheduled_task_store_for_agent(&self, agent_id: &str) -> ScheduledTaskStore {
-        ScheduledTaskStore::for_agent(self.pool.clone(), agent_id)
+    pub fn scheduled_task_store_for_agent(&self, agent_id: &str) -> SqliteScheduledTaskStore {
+        SqliteScheduledTaskStore::for_agent(self.pool.clone(), agent_id)
     }
 
     /// Convenience: build a `MemoryChunkStore` backed by this pool.

--- a/crates/storage/src/scheduled_tasks.rs
+++ b/crates/storage/src/scheduled_tasks.rs
@@ -1,9 +1,11 @@
 //! Scheduled task persistence (cron-style recurring prompts and one-shot tasks).
 
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use assistant_core::clock::{Clock, SystemClock};
+use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use sqlx::{Row, SqlitePool};
 use uuid::Uuid;
@@ -23,15 +25,45 @@ pub struct ScheduledTask {
     pub created_at: DateTime<Utc>,
 }
 
+/// Trait-based interface for scheduled task persistence.
+#[async_trait]
+pub trait ScheduledTaskStore: Send + Sync {
+    async fn insert(
+        &self,
+        name: &str,
+        cron_expr: &str,
+        prompt: &str,
+        once: bool,
+        next_run: Option<DateTime<Utc>>,
+    ) -> Result<Uuid>;
+
+    async fn due_tasks(&self, now: DateTime<Utc>) -> Result<Vec<ScheduledTask>>;
+
+    async fn list_all(&self) -> Result<Vec<ScheduledTask>>;
+
+    async fn record_run(
+        &self,
+        id: Uuid,
+        last_run: DateTime<Utc>,
+        next_run: Option<DateTime<Utc>>,
+    ) -> Result<()>;
+
+    async fn disable(&self, id: Uuid) -> Result<bool>;
+
+    async fn delete(&self, id: Uuid) -> Result<bool>;
+
+    async fn find_by_name(&self, name: &str) -> Result<Option<ScheduledTask>>;
+}
+
 /// SQLite-backed store for scheduled tasks.
-pub struct ScheduledTaskStore {
+pub struct SqliteScheduledTaskStore {
     pool: SqlitePool,
     agent_id: String,
     /// Clock for row timestamps. Default `Arc::new(SystemClock)`.
     clock: Arc<dyn Clock>,
 }
 
-impl ScheduledTaskStore {
+impl SqliteScheduledTaskStore {
     pub fn new(pool: SqlitePool) -> Self {
         Self {
             pool,
@@ -53,9 +85,12 @@ impl ScheduledTaskStore {
         self.clock = clock;
         self
     }
+}
 
+#[async_trait]
+impl ScheduledTaskStore for SqliteScheduledTaskStore {
     /// Insert a new scheduled task.
-    pub async fn insert(
+    async fn insert(
         &self,
         name: &str,
         cron_expr: &str,
@@ -87,7 +122,7 @@ impl ScheduledTaskStore {
     }
 
     /// List all enabled tasks whose next_run is at or before `now`.
-    pub async fn due_tasks(&self, now: DateTime<Utc>) -> Result<Vec<ScheduledTask>> {
+    async fn due_tasks(&self, now: DateTime<Utc>) -> Result<Vec<ScheduledTask>> {
         let rows = sqlx::query(
             "SELECT id, agent_id, name, cron_expr, prompt, enabled, once, last_run, next_run, created_at \
              FROM scheduled_tasks \
@@ -103,7 +138,7 @@ impl ScheduledTaskStore {
     }
 
     /// List all tasks.
-    pub async fn list_all(&self) -> Result<Vec<ScheduledTask>> {
+    async fn list_all(&self) -> Result<Vec<ScheduledTask>> {
         let rows = sqlx::query(
             "SELECT id, agent_id, name, cron_expr, prompt, enabled, once, last_run, next_run, created_at \
              FROM scheduled_tasks WHERE agent_id = ?1 ORDER BY created_at ASC",
@@ -116,7 +151,7 @@ impl ScheduledTaskStore {
     }
 
     /// Update the last_run and next_run timestamps after execution.
-    pub async fn record_run(
+    async fn record_run(
         &self,
         id: Uuid,
         last_run: DateTime<Utc>,
@@ -137,7 +172,7 @@ impl ScheduledTaskStore {
     }
 
     /// Disable a task (set `enabled = FALSE`).
-    pub async fn disable(&self, id: Uuid) -> Result<bool> {
+    async fn disable(&self, id: Uuid) -> Result<bool> {
         let result = sqlx::query(
             "UPDATE scheduled_tasks
              SET enabled = FALSE
@@ -151,7 +186,7 @@ impl ScheduledTaskStore {
     }
 
     /// Delete a task permanently.
-    pub async fn delete(&self, id: Uuid) -> Result<bool> {
+    async fn delete(&self, id: Uuid) -> Result<bool> {
         let result = sqlx::query("DELETE FROM scheduled_tasks WHERE id = ?1 AND agent_id = ?2")
             .bind(id.to_string())
             .bind(&self.agent_id)
@@ -161,7 +196,7 @@ impl ScheduledTaskStore {
     }
 
     /// Find a task by name (case-insensitive).
-    pub async fn find_by_name(&self, name: &str) -> Result<Option<ScheduledTask>> {
+    async fn find_by_name(&self, name: &str) -> Result<Option<ScheduledTask>> {
         let row = sqlx::query(
             "SELECT id, agent_id, name, cron_expr, prompt, enabled, once, last_run, next_run, created_at \
              FROM scheduled_tasks WHERE agent_id = ?1 AND LOWER(name) = LOWER(?2) LIMIT 1",
@@ -191,6 +226,157 @@ fn parse_row(r: sqlx::sqlite::SqliteRow) -> Result<ScheduledTask> {
     })
 }
 
+// ---------------------------------------------------------------------------
+// In-memory implementation
+// ---------------------------------------------------------------------------
+
+/// In-memory [`ScheduledTaskStore`]. HashMap<id, ScheduledTask>.
+pub struct InMemoryScheduledTaskStore {
+    state: Arc<Mutex<HashMap<Uuid, ScheduledTask>>>,
+    agent_id: String,
+    clock: Arc<dyn Clock>,
+}
+
+impl InMemoryScheduledTaskStore {
+    pub fn new() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(HashMap::new())),
+            agent_id: "default".to_string(),
+            clock: Arc::new(SystemClock),
+        }
+    }
+
+    pub fn for_agent(agent_id: impl Into<String>) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(HashMap::new())),
+            agent_id: agent_id.into(),
+            clock: Arc::new(SystemClock),
+        }
+    }
+
+    pub fn with_clock(mut self, clock: Arc<dyn Clock>) -> Self {
+        self.clock = clock;
+        self
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<Uuid, ScheduledTask>> {
+        match self.state.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        }
+    }
+}
+
+impl Default for InMemoryScheduledTaskStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ScheduledTaskStore for InMemoryScheduledTaskStore {
+    async fn insert(
+        &self,
+        name: &str,
+        cron_expr: &str,
+        prompt: &str,
+        once: bool,
+        next_run: Option<DateTime<Utc>>,
+    ) -> Result<Uuid> {
+        let id = Uuid::new_v4();
+        let now = self.clock.now();
+        let mut state = self.lock();
+        state.insert(
+            id,
+            ScheduledTask {
+                id,
+                agent_id: self.agent_id.clone(),
+                name: name.to_string(),
+                cron_expr: cron_expr.to_string(),
+                prompt: prompt.to_string(),
+                enabled: true,
+                once,
+                last_run: None,
+                next_run,
+                created_at: now,
+            },
+        );
+        Ok(id)
+    }
+
+    async fn due_tasks(&self, now: DateTime<Utc>) -> Result<Vec<ScheduledTask>> {
+        let state = self.lock();
+        let mut out: Vec<ScheduledTask> = state
+            .values()
+            .filter(|t| t.agent_id == self.agent_id && t.enabled)
+            .filter(|t| t.next_run.is_some_and(|nr| nr <= now))
+            .cloned()
+            .collect();
+        out.sort_by_key(|t| t.next_run);
+        Ok(out)
+    }
+
+    async fn list_all(&self) -> Result<Vec<ScheduledTask>> {
+        let state = self.lock();
+        let mut out: Vec<ScheduledTask> = state
+            .values()
+            .filter(|t| t.agent_id == self.agent_id)
+            .cloned()
+            .collect();
+        out.sort_by_key(|t| t.created_at);
+        Ok(out)
+    }
+
+    async fn record_run(
+        &self,
+        id: Uuid,
+        last_run: DateTime<Utc>,
+        next_run: Option<DateTime<Utc>>,
+    ) -> Result<()> {
+        let mut state = self.lock();
+        if let Some(t) = state.get_mut(&id)
+            && t.agent_id == self.agent_id
+        {
+            t.last_run = Some(last_run);
+            t.next_run = next_run;
+        }
+        Ok(())
+    }
+
+    async fn disable(&self, id: Uuid) -> Result<bool> {
+        let mut state = self.lock();
+        if let Some(t) = state.get_mut(&id)
+            && t.agent_id == self.agent_id
+            && t.enabled
+        {
+            t.enabled = false;
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
+    async fn delete(&self, id: Uuid) -> Result<bool> {
+        let mut state = self.lock();
+        if state
+            .get(&id)
+            .map(|t| t.agent_id == self.agent_id)
+            .unwrap_or(false)
+        {
+            state.remove(&id);
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
+    async fn find_by_name(&self, name: &str) -> Result<Option<ScheduledTask>> {
+        let state = self.lock();
+        Ok(state
+            .values()
+            .find(|t| t.agent_id == self.agent_id && t.name.eq_ignore_ascii_case(name))
+            .cloned())
+    }
+}
+
 // -- Tests ------------------------------------------------------------------
 
 #[cfg(test)]
@@ -199,7 +385,7 @@ mod tests {
     use crate::StorageLayer;
     use chrono::Duration;
 
-    async fn store() -> (StorageLayer, ScheduledTaskStore) {
+    async fn store() -> (StorageLayer, SqliteScheduledTaskStore) {
         let s = StorageLayer::new_in_memory().await.unwrap();
         let ts = s.scheduled_task_store();
         (s, ts)

--- a/crates/storage/tests/contract.rs
+++ b/crates/storage/tests/contract.rs
@@ -11,6 +11,7 @@ mod contract {
     pub mod conversation_store;
     pub mod log_store;
     pub mod push_subscription_store;
+    pub mod scheduled_task_store;
     pub mod slack_active_thread_store;
     pub mod trace_store;
     pub mod webhook_store;

--- a/crates/storage/tests/contract/scheduled_task_store.rs
+++ b/crates/storage/tests/contract/scheduled_task_store.rs
@@ -1,0 +1,119 @@
+//! Contract tests for [`ScheduledTaskStore`].
+
+use assistant_storage::{
+    InMemoryScheduledTaskStore, ScheduledTaskStore, SqliteScheduledTaskStore, StorageLayer,
+};
+use chrono::{Duration, Utc};
+
+async fn sqlite() -> Box<dyn ScheduledTaskStore> {
+    let storage = StorageLayer::new_in_memory().await.unwrap();
+    Box::new(SqliteScheduledTaskStore::new(storage.pool))
+}
+
+fn memory() -> Box<dyn ScheduledTaskStore> {
+    Box::new(InMemoryScheduledTaskStore::new())
+}
+
+async fn insert_and_list(store: Box<dyn ScheduledTaskStore>) {
+    let next = Utc::now() + Duration::hours(1);
+    store
+        .insert("daily", "0 0 9 * * *", "do thing", false, Some(next))
+        .await
+        .unwrap();
+    let tasks = store.list_all().await.unwrap();
+    assert_eq!(tasks.len(), 1);
+    assert_eq!(tasks[0].name, "daily");
+    assert!(tasks[0].enabled);
+}
+
+async fn due_tasks_only_returns_overdue(store: Box<dyn ScheduledTaskStore>) {
+    let past = Utc::now() - Duration::hours(1);
+    let future = Utc::now() + Duration::hours(1);
+    store
+        .insert("overdue", "*", "p", false, Some(past))
+        .await
+        .unwrap();
+    store
+        .insert("future", "*", "p", false, Some(future))
+        .await
+        .unwrap();
+    let due = store.due_tasks(Utc::now()).await.unwrap();
+    assert_eq!(due.len(), 1);
+    assert_eq!(due[0].name, "overdue");
+}
+
+async fn disable_marks_disabled(store: Box<dyn ScheduledTaskStore>) {
+    let id = store.insert("t", "*", "p", false, None).await.unwrap();
+    assert!(store.disable(id).await.unwrap());
+    let tasks = store.list_all().await.unwrap();
+    assert!(!tasks[0].enabled);
+    // Already disabled: second disable returns false.
+    assert!(!store.disable(id).await.unwrap());
+}
+
+async fn delete_removes(store: Box<dyn ScheduledTaskStore>) {
+    let id = store.insert("t", "*", "p", false, None).await.unwrap();
+    assert!(store.delete(id).await.unwrap());
+    assert!(store.list_all().await.unwrap().is_empty());
+}
+
+async fn find_by_name_case_insensitive(store: Box<dyn ScheduledTaskStore>) {
+    store
+        .insert("DailyReport", "*", "p", false, None)
+        .await
+        .unwrap();
+    assert!(store.find_by_name("dailyreport").await.unwrap().is_some());
+    assert!(store.find_by_name("DAILYREPORT").await.unwrap().is_some());
+    assert!(store.find_by_name("other").await.unwrap().is_none());
+}
+
+async fn record_run_updates_timestamps(store: Box<dyn ScheduledTaskStore>) {
+    let id = store.insert("t", "*", "p", false, None).await.unwrap();
+    let now = Utc::now();
+    let next = now + Duration::hours(1);
+    store.record_run(id, now, Some(next)).await.unwrap();
+    let tasks = store.list_all().await.unwrap();
+    assert_eq!(tasks[0].last_run, Some(now));
+    assert_eq!(tasks[0].next_run, Some(next));
+}
+
+macro_rules! contract_tests {
+    ($name:ident, $ctor:expr) => {
+        mod $name {
+            use super::*;
+
+            #[tokio::test]
+            async fn t_insert_and_list() {
+                insert_and_list($ctor).await;
+            }
+
+            #[tokio::test]
+            async fn t_due_tasks_only_returns_overdue() {
+                due_tasks_only_returns_overdue($ctor).await;
+            }
+
+            #[tokio::test]
+            async fn t_disable_marks_disabled() {
+                disable_marks_disabled($ctor).await;
+            }
+
+            #[tokio::test]
+            async fn t_delete_removes() {
+                delete_removes($ctor).await;
+            }
+
+            #[tokio::test]
+            async fn t_find_by_name_case_insensitive() {
+                find_by_name_case_insensitive($ctor).await;
+            }
+
+            #[tokio::test]
+            async fn t_record_run_updates_timestamps() {
+                record_run_updates_timestamps($ctor).await;
+            }
+        }
+    };
+}
+
+contract_tests!(sqlite_impl, sqlite().await);
+contract_tests!(memory_impl, memory());

--- a/crates/test-support/src/prelude.rs
+++ b/crates/test-support/src/prelude.rs
@@ -21,9 +21,9 @@ pub use assistant_core::clock::{Clock, FakeClock, SystemClock};
 pub use assistant_storage::{
     AgentStore, AttachmentStore, CommandEventStore, ConversationStore, InMemoryAgentStore,
     InMemoryAttachmentStore, InMemoryCommandEventStore, InMemoryConversationStore,
-    InMemoryLogStore, InMemoryPushSubscriptionStore, InMemorySlackActiveThreadStore,
-    InMemoryTraceStore, InMemoryWebhookStore, LogStore, PushSubscriptionStore,
-    SlackActiveThreadStore, TraceStore, WebhookStore,
+    InMemoryLogStore, InMemoryPushSubscriptionStore, InMemoryScheduledTaskStore,
+    InMemorySlackActiveThreadStore, InMemoryTraceStore, InMemoryWebhookStore, LogStore,
+    PushSubscriptionStore, ScheduledTaskStore, SlackActiveThreadStore, TraceStore, WebhookStore,
 };
 
 pub use crate::fixture::{Fixture, FixtureBuilder};

--- a/crates/tool-executor/src/builtins/cancel_task.rs
+++ b/crates/tool-executor/src/builtins/cancel_task.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use assistant_core::types::conversation::ExecutionContext;
 use assistant_core::{ToolHandler, ToolOutput};
+use assistant_storage::ScheduledTaskStore as _;
 use assistant_storage::StorageLayer;
 use async_trait::async_trait;
 use uuid::Uuid;

--- a/crates/tool-executor/src/builtins/list_tasks.rs
+++ b/crates/tool-executor/src/builtins/list_tasks.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use assistant_core::types::conversation::ExecutionContext;
 use assistant_core::{ToolHandler, ToolOutput};
+use assistant_storage::ScheduledTaskStore as _;
 use assistant_storage::StorageLayer;
 use async_trait::async_trait;
 

--- a/crates/tool-executor/src/builtins/schedule_task.rs
+++ b/crates/tool-executor/src/builtins/schedule_task.rs
@@ -8,6 +8,7 @@ use anyhow::Result;
 use assistant_core::clock::{Clock, SystemClock};
 use assistant_core::types::conversation::ExecutionContext;
 use assistant_core::{ToolHandler, ToolOutput};
+use assistant_storage::ScheduledTaskStore as _;
 use assistant_storage::StorageLayer;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};


### PR DESCRIPTION
ScheduledTaskStore trait + Sqlite/InMemory + 12 contract tests. Consumers in runtime scheduler + tool-executor builtins import the trait.