### PR TITLE
test(interfaces): backfill adapter + runner edge cases (Phase 9)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,8 +539,10 @@ version = "0.1.162"
 dependencies = [
  "anyhow",
  "assistant-core",
+ "assistant-llm-provider",
  "assistant-runtime",
  "assistant-storage",
+ "assistant-tool-executor",
  "assistant-transcription",
  "async-trait",
  "axum",

--- a/crates/interfaces/Cargo.toml
+++ b/crates/interfaces/Cargo.toml
@@ -64,6 +64,8 @@ base64 = { workspace = true }
 toml = { workspace = true }
 
 [dev-dependencies]
+assistant-llm-provider = { path = "../llm-provider" }
+assistant-tool-executor = { path = "../tool-executor" }
 toml = { workspace = true }
 wiremock = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros"] }

--- a/crates/interfaces/src/matrix/runner.rs
+++ b/crates/interfaces/src/matrix/runner.rs
@@ -127,4 +127,119 @@ mod tests {
                 .contains(&"!other:example.com".to_string());
         assert!(blocked);
     }
+
+    use super::*;
+    use assistant_storage::StorageLayer;
+
+    async fn make_orchestrator() -> Arc<Orchestrator> {
+        use assistant_core::types::agent::AssistantConfig;
+        use assistant_core::{LlmProvider, MessageBus};
+        use assistant_llm_provider::scripted::ScriptedLlmProvider;
+        use assistant_storage::registry::SkillRegistry;
+        use assistant_tool_executor::ToolExecutor;
+        let storage = Arc::new(StorageLayer::new_in_memory().await.unwrap());
+        let cfg = AssistantConfig::default();
+        let registry = Arc::new(SkillRegistry::new(storage.pool.clone()).await.unwrap());
+        let llm: Arc<dyn LlmProvider> = Arc::new(ScriptedLlmProvider::new());
+        let exec = Arc::new(ToolExecutor::new(
+            storage.clone(),
+            llm.clone(),
+            registry.clone(),
+            Arc::new(cfg.clone()),
+        ));
+        let bus: Arc<dyn MessageBus> = Arc::new(storage.message_bus());
+        Arc::new(Orchestrator::new(
+            llm,
+            storage.clone(),
+            exec,
+            registry,
+            bus,
+            &cfg,
+        ))
+    }
+
+    #[tokio::test]
+    async fn new_starts_without_transcription() {
+        let orch = make_orchestrator().await;
+        let iface = MatrixInterface::new(MatrixConfig::default(), orch);
+        assert!(iface.transcription.is_none());
+        assert!(iface.transcription_language.is_none());
+    }
+
+    #[tokio::test]
+    async fn with_transcription_sets_provider_and_language() {
+        use assistant_transcription::{
+            TranscriptionProvider, TranscriptionRequest, TranscriptionResult,
+        };
+        #[derive(Debug)]
+        struct DummyProvider;
+        #[async_trait::async_trait]
+        impl TranscriptionProvider for DummyProvider {
+            fn name(&self) -> &str {
+                "dummy"
+            }
+            async fn transcribe(
+                &self,
+                _req: TranscriptionRequest,
+            ) -> anyhow::Result<TranscriptionResult> {
+                Ok(TranscriptionResult {
+                    text: "x".into(),
+                    language: None,
+                    duration_secs: None,
+                })
+            }
+        }
+        let orch = make_orchestrator().await;
+        let iface = MatrixInterface::new(MatrixConfig::default(), orch)
+            .with_transcription(Arc::new(DummyProvider), Some("en".into()));
+        assert!(iface.transcription.is_some());
+        assert_eq!(iface.transcription_language.as_deref(), Some("en"));
+    }
+
+    #[tokio::test]
+    async fn run_errors_when_homeserver_missing() {
+        let orch = make_orchestrator().await;
+        let iface = MatrixInterface::new(
+            MatrixConfig {
+                homeserver_url: None,
+                ..Default::default()
+            },
+            orch,
+        );
+        let err = iface.run().await.unwrap_err();
+        assert!(err.to_string().contains("homeserver URL"));
+    }
+
+    #[tokio::test]
+    async fn run_errors_when_only_access_token_but_no_username() {
+        let orch = make_orchestrator().await;
+        let iface = MatrixInterface::new(
+            MatrixConfig {
+                homeserver_url: Some("https://matrix.example.com".into()),
+                access_token: Some("t".into()),
+                username: None,
+                ..Default::default()
+            },
+            orch,
+        );
+        let err = iface.run().await.unwrap_err();
+        assert!(err.to_string().contains("username"));
+    }
+
+    #[tokio::test]
+    async fn run_errors_when_no_credentials() {
+        let orch = make_orchestrator().await;
+        let iface = MatrixInterface::new(
+            MatrixConfig {
+                homeserver_url: Some("https://matrix.example.com".into()),
+                access_token: None,
+                username: None,
+                password: None,
+                ..Default::default()
+            },
+            orch,
+        );
+        let err = iface.run().await.unwrap_err();
+        assert!(err.to_string().contains("credentials"));
+    }
 }

--- a/crates/interfaces/src/mattermost/adapter.rs
+++ b/crates/interfaces/src/mattermost/adapter.rs
@@ -767,4 +767,136 @@ mod tests {
         let result = transcribe_mattermost_files(&payload, &client, &None, &None).await;
         assert!(result.is_none());
     }
+
+    // ── parse_platform_id ──────────────────────────────────────────────────
+
+    #[test]
+    fn parse_platform_id_splits_on_slash() {
+        let (channel, root) = parse_platform_id("ch-1/root-post");
+        assert_eq!(channel, "ch-1");
+        assert_eq!(root.as_deref(), Some("root-post"));
+    }
+
+    #[test]
+    fn parse_platform_id_without_slash_returns_no_root() {
+        let (channel, root) = parse_platform_id("ch-1");
+        assert_eq!(channel, "ch-1");
+        assert!(root.is_none());
+    }
+
+    // ── parse_posted_event — additional coverage ──────────────────────────
+
+    #[test]
+    fn parse_posted_event_drops_self_message() {
+        let payload = serde_json::json!({
+            "event": "posted",
+            "broadcast": { "channel_id": "ch1" },
+            "data": {
+                "post": serde_json::json!({
+                    "id": "p1",
+                    "user_id": "bot",  // matches bot_user_id
+                    "message": "hello",
+                    "root_id": ""
+                }).to_string()
+            }
+        });
+        assert!(parse_posted_event(&payload, "bot", &[], &[]).is_none());
+    }
+
+    #[test]
+    fn parse_posted_event_respects_channel_allowlist() {
+        let payload = serde_json::json!({
+            "event": "posted",
+            "broadcast": { "channel_id": "ch-blocked" },
+            "data": {
+                "post": serde_json::json!({
+                    "id": "p1",
+                    "user_id": "u1",
+                    "message": "hello",
+                    "root_id": ""
+                }).to_string()
+            }
+        });
+        let allowed = vec!["ch-allowed".to_string()];
+        assert!(parse_posted_event(&payload, "bot", &allowed, &[]).is_none());
+    }
+
+    #[test]
+    fn parse_posted_event_respects_user_allowlist() {
+        let payload = serde_json::json!({
+            "event": "posted",
+            "broadcast": { "channel_id": "ch1" },
+            "data": {
+                "post": serde_json::json!({
+                    "id": "p1",
+                    "user_id": "u-blocked",
+                    "message": "hello",
+                    "root_id": ""
+                }).to_string()
+            }
+        });
+        let allowed = vec!["u-allowed".to_string()];
+        assert!(parse_posted_event(&payload, "bot", &[], &allowed).is_none());
+    }
+
+    #[test]
+    fn parse_posted_event_thread_reply_uses_root_id_for_thread() {
+        let payload = serde_json::json!({
+            "event": "posted",
+            "broadcast": { "channel_id": "ch1" },
+            "data": {
+                "post": serde_json::json!({
+                    "id": "p2",
+                    "user_id": "u1",
+                    "message": "reply",
+                    "root_id": "p1-root"
+                }).to_string()
+            }
+        });
+        let msg = parse_posted_event(&payload, "bot", &[], &[]).unwrap();
+        assert_eq!(msg.thread_id.as_deref(), Some("p1-root"));
+        assert_eq!(msg.sender.platform_id, "ch1/p1-root");
+    }
+
+    #[test]
+    fn parse_posted_event_top_level_post_uses_own_id_as_thread_root() {
+        let payload = serde_json::json!({
+            "event": "posted",
+            "broadcast": { "channel_id": "ch1" },
+            "data": {
+                "post": serde_json::json!({
+                    "id": "p1",
+                    "user_id": "u1",
+                    "message": "top-level",
+                    "root_id": ""
+                }).to_string()
+            }
+        });
+        let msg = parse_posted_event(&payload, "bot", &[], &[]).unwrap();
+        // top-level posts get their own id as the thread root.
+        assert_eq!(msg.thread_id.as_deref(), Some("p1"));
+        assert_eq!(msg.sender.platform_id, "ch1/p1");
+    }
+
+    #[test]
+    fn parse_posted_event_returns_none_for_malformed_post() {
+        let payload = serde_json::json!({
+            "event": "posted",
+            "broadcast": { "channel_id": "ch1" },
+            "data": {
+                "post": "not-json-encoded-post-data",
+            }
+        });
+        assert!(parse_posted_event(&payload, "bot", &[], &[]).is_none());
+    }
+
+    #[test]
+    fn parse_posted_event_returns_none_when_post_field_missing() {
+        let payload = serde_json::json!({
+            "event": "posted",
+            "broadcast": { "channel_id": "ch1" },
+            "data": {}
+        });
+        assert!(parse_posted_event(&payload, "bot", &[], &[]).is_none());
+    }
 }

--- a/crates/interfaces/src/mattermost/runner.rs
+++ b/crates/interfaces/src/mattermost/runner.rs
@@ -117,4 +117,99 @@ mod tests {
         let blocked = !cfg.allowed_users.is_empty() && !cfg.allowed_users.contains(&known);
         assert!(!blocked);
     }
+
+    use super::*;
+    use assistant_storage::StorageLayer;
+
+    async fn make_orchestrator() -> Arc<Orchestrator> {
+        use assistant_core::types::agent::AssistantConfig;
+        use assistant_core::{LlmProvider, MessageBus};
+        use assistant_llm_provider::scripted::ScriptedLlmProvider;
+        use assistant_storage::registry::SkillRegistry;
+        use assistant_tool_executor::ToolExecutor;
+        let storage = Arc::new(StorageLayer::new_in_memory().await.unwrap());
+        let cfg = AssistantConfig::default();
+        let registry = Arc::new(SkillRegistry::new(storage.pool.clone()).await.unwrap());
+        let llm: Arc<dyn LlmProvider> = Arc::new(ScriptedLlmProvider::new());
+        let exec = Arc::new(ToolExecutor::new(
+            storage.clone(),
+            llm.clone(),
+            registry.clone(),
+            Arc::new(cfg.clone()),
+        ));
+        let bus: Arc<dyn MessageBus> = Arc::new(storage.message_bus());
+        Arc::new(Orchestrator::new(
+            llm,
+            storage.clone(),
+            exec,
+            registry,
+            bus,
+            &cfg,
+        ))
+    }
+
+    #[tokio::test]
+    async fn new_starts_without_transcription() {
+        let orch = make_orchestrator().await;
+        let iface = MattermostInterface::new(MattermostConfig::default(), orch);
+        assert!(iface.transcription.is_none());
+        assert!(iface.transcription_language.is_none());
+    }
+
+    #[tokio::test]
+    async fn with_transcription_sets_provider_and_language() {
+        use assistant_transcription::{
+            TranscriptionProvider, TranscriptionRequest, TranscriptionResult,
+        };
+        #[derive(Debug)]
+        struct DummyProvider;
+        #[async_trait::async_trait]
+        impl TranscriptionProvider for DummyProvider {
+            fn name(&self) -> &str {
+                "dummy"
+            }
+            async fn transcribe(&self, _req: TranscriptionRequest) -> Result<TranscriptionResult> {
+                Ok(TranscriptionResult {
+                    text: "x".into(),
+                    language: None,
+                    duration_secs: None,
+                })
+            }
+        }
+        let orch = make_orchestrator().await;
+        let iface = MattermostInterface::new(MattermostConfig::default(), orch)
+            .with_transcription(Arc::new(DummyProvider), Some("en".into()));
+        assert!(iface.transcription.is_some());
+        assert_eq!(iface.transcription_language.as_deref(), Some("en"));
+    }
+
+    #[tokio::test]
+    async fn run_errors_when_server_url_missing() {
+        let orch = make_orchestrator().await;
+        let iface = MattermostInterface::new(
+            MattermostConfig {
+                server_url: None,
+                token: Some("tok".into()),
+                ..Default::default()
+            },
+            orch,
+        );
+        let err = iface.run().await.unwrap_err();
+        assert!(err.to_string().contains("Mattermost server URL"));
+    }
+
+    #[tokio::test]
+    async fn run_errors_when_token_missing() {
+        let orch = make_orchestrator().await;
+        let iface = MattermostInterface::new(
+            MattermostConfig {
+                server_url: Some("https://mm.example.com".into()),
+                token: None,
+                ..Default::default()
+            },
+            orch,
+        );
+        let err = iface.run().await.unwrap_err();
+        assert!(err.to_string().contains("Mattermost token"));
+    }
 }

--- a/crates/interfaces/src/nextcloud/adapter.rs
+++ b/crates/interfaces/src/nextcloud/adapter.rs
@@ -842,6 +842,126 @@ mod tests {
             .expect("remove_reaction should succeed");
     }
 
+    // -- webhook_handler tests ----------------------------------------------
+
+    use crate::nextcloud::signing::sign_request;
+    use axum::body::Bytes;
+    use axum::extract::State;
+    use axum::http::HeaderMap;
+    use tokio::sync::mpsc::channel;
+
+    fn make_webhook_state() -> (
+        Arc<WebhookState>,
+        tokio::sync::mpsc::Receiver<ChannelMessage>,
+    ) {
+        let (tx, rx) = channel(8);
+        let state = Arc::new(WebhookState {
+            secret: SECRET.to_string(),
+            server_url: "http://nextcloud.example".to_string(),
+            allowed_channels: vec![],
+            allowed_users: vec![],
+            tx,
+            transcription: None,
+            transcription_language: None,
+        });
+        (state, rx)
+    }
+
+    fn sign_headers(secret: &str, body: &str) -> HeaderMap {
+        let (random, signature) = sign_request(secret, body).unwrap();
+        let mut headers = HeaderMap::new();
+        headers.insert("x-nextcloud-talk-signature", signature.parse().unwrap());
+        headers.insert("x-nextcloud-talk-random", random.parse().unwrap());
+        headers
+    }
+
+    #[tokio::test]
+    async fn webhook_handler_returns_401_when_signature_missing() {
+        let (state, _rx) = make_webhook_state();
+        let headers = HeaderMap::new();
+        let body = Bytes::from_static(b"{}");
+        let status = webhook_handler(State(state), headers, body).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn webhook_handler_returns_401_when_random_missing() {
+        let (state, _rx) = make_webhook_state();
+        let mut headers = HeaderMap::new();
+        headers.insert("x-nextcloud-talk-signature", "deadbeef".parse().unwrap());
+        let body = Bytes::from_static(b"{}");
+        let status = webhook_handler(State(state), headers, body).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn webhook_handler_returns_401_when_signature_invalid() {
+        let (state, _rx) = make_webhook_state();
+        let mut headers = HeaderMap::new();
+        headers.insert("x-nextcloud-talk-signature", "deadbeef".parse().unwrap());
+        headers.insert("x-nextcloud-talk-random", "abcdef".parse().unwrap());
+        let body = Bytes::from_static(b"{}");
+        let status = webhook_handler(State(state), headers, body).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn webhook_handler_returns_400_for_malformed_signed_body() {
+        let (state, _rx) = make_webhook_state();
+        let body_str = "not-valid-json";
+        let headers = sign_headers(SECRET, body_str);
+        let status = webhook_handler(State(state), headers, Bytes::from(body_str)).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn webhook_handler_ignores_non_create_event() {
+        let (state, _rx) = make_webhook_state();
+        // Valid envelope but `type != "Create"`.
+        let body_str = serde_json::json!({
+            "type": "Update",
+            "actor": { "type": "Person", "id": "users/alice", "name": "Alice" },
+            "object": {
+                "type": "Note",
+                "id": "msg-1",
+                "name": "message",
+                "content": "{}"
+            },
+            "target": { "type": "Collection", "id": TOKEN, "name": "general" },
+        })
+        .to_string();
+        let headers = sign_headers(SECRET, &body_str);
+        let status =
+            webhook_handler(State(state), headers, Bytes::from(body_str.into_bytes())).await;
+        // Non-Create events are silently OK.
+        assert_eq!(status, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn webhook_handler_ignores_bot_actor() {
+        let (state, _rx) = make_webhook_state();
+        let body_str = serde_json::json!({
+            "type": "Create",
+            "actor": {
+                "type": "Application",
+                "id": "bots/bot-1",
+                "name": "Bot",
+            },
+            "object": {
+                "type": "Note",
+                "id": "msg-1",
+                "name": "message",
+                "content": "{}",
+            },
+            "target": { "type": "Collection", "id": TOKEN, "name": "general" },
+        })
+        .to_string();
+        let headers = sign_headers(SECRET, &body_str);
+        let status =
+            webhook_handler(State(state), headers, Bytes::from(body_str.into_bytes())).await;
+        assert_eq!(status, StatusCode::OK);
+    }
+
     // -- Transcription wiring tests -------------------------------------------
 
     #[test]

--- a/crates/interfaces/src/signal/adapter.rs
+++ b/crates/interfaces/src/signal/adapter.rs
@@ -873,4 +873,76 @@ mod tests {
         };
         assert_eq!(adapter.conversation_key(&msg), "+19995550001");
     }
+
+    // ── build_reqwest_client ──────────────────────────────────────────────
+
+    #[test]
+    fn build_reqwest_client_no_auth_when_user_missing() {
+        let cfg = SignalConfig {
+            phone_number: Some("+14155550123".to_string()),
+            api_user: None,
+            ..Default::default()
+        };
+        // Just assert it builds without panicking.
+        let _ = build_reqwest_client(&cfg).unwrap();
+    }
+
+    #[test]
+    fn build_reqwest_client_includes_basic_auth_header_with_user() {
+        let cfg = SignalConfig {
+            phone_number: Some("+14155550123".to_string()),
+            api_user: Some("admin".to_string()),
+            api_password: Some("s3cret".to_string()),
+            ..Default::default()
+        };
+        let _ = build_reqwest_client(&cfg).unwrap();
+    }
+
+    #[test]
+    fn build_reqwest_client_handles_user_without_password() {
+        let cfg = SignalConfig {
+            phone_number: Some("+14155550123".to_string()),
+            api_user: Some("user-only".to_string()),
+            api_password: None,
+            ..Default::default()
+        };
+        let _ = build_reqwest_client(&cfg).unwrap();
+    }
+
+    // ── envelope_to_channel_message — direct invocation ─────────────────
+
+    #[test]
+    fn envelope_to_channel_message_combines_audio_transcript_when_text_present() {
+        let env = ParsedEnvelope {
+            source: "+10000000001".to_string(),
+            source_name: Some("Alice".to_string()),
+            timestamp: 12345,
+            message: "hello".to_string(),
+            group_id: None,
+            attachments: vec![],
+        };
+        let msg = envelope_to_channel_message(env, Some("[Voice]: hi".to_string())).unwrap();
+        match msg.content {
+            ChannelContent::Text(t) => {
+                assert!(t.starts_with("[Voice]: hi"));
+                assert!(t.contains("hello"));
+            }
+            other => panic!("expected Text, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn envelope_to_channel_message_uses_group_prefix_for_group_messages() {
+        let env = ParsedEnvelope {
+            source: "+10000000001".to_string(),
+            source_name: None,
+            timestamp: 999,
+            message: "in-group".to_string(),
+            group_id: Some("group-xyz".to_string()),
+            attachments: vec![],
+        };
+        let msg = envelope_to_channel_message(env, None).unwrap();
+        assert_eq!(msg.sender.platform_id, "group:group-xyz");
+        assert_eq!(msg.thread_id.as_deref(), Some("group-xyz"));
+    }
 }

--- a/crates/interfaces/src/signal/runner.rs
+++ b/crates/interfaces/src/signal/runner.rs
@@ -99,4 +99,72 @@ mod tests {
         let blocked = !cfg.allowed_senders.is_empty() && !cfg.allowed_senders.contains(&known);
         assert!(!blocked);
     }
+
+    use super::*;
+    use assistant_storage::StorageLayer;
+
+    async fn make_orchestrator() -> Arc<Orchestrator> {
+        use assistant_core::types::agent::AssistantConfig;
+        use assistant_core::{LlmProvider, MessageBus};
+        use assistant_llm_provider::scripted::ScriptedLlmProvider;
+        use assistant_storage::registry::SkillRegistry;
+        use assistant_tool_executor::ToolExecutor;
+        let storage = Arc::new(StorageLayer::new_in_memory().await.unwrap());
+        let cfg = AssistantConfig::default();
+        let registry = Arc::new(SkillRegistry::new(storage.pool.clone()).await.unwrap());
+        let llm: Arc<dyn LlmProvider> = Arc::new(ScriptedLlmProvider::new());
+        let exec = Arc::new(ToolExecutor::new(
+            storage.clone(),
+            llm.clone(),
+            registry.clone(),
+            Arc::new(cfg.clone()),
+        ));
+        let bus: Arc<dyn MessageBus> = Arc::new(storage.message_bus());
+        Arc::new(Orchestrator::new(
+            llm,
+            storage.clone(),
+            exec,
+            registry,
+            bus,
+            &cfg,
+        ))
+    }
+
+    #[tokio::test]
+    async fn new_starts_without_transcription() {
+        let orch = make_orchestrator().await;
+        let iface = SignalInterface::new(SignalConfig::default(), orch);
+        assert!(iface.transcription.is_none());
+        assert!(iface.transcription_language.is_none());
+    }
+
+    #[tokio::test]
+    async fn with_transcription_sets_provider_and_language() {
+        use assistant_transcription::{
+            TranscriptionProvider, TranscriptionRequest, TranscriptionResult,
+        };
+        #[derive(Debug)]
+        struct DummyProvider;
+        #[async_trait]
+        impl TranscriptionProvider for DummyProvider {
+            fn name(&self) -> &str {
+                "dummy"
+            }
+            async fn transcribe(
+                &self,
+                _req: TranscriptionRequest,
+            ) -> anyhow::Result<TranscriptionResult> {
+                Ok(TranscriptionResult {
+                    text: "x".into(),
+                    language: None,
+                    duration_secs: None,
+                })
+            }
+        }
+        let orch = make_orchestrator().await;
+        let iface = SignalInterface::new(SignalConfig::default(), orch)
+            .with_transcription(Arc::new(DummyProvider), Some("en".into()));
+        assert!(iface.transcription.is_some());
+        assert_eq!(iface.transcription_language.as_deref(), Some("en"));
+    }
 }

--- a/crates/interfaces/src/slack/runner.rs
+++ b/crates/interfaces/src/slack/runner.rs
@@ -114,3 +114,120 @@ impl InterfaceRunner for SlackInterface {
         SlackInterface::run(self).await
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assistant_core::types::channels::SlackConfig;
+
+    fn config_with_tokens(bot: Option<&str>, app: Option<&str>) -> SlackConfig {
+        SlackConfig {
+            bot_token: bot.map(String::from),
+            app_token: app.map(String::from),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn ambient_tools_returns_empty_when_bot_token_missing() {
+        let storage = assistant_storage::StorageLayer::new_in_memory()
+            .await
+            .unwrap();
+        let storage = Arc::new(storage);
+        // We don't actually need a real Orchestrator for ambient_tools; build one
+        // off the in-memory storage so the struct fields are populated.
+        let orch = make_orchestrator(storage.clone()).await;
+        let iface = SlackInterface::new(config_with_tokens(None, Some("xapp-1")), orch, storage);
+        assert!(iface.ambient_tools().is_empty());
+    }
+
+    #[tokio::test]
+    async fn ambient_tools_returns_empty_when_app_token_missing() {
+        let storage = assistant_storage::StorageLayer::new_in_memory()
+            .await
+            .unwrap();
+        let storage = Arc::new(storage);
+        let orch = make_orchestrator(storage.clone()).await;
+        let iface = SlackInterface::new(config_with_tokens(Some("xoxb-1"), None), orch, storage);
+        assert!(iface.ambient_tools().is_empty());
+    }
+
+    #[tokio::test]
+    async fn ambient_tools_returns_eight_tools_when_both_tokens_present() {
+        let storage = assistant_storage::StorageLayer::new_in_memory()
+            .await
+            .unwrap();
+        let storage = Arc::new(storage);
+        let orch = make_orchestrator(storage.clone()).await;
+        let iface = SlackInterface::new(
+            config_with_tokens(Some("xoxb-1"), Some("xapp-1")),
+            orch,
+            storage,
+        );
+        let tools = iface.ambient_tools();
+        assert_eq!(tools.len(), 8, "should expose all 8 ambient skills");
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert!(names.iter().any(|n| n.contains("post")));
+        assert!(names.iter().any(|n| n.contains("react")));
+    }
+
+    #[tokio::test]
+    async fn with_transcription_sets_provider() {
+        use assistant_transcription::{
+            TranscriptionProvider, TranscriptionRequest, TranscriptionResult,
+        };
+
+        #[derive(Debug)]
+        struct DummyProvider;
+        #[async_trait::async_trait]
+        impl TranscriptionProvider for DummyProvider {
+            fn name(&self) -> &str {
+                "dummy"
+            }
+            async fn transcribe(&self, _req: TranscriptionRequest) -> Result<TranscriptionResult> {
+                Ok(TranscriptionResult {
+                    text: "x".into(),
+                    language: None,
+                    duration_secs: None,
+                })
+            }
+        }
+
+        let storage = assistant_storage::StorageLayer::new_in_memory()
+            .await
+            .unwrap();
+        let storage = Arc::new(storage);
+        let orch = make_orchestrator(storage.clone()).await;
+        let iface = SlackInterface::new(SlackConfig::default(), orch, storage);
+        assert!(iface.transcription.is_none());
+        let iface = iface.with_transcription(Arc::new(DummyProvider), Some("en".into()));
+        assert!(iface.transcription.is_some());
+        assert_eq!(iface.transcription_language.as_deref(), Some("en"));
+    }
+
+    async fn make_orchestrator(storage: Arc<StorageLayer>) -> Arc<Orchestrator> {
+        use assistant_core::types::agent::AssistantConfig;
+        use assistant_core::{LlmProvider, MessageBus};
+        use assistant_llm_provider::scripted::ScriptedLlmProvider;
+        use assistant_storage::registry::SkillRegistry;
+        use assistant_tool_executor::ToolExecutor;
+        let cfg = AssistantConfig::default();
+        let registry = Arc::new(SkillRegistry::new(storage.pool.clone()).await.unwrap());
+        let llm: Arc<dyn LlmProvider> = Arc::new(ScriptedLlmProvider::new());
+        let exec = Arc::new(ToolExecutor::new(
+            storage.clone(),
+            llm.clone(),
+            registry.clone(),
+            Arc::new(cfg.clone()),
+        ));
+        let bus: Arc<dyn MessageBus> = Arc::new(storage.message_bus());
+        Arc::new(Orchestrator::new(
+            llm,
+            storage.clone(),
+            exec.clone(),
+            registry.clone(),
+            bus,
+            &cfg,
+        ))
+    }
+}


### PR DESCRIPTION
## Summary

Lifts `crates/interfaces` from 67.8% to **73.5%** via inline test additions across all 5 messenger adapters and their runner shims. Crate remains on `report_only` — bulk of remaining uncovered code is WebSocket/HTTP receive loops that require integration-grade test infrastructure (Docker-based or real servers).

This is breadth-first Phase 9 backfill — not a promotion. Each adapter's parser + auth-config edge cases are now covered.

### Adapter coverage

- **nextcloud/adapter.rs** (52.5%): `webhook_handler` 401 (missing signature/random, invalid sig), 400 (malformed signed body), 200 (non-Create / bot actor)
- **mattermost/adapter.rs** (56.2%): `parse_platform_id` with/without slash; `parse_posted_event` self-message, allowlist, thread-root, malformed post, missing post field
- **signal/adapter.rs** (69.7%): `build_reqwest_client` (no auth / basic-auth / user-without-password); `envelope_to_channel_message` combine-transcript + group-prefix

### Runner coverage

- **slack/runner.rs** (was 0%): `ambient_tools` empty/full; `with_transcription` wiring
- **mattermost/runner.rs** (was 38%): `new`/`with_transcription`; `run` errors when server URL or token missing
- **signal/runner.rs** (was 47.4%): `new`/`with_transcription` wiring
- **matrix/runner.rs** (was 25.3%): `new`/`with_transcription`; `run` errors when homeserver missing / access-token-without-username / no-credentials

### Wire-up

Adds `assistant-llm-provider` + `assistant-tool-executor` to interfaces' `[dev-dependencies]` so runner tests can build a minimal `Orchestrator` via `ScriptedLlmProvider`.

Part of `openspec/changes/workspace-test-coverage-floor` (Phase 9).

## Test plan

- [x] `cargo test -p assistant-interfaces --lib` — all targets green
- [x] `make lint` — clippy clean
- [x] `make coverage` — gate prints `Coverage gate passed`; interfaces at 73.5% (delta -6.5%, still report-only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage across multiple interface modules with new unit and integration tests
  * Added validation tests for configuration, credential handling, and message processing
  * Introduced test infrastructure and helper utilities for orchestrator setup

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cedricziel/assistant/pull/893?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->