### PR TITLE
feat(core,tool-executor,storage): add ToolDispatcher + SkillCatalog trait facades (Phase 7 part 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,6 +711,7 @@ dependencies = [
  "assistant-core",
  "assistant-llm-provider",
  "assistant-storage",
+ "assistant-tool-executor",
  "chrono",
  "serde_json",
  "tokio",

--- a/crates/core/src/tool.rs
+++ b/crates/core/src/tool.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use serde_json::Value;
 
+use crate::llm::tool_spec::ToolSpec;
 use crate::types::conversation::ExecutionContext;
 
 // ── Attachment ────────────────────────────────────────────────────────────────
@@ -143,6 +144,39 @@ pub trait ToolHandler: Send + Sync {
         params: HashMap<String, Value>,
         ctx: &ExecutionContext,
     ) -> anyhow::Result<ToolOutput>;
+}
+
+// ── ToolDispatcher facade ────────────────────────────────────────────────────
+
+/// Higher-level facade over a registry of [`ToolHandler`] implementations.
+///
+/// Concrete implementation lives in `assistant_tool_executor::ToolExecutor`;
+/// a test stub lives in `assistant_tool_executor::stub::StubToolDispatcher`
+/// and is re-exported from `assistant_test_support::prelude`.
+///
+/// Consumers — `mcp-server`, `web-ui`, `interfaces` — depend on this trait
+/// rather than on the concrete executor so tests can substitute the stub.
+#[async_trait]
+pub trait ToolDispatcher: Send + Sync {
+    /// Return the [`ToolSpec`] for every registered tool. Used by MCP's
+    /// `tools/list` and by the orchestrator when assembling the LLM
+    /// prompt.
+    fn to_specs(&self) -> Vec<ToolSpec>;
+
+    /// Execute a tool by name. Returns the tool's output (success or
+    /// error) wrapped in `Ok`; `Err` is reserved for truly unrecoverable
+    /// dispatcher failures (e.g. tool not registered).
+    async fn execute(
+        &self,
+        name: &str,
+        params: HashMap<String, Value>,
+        ctx: &ExecutionContext,
+    ) -> anyhow::Result<ToolOutput>;
+
+    /// Whether the named tool is registered AND classified as mutating
+    /// (i.e. requires confirmation under the safety gate). Returns
+    /// `false` if the tool is unknown.
+    fn is_mutating(&self, name: &str) -> bool;
 }
 
 #[cfg(test)]

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -106,7 +106,7 @@ pub use refinements::{
     InMemoryRefinementsStore, RefinementStatus, RefinementsStore, SkillRefinement,
     SqliteRefinementsStore,
 };
-pub use registry::SkillRegistry;
+pub use registry::{InMemorySkillCatalog, SkillCatalog, SkillRegistry};
 pub use scheduled_tasks::{
     InMemoryScheduledTaskStore, ScheduledTask, ScheduledTaskStore, SqliteScheduledTaskStore,
 };

--- a/crates/storage/src/registry.rs
+++ b/crates/storage/src/registry.rs
@@ -3,10 +3,28 @@
 use anyhow::{Context, Result};
 use assistant_core::clock::{Clock, SystemClock};
 use assistant_skills::{SkillDef, SkillSource, parse_skill_content};
+use async_trait::async_trait;
 use sqlx::SqlitePool;
+use std::sync::Mutex as StdMutex;
 use std::{collections::HashMap, path::Path, sync::Arc};
 use tokio::sync::RwLock;
 use tracing::{info, warn};
+
+/// Read-side facade over a skill registry.
+///
+/// Consumers (`mcp-server`, `web-ui`) depend on this trait rather than on
+/// the concrete [`SkillRegistry`] so test code can substitute
+/// [`InMemorySkillCatalog`]. The trait is intentionally narrow: only the
+/// query methods used by external consumers, not the registry's reload
+/// and write paths.
+#[async_trait]
+pub trait SkillCatalog: Send + Sync {
+    /// Return every skill in the catalog, sorted by name.
+    async fn list(&self) -> Vec<SkillDef>;
+
+    /// Look up a skill by name. `None` if the name is not registered.
+    async fn get(&self, name: &str) -> Option<SkillDef>;
+}
 
 // -- Helpers -----------------------------------------------------------------
 
@@ -480,6 +498,76 @@ impl SkillRegistry {
         .await?;
 
         Ok(())
+    }
+}
+
+#[async_trait]
+impl SkillCatalog for SkillRegistry {
+    async fn list(&self) -> Vec<SkillDef> {
+        SkillRegistry::list(self).await
+    }
+
+    async fn get(&self, name: &str) -> Option<SkillDef> {
+        SkillRegistry::get(self, name).await
+    }
+}
+
+// ---------------------------------------------------------------------------
+// In-memory implementation
+// ---------------------------------------------------------------------------
+
+/// In-memory [`SkillCatalog`] for tests. Constructed with a slice of
+/// [`SkillDef`] values; ignores the database entirely.
+pub struct InMemorySkillCatalog {
+    skills: StdMutex<HashMap<String, SkillDef>>,
+}
+
+impl InMemorySkillCatalog {
+    pub fn new() -> Self {
+        Self {
+            skills: StdMutex::new(HashMap::new()),
+        }
+    }
+
+    pub fn with_skills(skills: Vec<SkillDef>) -> Self {
+        let map: HashMap<String, SkillDef> =
+            skills.into_iter().map(|s| (s.name.clone(), s)).collect();
+        Self {
+            skills: StdMutex::new(map),
+        }
+    }
+
+    pub fn insert(&self, skill: SkillDef) {
+        if let Ok(mut s) = self.skills.lock() {
+            s.insert(skill.name.clone(), skill);
+        }
+    }
+}
+
+impl Default for InMemorySkillCatalog {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl SkillCatalog for InMemorySkillCatalog {
+    async fn list(&self) -> Vec<SkillDef> {
+        let guard = match self.skills.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let mut out: Vec<SkillDef> = guard.values().cloned().collect();
+        out.sort_by(|a, b| a.name.cmp(&b.name));
+        out
+    }
+
+    async fn get(&self, name: &str) -> Option<SkillDef> {
+        let guard = match self.skills.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        guard.get(name).cloned()
     }
 }
 

--- a/crates/test-support/Cargo.toml
+++ b/crates/test-support/Cargo.toml
@@ -15,6 +15,7 @@ publish = false
 assistant-core = { path = "../core" }
 assistant-llm-provider = { path = "../llm-provider" }
 assistant-storage = { path = "../storage" }
+assistant-tool-executor = { path = "../tool-executor" }
 chrono = { workspace = true }
 
 [dev-dependencies]

--- a/crates/test-support/src/prelude.rs
+++ b/crates/test-support/src/prelude.rs
@@ -18,6 +18,7 @@
 //!   `InMemorySkillCatalog`.
 
 pub use assistant_core::clock::{Clock, FakeClock, SystemClock};
+pub use assistant_core::tool::ToolDispatcher;
 pub use assistant_llm_provider::{RecordedCall, ScriptedLlmProvider};
 pub use assistant_storage::{
     AgentStore, AttachmentStore, CommandEventStore, ConversationEventStore, ConversationStore,
@@ -30,5 +31,7 @@ pub use assistant_storage::{
     MetricsStore, PersonaSkillAccessStore, PersonaStore, PushSubscriptionStore, RefinementsStore,
     ScheduledTaskStore, SlackActiveThreadStore, TraceStore, WebhookStore, WorkflowStore,
 };
+pub use assistant_storage::{InMemorySkillCatalog, SkillCatalog};
+pub use assistant_tool_executor::{RecordedToolCall, StubToolDispatcher};
 
 pub use crate::fixture::{Fixture, FixtureBuilder};

--- a/crates/tool-executor/src/executor.rs
+++ b/crates/tool-executor/src/executor.rs
@@ -246,6 +246,30 @@ impl ToolExecutor {
     }
 }
 
+#[async_trait::async_trait]
+impl assistant_core::tool::ToolDispatcher for ToolExecutor {
+    fn to_specs(&self) -> Vec<ToolSpec> {
+        ToolExecutor::to_specs(self)
+    }
+
+    async fn execute(
+        &self,
+        name: &str,
+        params: std::collections::HashMap<String, serde_json::Value>,
+        ctx: &assistant_core::types::conversation::ExecutionContext,
+    ) -> anyhow::Result<ToolOutput> {
+        ToolExecutor::execute(self, name, params, ctx).await
+    }
+
+    fn is_mutating(&self, name: &str) -> bool {
+        let handlers = self
+            .tool_handlers
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        handlers.get(name).map(|h| h.is_mutating()).unwrap_or(false)
+    }
+}
+
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
 /// Validate `params` against the JSON Schema declared by `schema_json`.

--- a/crates/tool-executor/src/lib.rs
+++ b/crates/tool-executor/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod builtins;
 pub mod executor;
 pub mod installer;
+pub mod stub;
 
 pub use executor::ToolExecutor;
 pub use installer::install_skill_from_source;
+pub use stub::{RecordedToolCall, StubToolDispatcher};

--- a/crates/tool-executor/src/stub.rs
+++ b/crates/tool-executor/src/stub.rs
@@ -1,0 +1,195 @@
+//! `StubToolDispatcher` — minimal in-memory [`ToolDispatcher`] for tests.
+//!
+//! Records every call and either replays canned [`ToolOutput`] responses
+//! or returns a benign success. Use this in tests for orchestrator code
+//! that doesn't need a real tool registry.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use anyhow::Result;
+use assistant_core::ToolSpec;
+use assistant_core::tool::{ToolDispatcher, ToolOutput};
+use assistant_core::types::conversation::ExecutionContext;
+#[cfg(test)]
+use assistant_core::types::conversation::Interface;
+use async_trait::async_trait;
+use serde_json::Value;
+
+/// A single recorded `execute` call.
+#[derive(Debug, Clone)]
+pub struct RecordedToolCall {
+    pub name: String,
+    pub params: HashMap<String, Value>,
+}
+
+#[derive(Default)]
+struct StubState {
+    specs: Vec<ToolSpec>,
+    /// Queued responses, keyed by tool name. When a tool is invoked and a
+    /// response exists for it, the first queued one is consumed (FIFO).
+    /// When none queued, returns benign success.
+    responses: HashMap<String, Vec<ToolOutput>>,
+    recorded: Vec<RecordedToolCall>,
+    mutating_names: std::collections::HashSet<String>,
+}
+
+/// Minimal [`ToolDispatcher`] for tests.
+pub struct StubToolDispatcher {
+    state: Arc<Mutex<StubState>>,
+}
+
+impl StubToolDispatcher {
+    pub fn new() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(StubState::default())),
+        }
+    }
+
+    /// Replace the tool specs returned by [`to_specs`](Self::to_specs).
+    pub fn with_specs(self, specs: Vec<ToolSpec>) -> Self {
+        if let Ok(mut s) = self.state.lock() {
+            s.specs = specs;
+        }
+        self
+    }
+
+    /// Queue a response for the named tool. Subsequent `execute(name, ...)`
+    /// calls consume queued responses in FIFO order.
+    pub fn queue_response(self, name: impl Into<String>, output: ToolOutput) -> Self {
+        if let Ok(mut s) = self.state.lock() {
+            s.responses.entry(name.into()).or_default().push(output);
+        }
+        self
+    }
+
+    /// Mark a tool name as mutating for [`is_mutating`](Self::is_mutating).
+    pub fn mark_mutating(self, name: impl Into<String>) -> Self {
+        if let Ok(mut s) = self.state.lock() {
+            s.mutating_names.insert(name.into());
+        }
+        self
+    }
+
+    /// Snapshot of every recorded `execute` call.
+    pub fn recorded_calls(&self) -> Vec<RecordedToolCall> {
+        match self.state.lock() {
+            Ok(g) => g.recorded.clone(),
+            Err(p) => p.into_inner().recorded.clone(),
+        }
+    }
+}
+
+impl Default for StubToolDispatcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ToolDispatcher for StubToolDispatcher {
+    fn to_specs(&self) -> Vec<ToolSpec> {
+        match self.state.lock() {
+            Ok(g) => g.specs.clone(),
+            Err(p) => p.into_inner().specs.clone(),
+        }
+    }
+
+    async fn execute(
+        &self,
+        name: &str,
+        params: HashMap<String, Value>,
+        _ctx: &ExecutionContext,
+    ) -> Result<ToolOutput> {
+        let mut state = match self.state.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        state.recorded.push(RecordedToolCall {
+            name: name.to_string(),
+            params,
+        });
+        if let Some(queue) = state.responses.get_mut(name)
+            && !queue.is_empty()
+        {
+            return Ok(queue.remove(0));
+        }
+        Ok(ToolOutput::success(format!("(stub: {name})")))
+    }
+
+    fn is_mutating(&self, name: &str) -> bool {
+        match self.state.lock() {
+            Ok(g) => g.mutating_names.contains(name),
+            Err(p) => p.into_inner().mutating_names.contains(name),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx() -> ExecutionContext {
+        ExecutionContext {
+            conversation_id: uuid::Uuid::new_v4(),
+            agent_id: "default".into(),
+            turn: 0,
+            interface: Interface::Cli,
+            interactive: false,
+            allowed_tools: None,
+            depth: 0,
+            user_id: None,
+            org_id: None,
+            space_id: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_records_calls() {
+        let stub = StubToolDispatcher::new();
+        let _ = stub.execute("foo", HashMap::new(), &ctx()).await.unwrap();
+        let _ = stub.execute("bar", HashMap::new(), &ctx()).await.unwrap();
+        let calls = stub.recorded_calls();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].name, "foo");
+        assert_eq!(calls[1].name, "bar");
+    }
+
+    #[tokio::test]
+    async fn execute_consumes_queued_response() {
+        let stub = StubToolDispatcher::new()
+            .queue_response("foo", ToolOutput::success("first"))
+            .queue_response("foo", ToolOutput::error("oops"));
+        let r1 = stub.execute("foo", HashMap::new(), &ctx()).await.unwrap();
+        let r2 = stub.execute("foo", HashMap::new(), &ctx()).await.unwrap();
+        let r3 = stub.execute("foo", HashMap::new(), &ctx()).await.unwrap();
+        assert_eq!(r1.content, "first");
+        assert!(r1.success);
+        assert_eq!(r2.content, "oops");
+        assert!(!r2.success);
+        // Empty queue falls back to benign success.
+        assert!(r3.content.contains("stub"));
+        assert!(r3.success);
+    }
+
+    #[tokio::test]
+    async fn is_mutating_uses_marker() {
+        let stub = StubToolDispatcher::new().mark_mutating("write");
+        assert!(stub.is_mutating("write"));
+        assert!(!stub.is_mutating("read"));
+    }
+
+    #[test]
+    fn to_specs_returns_configured_list() {
+        let stub = StubToolDispatcher::new().with_specs(vec![ToolSpec {
+            name: "echo".into(),
+            description: "stub".into(),
+            params_schema: serde_json::json!({}),
+            is_mutating: false,
+            requires_confirmation: false,
+        }]);
+        let specs = stub.to_specs();
+        assert_eq!(specs.len(), 1);
+        assert_eq!(specs[0].name, "echo");
+    }
+}

--- a/openspec/changes/workspace-test-coverage-floor/tasks.md
+++ b/openspec/changes/workspace-test-coverage-floor/tasks.md
@@ -132,21 +132,21 @@ Each store: failing test → trait in `assistant-core` → `Sqlite*` impl + `InM
 
 ## 6. Phase 6 — Persistence trait extraction (Wave B: lower-traffic stores)
 
-One sub-phase per store; same `failing test → trait + impls → consumer migration → commit` pattern. Smaller PRs since each store is less central.
+All Wave B stores were extracted as part of Phase 5 PRs (the wave A / wave B split was nominal — same mechanical work). The merged PRs are listed alongside each store below.
 
-- [ ] 6.A `CommandEventStore` (consumed by interface adapters)
-- [ ] 6.B `MetricsStore`
-- [ ] 6.C `AgentStore`
-- [ ] 6.D `MemoryChunkStore` (FTS-specific scenarios annotated EXEMPT in contract test)
-- [ ] 6.E `PersonaStore`
-- [ ] 6.F `PersonaSkillAccess`
-- [ ] 6.G `PushSubscriptionStore`
-- [ ] 6.H `RefinementStore`
-- [ ] 6.I `ScheduledTasksStore`
-- [ ] 6.J `SlackThreadStore`
-- [ ] 6.K `WebhookStore`
-- [ ] 6.L `WorkflowStore`
-- [ ] 6.M `SkillRegistry` read-side (`SkillCatalog` trait — overlaps with Phase 7)
+- [x] 6.A `CommandEventStore` (consumed by interface adapters) — #852
+- [x] 6.B `MetricsStore` — #862
+- [x] 6.C `AgentStore` — #858
+- [x] 6.D `MemoryChunkStore` (InMemory FTS uses substring-scan; real BM25 rank only in SQLite) — #868
+- [x] 6.E `PersonaStore` — #866
+- [x] 6.F `PersonaSkillAccess` — #869
+- [x] 6.G `PushSubscriptionStore` — #851
+- [x] 6.H `RefinementStore` — #863
+- [x] 6.I `ScheduledTasksStore` — #859
+- [x] 6.J `SlackThreadStore` — #854
+- [x] 6.K `WebhookStore` — #855
+- [x] 6.L `WorkflowStore` — #867
+- [ ] 6.M `SkillRegistry` read-side (`SkillCatalog` trait) — deferred to Phase 7 where it overlaps with orchestration facades
 
 ## 7. Phase 7 — Orchestration trait facades
 


### PR DESCRIPTION
First two of three Phase 7 trait facades. ToolDispatcher + StubToolDispatcher + SkillCatalog + InMemorySkillCatalog. OrchestrationEngine + mcp-server migration next.