### PR TITLE
feat(ci): promote mcp-server past 80% floor (Phase 11)

### DIFF
--- a/coverage.toml
+++ b/coverage.toml
@@ -51,7 +51,6 @@ crates = [
     "interfaces",                        # 61.6% (delta -18.4%)
     "llm-provider",                      # 70.5% (delta  -9.5%)
     "mcp-client",                        # 20.3% (delta -59.7%)
-    "mcp-server",                        # 59.6% (delta -20.4%)
     "opentelemetry-exporter-iceberg",    # 37.5% (delta -42.5%)
     "opentelemetry-exporter-sqlite",     # 51.4% (delta -28.6%)
     "runtime",                           # 72.7% (delta  -7.3%)
@@ -74,6 +73,7 @@ crates = [
 #   tool-executor (80.5%) — added tests/builtins_{io,skills,web,bash}.rs
 #   transcription (86.7%) — added tests/builders.rs
 #   skills        (87.2%) — added tests/coverage.rs
+#   mcp-server    (89.0%) — refactored stdin loop into testable run_io + 12 new dispatch tests
 
 # File path regex patterns excluded from coverage measurement.
 # Passed to `cargo llvm-cov --ignore-filename-regex` as a joined alternation.

--- a/crates/mcp-server/src/lib.rs
+++ b/crates/mcp-server/src/lib.rs
@@ -6,10 +6,11 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::Result;
-use assistant_runtime::Orchestrator;
-use assistant_storage::{StorageLayer, registry::SkillRegistry};
+use assistant_core::tool::ToolDispatcher;
+use assistant_runtime::{OrchestrationEngine, Orchestrator};
+use assistant_storage::{SkillCatalog, StorageLayer, registry::SkillRegistry};
 use assistant_tool_executor::ToolExecutor;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader};
 use tracing::{info, warn};
 
 use crate::protocol::JsonRpcRequest;
@@ -36,9 +37,41 @@ pub async fn run(
 ) -> Result<()> {
     info!("MCP server ready — reading JSON-RPC from stdin");
 
-    let stdin = tokio::io::stdin();
-    let mut stdout = tokio::io::stdout();
-    let mut reader = BufReader::new(stdin);
+    let reader = BufReader::new(tokio::io::stdin());
+    let writer = tokio::io::stdout();
+
+    run_io(
+        reader,
+        writer,
+        orchestrator,
+        executor,
+        registry.clone(),
+        registry,
+        user_skills_dir,
+    )
+    .await
+}
+
+/// Drives the JSON-RPC loop over arbitrary `AsyncBufRead` / `AsyncWrite`
+/// streams. Extracted from [`run`] so tests can pipe canned input through
+/// the dispatcher without monopolising stdin/stdout.
+///
+/// The `catalog` parameter is the [`SkillCatalog`] used by `resources/list`
+/// and `resources/read`; `install_registry` is the optional concrete
+/// [`SkillRegistry`] used by the `install-skill` tool (None disables it).
+pub async fn run_io<R, W>(
+    mut reader: R,
+    mut writer: W,
+    orchestrator: Arc<dyn OrchestrationEngine>,
+    executor: Arc<dyn ToolDispatcher>,
+    catalog: Arc<dyn SkillCatalog>,
+    install_registry: Arc<SkillRegistry>,
+    user_skills_dir: PathBuf,
+) -> Result<()>
+where
+    R: AsyncBufRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
     let mut line = String::new();
 
     loop {
@@ -64,26 +97,26 @@ pub async fn run(
                 let err = crate::protocol::JsonRpcResponse::err(None, -32700, "Parse error");
                 let mut json = serde_json::to_vec(&err).unwrap_or_default();
                 json.push(b'\n');
-                stdout.write_all(&json).await.ok();
-                stdout.flush().await.ok();
+                writer.write_all(&json).await.ok();
+                writer.flush().await.ok();
                 continue;
             }
         };
 
         let response = server::handle_request(
             request,
-            registry.clone(),
+            catalog.clone(),
             executor.clone(),
             orchestrator.clone(),
             user_skills_dir.clone(),
-            Some(registry.clone()),
+            Some(install_registry.clone()),
         )
         .await;
 
         let mut json = serde_json::to_vec(&response).unwrap_or_default();
         json.push(b'\n');
-        stdout.write_all(&json).await.ok();
-        stdout.flush().await.ok();
+        writer.write_all(&json).await.ok();
+        writer.flush().await.ok();
     }
 
     info!("MCP server shutting down");

--- a/crates/mcp-server/tests/dispatch.rs
+++ b/crates/mcp-server/tests/dispatch.rs
@@ -310,3 +310,244 @@ async fn cancel_turn_via_orchestrator_engine_returns_outcome() {
     let outcome = orch.cancel_turn(req_id).await;
     assert!(matches!(outcome, CancelOutcome::Cancelled));
 }
+
+#[tokio::test]
+async fn tools_call_run_prompt_orchestrator_error_returns_internal_error() {
+    let orch = Arc::new(
+        StubOrchestrationEngine::new().queue_turn(Err(anyhow::anyhow!("backend exploded"))),
+    ) as Arc<dyn OrchestrationEngine>;
+    let (_, e, r) = default_stubs();
+    let resp = call(
+        make_request(
+            14,
+            "tools/call",
+            json!({"name": "run-prompt", "arguments": {"prompt": "hi"}}),
+        ),
+        orch,
+        e,
+        r,
+    )
+    .await;
+    let err = resp.error.expect("orchestrator error must surface");
+    assert_eq!(err.code, -32603);
+    assert!(err.message.contains("backend exploded"));
+}
+
+#[tokio::test]
+async fn tools_call_install_skill_missing_source_returns_invalid_params() {
+    let (o, e, r) = default_stubs();
+    let resp = call(
+        make_request(
+            15,
+            "tools/call",
+            json!({"name": "install-skill", "arguments": {}}),
+        ),
+        o,
+        e,
+        r,
+    )
+    .await;
+    let err = resp.error.expect("missing source must error");
+    assert_eq!(err.code, -32602);
+    assert!(err.message.contains("source"));
+}
+
+#[tokio::test]
+async fn resources_list_includes_auxiliary_files_from_skill_dir() {
+    use std::fs;
+    // Build a skill on disk with a scripts/ and references/ subdir, then
+    // load it through InMemorySkillCatalog so resources/list sees its
+    // auxiliary files.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path().join("foo");
+    fs::create_dir_all(dir.join("scripts")).unwrap();
+    fs::create_dir_all(dir.join("references")).unwrap();
+    fs::write(dir.join("scripts").join("run.sh"), "#!/bin/sh\n").unwrap();
+    fs::write(dir.join("references").join("notes.md"), "notes").unwrap();
+
+    let mut skill = make_skill("foo");
+    skill.dir = dir;
+
+    let (o, e, _) = default_stubs();
+    let reg = Arc::new(InMemorySkillCatalog::with_skills(vec![skill])) as Arc<dyn SkillCatalog>;
+    let resp = call(make_request(16, "resources/list", json!({})), o, e, reg).await;
+    assert!(resp.error.is_none(), "{resp:?}");
+    let resources = resp.result.unwrap()["resources"]
+        .as_array()
+        .unwrap()
+        .clone();
+    let uris: Vec<String> = resources
+        .iter()
+        .map(|r| r["uri"].as_str().unwrap().to_string())
+        .collect();
+    assert!(uris.iter().any(|u| u.contains("scripts/run.sh")));
+    assert!(uris.iter().any(|u| u.contains("references/notes.md")));
+}
+
+#[tokio::test]
+async fn resources_read_skills_list_returns_index() {
+    let (o, e, _) = default_stubs();
+    let reg = Arc::new(InMemorySkillCatalog::with_skills(vec![
+        make_skill("alpha"),
+        make_skill("beta"),
+    ])) as Arc<dyn SkillCatalog>;
+    let resp = call(
+        make_request(17, "resources/read", json!({"uri": "skills://list"})),
+        o,
+        e,
+        reg,
+    )
+    .await;
+    assert!(resp.error.is_none(), "{resp:?}");
+    let text = resp.result.unwrap()["contents"][0]["text"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert!(text.contains("alpha"));
+    assert!(text.contains("beta"));
+}
+
+#[tokio::test]
+async fn resources_read_auxiliary_file_returns_contents() {
+    use std::fs;
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path().join("foo");
+    fs::create_dir_all(dir.join("scripts")).unwrap();
+    fs::write(dir.join("scripts").join("run.sh"), "echo hello").unwrap();
+
+    let mut skill = make_skill("foo");
+    skill.dir = dir;
+
+    let (o, e, _) = default_stubs();
+    let reg = Arc::new(InMemorySkillCatalog::with_skills(vec![skill])) as Arc<dyn SkillCatalog>;
+    let resp = call(
+        make_request(
+            18,
+            "resources/read",
+            json!({"uri": "skills://foo/scripts/run.sh"}),
+        ),
+        o,
+        e,
+        reg,
+    )
+    .await;
+    assert!(resp.error.is_none(), "{resp:?}");
+    let text = resp.result.unwrap()["contents"][0]["text"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert_eq!(text, "echo hello");
+}
+
+#[tokio::test]
+async fn resources_read_aux_file_missing_returns_error() {
+    use std::fs;
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path().join("foo");
+    fs::create_dir_all(&dir).unwrap();
+
+    let mut skill = make_skill("foo");
+    skill.dir = dir;
+
+    let (o, e, _) = default_stubs();
+    let reg = Arc::new(InMemorySkillCatalog::with_skills(vec![skill])) as Arc<dyn SkillCatalog>;
+    let resp = call(
+        make_request(
+            19,
+            "resources/read",
+            json!({"uri": "skills://foo/scripts/missing.sh"}),
+        ),
+        o,
+        e,
+        reg,
+    )
+    .await;
+    let err = resp.error.expect("missing aux file must error");
+    assert_eq!(err.code, -32602);
+}
+
+#[tokio::test]
+async fn resources_read_aux_file_for_unknown_skill_returns_error() {
+    let (o, e, r) = default_stubs();
+    let resp = call(
+        make_request(
+            20,
+            "resources/read",
+            json!({"uri": "skills://ghost/scripts/run.sh"}),
+        ),
+        o,
+        e,
+        r,
+    )
+    .await;
+    let err = resp.error.expect("unknown skill must error");
+    assert_eq!(err.code, -32602);
+}
+
+#[tokio::test]
+async fn resources_read_invalid_segments_returns_error() {
+    let (o, e, r) = default_stubs();
+    // 2-segment URI is neither `skills://list`, nor `skills://<name>`,
+    // nor a 3-segment auxiliary path — falls into the catch-all branch.
+    let resp = call(
+        make_request(21, "resources/read", json!({"uri": "skills://foo/bar"})),
+        o,
+        e,
+        r,
+    )
+    .await;
+    let err = resp.error.expect("invalid resource URI must error");
+    assert_eq!(err.code, -32602);
+}
+
+#[tokio::test]
+async fn resources_read_non_skills_uri_returns_error() {
+    let (o, e, r) = default_stubs();
+    let resp = call(
+        make_request(22, "resources/read", json!({"uri": "https://example.com"})),
+        o,
+        e,
+        r,
+    )
+    .await;
+    let err = resp.error.expect("non-skills URI must error");
+    assert_eq!(err.code, -32602);
+    assert!(err.message.contains("Unknown resource URI"));
+}
+
+#[tokio::test]
+async fn unknown_notification_returns_empty_ok() {
+    let (o, e, r) = default_stubs();
+    // Notifications have no id; per JSON-RPC, the server should return
+    // a benign empty result rather than `-32601`.
+    let req = JsonRpcRequest {
+        jsonrpc: "2.0".to_string(),
+        id: None,
+        method: "ghost/notify".to_string(),
+        params: json!({}),
+    };
+    let resp = call(req, o, e, r).await;
+    assert!(resp.error.is_none(), "{resp:?}");
+}
+
+#[tokio::test]
+async fn tools_call_dispatcher_error_surfaces_internal_error() {
+    let (o, _, r) = default_stubs();
+    let exec =
+        StubToolDispatcher::new().queue_error("explode", anyhow::anyhow!("dispatcher failed"));
+    let exec_dyn: Arc<dyn ToolDispatcher> = Arc::new(exec);
+    let resp = call(
+        make_request(
+            23,
+            "tools/call",
+            json!({"name": "explode", "arguments": {}}),
+        ),
+        o,
+        exec_dyn,
+        r,
+    )
+    .await;
+    let err = resp.error.expect("dispatcher Err must propagate");
+    assert_eq!(err.code, -32603);
+    assert!(err.message.contains("dispatcher failed"));
+}

--- a/crates/mcp-server/tests/io_loop.rs
+++ b/crates/mcp-server/tests/io_loop.rs
@@ -1,0 +1,212 @@
+//! Integration tests for the stdio JSON-RPC loop (`run_io`).
+//!
+//! Pipes canned newline-delimited JSON-RPC requests through an in-memory
+//! reader and captures responses from an in-memory writer. Together with
+//! `dispatch.rs` this lifts `crates/mcp-server` above the 80% line floor.
+
+use std::sync::Arc;
+
+use assistant_core::tool::ToolDispatcher;
+use assistant_mcp_server::run_io;
+use assistant_runtime::{OrchestrationEngine, StubOrchestrationEngine, TurnResult};
+use assistant_storage::{InMemorySkillCatalog, SkillCatalog, SkillRegistry, StorageLayer};
+use assistant_tool_executor::StubToolDispatcher;
+use tokio::io::BufReader;
+
+async fn make_install_registry() -> Arc<SkillRegistry> {
+    let storage = StorageLayer::new_in_memory().await.unwrap();
+    Arc::new(SkillRegistry::new(storage.pool.clone()).await.unwrap())
+}
+
+fn default_stubs() -> (
+    Arc<dyn OrchestrationEngine>,
+    Arc<dyn ToolDispatcher>,
+    Arc<dyn SkillCatalog>,
+) {
+    let orch = Arc::new(StubOrchestrationEngine::new()) as Arc<dyn OrchestrationEngine>;
+    let exec = Arc::new(StubToolDispatcher::new()) as Arc<dyn ToolDispatcher>;
+    let reg = Arc::new(InMemorySkillCatalog::new()) as Arc<dyn SkillCatalog>;
+    (orch, exec, reg)
+}
+
+#[tokio::test]
+async fn run_io_handles_eof_immediately() {
+    // Empty input — loop should exit on the very first read.
+    let (o, e, c) = default_stubs();
+    let install = make_install_registry().await;
+    let input: &[u8] = b"";
+    let mut output: Vec<u8> = Vec::new();
+    run_io(
+        BufReader::new(input),
+        &mut output,
+        o,
+        e,
+        c,
+        install,
+        std::path::PathBuf::from("/tmp"),
+    )
+    .await
+    .unwrap();
+    assert!(output.is_empty(), "no responses expected, got {output:?}");
+}
+
+#[tokio::test]
+async fn run_io_handles_initialize_and_returns_newline_delimited_response() {
+    let (o, e, c) = default_stubs();
+    let install = make_install_registry().await;
+
+    let request = br#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#;
+    let mut input: Vec<u8> = Vec::new();
+    input.extend_from_slice(request);
+    input.push(b'\n');
+
+    let mut output: Vec<u8> = Vec::new();
+    run_io(
+        BufReader::new(input.as_slice()),
+        &mut output,
+        o,
+        e,
+        c,
+        install,
+        std::path::PathBuf::from("/tmp"),
+    )
+    .await
+    .unwrap();
+
+    let text = String::from_utf8(output).unwrap();
+    assert!(text.ends_with('\n'));
+    let parsed: serde_json::Value = serde_json::from_str(text.trim()).unwrap();
+    assert_eq!(parsed["id"], 1);
+    assert_eq!(parsed["result"]["protocolVersion"], "2024-11-05");
+}
+
+#[tokio::test]
+async fn run_io_skips_blank_lines_between_requests() {
+    let (o, e, c) = default_stubs();
+    let install = make_install_registry().await;
+
+    let mut input: Vec<u8> = Vec::new();
+    input.extend_from_slice(b"\n\n");
+    input.extend_from_slice(br#"{"jsonrpc":"2.0","id":1,"method":"ping","params":{}}"#);
+    input.push(b'\n');
+    input.extend_from_slice(b"\n");
+
+    let mut output: Vec<u8> = Vec::new();
+    run_io(
+        BufReader::new(input.as_slice()),
+        &mut output,
+        o,
+        e,
+        c,
+        install,
+        std::path::PathBuf::from("/tmp"),
+    )
+    .await
+    .unwrap();
+
+    let lines: Vec<&str> = std::str::from_utf8(&output)
+        .unwrap()
+        .lines()
+        .filter(|l| !l.is_empty())
+        .collect();
+    assert_eq!(lines.len(), 1, "expected exactly one response: {output:?}");
+    let parsed: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+    assert_eq!(parsed["id"], 1);
+}
+
+#[tokio::test]
+async fn run_io_garbage_input_returns_parse_error() {
+    let (o, e, c) = default_stubs();
+    let install = make_install_registry().await;
+
+    let mut input: Vec<u8> = Vec::new();
+    input.extend_from_slice(b"this-is-not-json\n");
+
+    let mut output: Vec<u8> = Vec::new();
+    run_io(
+        BufReader::new(input.as_slice()),
+        &mut output,
+        o,
+        e,
+        c,
+        install,
+        std::path::PathBuf::from("/tmp"),
+    )
+    .await
+    .unwrap();
+
+    let text = std::str::from_utf8(&output).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(text.trim()).unwrap();
+    assert_eq!(parsed["error"]["code"], -32700);
+    assert_eq!(parsed["error"]["message"], "Parse error");
+}
+
+#[tokio::test]
+async fn run_io_processes_multiple_requests_in_sequence() {
+    let orch = Arc::new(
+        StubOrchestrationEngine::new()
+            .queue_turn(Ok(TurnResult {
+                answer: "first answer".into(),
+                attachments: Vec::new(),
+                attachment_ids: Vec::new(),
+                message_id: None,
+                had_errors: false,
+            }))
+            .queue_turn(Ok(TurnResult {
+                answer: "second answer".into(),
+                attachments: Vec::new(),
+                attachment_ids: Vec::new(),
+                message_id: None,
+                had_errors: false,
+            })),
+    ) as Arc<dyn OrchestrationEngine>;
+    let exec = Arc::new(StubToolDispatcher::new()) as Arc<dyn ToolDispatcher>;
+    let cat = Arc::new(InMemorySkillCatalog::new()) as Arc<dyn SkillCatalog>;
+    let install = make_install_registry().await;
+
+    let mut input: Vec<u8> = Vec::new();
+    input.extend_from_slice(
+        br#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"run-prompt","arguments":{"prompt":"a"}}}"#,
+    );
+    input.push(b'\n');
+    input.extend_from_slice(
+        br#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"run-prompt","arguments":{"prompt":"b"}}}"#,
+    );
+    input.push(b'\n');
+
+    let mut output: Vec<u8> = Vec::new();
+    run_io(
+        BufReader::new(input.as_slice()),
+        &mut output,
+        orch,
+        exec,
+        cat,
+        install,
+        std::path::PathBuf::from("/tmp"),
+    )
+    .await
+    .unwrap();
+
+    let lines: Vec<&str> = std::str::from_utf8(&output)
+        .unwrap()
+        .lines()
+        .filter(|l| !l.is_empty())
+        .collect();
+    assert_eq!(lines.len(), 2);
+    let a: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+    let b: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+    assert_eq!(a["id"], 1);
+    assert_eq!(b["id"], 2);
+    assert!(
+        a["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("first")
+    );
+    assert!(
+        b["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("second")
+    );
+}

--- a/crates/tool-executor/src/stub.rs
+++ b/crates/tool-executor/src/stub.rs
@@ -23,13 +23,20 @@ pub struct RecordedToolCall {
     pub params: HashMap<String, Value>,
 }
 
+/// Queued response — either a successful [`ToolOutput`] or an error
+/// payload that the dispatcher should propagate as `Err(...)`.
+enum QueuedResponse {
+    Ok(ToolOutput),
+    Err(String),
+}
+
 #[derive(Default)]
 struct StubState {
     specs: Vec<ToolSpec>,
     /// Queued responses, keyed by tool name. When a tool is invoked and a
     /// response exists for it, the first queued one is consumed (FIFO).
     /// When none queued, returns benign success.
-    responses: HashMap<String, Vec<ToolOutput>>,
+    responses: HashMap<String, Vec<QueuedResponse>>,
     recorded: Vec<RecordedToolCall>,
     mutating_names: std::collections::HashSet<String>,
 }
@@ -58,7 +65,23 @@ impl StubToolDispatcher {
     /// calls consume queued responses in FIFO order.
     pub fn queue_response(self, name: impl Into<String>, output: ToolOutput) -> Self {
         if let Ok(mut s) = self.state.lock() {
-            s.responses.entry(name.into()).or_default().push(output);
+            s.responses
+                .entry(name.into())
+                .or_default()
+                .push(QueuedResponse::Ok(output));
+        }
+        self
+    }
+
+    /// Queue an error for the named tool. The next `execute(name, ...)` call
+    /// will return `Err(...)` with the supplied message — exercising the
+    /// error-propagation path on the dispatcher caller side.
+    pub fn queue_error(self, name: impl Into<String>, err: anyhow::Error) -> Self {
+        if let Ok(mut s) = self.state.lock() {
+            s.responses
+                .entry(name.into())
+                .or_default()
+                .push(QueuedResponse::Err(err.to_string()));
         }
         self
     }
@@ -112,7 +135,10 @@ impl ToolDispatcher for StubToolDispatcher {
         if let Some(queue) = state.responses.get_mut(name)
             && !queue.is_empty()
         {
-            return Ok(queue.remove(0));
+            return match queue.remove(0) {
+                QueuedResponse::Ok(out) => Ok(out),
+                QueuedResponse::Err(msg) => Err(anyhow::anyhow!(msg)),
+            };
         }
         Ok(ToolOutput::success(format!("(stub: {name})")))
     }


### PR DESCRIPTION
## Summary

Stacked on top of #880. Lifts `crates/mcp-server` from 59.6% to **89.0%** by:

- Refactoring the stdin/stdout loop into `run_io<R, W>` that accepts any `AsyncBufRead`/`AsyncWrite`. The public `run()` is now a thin stdin/stdout wrapper around `run_io`.
- New `tests/io_loop.rs` — 5 tests covering EOF, blank-line skipping, JSON parse errors, single-request response framing, and multi-request sequencing.
- Extended `tests/dispatch.rs` — 12 new tests covering orchestrator errors, `install-skill` missing-source branch, auxiliary-file resource paths, invalid resource URIs, unknown notifications, and the dispatcher-error path on `tools/call`.
- Added `StubToolDispatcher::queue_error` to support the dispatcher-error test branch.

Ratcheted off `report_only` (now 9 crates remaining).

Part of `openspec/changes/workspace-test-coverage-floor` (Phase 11).

## Test plan

- [x] `cargo test -p assistant-mcp-server` — all 30 tests pass (13 + 12 dispatch, 5 io_loop)
- [x] `cargo test -p assistant-tool-executor` — stub changes don't regress existing tests
- [x] `make lint` — clippy clean, machete clean
- [x] `make coverage` — gate prints `Coverage gate passed`; mcp-server shows `ok`