### PR TITLE
fix(app): suppress onReorder deprecation lint for Flutter 3.44

### DIFF
--- a/app/lib/features/workflows/workflow_editor_screen.dart
+++ b/app/lib/features/workflows/workflow_editor_screen.dart
@@ -1258,13 +1258,13 @@ class _MobileWorkflowEditor extends StatelessWidget {
           child: ReorderableListView.builder(
             padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
             itemCount: nodes.length,
-            // ignore: deprecated_member_use
             // Flutter 3.44 deprecated `onReorder` in favour of
-            // `onReorderItem` (which adjusts `newIndex` automatically). We
-            // continue to support both 3.41 (no `onReorderItem`) and 3.44+
-            // by keeping the manual index adjustment behind the deprecation
-            // ignore. Migrate to `onReorderItem` once the minimum Flutter
-            // version is bumped to >= 3.42.
+            // `onReorderItem` (which adjusts `newIndex` automatically). The
+            // new callback isn't available in Flutter 3.41, so we keep the
+            // manual `newIndex--` adjustment behind a deprecation ignore.
+            // Migrate to `onReorderItem` once the minimum Flutter version
+            // is bumped to >= 3.42.
+            // ignore: deprecated_member_use
             onReorder: (oldIndex, newIndex) {
               if (newIndex > oldIndex) newIndex--;
               final updated = List<EditorNode>.from(nodes);

--- a/app/lib/features/workflows/workflow_editor_screen.dart
+++ b/app/lib/features/workflows/workflow_editor_screen.dart
@@ -1258,6 +1258,13 @@ class _MobileWorkflowEditor extends StatelessWidget {
           child: ReorderableListView.builder(
             padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
             itemCount: nodes.length,
+            // ignore: deprecated_member_use
+            // Flutter 3.44 deprecated `onReorder` in favour of
+            // `onReorderItem` (which adjusts `newIndex` automatically). We
+            // continue to support both 3.41 (no `onReorderItem`) and 3.44+
+            // by keeping the manual index adjustment behind the deprecation
+            // ignore. Migrate to `onReorderItem` once the minimum Flutter
+            // version is bumped to >= 3.42.
             onReorder: (oldIndex, newIndex) {
               if (newIndex > oldIndex) newIndex--;
               final updated = List<EditorNode>.from(nodes);

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -1365,10 +1365,10 @@ packages:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: f8a08a13fb8f0f8c590df89d745000bed44a673ed94bac846739e1a016875c21
+      sha256: "1581ffbf7a0e333b380d6a30737d78516b826cb35beb7fb0bf8a3ea0c678b465"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.7"
+    version: "2.5.8"
   sqflite_darwin:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary

Flutter 3.44 (the version `flutter-version: 3.x` in `.github/workflows/flutter.yml` currently resolves to) deprecated `ReorderableListView.builder.onReorder` in favour of `onReorderItem`. With `flutter analyze --fatal-infos` this surfaces as a build failure, blocking PR #879 and any future PR touching `app/**`.

The replacement callback (`onReorderItem`) is not available in Flutter 3.41, which is still the version most local installs ship. So this PR keeps the manual `newIndex--` adjustment behind a single `// ignore: deprecated_member_use` directive — unblocks CI without forcing every contributor to upgrade Flutter.

The proper migration is a follow-up that bumps the minimum Flutter version to ≥ 3.42 and switches to `onReorderItem`. Tracked inline.

Also bumps `sqflite_common` 2.5.7 → 2.5.8 to satisfy `dart_pre_commit` (the pre-commit hook now requires that constraint to resolve).

## Test plan

- [x] `cd app && flutter analyze --fatal-infos` — clean ("No issues found!")
- [x] `flutter test` — all 1010 tests pass
- [x] Pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deprecation handling comments in the mobile editor to maintain compatibility across Flutter versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cedricziel/assistant/pull/884?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->