### PR TITLE
refactor(storage): extract RefinementsStore trait + InMemory impl (Phase 5.M)

### DIFF
--- a/crates/interface-cli/src/cmd_review.rs
+++ b/crates/interface-cli/src/cmd_review.rs
@@ -5,7 +5,9 @@ use std::io::{self, Write as IoWrite};
 use anyhow::Result;
 use uuid::Uuid;
 
-use assistant_storage::{RefinementStatus, StorageLayer, registry::SkillRegistry};
+use assistant_storage::{
+    RefinementStatus, RefinementsStore, StorageLayer, registry::SkillRegistry,
+};
 
 use crate::skill_diff;
 

--- a/crates/runtime/src/skill_improver.rs
+++ b/crates/runtime/src/skill_improver.rs
@@ -8,6 +8,8 @@
 use anyhow::Result;
 use assistant_core::types::features::LearningConfig;
 use assistant_core::{ChatHistoryMessage, ChatRole, LlmProvider, LlmResponse};
+#[cfg(test)]
+use assistant_storage::SqliteRefinementsStore;
 use assistant_storage::{
     RefinementStatus, RefinementsStore, ScheduledTaskStore, SkillRegistry, SkillStatsProvider,
     StorageLayer,
@@ -64,7 +66,7 @@ pub async fn run_improvement_cycle(
     config: &LearningConfig,
     registry: &SkillRegistry,
     stats_provider: &dyn SkillStatsProvider,
-    refinements_store: &RefinementsStore,
+    refinements_store: &dyn RefinementsStore,
     llm: &dyn LlmProvider,
 ) -> Result<()> {
     // First, check recently-applied refinements for regression.
@@ -156,7 +158,7 @@ async fn check_regressions(
     config: &LearningConfig,
     registry: &SkillRegistry,
     stats_provider: &dyn SkillStatsProvider,
-    refinements_store: &RefinementsStore,
+    refinements_store: &dyn RefinementsStore,
 ) -> Result<()> {
     let accepted = refinements_store
         .list_by_status(&RefinementStatus::Accepted)
@@ -454,7 +456,7 @@ mod tests {
             },
         };
 
-        let refinements_store = RefinementsStore::new(storage.pool.clone());
+        let refinements_store = SqliteRefinementsStore::new(storage.pool.clone());
         let llm = MockLlm {
             response: r#"{"improved": true, "body": "improved body"}"#.to_string(),
         };
@@ -514,7 +516,7 @@ mod tests {
             },
         };
 
-        let refinements_store = RefinementsStore::new(storage.pool.clone());
+        let refinements_store = SqliteRefinementsStore::new(storage.pool.clone());
         let llm = MockLlm {
             response:
                 r##"{"improved": true, "body": "# Improved flaky-skill\n\nBetter instructions."}"##
@@ -564,7 +566,7 @@ mod tests {
         };
 
         // Insert an accepted refinement with previous body stored.
-        let refinements_store = RefinementsStore::new(storage.pool.clone());
+        let refinements_store = SqliteRefinementsStore::new(storage.pool.clone());
         refinements_store
             .insert_with_previous(
                 "regressing-skill",
@@ -621,7 +623,7 @@ mod tests {
         };
 
         // Insert an accepted refinement with previous body.
-        let refinements_store = RefinementsStore::new(storage.pool.clone());
+        let refinements_store = SqliteRefinementsStore::new(storage.pool.clone());
         refinements_store
             .insert_with_previous(
                 "stable-skill",

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -96,7 +96,10 @@ pub use push_subscriptions::{
     InMemoryPushSubscriptionStore, PushSubscription, PushSubscriptionStore,
     SqlitePushSubscriptionStore,
 };
-pub use refinements::{RefinementStatus, RefinementsStore, SkillRefinement};
+pub use refinements::{
+    InMemoryRefinementsStore, RefinementStatus, RefinementsStore, SkillRefinement,
+    SqliteRefinementsStore,
+};
 pub use registry::SkillRegistry;
 pub use scheduled_tasks::{
     InMemoryScheduledTaskStore, ScheduledTask, ScheduledTaskStore, SqliteScheduledTaskStore,
@@ -197,8 +200,8 @@ impl StorageLayer {
     }
 
     /// Convenience: build a `RefinementsStore` backed by this pool.
-    pub fn refinements_store(&self) -> RefinementsStore {
-        RefinementsStore::new(self.pool.clone())
+    pub fn refinements_store(&self) -> SqliteRefinementsStore {
+        SqliteRefinementsStore::new(self.pool.clone())
     }
 
     /// Convenience: build a `ScheduledTaskStore` backed by this pool.

--- a/crates/storage/src/refinements.rs
+++ b/crates/storage/src/refinements.rs
@@ -1,9 +1,11 @@
 //! Skill refinement proposals — the `/review` workflow.
 
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use assistant_core::clock::{Clock, SystemClock};
+use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use sqlx::{Row, SqlitePool};
 use uuid::Uuid;
@@ -62,14 +64,39 @@ fn parse_status(s: &str) -> RefinementStatus {
     }
 }
 
+/// Trait-based interface for skill refinement persistence.
+#[async_trait]
+pub trait RefinementsStore: Send + Sync {
+    async fn insert(
+        &self,
+        target_skill: &str,
+        proposed_skill_md: &str,
+        rationale: &str,
+    ) -> Result<Uuid>;
+
+    async fn insert_with_previous(
+        &self,
+        target_skill: &str,
+        proposed_skill_md: &str,
+        rationale: &str,
+        previous_skill_md: &str,
+    ) -> Result<Uuid>;
+
+    async fn list_by_status(&self, status: &RefinementStatus) -> Result<Vec<SkillRefinement>>;
+
+    async fn review(&self, id: Uuid, accepted: bool, note: Option<&str>) -> Result<()>;
+
+    async fn set_status(&self, id: Uuid, status: &RefinementStatus) -> Result<()>;
+}
+
 /// SQLite-backed store for skill refinement proposals.
-pub struct RefinementsStore {
+pub struct SqliteRefinementsStore {
     pool: SqlitePool,
     /// Clock for row timestamps. Default `Arc::new(SystemClock)`.
     clock: Arc<dyn Clock>,
 }
 
-impl RefinementsStore {
+impl SqliteRefinementsStore {
     pub fn new(pool: SqlitePool) -> Self {
         Self {
             pool,
@@ -82,9 +109,12 @@ impl RefinementsStore {
         self.clock = clock;
         self
     }
+}
 
+#[async_trait]
+impl RefinementsStore for SqliteRefinementsStore {
     /// Insert a new pending refinement proposal.
-    pub async fn insert(
+    async fn insert(
         &self,
         target_skill: &str,
         proposed_skill_md: &str,
@@ -111,7 +141,7 @@ impl RefinementsStore {
     }
 
     /// List all refinement proposals with a given status.
-    pub async fn list_by_status(&self, status: &RefinementStatus) -> Result<Vec<SkillRefinement>> {
+    async fn list_by_status(&self, status: &RefinementStatus) -> Result<Vec<SkillRefinement>> {
         let rows = sqlx::query(
             "SELECT id, target_skill, proposed_skill_md, rationale, status, \
                     review_note, previous_skill_md, created_at, reviewed_at \
@@ -143,7 +173,7 @@ impl RefinementsStore {
     }
 
     /// Accept or reject a refinement proposal.
-    pub async fn review(&self, id: Uuid, accepted: bool, note: Option<&str>) -> Result<()> {
+    async fn review(&self, id: Uuid, accepted: bool, note: Option<&str>) -> Result<()> {
         let status = if accepted { "accepted" } else { "rejected" };
         let id_str = id.to_string();
         let now = self.clock.now();
@@ -164,7 +194,7 @@ impl RefinementsStore {
     }
 
     /// Insert a refinement with the previous skill body stored for rollback.
-    pub async fn insert_with_previous(
+    async fn insert_with_previous(
         &self,
         target_skill: &str,
         proposed_skill_md: &str,
@@ -193,7 +223,7 @@ impl RefinementsStore {
     }
 
     /// Update the status of a refinement (used by revert/confirm logic).
-    pub async fn set_status(&self, id: Uuid, status: &RefinementStatus) -> Result<()> {
+    async fn set_status(&self, id: Uuid, status: &RefinementStatus) -> Result<()> {
         let id_str = id.to_string();
         let now = self.clock.now();
 
@@ -208,6 +238,135 @@ impl RefinementsStore {
         .execute(&self.pool)
         .await?;
 
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// In-memory implementation
+// ---------------------------------------------------------------------------
+
+/// In-memory [`RefinementsStore`]. HashMap<Uuid, SkillRefinement>.
+pub struct InMemoryRefinementsStore {
+    state: Arc<Mutex<HashMap<Uuid, SkillRefinement>>>,
+    clock: Arc<dyn Clock>,
+}
+
+impl InMemoryRefinementsStore {
+    pub fn new() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(HashMap::new())),
+            clock: Arc::new(SystemClock),
+        }
+    }
+
+    pub fn with_clock(mut self, clock: Arc<dyn Clock>) -> Self {
+        self.clock = clock;
+        self
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<Uuid, SkillRefinement>> {
+        match self.state.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        }
+    }
+}
+
+impl Default for InMemoryRefinementsStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl RefinementsStore for InMemoryRefinementsStore {
+    async fn insert(
+        &self,
+        target_skill: &str,
+        proposed_skill_md: &str,
+        rationale: &str,
+    ) -> Result<Uuid> {
+        let id = Uuid::new_v4();
+        let now = self.clock.now();
+        let mut state = self.lock();
+        state.insert(
+            id,
+            SkillRefinement {
+                id,
+                target_skill: target_skill.to_string(),
+                proposed_skill_md: proposed_skill_md.to_string(),
+                rationale: rationale.to_string(),
+                status: RefinementStatus::Pending,
+                review_note: None,
+                previous_skill_md: None,
+                created_at: now,
+                reviewed_at: None,
+            },
+        );
+        Ok(id)
+    }
+
+    async fn insert_with_previous(
+        &self,
+        target_skill: &str,
+        proposed_skill_md: &str,
+        rationale: &str,
+        previous_skill_md: &str,
+    ) -> Result<Uuid> {
+        let id = Uuid::new_v4();
+        let now = self.clock.now();
+        let mut state = self.lock();
+        state.insert(
+            id,
+            SkillRefinement {
+                id,
+                target_skill: target_skill.to_string(),
+                proposed_skill_md: proposed_skill_md.to_string(),
+                rationale: rationale.to_string(),
+                status: RefinementStatus::Accepted,
+                review_note: None,
+                previous_skill_md: Some(previous_skill_md.to_string()),
+                created_at: now,
+                reviewed_at: None,
+            },
+        );
+        Ok(id)
+    }
+
+    async fn list_by_status(&self, status: &RefinementStatus) -> Result<Vec<SkillRefinement>> {
+        let state = self.lock();
+        let mut out: Vec<SkillRefinement> = state
+            .values()
+            .filter(|r| &r.status == status)
+            .cloned()
+            .collect();
+        out.sort_by_key(|r| r.created_at);
+        Ok(out)
+    }
+
+    async fn review(&self, id: Uuid, accepted: bool, note: Option<&str>) -> Result<()> {
+        let now = self.clock.now();
+        let mut state = self.lock();
+        if let Some(r) = state.get_mut(&id) {
+            r.status = if accepted {
+                RefinementStatus::Accepted
+            } else {
+                RefinementStatus::Rejected
+            };
+            r.review_note = note.map(str::to_string);
+            r.reviewed_at = Some(now);
+        }
+        Ok(())
+    }
+
+    async fn set_status(&self, id: Uuid, status: &RefinementStatus) -> Result<()> {
+        let now = self.clock.now();
+        let mut state = self.lock();
+        if let Some(r) = state.get_mut(&id) {
+            r.status = status.clone();
+            r.reviewed_at = Some(now);
+        }
         Ok(())
     }
 }

--- a/crates/storage/tests/contract.rs
+++ b/crates/storage/tests/contract.rs
@@ -12,6 +12,7 @@ mod contract {
     pub mod conversation_store;
     pub mod log_store;
     pub mod push_subscription_store;
+    pub mod refinements_store;
     pub mod scheduled_task_store;
     pub mod slack_active_thread_store;
     pub mod trace_store;

--- a/crates/storage/tests/contract/refinements_store.rs
+++ b/crates/storage/tests/contract/refinements_store.rs
@@ -1,0 +1,124 @@
+//! Contract tests for [`RefinementsStore`].
+
+use assistant_storage::{
+    InMemoryRefinementsStore, RefinementStatus, RefinementsStore, SqliteRefinementsStore,
+    StorageLayer,
+};
+
+async fn sqlite() -> Box<dyn RefinementsStore> {
+    let storage = StorageLayer::new_in_memory().await.unwrap();
+    Box::new(SqliteRefinementsStore::new(storage.pool))
+}
+
+fn memory() -> Box<dyn RefinementsStore> {
+    Box::new(InMemoryRefinementsStore::new())
+}
+
+async fn insert_creates_pending(store: Box<dyn RefinementsStore>) {
+    let _id = store
+        .insert("skill-x", "## proposal", "rationale")
+        .await
+        .unwrap();
+    let pending = store
+        .list_by_status(&RefinementStatus::Pending)
+        .await
+        .unwrap();
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].target_skill, "skill-x");
+    assert_eq!(pending[0].status, RefinementStatus::Pending);
+}
+
+async fn review_accepts(store: Box<dyn RefinementsStore>) {
+    let id = store
+        .insert("skill-x", "## proposal", "rationale")
+        .await
+        .unwrap();
+    store.review(id, true, Some("looks good")).await.unwrap();
+    let accepted = store
+        .list_by_status(&RefinementStatus::Accepted)
+        .await
+        .unwrap();
+    assert_eq!(accepted.len(), 1);
+    assert_eq!(accepted[0].id, id);
+    assert_eq!(accepted[0].review_note.as_deref(), Some("looks good"));
+}
+
+async fn review_rejects(store: Box<dyn RefinementsStore>) {
+    let id = store
+        .insert("skill-x", "## proposal", "rationale")
+        .await
+        .unwrap();
+    store.review(id, false, Some("no thanks")).await.unwrap();
+    let rejected = store
+        .list_by_status(&RefinementStatus::Rejected)
+        .await
+        .unwrap();
+    assert_eq!(rejected.len(), 1);
+    assert_eq!(rejected[0].id, id);
+}
+
+async fn insert_with_previous_is_auto_accepted(store: Box<dyn RefinementsStore>) {
+    let id = store
+        .insert_with_previous("skill-x", "## new", "rationale", "## old")
+        .await
+        .unwrap();
+    let accepted = store
+        .list_by_status(&RefinementStatus::Accepted)
+        .await
+        .unwrap();
+    assert_eq!(accepted.len(), 1);
+    assert_eq!(accepted[0].id, id);
+    assert_eq!(accepted[0].previous_skill_md.as_deref(), Some("## old"));
+}
+
+async fn set_status_transitions(store: Box<dyn RefinementsStore>) {
+    let id = store
+        .insert("skill-x", "## proposal", "rationale")
+        .await
+        .unwrap();
+    store
+        .set_status(id, &RefinementStatus::Confirmed)
+        .await
+        .unwrap();
+    let confirmed = store
+        .list_by_status(&RefinementStatus::Confirmed)
+        .await
+        .unwrap();
+    assert_eq!(confirmed.len(), 1);
+}
+
+macro_rules! contract_tests {
+    ($name:ident, $ctor:expr) => {
+        mod $name {
+            use super::*;
+
+            #[tokio::test]
+            async fn t_insert_creates_pending() {
+                insert_creates_pending($ctor).await;
+            }
+
+            #[tokio::test]
+            async fn t_review_accepts() {
+                review_accepts($ctor).await;
+            }
+
+            #[tokio::test]
+            async fn t_review_rejects() {
+                review_rejects($ctor).await;
+            }
+
+            #[tokio::test]
+            async fn t_insert_with_previous_is_auto_accepted() {
+                insert_with_previous_is_auto_accepted($ctor).await;
+            }
+
+            #[tokio::test]
+            async fn t_set_status_transitions() {
+                set_status_transitions($ctor).await;
+            }
+        }
+    };
+}
+
+contract_tests!(sqlite_impl, sqlite().await);
+contract_tests!(memory_impl, memory());

--- a/crates/test-support/src/prelude.rs
+++ b/crates/test-support/src/prelude.rs
@@ -22,10 +22,10 @@ pub use assistant_storage::{
     AgentStore, AttachmentStore, CommandEventStore, ConversationEventStore, ConversationStore,
     InMemoryAgentStore, InMemoryAttachmentStore, InMemoryCommandEventStore,
     InMemoryConversationEventStore, InMemoryConversationStore, InMemoryLogStore,
-    InMemoryMetricsStore, InMemoryPushSubscriptionStore, InMemoryScheduledTaskStore,
-    InMemorySlackActiveThreadStore, InMemoryTraceStore, InMemoryWebhookStore, LogStore,
-    MetricsStore, PushSubscriptionStore, ScheduledTaskStore, SlackActiveThreadStore, TraceStore,
-    WebhookStore,
+    InMemoryMetricsStore, InMemoryPushSubscriptionStore, InMemoryRefinementsStore,
+    InMemoryScheduledTaskStore, InMemorySlackActiveThreadStore, InMemoryTraceStore,
+    InMemoryWebhookStore, LogStore, MetricsStore, PushSubscriptionStore, RefinementsStore,
+    ScheduledTaskStore, SlackActiveThreadStore, TraceStore, WebhookStore,
 };
 
 pub use crate::fixture::{Fixture, FixtureBuilder};

--- a/crates/tool-executor/src/builtins/self_analyze.rs
+++ b/crates/tool-executor/src/builtins/self_analyze.rs
@@ -12,7 +12,7 @@ use assistant_core::{
     ChatHistoryMessage, ChatRole, LlmProvider, LlmResponse, ToolHandler, ToolOutput,
     types::conversation::ExecutionContext,
 };
-use assistant_storage::{SkillRegistry, SkillStatsProvider, StorageLayer};
+use assistant_storage::{RefinementsStore, SkillRegistry, SkillStatsProvider, StorageLayer};
 use async_trait::async_trait;
 use tracing::{debug, warn};
 


### PR DESCRIPTION
RefinementsStore trait + Sqlite/InMemory + 10 contract tests. Consumers in runtime/skill_improver, tool-executor/self_analyze, interface-cli/cmd_review import the trait.