### PR TITLE
feat(ci): promote opentelemetry-exporter-sqlite past 80% floor (Phase 11)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4074,6 +4074,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "sqlx",
+ "tempfile",
  "tokio",
  "tracing",
  "uuid",

--- a/coverage.toml
+++ b/coverage.toml
@@ -50,7 +50,6 @@ crates = [
     "interface-cli",                     # 28.9% (delta -51.1%)
     "interfaces",                        # 61.6% (delta -18.4%)
     "mcp-client",                        # 20.3% (delta -59.7%)
-    "opentelemetry-exporter-sqlite",     # 51.4% (delta -28.6%)
 ]
 
 # Crates promoted off `report_only` and now ENFORCING the 80% floor.
@@ -74,6 +73,7 @@ crates = [
 #   runtime       (80.3%) — bootstrap, memory_indexer, scheduler/loop+prune, compaction chunked path, dispatch helpers, title_generator helpers, skill_learner format_history_for_judge, interface_trait default impls
 #   web-ui        (80.1%) — a2a handlers + routers, push.rs crypto (encrypt_payload, build_vapid_jwt, signing_key), oauth session_cookie + escape_html_attr, iceberg pure helpers (warehouse_path, bucket_key, collect_parquet_files), api/webhooks toggle/rotate/update, api/conversations PATCH/DELETE edge cases, api/skills get/update/delete edge cases, auth.rs login_html + parse_host_from_url + extract_cookie edge cases, lib.rs harden_agent_card + nats_reachable + resolve_base_url, api/mod.rs internal_error + empty_string_as_none
 #   opentelemetry-exporter-iceberg (81.2%) — log + metric e2e exports via SdkMeterProvider/SdkLoggerProvider, partition::granularity_to_partition_int + partition_spec, catalog::warehouse_path + build_file_io + build_catalog + ensure_namespace
+#   opentelemetry-exporter-sqlite (80.5%) — metric e2e exports via SdkMeterProvider over file-backed SQLite + log helper-fn coverage (any_value_to_json/Map/Bytes, all severity variants)
 
 # File path regex patterns excluded from coverage measurement.
 # Passed to `cargo llvm-cov --ignore-filename-regex` as a joined alternation.

--- a/crates/opentelemetry-exporter-sqlite/Cargo.toml
+++ b/crates/opentelemetry-exporter-sqlite/Cargo.toml
@@ -21,7 +21,9 @@ uuid = { workspace = true }
 workspace = true
 
 [dev-dependencies]
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+opentelemetry-semantic-conventions = { workspace = true }
+tempfile = { workspace = true }
 
 # Panic-free contract: production code propagates errors via `anyhow::Result`.
 # Tests are exempt because `make lint` (`cargo clippy --workspace`) does not

--- a/crates/opentelemetry-exporter-sqlite/src/log.rs
+++ b/crates/opentelemetry-exporter-sqlite/src/log.rs
@@ -441,4 +441,64 @@ mod tests {
         assert_eq!(v["k1"], "v1");
         assert_eq!(v["k2"], 42);
     }
+
+    #[test]
+    fn any_value_to_json_handles_double_and_bytes_and_map() {
+        // Double.
+        assert_eq!(
+            any_value_to_json(&AnyValue::Double(1.5)),
+            serde_json::json!(1.5)
+        );
+        // Bytes renders via Debug.
+        let bytes = AnyValue::Bytes(Box::new(vec![1u8, 2, 3]));
+        match any_value_to_json(&bytes) {
+            serde_json::Value::String(s) => assert!(s.contains("1") && s.contains("3")),
+            other => panic!("expected string Debug repr, got {other:?}"),
+        }
+        // Map nests recursively.
+        let map_val = AnyValue::Map(Box::new(
+            vec![("inner".into(), AnyValue::Int(99))]
+                .into_iter()
+                .collect(),
+        ));
+        let v = any_value_to_json(&map_val);
+        assert_eq!(v["inner"], 99);
+    }
+
+    #[test]
+    fn any_value_to_string_handles_bytes_list_map() {
+        let bytes = AnyValue::Bytes(Box::new(vec![1u8, 2]));
+        let s = any_value_to_string(&bytes);
+        assert!(s.contains("1"));
+        let list = AnyValue::ListAny(vec![AnyValue::Int(1), AnyValue::Int(2)].into());
+        let s = any_value_to_string(&list);
+        assert!(s.contains("1"));
+        let map_val = AnyValue::Map(Box::new(
+            vec![("k".into(), AnyValue::Int(1))].into_iter().collect(),
+        ));
+        let s = any_value_to_string(&map_val);
+        assert!(s.contains("k"));
+    }
+
+    #[test]
+    fn severity_to_i32_covers_all_severity_variants() {
+        // Already covers 8 variants in severity_to_i32_maps_across_severity_classes.
+        // Add the remaining intermediate severities to exercise full match arms.
+        assert_eq!(severity_to_i32(Severity::Trace2), 2);
+        assert_eq!(severity_to_i32(Severity::Trace3), 3);
+        assert_eq!(severity_to_i32(Severity::Debug2), 6);
+        assert_eq!(severity_to_i32(Severity::Debug3), 7);
+        assert_eq!(severity_to_i32(Severity::Debug4), 8);
+        assert_eq!(severity_to_i32(Severity::Info2), 10);
+        assert_eq!(severity_to_i32(Severity::Info3), 11);
+        assert_eq!(severity_to_i32(Severity::Info4), 12);
+        assert_eq!(severity_to_i32(Severity::Warn2), 14);
+        assert_eq!(severity_to_i32(Severity::Warn3), 15);
+        assert_eq!(severity_to_i32(Severity::Warn4), 16);
+        assert_eq!(severity_to_i32(Severity::Error2), 18);
+        assert_eq!(severity_to_i32(Severity::Error3), 19);
+        assert_eq!(severity_to_i32(Severity::Error4), 20);
+        assert_eq!(severity_to_i32(Severity::Fatal2), 22);
+        assert_eq!(severity_to_i32(Severity::Fatal3), 23);
+    }
 }

--- a/crates/opentelemetry-exporter-sqlite/tests/metric_export_e2e.rs
+++ b/crates/opentelemetry-exporter-sqlite/tests/metric_export_e2e.rs
@@ -1,0 +1,199 @@
+//! End-to-end metric export tests for `SqliteMetricExporter`.
+//!
+//! Uses the same `SdkMeterProvider` + `PeriodicReader` pattern as the
+//! sibling iceberg exporter's metric tests. Forces a synchronous flush
+//! via `provider.shutdown()` and validates rows land in the
+//! `metric_points` SQLite table.
+
+use std::time::Duration;
+
+use opentelemetry::KeyValue;
+use opentelemetry::metrics::MeterProvider as _;
+use opentelemetry_exporter_sqlite::SqliteMetricExporter;
+use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
+use opentelemetry_semantic_conventions::attribute::SERVICE_NAME;
+use sqlx::SqlitePool;
+use sqlx::sqlite::SqlitePoolOptions;
+
+async fn test_pool() -> (SqlitePool, tempfile::TempDir) {
+    // File-backed DB so that connections taken from the pool see the
+    // same schema. `sqlite::memory:` gives each connection its own DB
+    // which breaks tests that span multiple acquisitions.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("metrics.db");
+    let url = format!("sqlite://{}?mode=rwc", path.display());
+
+    let pool = SqlitePoolOptions::new()
+        .max_connections(5)
+        .connect(&url)
+        .await
+        .unwrap();
+    sqlx::query("PRAGMA journal_mode=WAL;")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    sqlx::raw_sql(include_str!("../../../migrations/015_metrics.sql"))
+        .execute(&pool)
+        .await
+        .unwrap();
+    // 019 adds the agent_id column referenced by the exporter's INSERTs.
+    sqlx::raw_sql(include_str!(
+        "../../../migrations/019_metrics_agent_scope.sql"
+    ))
+    .execute(&pool)
+    .await
+    .unwrap();
+    (pool, dir)
+}
+
+fn build_provider(pool: SqlitePool, resource: Resource) -> SdkMeterProvider {
+    let exporter = SqliteMetricExporter::new(pool);
+    let reader = PeriodicReader::builder(exporter)
+        .with_interval(Duration::from_secs(3600))
+        .build();
+    SdkMeterProvider::builder()
+        .with_resource(resource)
+        .with_reader(reader)
+        .build()
+}
+
+fn resource(name: &str) -> Resource {
+    Resource::builder_empty()
+        .with_attributes([KeyValue::new(SERVICE_NAME, name.to_string())])
+        .build()
+}
+
+async fn flush_and_settle(provider: &SdkMeterProvider) {
+    // Force a flush, then yield to let the PeriodicReader's task drain.
+    let _ = provider.force_flush();
+    for _ in 0..20 {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        tokio::task::yield_now().await;
+    }
+    let _ = provider.shutdown();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn counter_increments_persist_as_sum_rows() {
+    let (pool, _dir) = test_pool().await;
+    let provider = build_provider(pool.clone(), resource("counter-test"));
+
+    let meter = provider.meter("test-scope");
+    let counter = meter.u64_counter("requests").build();
+    counter.add(1, &[KeyValue::new("route", "/a")]);
+    counter.add(4, &[KeyValue::new("route", "/a")]);
+
+    flush_and_settle(&provider).await;
+
+    let count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM metric_points WHERE metric_name = 'requests'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert!(count >= 1, "expected at least one metric row, got {count}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn histogram_records_persist_with_bounds_and_buckets() {
+    let (pool, _dir) = test_pool().await;
+    let provider = build_provider(pool.clone(), resource("hist-test"));
+
+    let meter = provider.meter("test-scope");
+    let hist = meter.f64_histogram("latency_seconds").build();
+    hist.record(0.1, &[]);
+    hist.record(0.5, &[]);
+    hist.record(1.0, &[]);
+
+    flush_and_settle(&provider).await;
+
+    let count_opt: Option<(i64, Option<f64>, Option<String>, Option<String>)> = sqlx::query_as(
+        "SELECT count, sum, bounds, bucket_counts \
+             FROM metric_points WHERE metric_name = 'latency_seconds' LIMIT 1",
+    )
+    .fetch_optional(&pool)
+    .await
+    .unwrap();
+    assert!(count_opt.is_some(), "histogram row must exist");
+    let (cnt, sum, bounds, buckets) = count_opt.unwrap();
+    assert_eq!(cnt, 3);
+    assert!(sum.unwrap() > 1.0);
+    assert!(bounds.is_some());
+    assert!(buckets.is_some());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn i64_up_down_counter_persists() {
+    let (pool, _dir) = test_pool().await;
+    let provider = build_provider(pool.clone(), resource("i64-counter-test"));
+
+    let meter = provider.meter("test-scope");
+    let counter = meter.i64_up_down_counter("delta").build();
+    counter.add(5, &[]);
+    counter.add(-2, &[]);
+
+    flush_and_settle(&provider).await;
+
+    let count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM metric_points WHERE metric_name = 'delta'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert!(count >= 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn metric_with_gen_ai_attrs_populates_denormalized_columns() {
+    use opentelemetry_semantic_conventions::attribute::{
+        GEN_AI_OPERATION_NAME, GEN_AI_REQUEST_MODEL,
+    };
+
+    let (pool, _dir) = test_pool().await;
+    let provider = build_provider(pool.clone(), resource("gen-ai-test"));
+
+    let meter = provider.meter("test-scope");
+    let counter = meter.u64_counter("gen_ai.client.token.usage").build();
+    counter.add(
+        100,
+        &[
+            KeyValue::new(GEN_AI_REQUEST_MODEL, "gpt-4o"),
+            KeyValue::new("gen_ai.provider.name", "openai"),
+            KeyValue::new(GEN_AI_OPERATION_NAME, "chat"),
+        ],
+    );
+
+    flush_and_settle(&provider).await;
+
+    let row_opt: Option<(Option<String>, Option<String>, Option<String>)> = sqlx::query_as(
+        "SELECT model, provider, operation FROM metric_points \
+             WHERE metric_name = 'gen_ai.client.token.usage' LIMIT 1",
+    )
+    .fetch_optional(&pool)
+    .await
+    .unwrap();
+    assert!(row_opt.is_some(), "gen-ai metric row must exist");
+    let (model, provider_col, operation) = row_opt.unwrap();
+    assert_eq!(model.as_deref(), Some("gpt-4o"));
+    assert_eq!(provider_col.as_deref(), Some("openai"));
+    assert_eq!(operation.as_deref(), Some("chat"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn multiple_metrics_share_resource_row() {
+    let (pool, _dir) = test_pool().await;
+    let provider = build_provider(pool.clone(), resource("multi-test"));
+
+    let meter = provider.meter("test-scope");
+    meter.u64_counter("m1").build().add(1, &[]);
+    meter.u64_counter("m2").build().add(1, &[]);
+    meter.u64_counter("m3").build().add(1, &[]);
+
+    flush_and_settle(&provider).await;
+
+    let resource_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM resources")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(resource_count, 1);
+}


### PR DESCRIPTION
## Summary

Lifts `crates/opentelemetry-exporter-sqlite` from 59.5% to **80.5%** via end-to-end metric export tests and additional helper-fn coverage. Ratchets off `report_only`. `report_only` drops from 5 to 4.

### Two obstacles diagnosed and fixed

1. **`sqlite::memory:` per-connection isolation** — each pool acquisition got its own ephemeral DB so the test's verify SELECT couldn't see the exporter's INSERTs. Fix: tempfile-backed DB so all connections share one file.
2. **Missing `agent_id` column** — migration 015 introduced `metric_points` without `agent_id`, but the exporter's INSERT binds it. Migration 019 adds it. Fix: include both migrations in the `test_pool` helper.

### New tests

- **`tests/metric_export_e2e.rs`** (new) — `SdkMeterProvider` + `PeriodicReader` driving:
  - `counter_increments_persist_as_sum_rows`
  - `histogram_records_persist_with_bounds_and_buckets`
  - `i64_up_down_counter_persists`
  - `metric_with_gen_ai_attrs_populates_denormalized_columns`
  - `multiple_metrics_share_resource_row`
- **`log.rs`** additional helper coverage:
  - `any_value_to_json` for Double / Bytes / Map (recursive)
  - `any_value_to_string` for Bytes / List / Map
  - `severity_to_i32` covers all 24 severity variants (Trace2/3, Debug2/3/4, Info2/3/4, Warn2/3/4, Error2/3/4, Fatal2/3)

Dev-deps gain `tempfile` and `opentelemetry-semantic-conventions`.

Remaining `report_only` (4 crates): `bus-nats`, `interface-cli`, `mcp-client`, `interfaces`.

Part of `openspec/changes/workspace-test-coverage-floor` (Phase 11).

## Test plan

- [x] `cargo test -p opentelemetry-exporter-sqlite` — all targets green
- [x] `make lint` — clippy clean
- [x] `make coverage` — gate prints `Coverage gate passed`; otel-sqlite shows `ok` at 80.5%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit test coverage for log exporter conversion functions
  * Added end-to-end tests for metric persistence and database operations

* **Chores**
  * Updated coverage enforcement configuration for SQLite exporter
  * Added development dependencies for testing infrastructure

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cedricziel/assistant/pull/895?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->