### PR TITLE
feat(ci): promote opentelemetry-exporter-iceberg past 80% floor (Phase 11)

### DIFF
--- a/coverage.toml
+++ b/coverage.toml
@@ -50,7 +50,6 @@ crates = [
     "interface-cli",                     # 28.9% (delta -51.1%)
     "interfaces",                        # 61.6% (delta -18.4%)
     "mcp-client",                        # 20.3% (delta -59.7%)
-    "opentelemetry-exporter-iceberg",    # 37.5% (delta -42.5%)
     "opentelemetry-exporter-sqlite",     # 51.4% (delta -28.6%)
 ]
 
@@ -74,6 +73,7 @@ crates = [
 #   llm-provider  (80.3%) — pure-function tests across anthropic, openai/oauth, chat_completions, ollama
 #   runtime       (80.3%) — bootstrap, memory_indexer, scheduler/loop+prune, compaction chunked path, dispatch helpers, title_generator helpers, skill_learner format_history_for_judge, interface_trait default impls
 #   web-ui        (80.1%) — a2a handlers + routers, push.rs crypto (encrypt_payload, build_vapid_jwt, signing_key), oauth session_cookie + escape_html_attr, iceberg pure helpers (warehouse_path, bucket_key, collect_parquet_files), api/webhooks toggle/rotate/update, api/conversations PATCH/DELETE edge cases, api/skills get/update/delete edge cases, auth.rs login_html + parse_host_from_url + extract_cookie edge cases, lib.rs harden_agent_card + nats_reachable + resolve_base_url, api/mod.rs internal_error + empty_string_as_none
+#   opentelemetry-exporter-iceberg (81.2%) — log + metric e2e exports via SdkMeterProvider/SdkLoggerProvider, partition::granularity_to_partition_int + partition_spec, catalog::warehouse_path + build_file_io + build_catalog + ensure_namespace
 
 # File path regex patterns excluded from coverage measurement.
 # Passed to `cargo llvm-cov --ignore-filename-regex` as a joined alternation.

--- a/crates/opentelemetry-exporter-iceberg/src/catalog.rs
+++ b/crates/opentelemetry-exporter-iceberg/src/catalog.rs
@@ -91,3 +91,60 @@ fn warehouse_path(config: &IcebergConfig) -> String {
             })
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assistant_core::types::observability::PartitionGranularity;
+
+    fn test_config(warehouse: Option<&str>) -> IcebergConfig {
+        IcebergConfig {
+            warehouse: warehouse.map(String::from),
+            namespace: "test".to_string(),
+            partition: PartitionGranularity::None,
+            catalog_uri: None,
+        }
+    }
+
+    #[test]
+    fn warehouse_path_uses_explicit_value() {
+        let cfg = test_config(Some("/custom/wh"));
+        assert_eq!(warehouse_path(&cfg), "/custom/wh");
+    }
+
+    #[test]
+    fn warehouse_path_falls_back_to_assistant_iceberg() {
+        let cfg = test_config(None);
+        // Should resolve to ~/.assistant/iceberg or ./.assistant/iceberg.
+        let p = warehouse_path(&cfg);
+        assert!(p.ends_with(".assistant/iceberg"), "got: {p}");
+    }
+
+    #[test]
+    fn build_file_io_returns_filesystem_backend() {
+        let cfg = test_config(Some("/tmp/wh"));
+        // Smoke test: the function returns successfully and produces a FileIO.
+        let _io = build_file_io(&cfg);
+    }
+
+    #[tokio::test]
+    async fn build_catalog_creates_memory_catalog_when_no_uri() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = test_config(Some(tmp.path().to_str().unwrap()));
+        let catalog = build_catalog(&cfg).await.unwrap();
+
+        let ns = ensure_namespace(catalog.as_ref(), "ns_test").await.unwrap();
+        assert_eq!(ns.to_string(), "ns_test");
+    }
+
+    #[tokio::test]
+    async fn ensure_namespace_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = test_config(Some(tmp.path().to_str().unwrap()));
+        let catalog = build_catalog(&cfg).await.unwrap();
+
+        let first = ensure_namespace(catalog.as_ref(), "ns_dup").await.unwrap();
+        let second = ensure_namespace(catalog.as_ref(), "ns_dup").await.unwrap();
+        assert_eq!(first.to_string(), second.to_string());
+    }
+}

--- a/crates/opentelemetry-exporter-iceberg/src/partition.rs
+++ b/crates/opentelemetry-exporter-iceberg/src/partition.rs
@@ -91,3 +91,74 @@ fn granularity_to_partition_int(micros: i64, granularity: &PartitionGranularity)
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Reference timestamp: 2026-05-19T08:00:00Z = 1779523200 seconds.
+    const REF_MICROS: i64 = 1779523200_000_000;
+
+    #[test]
+    fn granularity_none_returns_zero() {
+        assert_eq!(
+            granularity_to_partition_int(REF_MICROS, &PartitionGranularity::None),
+            0
+        );
+    }
+
+    #[test]
+    fn granularity_hour_divides_by_3600_seconds() {
+        let expected = (REF_MICROS / 3_600_000_000_i64) as i32;
+        assert_eq!(
+            granularity_to_partition_int(REF_MICROS, &PartitionGranularity::Hour),
+            expected
+        );
+    }
+
+    #[test]
+    fn granularity_day_divides_by_86400_seconds() {
+        let expected = (REF_MICROS / 86_400_000_000_i64) as i32;
+        assert_eq!(
+            granularity_to_partition_int(REF_MICROS, &PartitionGranularity::Day),
+            expected
+        );
+    }
+
+    #[test]
+    fn granularity_year_returns_years_since_1970() {
+        // 2026 → 56 years after 1970.
+        assert_eq!(
+            granularity_to_partition_int(REF_MICROS, &PartitionGranularity::Year),
+            56
+        );
+    }
+
+    #[test]
+    fn granularity_month_returns_months_since_jan_1970() {
+        // 2026-05 → 56 years * 12 + (5-1) = 672 + 4 = 676.
+        assert_eq!(
+            granularity_to_partition_int(REF_MICROS, &PartitionGranularity::Month),
+            676
+        );
+    }
+
+    #[test]
+    fn partition_spec_returns_none_for_none_granularity() {
+        let spec = partition_spec(&PartitionGranularity::None, 1, "ts_day").unwrap();
+        assert!(spec.is_none());
+    }
+
+    #[test]
+    fn partition_spec_returns_some_for_each_time_granularity() {
+        for g in [
+            PartitionGranularity::Year,
+            PartitionGranularity::Month,
+            PartitionGranularity::Day,
+            PartitionGranularity::Hour,
+        ] {
+            let spec = partition_spec(&g, 7, "ts_p").unwrap();
+            assert!(spec.is_some(), "{g:?} must produce an UnboundPartitionSpec",);
+        }
+    }
+}

--- a/crates/opentelemetry-exporter-iceberg/tests/e2e_write_read.rs
+++ b/crates/opentelemetry-exporter-iceberg/tests/e2e_write_read.rs
@@ -29,6 +29,31 @@ fn test_config(warehouse: &str) -> IcebergConfig {
     }
 }
 
+use opentelemetry::logs::{AnyValue, LogRecord as _, Logger as _, LoggerProvider as _, Severity};
+use opentelemetry_exporter_iceberg::IcebergLogExporter;
+use opentelemetry_sdk::logs::{LogBatch, LogExporter, SdkLogRecord, SdkLoggerProvider};
+
+fn new_log_record() -> SdkLogRecord {
+    let provider = SdkLoggerProvider::builder().build();
+    let logger = provider.logger("test");
+    logger.create_log_record()
+}
+
+fn make_log(severity: Severity, body: &str, target: &str) -> (SdkLogRecord, InstrumentationScope) {
+    let mut record = new_log_record();
+    record.set_severity_number(severity);
+    record.set_severity_text(match severity {
+        Severity::Info | Severity::Info2 | Severity::Info3 | Severity::Info4 => "INFO",
+        Severity::Warn | Severity::Warn2 | Severity::Warn3 | Severity::Warn4 => "WARN",
+        Severity::Error | Severity::Error2 | Severity::Error3 | Severity::Error4 => "ERROR",
+        _ => "TRACE",
+    });
+    record.set_body(AnyValue::String(body.to_string().into()));
+    record.set_timestamp(SystemTime::UNIX_EPOCH);
+    record.set_target(target.to_string());
+    (record, InstrumentationScope::builder("test").build())
+}
+
 fn make_span(name: &'static str) -> SpanData {
     let trace_id = TraceId::from_hex("4bf92f3577b34da6a3ce929d0e0e4736").unwrap();
     let span_id = SpanId::from_hex("00f067aa0ba902b7").unwrap();
@@ -144,6 +169,103 @@ async fn span_exported_with_day_partition_succeeds() {
         !parquet_files.is_empty(),
         "at least one Parquet file must be written for the partitioned export"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Log exporter tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn log_is_written_and_queryable() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let warehouse = dir.path().to_str().unwrap();
+    let config = test_config(warehouse);
+
+    let exporter = IcebergLogExporter::new(config)
+        .await
+        .expect("IcebergLogExporter::new");
+
+    let (record, scope) = make_log(Severity::Info, "hello-log-line", "test-target");
+    let items = vec![(record, scope)];
+    let refs: Vec<(&SdkLogRecord, &InstrumentationScope)> =
+        items.iter().map(|(r, s)| (r, s)).collect();
+    let batch = LogBatch::new(&refs);
+
+    let result: OTelSdkResult = exporter.export(batch).await;
+    assert!(result.is_ok(), "log export must succeed: {result:?}");
+
+    // A Parquet file should have landed in the warehouse.
+    let parquet_files = find_parquet_files(warehouse);
+    assert!(
+        !parquet_files.is_empty(),
+        "at least one Parquet file must be written for the log export"
+    );
+}
+
+#[tokio::test]
+async fn log_with_day_partition_succeeds() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let warehouse = dir.path().to_str().unwrap();
+    let mut config = test_config(warehouse);
+    config.partition = PartitionGranularity::Day;
+
+    let exporter = IcebergLogExporter::new(config)
+        .await
+        .expect("IcebergLogExporter::new");
+
+    let (record, scope) = make_log(Severity::Warn, "disk almost full", "infra::monitor");
+    let items = vec![(record, scope)];
+    let refs: Vec<(&SdkLogRecord, &InstrumentationScope)> =
+        items.iter().map(|(r, s)| (r, s)).collect();
+    let batch = LogBatch::new(&refs);
+    exporter.export(batch).await.expect("log export");
+
+    let parquet_files = find_parquet_files(warehouse);
+    assert!(
+        !parquet_files.is_empty(),
+        "day-partitioned log export must write at least one Parquet file"
+    );
+}
+
+#[tokio::test]
+async fn log_exporter_handles_empty_batch() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let warehouse = dir.path().to_str().unwrap();
+    let config = test_config(warehouse);
+    let exporter = IcebergLogExporter::new(config)
+        .await
+        .expect("IcebergLogExporter::new");
+
+    let items: Vec<(SdkLogRecord, InstrumentationScope)> = vec![];
+    let refs: Vec<(&SdkLogRecord, &InstrumentationScope)> =
+        items.iter().map(|(r, s)| (r, s)).collect();
+    let batch = LogBatch::new(&refs);
+    // Empty batch should not error.
+    let result = exporter.export(batch).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn multiple_log_records_in_one_batch_write_parquet() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let warehouse = dir.path().to_str().unwrap();
+    let config = test_config(warehouse);
+    let exporter = IcebergLogExporter::new(config)
+        .await
+        .expect("IcebergLogExporter::new");
+
+    let items: Vec<(SdkLogRecord, InstrumentationScope)> = vec![
+        make_log(Severity::Info, "first", "app"),
+        make_log(Severity::Warn, "second", "app"),
+        make_log(Severity::Error, "third", "app"),
+    ];
+    let refs: Vec<(&SdkLogRecord, &InstrumentationScope)> =
+        items.iter().map(|(r, s)| (r, s)).collect();
+    let batch = LogBatch::new(&refs);
+    exporter.export(batch).await.expect("export");
+
+    let parquet_files = find_parquet_files(warehouse);
+    assert!(!parquet_files.is_empty());
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/opentelemetry-exporter-iceberg/tests/metric_export_e2e.rs
+++ b/crates/opentelemetry-exporter-iceberg/tests/metric_export_e2e.rs
@@ -1,0 +1,155 @@
+//! End-to-end metric export tests for `IcebergMetricExporter`.
+//!
+//! Uses `SdkMeterProvider` + `PeriodicReader` to drive real instruments
+//! through the SDK pipeline and asserts the resulting Parquet files
+//! land in the warehouse.
+
+use std::path::Path;
+use std::time::Duration;
+
+use assistant_core::types::observability::{IcebergConfig, PartitionGranularity};
+use opentelemetry::KeyValue;
+use opentelemetry::metrics::MeterProvider as _;
+use opentelemetry_exporter_iceberg::IcebergMetricExporter;
+use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
+use opentelemetry_semantic_conventions::attribute::SERVICE_NAME;
+
+fn test_config(warehouse: &str) -> IcebergConfig {
+    IcebergConfig {
+        warehouse: Some(warehouse.to_string()),
+        namespace: "test".to_string(),
+        partition: PartitionGranularity::None,
+        catalog_uri: None,
+    }
+}
+
+fn find_parquet_files(root: &str) -> Vec<std::path::PathBuf> {
+    let mut results = Vec::new();
+    collect_parquet(Path::new(root), &mut results);
+    results
+}
+
+fn collect_parquet(dir: &Path, out: &mut Vec<std::path::PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_parquet(&path, out);
+        } else if path.extension().is_some_and(|e| e == "parquet") {
+            out.push(path);
+        }
+    }
+}
+
+async fn make_provider(warehouse: &str) -> SdkMeterProvider {
+    let exporter = IcebergMetricExporter::new(test_config(warehouse))
+        .await
+        .expect("IcebergMetricExporter::new");
+    let reader = PeriodicReader::builder(exporter)
+        .with_interval(Duration::from_secs(3600))
+        .build();
+    let resource = Resource::builder_empty()
+        .with_attributes([KeyValue::new(SERVICE_NAME, "metric-test")])
+        .build();
+    SdkMeterProvider::builder()
+        .with_resource(resource)
+        .with_reader(reader)
+        .build()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn counter_increments_write_parquet() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let warehouse = dir.path().to_str().unwrap();
+    let provider = make_provider(warehouse).await;
+
+    let meter = provider.meter("test-scope");
+    let counter = meter.u64_counter("requests").build();
+    counter.add(1, &[KeyValue::new("route", "/a")]);
+    counter.add(4, &[KeyValue::new("route", "/a")]);
+
+    provider.shutdown().unwrap();
+
+    let parquet_files = find_parquet_files(warehouse);
+    assert!(
+        !parquet_files.is_empty(),
+        "counter metric must produce at least one Parquet file"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn histogram_records_write_parquet() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let warehouse = dir.path().to_str().unwrap();
+    let provider = make_provider(warehouse).await;
+
+    let meter = provider.meter("test-scope");
+    let hist = meter.f64_histogram("latency_seconds").build();
+    hist.record(0.1, &[]);
+    hist.record(0.5, &[]);
+    hist.record(1.0, &[]);
+
+    provider.shutdown().unwrap();
+
+    let parquet_files = find_parquet_files(warehouse);
+    assert!(
+        !parquet_files.is_empty(),
+        "histogram metric must produce at least one Parquet file"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn day_partitioned_metric_export_succeeds() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let warehouse = dir.path().to_str().unwrap();
+
+    let mut config = test_config(warehouse);
+    config.partition = PartitionGranularity::Day;
+    let exporter = IcebergMetricExporter::new(config)
+        .await
+        .expect("IcebergMetricExporter::new");
+    let reader = PeriodicReader::builder(exporter)
+        .with_interval(Duration::from_secs(3600))
+        .build();
+    let resource = Resource::builder_empty()
+        .with_attributes([KeyValue::new(SERVICE_NAME, "day-partition")])
+        .build();
+    let provider = SdkMeterProvider::builder()
+        .with_resource(resource)
+        .with_reader(reader)
+        .build();
+
+    let meter = provider.meter("scope");
+    let counter = meter.u64_counter("requests").build();
+    counter.add(1, &[]);
+    provider.shutdown().unwrap();
+
+    let parquet_files = find_parquet_files(warehouse);
+    assert!(
+        !parquet_files.is_empty(),
+        "day-partitioned metric export must write at least one Parquet file"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn multiple_metric_kinds_share_warehouse() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let warehouse = dir.path().to_str().unwrap();
+    let provider = make_provider(warehouse).await;
+
+    let meter = provider.meter("scope");
+    meter.u64_counter("c").build().add(1, &[]);
+    meter.i64_up_down_counter("ud").build().add(-2, &[]);
+    meter.f64_histogram("h").build().record(0.5, &[]);
+
+    provider.shutdown().unwrap();
+
+    let parquet_files = find_parquet_files(warehouse);
+    assert!(
+        !parquet_files.is_empty(),
+        "mixed-kind metrics must produce at least one Parquet file"
+    );
+}


### PR DESCRIPTION
## Summary

Lifts `crates/opentelemetry-exporter-iceberg` from 37.5% to **81.2%** via end-to-end log + metric export tests and pure-helper tests. Ratchets off `report_only`. `report_only` drops from 6 to 5.

### New tests

- **tests/e2e_write_read.rs** — log export coverage:
  - `log_is_written_and_queryable` (Info + target, parquet written)
  - `log_with_day_partition_succeeds` (day-partitioned warehouse layout)
  - `log_exporter_handles_empty_batch`
  - `multiple_log_records_in_one_batch_write_parquet` (Info/Warn/Error)

- **tests/metric_export_e2e.rs** (new) — metric coverage via `SdkMeterProvider` + `PeriodicReader`:
  - `counter_increments_write_parquet`
  - `histogram_records_write_parquet`
  - `day_partitioned_metric_export_succeeds`
  - `multiple_metric_kinds_share_warehouse` (counter + up_down_counter + histogram in one batch)

- **partition.rs**: `granularity_to_partition_int` for None/Hour/Day/Month/Year + `partition_spec` returns None for None, Some for each time granularity

- **catalog.rs**: `warehouse_path` explicit + fallback paths, `build_file_io` smoke, `build_catalog` memory backend, `ensure_namespace` idempotence

### Note

The `metric_export_e2e` tests use `provider.shutdown()` which the iceberg exporter's `PushMetricExporter::export` handles correctly (the iceberg impl is straightforward `self.export_inner(metrics).await`, unlike the sqlite exporter which needs Tokio handle gymnastics to bridge sync/async).

Remaining `report_only` (5 crates): `bus-nats`, `interface-cli`, `mcp-client`, `opentelemetry-exporter-sqlite`, `interfaces`.

Part of `openspec/changes/workspace-test-coverage-floor` (Phase 11).

## Test plan

- [x] `cargo test -p opentelemetry-exporter-iceberg` — all targets green
- [x] `make lint` — clippy clean
- [x] `make coverage` — gate prints `Coverage gate passed`; iceberg shows `ok` at 81.2%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive end-to-end test coverage for OpenTelemetry log and metric exports to the Iceberg warehouse.
  * Added unit tests for catalog, namespace, and partition configuration functionality.

* **Chores**
  * Updated code coverage enforcement configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cedricziel/assistant/pull/894?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->