### PR TITLE
feat(ci): promote web-ui past 80% floor (Phase 11)

### DIFF
--- a/coverage.toml
+++ b/coverage.toml
@@ -52,7 +52,6 @@ crates = [
     "mcp-client",                        # 20.3% (delta -59.7%)
     "opentelemetry-exporter-iceberg",    # 37.5% (delta -42.5%)
     "opentelemetry-exporter-sqlite",     # 51.4% (delta -28.6%)
-    "web-ui",                            # 73.3% (delta  -6.7%)
 ]
 
 # Crates promoted off `report_only` and now ENFORCING the 80% floor.
@@ -74,6 +73,7 @@ crates = [
 #   mcp-server    (89.0%) — refactored stdin loop into testable run_io + 12 new dispatch tests
 #   llm-provider  (80.3%) — pure-function tests across anthropic, openai/oauth, chat_completions, ollama
 #   runtime       (80.3%) — bootstrap, memory_indexer, scheduler/loop+prune, compaction chunked path, dispatch helpers, title_generator helpers, skill_learner format_history_for_judge, interface_trait default impls
+#   web-ui        (80.1%) — a2a handlers + routers, push.rs crypto (encrypt_payload, build_vapid_jwt, signing_key), oauth session_cookie + escape_html_attr, iceberg pure helpers (warehouse_path, bucket_key, collect_parquet_files), api/webhooks toggle/rotate/update, api/conversations PATCH/DELETE edge cases, api/skills get/update/delete edge cases, auth.rs login_html + parse_host_from_url + extract_cookie edge cases, lib.rs harden_agent_card + nats_reachable + resolve_base_url, api/mod.rs internal_error + empty_string_as_none
 
 # File path regex patterns excluded from coverage measurement.
 # Passed to `cargo llvm-cov --ignore-filename-regex` as a joined alternation.

--- a/crates/web-ui/src/a2a/handlers_tests.rs
+++ b/crates/web-ui/src/a2a/handlers_tests.rs
@@ -1,0 +1,374 @@
+//! Coverage for the A2A HTTP handlers using direct `oneshot` calls
+//! against the built router.
+
+#![cfg(test)]
+
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode};
+use axum::routing::{delete, get, post};
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+
+use super::handlers::{
+    A2AState, build_default_agent_card, cancel_task, create_push_notification_config,
+    delete_push_notification_config, get_agent_card_well_known, get_extended_agent_card,
+    get_push_notification_config, get_task, list_push_notification_configs, list_tasks,
+    send_message,
+};
+use super::task_store::TaskStore;
+
+fn make_state(base_url: &str) -> A2AState {
+    A2AState {
+        task_store: TaskStore::new(),
+        agent_card: build_default_agent_card(base_url),
+    }
+}
+
+/// Build a minimal Router exposing every A2A handler under test paths.
+fn make_app(state: A2AState) -> Router {
+    Router::new()
+        .route("/.well-known/agent.json", get(get_agent_card_well_known))
+        .route(
+            "/agent/authenticatedExtendedCard",
+            get(get_extended_agent_card),
+        )
+        .route("/message/send", post(send_message))
+        .route("/tasks/{id}", get(get_task))
+        .route("/tasks", get(list_tasks))
+        .route("/tasks/{id}/cancel", post(cancel_task))
+        .route("/tasks/{id}/push", post(create_push_notification_config))
+        .route(
+            "/tasks/{id}/push/{config_id}",
+            get(get_push_notification_config),
+        )
+        .route("/tasks/{id}/push-list", get(list_push_notification_configs))
+        .route(
+            "/tasks/{id}/push/{config_id}/delete",
+            delete(delete_push_notification_config),
+        )
+        .with_state(state)
+}
+
+async fn body_json(body: Body) -> serde_json::Value {
+    let b = body.collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&b).unwrap()
+}
+
+// ── build_default_agent_card ────────────────────────────────────────────
+
+#[test]
+fn build_default_agent_card_includes_base_url_in_supported_interface() {
+    let card = build_default_agent_card("https://example.com");
+    assert_eq!(card.name, "Assistant");
+    assert!(!card.supported_interfaces.is_empty());
+    assert_eq!(card.supported_interfaces[0].url, "https://example.com");
+    assert!(!card.skills.is_empty());
+    assert_eq!(card.default_input_modes, vec!["text/plain"]);
+}
+
+#[test]
+fn build_default_agent_card_streaming_capability_is_true() {
+    let card = build_default_agent_card("https://x.test");
+    assert_eq!(card.capabilities.streaming, Some(true));
+    assert_eq!(card.capabilities.push_notifications, Some(false));
+}
+
+// ── GET /.well-known/agent.json ─────────────────────────────────────────
+
+#[tokio::test]
+async fn well_known_agent_card_returns_200_with_card() {
+    let app = make_app(make_state("https://example.com"));
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/.well-known/agent.json")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp.into_body()).await;
+    assert_eq!(json["name"], "Assistant");
+}
+
+#[tokio::test]
+async fn extended_agent_card_returns_200() {
+    let app = make_app(make_state("https://example.com"));
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/agent/authenticatedExtendedCard")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp.into_body()).await;
+    assert!(json["name"].is_string());
+}
+
+// ── Tasks ───────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn get_task_returns_404_for_unknown_id() {
+    let app = make_app(make_state("https://example.com"));
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/tasks/no-such-task")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn list_tasks_with_no_tasks_returns_200_and_empty_list() {
+    let app = make_app(make_state("https://example.com"));
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/tasks")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp.into_body()).await;
+    // The shape depends on the schema; just assert it's a JSON object/array.
+    assert!(json.is_object() || json.is_array(), "got: {json}");
+}
+
+#[tokio::test]
+async fn cancel_task_unknown_id_returns_404() {
+    let app = make_app(make_state("https://example.com"));
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/tasks/no-such-task/cancel")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn get_task_returns_created_task_when_present() {
+    let state = make_state("https://example.com");
+    let task = state.task_store.create_task(None).await;
+    let id = task.id.clone();
+    let app = make_app(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/tasks/{id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp.into_body()).await;
+    assert_eq!(json["id"], id);
+}
+
+#[tokio::test]
+async fn cancel_task_existing_returns_200() {
+    let state = make_state("https://example.com");
+    let task = state.task_store.create_task(None).await;
+    let id = task.id.clone();
+    let app = make_app(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri(format!("/tasks/{id}/cancel"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+// ── Push notification configs ───────────────────────────────────────────
+
+fn push_config_request_body(task_id: &str, config_id: &str) -> serde_json::Value {
+    serde_json::json!({
+        "taskId": task_id,
+        "config": {
+            "id": config_id,
+            "url": "https://hook.example.com/notify",
+        }
+    })
+}
+
+#[tokio::test]
+async fn create_push_config_for_unknown_task_returns_404() {
+    let app = make_app(make_state("https://example.com"));
+    let body = push_config_request_body("no-such-task", "cfg-1");
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/tasks/no-such-task/push")
+                .header("Content-Type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn get_push_config_unknown_returns_404() {
+    let app = make_app(make_state("https://example.com"));
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/tasks/no-such-task/push/cfg-1")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn list_push_configs_unknown_task_returns_empty_array() {
+    let app = make_app(make_state("https://example.com"));
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/tasks/no-such-task/push-list")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    // The handler returns 200 with an empty configs array for unknown task.
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp.into_body()).await;
+    let configs = json["configs"].as_array().unwrap();
+    assert!(configs.is_empty(), "expected empty configs; got: {json}");
+}
+
+#[tokio::test]
+async fn delete_push_config_unknown_returns_404() {
+    let app = make_app(make_state("https://example.com"));
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method(Method::DELETE)
+                .uri("/tasks/no-such-task/push/cfg-1/delete")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn create_then_get_then_list_then_delete_push_config_round_trip() {
+    let state = make_state("https://example.com");
+    let task = state.task_store.create_task(None).await;
+    let task_id = task.id.clone();
+    let app = make_app(state);
+
+    // CREATE
+    let body = push_config_request_body(&task_id, "cfg-x");
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri(format!("/tasks/{task_id}/push"))
+                .header("Content-Type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(
+        resp.status().is_success(),
+        "create push config should succeed: {}",
+        resp.status()
+    );
+
+    // GET
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/tasks/{task_id}/push/cfg-x"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // LIST
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/tasks/{task_id}/push-list"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp.into_body()).await;
+    assert!(json.is_object() || json.is_array());
+
+    // DELETE
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method(Method::DELETE)
+                .uri(format!("/tasks/{task_id}/push/cfg-x/delete"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+}
+
+// ── send_message ────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn send_message_with_invalid_body_returns_400() {
+    let app = make_app(make_state("https://example.com"));
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/message/send")
+                .header("Content-Type", "application/json")
+                .body(Body::from("not json"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    // Axum's Json extractor returns 400 for invalid JSON.
+    assert!(
+        resp.status().is_client_error(),
+        "expected 4xx; got {}",
+        resp.status()
+    );
+}

--- a/crates/web-ui/src/a2a/mod.rs
+++ b/crates/web-ui/src/a2a/mod.rs
@@ -57,3 +57,81 @@ pub fn protected_router() -> Router<A2AState> {
                 .delete(handlers::delete_push_notification_config),
         )
 }
+
+#[cfg(test)]
+mod router_tests {
+    use super::*;
+    use crate::a2a::handlers::build_default_agent_card;
+    use crate::a2a::task_store::TaskStore;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    fn make_state() -> A2AState {
+        A2AState {
+            task_store: TaskStore::new(),
+            agent_card: build_default_agent_card("https://example.com"),
+        }
+    }
+
+    #[tokio::test]
+    async fn public_router_serves_well_known_agent_card() {
+        let app = public_router().with_state(make_state());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/.well-known/agent.json")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn protected_router_exposes_authenticated_extended_card() {
+        let app = protected_router().with_state(make_state());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/agent/authenticatedExtendedCard")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn protected_router_exposes_tasks_endpoint() {
+        let app = protected_router().with_state(make_state());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/tasks")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn public_router_does_not_expose_protected_paths() {
+        let app = public_router().with_state(make_state());
+        // /tasks is not on the public router; should 404 (no matching route).
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/tasks")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/crates/web-ui/src/a2a/mod.rs
+++ b/crates/web-ui/src/a2a/mod.rs
@@ -6,6 +6,8 @@
 
 pub mod agent_store;
 pub mod handlers;
+#[cfg(test)]
+mod handlers_tests;
 pub mod task_store;
 
 use axum::Router;

--- a/crates/web-ui/src/api/conversations.rs
+++ b/crates/web-ui/src/api/conversations.rs
@@ -831,6 +831,103 @@ mod tests {
         assert_eq!(updated.title.as_deref(), Some("New Name"));
     }
 
+    #[tokio::test]
+    async fn patch_conversation_bad_uuid_returns_400() {
+        let server = MockServer::start().await;
+        let (state, _) = test_state(&server.uri()).await;
+        let resp = app(state)
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/conversations/not-a-uuid")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(r#"{"title":"x"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn patch_conversation_unknown_id_returns_404() {
+        let server = MockServer::start().await;
+        let (state, _) = test_state(&server.uri()).await;
+        let id = uuid::Uuid::new_v4();
+        let resp = app(state)
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri(format!("/conversations/{id}"))
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(r#"{"title":"x"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn delete_conversation_bad_uuid_returns_400() {
+        let server = MockServer::start().await;
+        let (state, _) = test_state(&server.uri()).await;
+        let resp = app(state)
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/conversations/not-a-uuid")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn create_conversation_with_empty_body_returns_201_with_untitled() {
+        let server = MockServer::start().await;
+        let (state, _) = test_state(&server.uri()).await;
+        let resp = app(state)
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/conversations")
+                    .header("Content-Type", "application/json")
+                    // Completely absent body field — serde defaults kick in.
+                    .body(Body::from(r#"{}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let json = body_json(resp.into_body()).await;
+        assert_eq!(json["title"], "Untitled");
+    }
+
+    #[tokio::test]
+    async fn create_conversation_malformed_json_returns_400_or_422() {
+        let server = MockServer::start().await;
+        let (state, _) = test_state(&server.uri()).await;
+        let resp = app(state)
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/conversations")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from("{not valid"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            resp.status().is_client_error(),
+            "expected 4xx; got {}",
+            resp.status()
+        );
+    }
+
     // -- Runtime agent_id switch -----------------------------------------------
 
     #[tokio::test]

--- a/crates/web-ui/src/api/mod.rs
+++ b/crates/web-ui/src/api/mod.rs
@@ -292,4 +292,57 @@ pub fn api_router() -> Router<ApiState> {
         )
 }
 
+#[cfg(test)]
+mod helper_tests {
+    use super::{empty_string_as_none, internal_error};
+    use axum::http::StatusCode;
+    use serde::Deserialize;
+
+    #[test]
+    fn internal_error_returns_500_with_display_string() {
+        let (status, body) = internal_error("boom");
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(body, "boom");
+    }
+
+    #[test]
+    fn internal_error_works_with_anyhow_error() {
+        let err = anyhow::anyhow!("disk full");
+        let (status, body) = internal_error(&err);
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(body.contains("disk full"));
+    }
+
+    #[derive(Deserialize, Debug)]
+    struct Wrap {
+        #[serde(default, deserialize_with = "empty_string_as_none")]
+        value: Option<i32>,
+    }
+
+    #[test]
+    fn empty_string_as_none_returns_none_for_missing_field() {
+        let w: Wrap = serde_json::from_str("{}").unwrap();
+        assert_eq!(w.value, None);
+    }
+
+    #[test]
+    fn empty_string_as_none_returns_none_for_empty_string() {
+        let w: Wrap = serde_json::from_str(r#"{"value": ""}"#).unwrap();
+        assert_eq!(w.value, None);
+    }
+
+    #[test]
+    fn empty_string_as_none_parses_non_empty_string() {
+        let w: Wrap = serde_json::from_str(r#"{"value": "42"}"#).unwrap();
+        assert_eq!(w.value, Some(42));
+    }
+
+    #[test]
+    fn empty_string_as_none_errors_on_invalid_value() {
+        let err = serde_json::from_str::<Wrap>(r#"{"value": "abc"}"#).unwrap_err();
+        // Parse error from `i32::from_str` surfaces via serde::de::Error::custom.
+        assert!(err.to_string().contains("invalid"));
+    }
+}
+
 // -- Handlers ----------------------------------------------------------------

--- a/crates/web-ui/src/api/skills.rs
+++ b/crates/web-ui/src/api/skills.rs
@@ -703,4 +703,80 @@ mod tests {
             "listing skills for another user's persona must be denied"
         );
     }
+
+    #[tokio::test]
+    async fn get_skill_returns_detail_for_existing_skill() {
+        let (state, _) = test_state().await;
+        // Seed via POST /skills.
+        let body = r#"{"name":"detail-skill","description":"D","body":"B"}"#;
+        app(state.clone())
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/skills")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let resp = app(state)
+            .oneshot(
+                Request::builder()
+                    .uri("/skills/detail-skill")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json = body_json(resp.into_body()).await;
+        assert_eq!(json["name"], "detail-skill");
+        assert_eq!(json["description"], "D");
+        assert_eq!(json["body"], "B");
+        assert_eq!(json["is_builtin"], false);
+    }
+
+    #[tokio::test]
+    async fn update_skill_unknown_returns_404() {
+        let (state, _) = test_state().await;
+        let body = r#"{"description":"x","body":"y"}"#;
+        let resp = app(state)
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/skills/no-such-skill")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            resp.status() == StatusCode::NOT_FOUND || resp.status() == StatusCode::FORBIDDEN,
+            "unknown or non-user skill must 404/403; got {}",
+            resp.status()
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_unknown_skill_returns_404_or_403() {
+        let (state, _) = test_state().await;
+        let resp = app(state)
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/skills/no-such-skill-xyz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            resp.status() == StatusCode::NOT_FOUND || resp.status() == StatusCode::FORBIDDEN,
+            "unknown or non-user skill must 404/403; got {}",
+            resp.status()
+        );
+    }
 }

--- a/crates/web-ui/src/api/webhooks.rs
+++ b/crates/web-ui/src/api/webhooks.rs
@@ -985,4 +985,124 @@ mod tests {
             .unwrap();
         assert_eq!(resp.status(), StatusCode::NO_CONTENT);
     }
+
+    async fn create_webhook_for_state(state: &WebhooksApiState, name: &str) -> String {
+        let resp = app(state.clone())
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/webhooks")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(create_payload(name, "https://example.com/h")))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let detail = body_json(resp.into_body()).await;
+        detail["id"].as_str().unwrap().to_string()
+    }
+
+    #[tokio::test]
+    async fn toggle_webhook_flips_active_then_returns_200() {
+        let (state, _) = test_state().await;
+        let id = create_webhook_for_state(&state, "Toggle Me").await;
+
+        let resp = app(state)
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/webhooks/{id}/toggle"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json = body_json(resp.into_body()).await;
+        // Newly created webhook starts active=true; after toggle it should be false.
+        assert_eq!(json["active"], false);
+    }
+
+    #[tokio::test]
+    async fn rotate_secret_for_existing_webhook_returns_200_with_new_secret() {
+        let (state, _) = test_state().await;
+        let id = create_webhook_for_state(&state, "Rotate Me").await;
+
+        let resp = app(state)
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/webhooks/{id}/rotate-secret"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json = body_json(resp.into_body()).await;
+        // Secret should be a 64-char hex string.
+        let secret = json["secret"].as_str().unwrap();
+        assert_eq!(secret.len(), 64);
+        assert!(secret.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[tokio::test]
+    async fn update_webhook_partial_change_keeps_other_fields() {
+        let (state, _) = test_state().await;
+        let id = create_webhook_for_state(&state, "Original").await;
+
+        // PUT with only `name` field — should leave url + event_types intact.
+        let resp = app(state)
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri(format!("/webhooks/{id}"))
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(r#"{"name":"Renamed"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json = body_json(resp.into_body()).await;
+        assert_eq!(json["name"], "Renamed");
+        // URL preserved.
+        assert_eq!(json["url"], "https://example.com/h");
+    }
+
+    #[tokio::test]
+    async fn update_webhook_unknown_id_returns_404() {
+        let (state, _) = test_state().await;
+        let resp = app(state)
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/webhooks/no-such-id")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(r#"{"name":"x"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn update_webhook_with_invalid_url_returns_400() {
+        let (state, _) = test_state().await;
+        let id = create_webhook_for_state(&state, "Bad URL").await;
+        let resp = app(state)
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri(format!("/webhooks/{id}"))
+                    .header("Content-Type", "application/json")
+                    // Localhost blocked by SSRF check.
+                    .body(Body::from(r#"{"url":"http://localhost/h"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
 }

--- a/crates/web-ui/src/auth.rs
+++ b/crates/web-ui/src/auth.rs
@@ -1236,4 +1236,85 @@ mod tests {
             Some("xyz")
         );
     }
+
+    // ── login_html ──────────────────────────────────────────────────────
+
+    #[test]
+    fn login_html_without_error_omits_error_div() {
+        let Html(body) = login_html(None);
+        assert!(body.contains("<form method=\"POST\" action=\"/login\""));
+        // The class is declared in the CSS style block regardless; we only
+        // care that there's no error <div role="alert">.
+        assert!(!body.contains(r#"role="alert""#));
+        assert!(!body.contains("id=\"login-error\""));
+    }
+
+    #[test]
+    fn login_html_with_error_renders_alert_block() {
+        let Html(body) = login_html(Some("Invalid token."));
+        assert!(body.contains("login-error"));
+        assert!(body.contains("Invalid token."));
+        assert!(body.contains(r#"role="alert""#));
+    }
+
+    // ── parse_host_from_url ─────────────────────────────────────────────
+
+    #[test]
+    fn parse_host_from_url_strips_scheme_and_path() {
+        assert_eq!(
+            parse_host_from_url("https://example.com/path"),
+            Some("example.com".to_string())
+        );
+        assert_eq!(
+            parse_host_from_url("http://localhost:8080/api"),
+            Some("localhost:8080".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_host_from_url_returns_none_for_missing_scheme() {
+        assert!(parse_host_from_url("example.com").is_none());
+        assert!(parse_host_from_url("ftp://example.com").is_none());
+        assert!(parse_host_from_url("").is_none());
+    }
+
+    #[test]
+    fn parse_host_from_url_returns_none_for_scheme_only() {
+        assert!(parse_host_from_url("https://").is_none());
+        assert!(parse_host_from_url("http://").is_none());
+    }
+
+    #[test]
+    fn parse_host_from_url_trims_whitespace_around_input() {
+        assert_eq!(
+            parse_host_from_url("  https://example.com  "),
+            Some("example.com".to_string())
+        );
+    }
+
+    // ── extract_cookie — edge cases ────────────────────────────────────
+
+    #[test]
+    fn extract_cookie_handles_leading_whitespace_in_each_pair() {
+        let cookies = " foo=bar;  baz=qux  ; assistant_session=xyz";
+        assert_eq!(extract_cookie(cookies, "assistant_session"), Some("xyz"));
+        assert_eq!(extract_cookie(cookies, "baz"), Some("qux"));
+        assert_eq!(extract_cookie(cookies, "foo"), Some("bar"));
+    }
+
+    #[test]
+    fn extract_cookie_returns_none_for_empty_cookie_header() {
+        assert!(extract_cookie("", "assistant_session").is_none());
+    }
+
+    #[test]
+    fn extract_cookie_does_not_match_prefix_of_another_name() {
+        // Without the `=` check the function might match `foo_session` for
+        // a query of `foo`. Regression test for the strip_prefix logic.
+        let cookies = "foo_session=xyz; other=val";
+        // Asserting the actual behavior: `foo_session` does NOT match `foo`
+        // because after `strip_prefix("foo")` we get `_session=xyz`, which
+        // starts with `_`, not `=` — so the function returns None for `foo`.
+        assert!(extract_cookie(cookies, "foo").is_none());
+    }
 }

--- a/crates/web-ui/src/backends/iceberg.rs
+++ b/crates/web-ui/src/backends/iceberg.rs
@@ -776,6 +776,101 @@ fn bucket_key(ts: &DateTime<Utc>, bucket_minutes: i64) -> String {
         .to_string()
 }
 
+#[cfg(test)]
+mod helper_tests {
+    use super::*;
+
+    #[test]
+    fn warehouse_path_uses_explicit_value_when_provided() {
+        let mut cfg = IcebergConfig::default();
+        cfg.warehouse = Some("/custom/path".to_string());
+        assert_eq!(warehouse_path(&cfg), PathBuf::from("/custom/path"));
+    }
+
+    #[test]
+    fn warehouse_path_expands_tilde_prefix() {
+        let mut cfg = IcebergConfig::default();
+        cfg.warehouse = Some("~/warehouse".to_string());
+        let p = warehouse_path(&cfg);
+        // Should NOT still contain a literal tilde once home is known.
+        if let Some(home) = dirs::home_dir() {
+            assert_eq!(p, home.join("warehouse"));
+        } else {
+            // No home → falls back to literal path.
+            assert_eq!(p, PathBuf::from("~/warehouse"));
+        }
+    }
+
+    #[test]
+    fn warehouse_path_uses_default_when_unset() {
+        let cfg = IcebergConfig::default();
+        let p = warehouse_path(&cfg);
+        // Default is "~/.assistant/iceberg" — expanded if home exists.
+        if let Some(home) = dirs::home_dir() {
+            assert_eq!(p, home.join(".assistant/iceberg"));
+        } else {
+            assert_eq!(p, PathBuf::from("~/.assistant/iceberg"));
+        }
+    }
+
+    #[test]
+    fn bucket_key_rounds_to_60_minute_buckets_by_default() {
+        // 2026-05-19T08:37:12Z with bucket_minutes=60 → 2026-05-19T08:00:00Z
+        let ts: DateTime<Utc> = "2026-05-19T08:37:12Z".parse().unwrap();
+        assert_eq!(bucket_key(&ts, 60), "2026-05-19T08:00:00Z");
+    }
+
+    #[test]
+    fn bucket_key_rounds_to_15_minute_buckets() {
+        let ts: DateTime<Utc> = "2026-05-19T08:47:30Z".parse().unwrap();
+        // 8:47 falls in the 8:45-9:00 bucket.
+        assert_eq!(bucket_key(&ts, 15), "2026-05-19T08:45:00Z");
+    }
+
+    #[test]
+    fn bucket_key_handles_zero_and_negative_bucket_minutes_safely() {
+        let ts: DateTime<Utc> = "2026-05-19T08:00:30Z".parse().unwrap();
+        // .max(1) clamps to 1-minute bucket.
+        assert_eq!(bucket_key(&ts, 0), "2026-05-19T08:00:00Z");
+        assert_eq!(bucket_key(&ts, -5), "2026-05-19T08:00:00Z");
+    }
+
+    #[test]
+    fn collect_parquet_files_returns_empty_for_missing_dir() {
+        let p = std::path::Path::new("/no/such/dir/anywhere");
+        assert!(collect_parquet_files(p).is_empty());
+    }
+
+    #[test]
+    fn collect_parquet_files_ignores_non_parquet_extensions() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("data.txt"), b"hi").unwrap();
+        std::fs::write(tmp.path().join("data.parquet"), b"\x00\x00").unwrap();
+        let files = collect_parquet_files(tmp.path());
+        assert_eq!(files.len(), 1);
+        assert!(files[0].ends_with("data.parquet"));
+    }
+
+    #[test]
+    fn collect_parquet_files_recurses_into_subdirectories() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("a/b/c")).unwrap();
+        std::fs::write(tmp.path().join("a/x.parquet"), b"\x00").unwrap();
+        std::fs::write(tmp.path().join("a/b/y.parquet"), b"\x00").unwrap();
+        std::fs::write(tmp.path().join("a/b/c/z.parquet"), b"\x00").unwrap();
+        let files = collect_parquet_files(tmp.path());
+        assert_eq!(files.len(), 3);
+    }
+
+    #[test]
+    fn read_parquet_errors_on_garbage_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("bad.parquet");
+        std::fs::write(&path, b"not parquet data").unwrap();
+        assert!(read_parquet(&path).is_err());
+    }
+}
+
 #[async_trait]
 impl MetricsBackend for IcebergMetricsBackend {
     async fn summary(&self, window_hours: i64, agent_id: &str) -> Result<MetricsSummary> {

--- a/crates/web-ui/src/oauth/mod.rs
+++ b/crates/web-ui/src/oauth/mod.rs
@@ -214,6 +214,44 @@ pub(crate) async fn build_auth_context_for_user(
 }
 
 #[cfg(test)]
+mod escape_tests {
+    use super::escape_html_attr;
+
+    #[test]
+    fn escape_html_attr_replaces_all_dangerous_chars() {
+        assert_eq!(escape_html_attr("&"), "&amp;");
+        assert_eq!(escape_html_attr("\""), "&quot;");
+        assert_eq!(escape_html_attr("'"), "&#x27;");
+        assert_eq!(escape_html_attr("<"), "&lt;");
+        assert_eq!(escape_html_attr(">"), "&gt;");
+    }
+
+    #[test]
+    fn escape_html_attr_handles_compound_input() {
+        let input = r#"<script>alert("xss & 'pwn'")</script>"#;
+        let escaped = escape_html_attr(input);
+        assert!(!escaped.contains('<'));
+        assert!(!escaped.contains('>'));
+        assert!(!escaped.contains('"'));
+        assert!(!escaped.contains('\''));
+        assert!(escaped.contains("&lt;"));
+        assert!(escaped.contains("&gt;"));
+        assert!(escaped.contains("&amp;"));
+        assert!(escaped.contains("&quot;"));
+        assert!(escaped.contains("&#x27;"));
+    }
+
+    #[test]
+    fn escape_html_attr_preserves_safe_text() {
+        assert_eq!(escape_html_attr(""), "");
+        assert_eq!(escape_html_attr("hello world"), "hello world");
+        assert_eq!(escape_html_attr("0123abc-._~"), "0123abc-._~");
+        // UTF-8 / emoji passes through unchanged.
+        assert_eq!(escape_html_attr("héllo 🦀"), "héllo 🦀");
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use axum::body::Body;

--- a/crates/web-ui/src/oauth/token.rs
+++ b/crates/web-ui/src/oauth/token.rs
@@ -261,6 +261,44 @@ fn session_cookie(jwt: &str, secure: bool, max_age_secs: u64) -> Option<HeaderVa
     HeaderValue::try_from(value).ok()
 }
 
+#[cfg(test)]
+mod tests {
+    use super::session_cookie;
+
+    #[test]
+    fn session_cookie_emits_httponly_samesite_lax_cookie() {
+        let cookie = session_cookie("eyJhbGciOiJIUzI1NiJ9.payload.sig", false, 3600).unwrap();
+        let s = cookie.to_str().unwrap();
+        assert!(s.starts_with("assistant_session=eyJ"));
+        assert!(s.contains("HttpOnly"));
+        assert!(s.contains("SameSite=Lax"));
+        assert!(s.contains("Path=/"));
+        assert!(s.contains("Max-Age=3600"));
+    }
+
+    #[test]
+    fn session_cookie_adds_secure_attr_when_secure_true() {
+        let cookie = session_cookie("jwt.value.sig", true, 7200).unwrap();
+        let s = cookie.to_str().unwrap();
+        assert!(s.contains("; Secure"));
+        assert!(s.contains("Max-Age=7200"));
+    }
+
+    #[test]
+    fn session_cookie_omits_secure_attr_when_secure_false() {
+        let cookie = session_cookie("jwt.value.sig", false, 60).unwrap();
+        let s = cookie.to_str().unwrap();
+        assert!(!s.contains("Secure"));
+    }
+
+    #[test]
+    fn session_cookie_returns_none_for_rejected_bytes() {
+        // Newline characters are forbidden in cookie values.
+        let result = session_cookie("bad\nvalue", false, 60);
+        assert!(result.is_none());
+    }
+}
+
 async fn handle_device_code(state: OAuthState, req: TokenRequest) -> axum::response::Response {
     let device_code = match req.device_code {
         Some(c) => c,

--- a/crates/web-ui/src/push.rs
+++ b/crates/web-ui/src/push.rs
@@ -469,4 +469,123 @@ mod tests {
         // Reference the mock server so the compiler doesn't elide it.
         let _ = server.uri();
     }
+
+    // ── encrypt_payload ──────────────────────────────────────────────────
+
+    #[test]
+    fn encrypt_payload_produces_nonempty_aes128gcm_record() {
+        // Generate a fresh subscriber keypair; the public key is the
+        // 65-byte uncompressed P-256 point.
+        let subscriber_secret =
+            p256::ecdsa::SigningKey::random(&mut p256::elliptic_curve::rand_core::OsRng);
+        let subscriber_pub_bytes = subscriber_secret
+            .verifying_key()
+            .to_encoded_point(false)
+            .as_bytes()
+            .to_vec();
+        let auth_secret: [u8; 16] = [0xa5; 16];
+
+        let (encrypted, sender_pub, salt) =
+            encrypt_payload(b"hello world", &subscriber_pub_bytes, &auth_secret).unwrap();
+        // Header: salt (16) + rs (4) + keyid_len (1) + keyid (65) = 86 bytes
+        // followed by ciphertext.
+        assert!(encrypted.len() > 86);
+        assert_eq!(sender_pub.len(), 65, "sender pub must be uncompressed");
+        assert_eq!(salt.len(), 16, "salt must be 16 bytes");
+        // First byte of an uncompressed point is 0x04.
+        assert_eq!(sender_pub[0], 0x04);
+    }
+
+    #[test]
+    fn encrypt_payload_rejects_invalid_subscriber_pub_key() {
+        let auth_secret = [0u8; 16];
+        let result = encrypt_payload(b"hello", b"not-a-key", &auth_secret);
+        assert!(result.is_err(), "invalid sub-pub bytes must Err");
+    }
+
+    #[test]
+    fn encrypt_payload_uses_different_salt_each_call() {
+        let subscriber_secret =
+            p256::ecdsa::SigningKey::random(&mut p256::elliptic_curve::rand_core::OsRng);
+        let pub_bytes = subscriber_secret
+            .verifying_key()
+            .to_encoded_point(false)
+            .as_bytes()
+            .to_vec();
+        let auth: [u8; 16] = [0xff; 16];
+        let (_, _, salt1) = encrypt_payload(b"a", &pub_bytes, &auth).unwrap();
+        let (_, _, salt2) = encrypt_payload(b"a", &pub_bytes, &auth).unwrap();
+        assert_ne!(salt1, salt2, "salt must be random per call");
+    }
+
+    // ── build_vapid_jwt ──────────────────────────────────────────────────
+
+    #[test]
+    fn build_vapid_jwt_returns_three_dot_separated_segments() {
+        let (priv_b64, _) = generate_vapid_keypair().unwrap();
+        let pem_bytes = URL_SAFE_NO_PAD.decode(&priv_b64).unwrap();
+        let pem_str = std::str::from_utf8(&pem_bytes).unwrap();
+        use p256::pkcs8::DecodePrivateKey as _;
+        let key = SigningKey::from_pkcs8_pem(pem_str).unwrap();
+        let jwt = build_vapid_jwt(&key, "https://fcm.googleapis.com/fcm/send/abc").unwrap();
+        let parts: Vec<&str> = jwt.split('.').collect();
+        assert_eq!(parts.len(), 3);
+        // All parts must be base64url-decodable.
+        for p in &parts {
+            URL_SAFE_NO_PAD.decode(p).unwrap();
+        }
+    }
+
+    #[test]
+    fn build_vapid_jwt_payload_includes_correct_audience() {
+        let (priv_b64, _) = generate_vapid_keypair().unwrap();
+        let pem_bytes = URL_SAFE_NO_PAD.decode(&priv_b64).unwrap();
+        let pem_str = std::str::from_utf8(&pem_bytes).unwrap();
+        use p256::pkcs8::DecodePrivateKey as _;
+        let key = SigningKey::from_pkcs8_pem(pem_str).unwrap();
+        let jwt = build_vapid_jwt(&key, "https://fcm.googleapis.com/fcm/send/abc").unwrap();
+        let parts: Vec<&str> = jwt.split('.').collect();
+        let payload_bytes = URL_SAFE_NO_PAD.decode(parts[1]).unwrap();
+        let payload: serde_json::Value = serde_json::from_slice(&payload_bytes).unwrap();
+        assert_eq!(payload["aud"], "https://fcm.googleapis.com");
+        assert!(payload["exp"].is_u64());
+        assert_eq!(payload["sub"], "mailto:push@assistant.local");
+    }
+
+    #[test]
+    fn build_vapid_jwt_errors_on_invalid_endpoint() {
+        let (priv_b64, _) = generate_vapid_keypair().unwrap();
+        let pem_bytes = URL_SAFE_NO_PAD.decode(&priv_b64).unwrap();
+        let pem_str = std::str::from_utf8(&pem_bytes).unwrap();
+        use p256::pkcs8::DecodePrivateKey as _;
+        let key = SigningKey::from_pkcs8_pem(pem_str).unwrap();
+        let err = build_vapid_jwt(&key, "not a url").unwrap_err();
+        assert!(err.to_string().contains("Invalid push endpoint URL"));
+    }
+
+    // ── signing_key (dispatcher helper) ──────────────────────────────────
+
+    #[tokio::test]
+    async fn signing_key_decodes_round_tripped_pem() {
+        let storage = assistant_storage::StorageLayer::new_in_memory()
+            .await
+            .unwrap();
+        let store = Arc::new(SqlitePushSubscriptionStore::new(storage.pool.clone()));
+        let (priv_b64, _) = generate_vapid_keypair().unwrap();
+        let dispatcher = PushDispatcher::new(priv_b64, store);
+        assert!(
+            dispatcher.signing_key().is_ok(),
+            "valid PEM must decode back to a signing key"
+        );
+    }
+
+    #[tokio::test]
+    async fn signing_key_errors_on_invalid_base64() {
+        let storage = assistant_storage::StorageLayer::new_in_memory()
+            .await
+            .unwrap();
+        let store = Arc::new(SqlitePushSubscriptionStore::new(storage.pool.clone()));
+        let dispatcher = PushDispatcher::new("not-base64!@#$".to_string(), store);
+        assert!(dispatcher.signing_key().is_err());
+    }
 }


### PR DESCRIPTION
## Summary

Lifts `crates/web-ui` from 77.1% to **80.1%** via inline test additions and ratchets it off `report_only` in `coverage.toml`. `report_only` count drops from 7 to 6.

This is a large crate (~17,500 lines) covering REST + SSE + OAuth + A2A endpoints. The strategy was breadth-first: ~50 targeted tests across ~14 modules rather than deep coverage of any single handler.

### New tests by area

| Module | Coverage win |
| --- | --- |
| `a2a/handlers.rs` + new `handlers_tests.rs` (was 0%) | Agent card, tasks CRUD, push notification config CRUD, bad-body 4xx |
| `a2a/mod.rs` (new `router_tests`) | `public_router` serves well-known + does NOT expose protected; `protected_router` serves extended-card + tasks |
| `push.rs` (was 35.5%) | `encrypt_payload` aes128gcm record + random salt + invalid pub-key, `build_vapid_jwt` three-segment + audience + invalid endpoint, `signing_key` round-trip + invalid base64 |
| `oauth/token.rs` (was 38.9%) | `session_cookie` HttpOnly/SameSite/Path/Max-Age, Secure attr toggle, rejected-bytes None |
| `oauth/mod.rs` | `escape_html_attr` all 5 chars + UTF-8 passthrough |
| `backends/iceberg.rs` (was 0%) | `warehouse_path` (explicit/tilde/default), `bucket_key` (60/15-min, non-positive clamp), `collect_parquet_files` (missing dir, extension filter, recursion), `read_parquet` (bad file) |
| `api/webhooks.rs` | `toggle`, `rotate_secret`, `update` partial-field + unknown-id 404 + invalid-URL 400 |
| `api/conversations.rs` | PATCH bad-uuid + unknown 404, DELETE bad-uuid 400, POST empty + malformed JSON |
| `api/skills.rs` | get_skill detail, update/delete unknown 404/403 |
| `api/spaces.rs`, `api/agents.rs`, `api/users.rs`, `api/workflows.rs` | CRUD edge cases — get/update/delete missing, validation, permissions |
| `api/mod.rs` | `internal_error`, `empty_string_as_none` deserialiser |
| `auth.rs` | `login_html` with/without error, `parse_host_from_url`, `extract_cookie` edge cases |
| `lib.rs` | `harden_agent_card`, `nats_reachable` (5 connection-failure cases), `resolve_base_url` |

Web-ui now enforces the 80% floor as a one-way ratchet. Remaining `report_only` crates (6): `mcp-client`, `interface-cli`, `bus-nats`, `opentelemetry-exporter-iceberg`, `opentelemetry-exporter-sqlite`, `interfaces`.

Part of `openspec/changes/workspace-test-coverage-floor` (Phase 11).

## Test plan

- [x] `cargo test -p assistant-web-ui --lib` — all targets green
- [x] `make lint` — clippy clean
- [x] `make coverage` — gate prints `Coverage gate passed`; web-ui shows `ok` at 80.1%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for A2A handlers, API endpoints (conversations, skills, webhooks), authentication, OAuth, and push notifications.
  * Added comprehensive unit and integration tests for error handling, edge cases, validation logic, and internal helper functions across the codebase.

* **Chores**
  * Updated CI coverage configuration to enforce the 80% code coverage floor for the web-ui crate.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cedricziel/assistant/pull/887?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->