### PR TITLE
refactor(storage): extract ConversationEventStore trait + InMemory impl (Phase 5.K)

### DIFF
--- a/crates/runtime/src/scheduler/prune.rs
+++ b/crates/runtime/src/scheduler/prune.rs
@@ -1,6 +1,7 @@
 //! Periodic conversation-event pruning — drops rows that have aged past
 //! their configured TTL.
 
+use assistant_storage::ConversationEventStore as _;
 use tracing::{info, warn};
 
 use assistant_storage::StorageLayer;

--- a/crates/runtime/src/scheduler/reap.rs
+++ b/crates/runtime/src/scheduler/reap.rs
@@ -1,6 +1,7 @@
 //! Crash-recovery sweep: reclaim stale bus messages and close orphaned
 //! SSE event streams left over after a server restart.
 
+use assistant_storage::ConversationEventStore as _;
 use std::time::Duration;
 
 use tracing::{info, warn};

--- a/crates/runtime/src/scheduler/tests/reap.rs
+++ b/crates/runtime/src/scheduler/tests/reap.rs
@@ -2,6 +2,7 @@
 //! runs and stale bus messages.
 
 use assistant_core::{MessageBus, topic};
+use assistant_storage::ConversationEventStore as _;
 use uuid::Uuid;
 use wiremock::MockServer;
 

--- a/crates/storage/src/conversation_events.rs
+++ b/crates/storage/src/conversation_events.rs
@@ -5,10 +5,11 @@
 //! Events are ephemeral: `expires_at` drives TTL-based pruning.
 
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use assistant_core::clock::{Clock, SystemClock};
+use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
 use serde_json::Value;
 use sqlx::{Row, SqlitePool};
@@ -31,9 +32,43 @@ pub struct ConversationEventRow {
     pub expires_at: DateTime<Utc>,
 }
 
+/// Trait-based interface for conversation event log persistence.
+#[async_trait]
+pub trait ConversationEventStore: Send + Sync {
+    async fn append_event(
+        &self,
+        run_id: &str,
+        conversation_id: &str,
+        sequence: i64,
+        event_type: &str,
+        payload: &Value,
+    ) -> Result<()>;
+
+    async fn list_events_since(
+        &self,
+        run_id: &str,
+        since: i64,
+    ) -> Result<Vec<ConversationEventRow>>;
+
+    async fn has_events(&self, run_id: &str) -> Result<bool>;
+
+    async fn is_run_complete(&self, run_id: &str) -> Result<bool>;
+
+    async fn prune_expired(&self) -> Result<u64>;
+
+    async fn find_incomplete_runs(&self, older_than: Duration) -> Result<Vec<(String, String)>>;
+
+    async fn append_synthetic_terminal(
+        &self,
+        run_id: &str,
+        conversation_id: &str,
+        message: &str,
+    ) -> Result<i64>;
+}
+
 /// SQLite-backed store for conversation event log entries.
 #[derive(Clone)]
-pub struct ConversationEventStore {
+pub struct SqliteConversationEventStore {
     pool: SqlitePool,
     /// How long events are retained before pruning.
     ttl: Duration,
@@ -41,7 +76,7 @@ pub struct ConversationEventStore {
     clock: Arc<dyn Clock>,
 }
 
-impl ConversationEventStore {
+impl SqliteConversationEventStore {
     pub fn new(pool: SqlitePool) -> Self {
         Self {
             pool,
@@ -57,12 +92,15 @@ impl ConversationEventStore {
             clock: Arc::new(SystemClock),
         }
     }
+}
 
+#[async_trait]
+impl ConversationEventStore for SqliteConversationEventStore {
     /// Append a single event to the log.
     ///
     /// `sequence` must be monotonically increasing within a `run_id`.
     /// The unique index on `(run_id, sequence)` enforces this at the DB level.
-    pub async fn append_event(
+    async fn append_event(
         &self,
         run_id: &str,
         conversation_id: &str,
@@ -90,7 +128,7 @@ impl ConversationEventStore {
     }
 
     /// Return all events for `run_id` with `sequence >= since`, ordered by sequence.
-    pub async fn list_events_since(
+    async fn list_events_since(
         &self,
         run_id: &str,
         since: i64,
@@ -113,7 +151,7 @@ impl ConversationEventStore {
     ///
     /// Used to distinguish "run not found" (no rows at all) from "run expired"
     /// (rows existed but TTL elapsed and were pruned).
-    pub async fn has_events(&self, run_id: &str) -> Result<bool> {
+    async fn has_events(&self, run_id: &str) -> Result<bool> {
         let count: i64 =
             sqlx::query_scalar("SELECT COUNT(*) FROM conversation_events WHERE run_id = ?1")
                 .bind(run_id)
@@ -123,7 +161,7 @@ impl ConversationEventStore {
     }
 
     /// Return `true` if the run has completed (a `done` or `agent_error` event was persisted).
-    pub async fn is_run_complete(&self, run_id: &str) -> Result<bool> {
+    async fn is_run_complete(&self, run_id: &str) -> Result<bool> {
         let count: i64 = sqlx::query_scalar(
             "SELECT COUNT(*) FROM conversation_events \
              WHERE run_id = ?1 AND (event_type = 'done' OR event_type = 'agent_error')",
@@ -135,7 +173,7 @@ impl ConversationEventStore {
     }
 
     /// Delete all rows where `expires_at < now`. Returns the number of rows deleted.
-    pub async fn prune_expired(&self) -> Result<u64> {
+    async fn prune_expired(&self) -> Result<u64> {
         let now = self.clock.now();
         let result = sqlx::query("DELETE FROM conversation_events WHERE expires_at < ?1")
             .bind(now)
@@ -150,10 +188,7 @@ impl ConversationEventStore {
     ///
     /// Returns `(run_id, conversation_id)` pairs for orphaned runs that likely
     /// died mid-stream (e.g. server restart).
-    pub async fn find_incomplete_runs(
-        &self,
-        older_than: Duration,
-    ) -> Result<Vec<(String, String)>> {
+    async fn find_incomplete_runs(&self, older_than: Duration) -> Result<Vec<(String, String)>> {
         let cutoff = self.clock.now() - older_than;
         let rows = sqlx::query(
             "SELECT DISTINCT ce.run_id, ce.conversation_id \
@@ -186,7 +221,7 @@ impl ConversationEventStore {
     /// Auto-determines the next sequence number. The payload includes
     /// `"synthetic": true` so clients can distinguish crash recovery from real
     /// errors.
-    pub async fn append_synthetic_terminal(
+    async fn append_synthetic_terminal(
         &self,
         run_id: &str,
         conversation_id: &str,
@@ -268,6 +303,169 @@ impl RunBroadcaster {
     }
 }
 
+// ---------------------------------------------------------------------------
+// In-memory implementation
+// ---------------------------------------------------------------------------
+
+/// In-memory [`ConversationEventStore`]. Vec<ConversationEventRow> backed.
+pub struct InMemoryConversationEventStore {
+    state: Arc<Mutex<Vec<ConversationEventRow>>>,
+    ttl: Duration,
+    clock: Arc<dyn Clock>,
+    next_id: Arc<Mutex<i64>>,
+}
+
+impl InMemoryConversationEventStore {
+    pub fn new() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(Vec::new())),
+            ttl: Duration::hours(DEFAULT_EVENT_TTL_HOURS),
+            clock: Arc::new(SystemClock),
+            next_id: Arc::new(Mutex::new(0)),
+        }
+    }
+
+    pub fn with_ttl(ttl: Duration) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(Vec::new())),
+            ttl,
+            clock: Arc::new(SystemClock),
+            next_id: Arc::new(Mutex::new(0)),
+        }
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, Vec<ConversationEventRow>> {
+        match self.state.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        }
+    }
+
+    fn next_id(&self) -> i64 {
+        let mut id = match self.next_id.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        *id += 1;
+        *id
+    }
+}
+
+impl Default for InMemoryConversationEventStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ConversationEventStore for InMemoryConversationEventStore {
+    async fn append_event(
+        &self,
+        run_id: &str,
+        conversation_id: &str,
+        sequence: i64,
+        event_type: &str,
+        payload: &Value,
+    ) -> Result<()> {
+        let now = self.clock.now();
+        let expires_at = now + self.ttl;
+        let id = self.next_id();
+        let mut state = self.lock();
+        state.push(ConversationEventRow {
+            id,
+            run_id: run_id.to_string(),
+            conversation_id: conversation_id.to_string(),
+            sequence,
+            event_type: event_type.to_string(),
+            payload: payload.clone(),
+            created_at: now,
+            expires_at,
+        });
+        Ok(())
+    }
+
+    async fn list_events_since(
+        &self,
+        run_id: &str,
+        since: i64,
+    ) -> Result<Vec<ConversationEventRow>> {
+        let state = self.lock();
+        let mut out: Vec<ConversationEventRow> = state
+            .iter()
+            .filter(|e| e.run_id == run_id && e.sequence >= since)
+            .cloned()
+            .collect();
+        out.sort_by_key(|e| e.sequence);
+        Ok(out)
+    }
+
+    async fn has_events(&self, run_id: &str) -> Result<bool> {
+        let state = self.lock();
+        Ok(state.iter().any(|e| e.run_id == run_id))
+    }
+
+    async fn is_run_complete(&self, run_id: &str) -> Result<bool> {
+        let state = self.lock();
+        Ok(state.iter().any(|e| {
+            e.run_id == run_id && (e.event_type == "done" || e.event_type == "agent_error")
+        }))
+    }
+
+    async fn prune_expired(&self) -> Result<u64> {
+        let now = self.clock.now();
+        let mut state = self.lock();
+        let before = state.len();
+        state.retain(|e| e.expires_at >= now);
+        Ok((before - state.len()) as u64)
+    }
+
+    async fn find_incomplete_runs(&self, older_than: Duration) -> Result<Vec<(String, String)>> {
+        let cutoff = self.clock.now() - older_than;
+        let state = self.lock();
+        let mut runs: Vec<(String, String)> = Vec::new();
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for e in state.iter() {
+            if e.event_type == "run_started" && e.created_at < cutoff && !seen.contains(&e.run_id) {
+                let complete = state.iter().any(|other| {
+                    other.run_id == e.run_id
+                        && (other.event_type == "done" || other.event_type == "agent_error")
+                });
+                if !complete {
+                    seen.insert(e.run_id.clone());
+                    runs.push((e.run_id.clone(), e.conversation_id.clone()));
+                }
+            }
+        }
+        Ok(runs)
+    }
+
+    async fn append_synthetic_terminal(
+        &self,
+        run_id: &str,
+        conversation_id: &str,
+        message: &str,
+    ) -> Result<i64> {
+        let next_seq = {
+            let state = self.lock();
+            state
+                .iter()
+                .filter(|e| e.run_id == run_id)
+                .map(|e| e.sequence)
+                .max()
+                .unwrap_or(0)
+                + 1
+        };
+
+        let payload = serde_json::json!({
+            "synthetic": true,
+            "message": message,
+        });
+        self.append_event(run_id, conversation_id, next_seq, "agent_error", &payload)
+            .await?;
+        Ok(next_seq)
+    }
+}
+
 fn parse_row(r: &sqlx::sqlite::SqliteRow) -> Result<ConversationEventRow> {
     let payload_str: String = r.try_get("payload")?;
     let payload: Value = serde_json::from_str(&payload_str)?;
@@ -288,9 +486,9 @@ mod tests {
     use super::*;
     use crate::StorageLayer;
 
-    async fn make_store() -> ConversationEventStore {
+    async fn make_store() -> SqliteConversationEventStore {
         let sl = StorageLayer::new_in_memory().await.unwrap();
-        ConversationEventStore::new(sl.pool)
+        SqliteConversationEventStore::new(sl.pool)
     }
 
     #[tokio::test]
@@ -380,7 +578,7 @@ mod tests {
     #[tokio::test]
     async fn prune_expired_removes_old_rows() {
         let sl = StorageLayer::new_in_memory().await.unwrap();
-        let store = ConversationEventStore::with_ttl(
+        let store = SqliteConversationEventStore::with_ttl(
             sl.pool.clone(),
             Duration::seconds(-1), // already expired on insert
         );

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -73,7 +73,8 @@ pub use conversation_broadcaster::{
     ConversationBroadcast, ConversationEvent, InMemoryConversationBroadcaster,
 };
 pub use conversation_events::{
-    ConversationEventRow, ConversationEventStore, LiveEvent, RunBroadcaster,
+    ConversationEventRow, ConversationEventStore, InMemoryConversationEventStore, LiveEvent,
+    RunBroadcaster, SqliteConversationEventStore,
 };
 pub use conversations::{
     ConversationRecord, ConversationStore, InMemoryConversationStore, SqliteConversationStore,
@@ -170,8 +171,8 @@ impl StorageLayer {
     }
 
     /// Convenience: build a [`ConversationEventStore`] backed by this pool.
-    pub fn conversation_event_store(&self) -> ConversationEventStore {
-        ConversationEventStore::new(self.pool.clone())
+    pub fn conversation_event_store(&self) -> SqliteConversationEventStore {
+        SqliteConversationEventStore::new(self.pool.clone())
     }
 
     /// Convenience: build a `SqliteLogStore` backed by this pool.

--- a/crates/storage/tests/contract.rs
+++ b/crates/storage/tests/contract.rs
@@ -8,6 +8,7 @@ mod contract {
     pub mod agent_store;
     pub mod attachment_store;
     pub mod command_event_store;
+    pub mod conversation_event_store;
     pub mod conversation_store;
     pub mod log_store;
     pub mod push_subscription_store;

--- a/crates/storage/tests/contract/conversation_event_store.rs
+++ b/crates/storage/tests/contract/conversation_event_store.rs
@@ -1,0 +1,167 @@
+//! Contract tests for [`ConversationEventStore`].
+
+use assistant_storage::{
+    ConversationEventStore, InMemoryConversationEventStore, SqliteConversationEventStore,
+    StorageLayer,
+};
+use chrono::Duration;
+use serde_json::json;
+
+async fn sqlite() -> Box<dyn ConversationEventStore> {
+    let storage = StorageLayer::new_in_memory().await.unwrap();
+    Box::new(SqliteConversationEventStore::new(storage.pool))
+}
+
+fn memory() -> Box<dyn ConversationEventStore> {
+    Box::new(InMemoryConversationEventStore::new())
+}
+
+async fn append_and_list_events(store: Box<dyn ConversationEventStore>) {
+    store
+        .append_event("r1", "c1", 0, "run_started", &json!({}))
+        .await
+        .unwrap();
+    store
+        .append_event("r1", "c1", 1, "chunk", &json!({"text": "hi"}))
+        .await
+        .unwrap();
+    let events = store.list_events_since("r1", 0).await.unwrap();
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0].event_type, "run_started");
+    assert_eq!(events[1].event_type, "chunk");
+}
+
+async fn list_events_since_cursor(store: Box<dyn ConversationEventStore>) {
+    store
+        .append_event("r1", "c1", 0, "run_started", &json!({}))
+        .await
+        .unwrap();
+    store
+        .append_event("r1", "c1", 1, "chunk", &json!({}))
+        .await
+        .unwrap();
+    store
+        .append_event("r1", "c1", 2, "done", &json!({}))
+        .await
+        .unwrap();
+    let later = store.list_events_since("r1", 1).await.unwrap();
+    assert_eq!(later.len(), 2);
+    assert_eq!(later[0].sequence, 1);
+    assert_eq!(later[1].sequence, 2);
+}
+
+async fn has_events_distinguishes_missing_run(store: Box<dyn ConversationEventStore>) {
+    assert!(!store.has_events("unknown").await.unwrap());
+    store
+        .append_event("r1", "c1", 0, "run_started", &json!({}))
+        .await
+        .unwrap();
+    assert!(store.has_events("r1").await.unwrap());
+}
+
+async fn is_run_complete_detects_done(store: Box<dyn ConversationEventStore>) {
+    store
+        .append_event("r1", "c1", 0, "run_started", &json!({}))
+        .await
+        .unwrap();
+    assert!(!store.is_run_complete("r1").await.unwrap());
+    store
+        .append_event("r1", "c1", 1, "done", &json!({}))
+        .await
+        .unwrap();
+    assert!(store.is_run_complete("r1").await.unwrap());
+}
+
+async fn is_run_complete_detects_agent_error(store: Box<dyn ConversationEventStore>) {
+    store
+        .append_event("r1", "c1", 0, "run_started", &json!({}))
+        .await
+        .unwrap();
+    store
+        .append_event("r1", "c1", 1, "agent_error", &json!({}))
+        .await
+        .unwrap();
+    assert!(store.is_run_complete("r1").await.unwrap());
+}
+
+async fn append_synthetic_terminal_assigns_sequence(store: Box<dyn ConversationEventStore>) {
+    store
+        .append_event("r1", "c1", 0, "run_started", &json!({}))
+        .await
+        .unwrap();
+    let seq = store
+        .append_synthetic_terminal("r1", "c1", "crashed")
+        .await
+        .unwrap();
+    assert_eq!(seq, 1);
+    let events = store.list_events_since("r1", 0).await.unwrap();
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[1].event_type, "agent_error");
+    assert_eq!(events[1].sequence, 1);
+    assert_eq!(
+        events[1].payload.get("synthetic").and_then(|v| v.as_bool()),
+        Some(true)
+    );
+}
+
+async fn find_incomplete_runs_filters_by_age(store: Box<dyn ConversationEventStore>) {
+    // Append a run_started with a created_at far in the past would require
+    // a clock-injected impl; here we just verify the function returns empty
+    // for recently-started runs.
+    store
+        .append_event("r1", "c1", 0, "run_started", &json!({}))
+        .await
+        .unwrap();
+    let incomplete = store
+        .find_incomplete_runs(Duration::hours(1))
+        .await
+        .unwrap();
+    // Just-started run is NOT older than 1 hour → not flagged.
+    assert!(incomplete.is_empty());
+}
+
+macro_rules! contract_tests {
+    ($name:ident, $ctor:expr) => {
+        mod $name {
+            use super::*;
+
+            #[tokio::test]
+            async fn t_append_and_list_events() {
+                append_and_list_events($ctor).await;
+            }
+
+            #[tokio::test]
+            async fn t_list_events_since_cursor() {
+                list_events_since_cursor($ctor).await;
+            }
+
+            #[tokio::test]
+            async fn t_has_events_distinguishes_missing_run() {
+                has_events_distinguishes_missing_run($ctor).await;
+            }
+
+            #[tokio::test]
+            async fn t_is_run_complete_detects_done() {
+                is_run_complete_detects_done($ctor).await;
+            }
+
+            #[tokio::test]
+            async fn t_is_run_complete_detects_agent_error() {
+                is_run_complete_detects_agent_error($ctor).await;
+            }
+
+            #[tokio::test]
+            async fn t_append_synthetic_terminal_assigns_sequence() {
+                append_synthetic_terminal_assigns_sequence($ctor).await;
+            }
+
+            #[tokio::test]
+            async fn t_find_incomplete_runs_filters_by_age() {
+                find_incomplete_runs_filters_by_age($ctor).await;
+            }
+        }
+    };
+}
+
+contract_tests!(sqlite_impl, sqlite().await);
+contract_tests!(memory_impl, memory());

--- a/crates/test-support/src/prelude.rs
+++ b/crates/test-support/src/prelude.rs
@@ -19,11 +19,12 @@
 
 pub use assistant_core::clock::{Clock, FakeClock, SystemClock};
 pub use assistant_storage::{
-    AgentStore, AttachmentStore, CommandEventStore, ConversationStore, InMemoryAgentStore,
-    InMemoryAttachmentStore, InMemoryCommandEventStore, InMemoryConversationStore,
-    InMemoryLogStore, InMemoryPushSubscriptionStore, InMemoryScheduledTaskStore,
-    InMemorySlackActiveThreadStore, InMemoryTraceStore, InMemoryWebhookStore, LogStore,
-    PushSubscriptionStore, ScheduledTaskStore, SlackActiveThreadStore, TraceStore, WebhookStore,
+    AgentStore, AttachmentStore, CommandEventStore, ConversationEventStore, ConversationStore,
+    InMemoryAgentStore, InMemoryAttachmentStore, InMemoryCommandEventStore,
+    InMemoryConversationEventStore, InMemoryConversationStore, InMemoryLogStore,
+    InMemoryPushSubscriptionStore, InMemoryScheduledTaskStore, InMemorySlackActiveThreadStore,
+    InMemoryTraceStore, InMemoryWebhookStore, LogStore, PushSubscriptionStore, ScheduledTaskStore,
+    SlackActiveThreadStore, TraceStore, WebhookStore,
 };
 
 pub use crate::fixture::{Fixture, FixtureBuilder};

--- a/crates/web-ui/src/api/messages.rs
+++ b/crates/web-ui/src/api/messages.rs
@@ -1195,9 +1195,9 @@ mod tests {
 
     use assistant_runtime::CommandRegistry;
     use assistant_storage::{
-        CommandEventStore, ConversationStore, InMemoryConversationBroadcaster, RunBroadcaster,
-        SkillRegistry, SqliteAttachmentStore, SqliteCommandEventStore, SqliteConversationStore,
-        StorageLayer,
+        CommandEventStore, ConversationEventStore, ConversationStore,
+        InMemoryConversationBroadcaster, RunBroadcaster, SkillRegistry, SqliteAttachmentStore,
+        SqliteCommandEventStore, SqliteConversationStore, StorageLayer,
     };
 
     use super::super::ApiState;
@@ -1824,7 +1824,7 @@ mod tests {
     async fn stream_run_events_returns_404_for_pruned_run() {
         let sl = Arc::new(StorageLayer::new_in_memory().await.unwrap());
         // Use a very short TTL (already negative = instantly expired).
-        let short_ttl_store = assistant_storage::ConversationEventStore::with_ttl(
+        let short_ttl_store = assistant_storage::SqliteConversationEventStore::with_ttl(
             sl.pool.clone(),
             chrono::Duration::seconds(-1),
         );
@@ -1891,7 +1891,7 @@ mod tests {
             transcription_provider: None,
             tts_provider: None,
             audio_store: Arc::new(crate::audio_store::AudioStore::new()),
-            event_store: short_ttl_store,
+            event_store: Arc::new(short_ttl_store),
             run_broadcaster: RunBroadcaster::new(),
             attachment_store: Arc::new(SqliteAttachmentStore::new(sl.pool.clone())),
             command_registry: Arc::new(CommandRegistry::new()),

--- a/crates/web-ui/src/api/mod.rs
+++ b/crates/web-ui/src/api/mod.rs
@@ -127,7 +127,7 @@ use assistant_runtime::{AssistantInterface, CommandRegistry, Orchestrator};
 use assistant_storage::{
     AttachmentStore, CommandEventStore, ConversationBroadcast, ConversationEventStore,
     InMemoryConversationBroadcaster, RunBroadcaster, SqliteAttachmentStore,
-    SqliteCommandEventStore,
+    SqliteCommandEventStore, SqliteConversationEventStore,
 };
 use assistant_transcription::{TranscriptionProvider, TtsProvider};
 use axum::{
@@ -163,7 +163,7 @@ pub struct ApiState {
     /// In-memory store for tool-synthesized audio blobs.
     pub audio_store: Arc<crate::audio_store::AudioStore>,
     /// Durable event log store for conversation streaming runs.
-    pub event_store: ConversationEventStore,
+    pub event_store: Arc<dyn ConversationEventStore>,
     /// In-memory broadcast registry for live-tailing active runs.
     pub run_broadcaster: RunBroadcaster,
     /// Persistent attachment storage (metadata in SQLite, bytes on disk).
@@ -191,7 +191,8 @@ impl ApiState {
         agent_id: Arc<RwLock<String>>,
         orchestrator_ref: Arc<Orchestrator>,
     ) -> Self {
-        let event_store = ConversationEventStore::new(pool.clone());
+        let event_store: Arc<dyn ConversationEventStore> =
+            Arc::new(SqliteConversationEventStore::new(pool.clone()));
         let attachment_store: Arc<dyn AttachmentStore> =
             Arc::new(SqliteAttachmentStore::new(pool.clone()));
         let command_event_store: Arc<dyn CommandEventStore> =

--- a/crates/web-ui/src/api/test_helpers.rs
+++ b/crates/web-ui/src/api/test_helpers.rs
@@ -22,7 +22,8 @@ use assistant_llm_provider::retry::RetryConfig;
 use assistant_runtime::{CommandRegistry, Orchestrator};
 use assistant_storage::{
     AttachmentStore, CommandEventStore, ConversationEventStore, InMemoryConversationBroadcaster,
-    RunBroadcaster, SkillRegistry, SqliteAttachmentStore, SqliteCommandEventStore, StorageLayer,
+    RunBroadcaster, SkillRegistry, SqliteAttachmentStore, SqliteCommandEventStore,
+    SqliteConversationEventStore, StorageLayer,
 };
 use assistant_tool_executor::ToolExecutor;
 use assistant_transcription::{TranscriptionProvider, TranscriptionRequest, TranscriptionResult};
@@ -118,7 +119,7 @@ pub(crate) async fn test_state(llm_url: &str) -> (ApiState, Arc<StorageLayer>) {
         transcription_provider: None,
         tts_provider: None,
         audio_store: Arc::new(crate::audio_store::AudioStore::new()),
-        event_store: ConversationEventStore::new(storage.pool.clone()),
+        event_store: Arc::new(SqliteConversationEventStore::new(storage.pool.clone())),
         run_broadcaster: RunBroadcaster::new(),
         attachment_store: Arc::new(SqliteAttachmentStore::new(storage.pool.clone())),
         command_registry: Arc::new(CommandRegistry::new()),
@@ -176,7 +177,7 @@ pub(crate) async fn event_log_state() -> (ApiState, Arc<StorageLayer>) {
         transcription_provider: None,
         tts_provider: None,
         audio_store: Arc::new(crate::audio_store::AudioStore::new()),
-        event_store: ConversationEventStore::new(storage.pool.clone()),
+        event_store: Arc::new(SqliteConversationEventStore::new(storage.pool.clone())),
         run_broadcaster: RunBroadcaster::new(),
         attachment_store: Arc::new(SqliteAttachmentStore::new(storage.pool.clone())),
         command_registry: Arc::new(CommandRegistry::new()),


### PR DESCRIPTION
ConversationEventStore trait + Sqlite/InMemory + 14 contract tests. ApiState holds Arc<dyn ConversationEventStore>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured conversation event storage architecture to enable multiple storage backend implementations with a unified interface, while maintaining full backward compatibility.

* **Tests**
  * Added comprehensive contract test suite for conversation event storage, ensuring consistent behavior and reliability across all implementations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cedricziel/assistant/pull/860?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->