### PR TITLE
feat(ci): promote assistant-interfaces past 80% floor (Phase 11)

### DIFF
--- a/coverage.toml
+++ b/coverage.toml
@@ -48,7 +48,6 @@ crates = [
     # Last measured (2026-05-18 via `make coverage`):
     "bus-nats",                          # 34.4% (delta -45.6%)
     "interface-cli",                     # 28.9% (delta -51.1%)
-    "interfaces",                        # 61.6% (delta -18.4%)
     "mcp-client",                        # 20.3% (delta -59.7%)
 ]
 
@@ -74,6 +73,7 @@ crates = [
 #   web-ui        (80.1%) — a2a handlers + routers, push.rs crypto (encrypt_payload, build_vapid_jwt, signing_key), oauth session_cookie + escape_html_attr, iceberg pure helpers (warehouse_path, bucket_key, collect_parquet_files), api/webhooks toggle/rotate/update, api/conversations PATCH/DELETE edge cases, api/skills get/update/delete edge cases, auth.rs login_html + parse_host_from_url + extract_cookie edge cases, lib.rs harden_agent_card + nats_reachable + resolve_base_url, api/mod.rs internal_error + empty_string_as_none
 #   opentelemetry-exporter-iceberg (81.2%) — log + metric e2e exports via SdkMeterProvider/SdkLoggerProvider, partition::granularity_to_partition_int + partition_spec, catalog::warehouse_path + build_file_io + build_catalog + ensure_namespace
 #   opentelemetry-exporter-sqlite (80.5%) — metric e2e exports via SdkMeterProvider over file-backed SQLite + log helper-fn coverage (any_value_to_json/Map/Bytes, all severity variants)
+#   interfaces    (80.9%) — wiremock-driven tests for all 8 slack ambient skills (post/react/delete/update/list/get-history/lookup-user/send-dm), slack per-turn tools (reply/react/upload three-step flow), matrix tools (build_matrix_tools + reply handler), nextcloud runner (new/with_shutdown/with_transcription/run-error paths), mattermost tools success paths (full upload flow + already-exists branch), common.rs (rand_jitter + sleep_backoff cap/early-cancel)
 
 # File path regex patterns excluded from coverage measurement.
 # Passed to `cargo llvm-cov --ignore-filename-regex` as a joined alternation.

--- a/crates/interfaces/src/common.rs
+++ b/crates/interfaces/src/common.rs
@@ -29,6 +29,57 @@ pub async fn sleep_backoff(
     *backoff = (*backoff * 2).min(BACKOFF_MAX);
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rand_jitter_in_unit_interval() {
+        for _ in 0..50 {
+            let v = rand_jitter();
+            assert!((0.0..1.0).contains(&v), "{v} not in [0,1)");
+        }
+    }
+
+    #[tokio::test]
+    async fn sleep_backoff_doubles_within_cap_when_stop_aborts() {
+        // Use a tiny initial backoff + immediate stop so the test doesn't
+        // actually sleep for any meaningful time. We only care about the
+        // doubling side-effect.
+        let mut backoff = Duration::from_secs(1);
+        let (tx, mut rx) = tokio::sync::watch::channel(false);
+        tx.send(true).unwrap();
+        sleep_backoff(&mut backoff, &mut rx).await;
+        assert_eq!(backoff, Duration::from_secs(2));
+    }
+
+    #[tokio::test]
+    async fn sleep_backoff_returns_early_when_stop_signal_fires() {
+        let mut backoff = Duration::from_secs(60);
+        let (tx, mut rx) = tokio::sync::watch::channel(false);
+        // Fire stop signal immediately; the select should pick the stop branch
+        // and return without sleeping the full 60s.
+        tx.send(true).unwrap();
+        let start = std::time::Instant::now();
+        sleep_backoff(&mut backoff, &mut rx).await;
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "expected early cancel"
+        );
+        // Backoff still doubles but is capped at BACKOFF_MAX.
+        assert_eq!(backoff, BACKOFF_MAX);
+    }
+
+    #[tokio::test]
+    async fn sleep_backoff_caps_at_max() {
+        let mut backoff = BACKOFF_MAX;
+        let (tx, mut rx) = tokio::sync::watch::channel(false);
+        tx.send(true).unwrap();
+        sleep_backoff(&mut backoff, &mut rx).await;
+        assert_eq!(backoff, BACKOFF_MAX, "must not exceed BACKOFF_MAX");
+    }
+}
+
 /// Simple LCG-based float in `[0, 1)` without pulling in `rand`.
 pub fn rand_jitter() -> f64 {
     // Use wall-clock subsec-nanos as the seed source. This is sufficient

--- a/crates/interfaces/src/matrix/tools.rs
+++ b/crates/interfaces/src/matrix/tools.rs
@@ -67,3 +67,85 @@ impl ToolHandler for MatrixReplyHandler {
 pub fn build_matrix_tools(room_id: String, client: Arc<MatrixClient>) -> Vec<Arc<dyn ToolHandler>> {
     vec![Arc::new(MatrixReplyHandler { room_id, client })]
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assistant_core::types::conversation::{ExecutionContext, Interface};
+    use uuid::Uuid;
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn ctx() -> ExecutionContext {
+        ExecutionContext {
+            conversation_id: Uuid::new_v4(),
+            agent_id: "test".to_string(),
+            turn: 0,
+            interface: Interface::Matrix,
+            interactive: false,
+            allowed_tools: None,
+            depth: 0,
+            user_id: None,
+            org_id: None,
+            space_id: None,
+        }
+    }
+
+    fn client_at(server: &MockServer) -> Arc<MatrixClient> {
+        Arc::new(MatrixClient::new_with_token(server.uri(), "tok", "@bot:example.com").unwrap())
+    }
+
+    #[tokio::test]
+    async fn build_returns_single_reply_handler() {
+        let server = MockServer::start().await;
+        let tools = build_matrix_tools("!room:example.com".to_string(), client_at(&server));
+        assert_eq!(tools.len(), 1);
+        let h = &tools[0];
+        assert_eq!(h.name(), "matrix-reply");
+        assert!(h.is_mutating());
+        assert!(h.description().contains("Matrix"));
+        assert!(h.params_schema().get("required").is_some());
+    }
+
+    #[tokio::test]
+    async fn run_posts_message_when_text_present() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"event_id": "$1"})),
+            )
+            .mount(&server)
+            .await;
+        let tools = build_matrix_tools("!room:example.com".to_string(), client_at(&server));
+        let mut params = HashMap::new();
+        params.insert("text".into(), json!("hello"));
+        let out = tools[0].run(params, &ctx()).await.unwrap();
+        assert!(out.success);
+    }
+
+    #[tokio::test]
+    async fn run_errors_on_missing_text() {
+        let server = MockServer::start().await;
+        let tools = build_matrix_tools("!room:example.com".to_string(), client_at(&server));
+        let out = tools[0].run(HashMap::new(), &ctx()).await.unwrap();
+        assert!(!out.success);
+        assert!(out.content.contains("text"));
+    }
+
+    #[tokio::test]
+    async fn run_reports_failure_on_server_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .respond_with(
+                ResponseTemplate::new(500)
+                    .set_body_json(serde_json::json!({"errcode": "M_UNKNOWN"})),
+            )
+            .mount(&server)
+            .await;
+        let tools = build_matrix_tools("!room:example.com".to_string(), client_at(&server));
+        let mut params = HashMap::new();
+        params.insert("text".into(), json!("hi"));
+        let out = tools[0].run(params, &ctx()).await.unwrap();
+        assert!(!out.success);
+    }
+}

--- a/crates/interfaces/src/mattermost/tools.rs
+++ b/crates/interfaces/src/mattermost/tools.rs
@@ -394,4 +394,126 @@ mod tests {
         assert!(!out.success);
         assert!(out.content.contains("filename"));
     }
+
+    #[tokio::test]
+    async fn react_treats_already_exists_as_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/v4/reactions"))
+            .respond_with(ResponseTemplate::new(500).set_body_json(
+                json!({"id": "app.reaction.save.exists", "message": "reaction already exists"}),
+            ))
+            .mount(&server)
+            .await;
+
+        let tools = build_mattermost_tools(
+            "C1".into(),
+            "P1".into(),
+            None,
+            "U_BOT".into(),
+            make_client(&server).await,
+        );
+        let react = find_tool(&tools, "mattermost-react");
+        let out = react
+            .run(params(&[("emoji", json!("smile"))]), &ctx())
+            .await
+            .unwrap();
+        assert!(out.success);
+        assert!(out.content.contains("already"));
+    }
+
+    #[tokio::test]
+    async fn react_propagates_non_duplicate_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/v4/reactions"))
+            .respond_with(
+                ResponseTemplate::new(500)
+                    .set_body_json(json!({"id": "app.reaction.save.unknown", "message": "boom"})),
+            )
+            .mount(&server)
+            .await;
+        let tools = build_mattermost_tools(
+            "C1".into(),
+            "P1".into(),
+            None,
+            "U_BOT".into(),
+            make_client(&server).await,
+        );
+        let react = find_tool(&tools, "mattermost-react");
+        let out = react
+            .run(params(&[("emoji", json!("smile"))]), &ctx())
+            .await
+            .unwrap();
+        assert!(!out.success);
+    }
+
+    #[tokio::test]
+    async fn upload_full_flow_posts_message_with_file() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/v4/files"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+                "file_infos": [{"id": "FID1", "name": "x.txt"}]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/api/v4/posts"))
+            .respond_with(
+                ResponseTemplate::new(201).set_body_json(json!({"id": "P_UP", "channel_id": "C1"})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let tools = build_mattermost_tools(
+            "C1".into(),
+            "P1".into(),
+            None,
+            "U_BOT".into(),
+            make_client(&server).await,
+        );
+        let upload = find_tool(&tools, "mattermost-upload");
+        let out = upload
+            .run(
+                params(&[
+                    ("filename", json!("x.txt")),
+                    ("content", json!("hello")),
+                    ("message", json!("see attachment")),
+                ]),
+                &ctx(),
+            )
+            .await
+            .unwrap();
+        assert!(out.success);
+    }
+
+    #[tokio::test]
+    async fn upload_error_when_no_file_ids_returned() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/v4/files"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(json!({ "file_infos": [] })))
+            .mount(&server)
+            .await;
+        let tools = build_mattermost_tools(
+            "C1".into(),
+            "P1".into(),
+            None,
+            "U_BOT".into(),
+            make_client(&server).await,
+        );
+        let upload = find_tool(&tools, "mattermost-upload");
+        let out = upload
+            .run(
+                params(&[("filename", json!("x.txt")), ("content", json!("hello"))]),
+                &ctx(),
+            )
+            .await
+            .unwrap();
+        assert!(!out.success);
+        assert!(out.content.contains("no file IDs"));
+    }
 }

--- a/crates/interfaces/src/nextcloud/runner.rs
+++ b/crates/interfaces/src/nextcloud/runner.rs
@@ -109,6 +109,102 @@ mod tests {
     use tokio::sync::Mutex;
     use uuid::Uuid;
 
+    use super::*;
+    use assistant_storage::StorageLayer;
+
+    async fn make_orchestrator() -> Arc<Orchestrator> {
+        use assistant_core::types::agent::AssistantConfig;
+        use assistant_core::{LlmProvider, MessageBus};
+        use assistant_llm_provider::scripted::ScriptedLlmProvider;
+        use assistant_storage::registry::SkillRegistry;
+        use assistant_tool_executor::ToolExecutor;
+        let storage = Arc::new(StorageLayer::new_in_memory().await.unwrap());
+        let cfg = AssistantConfig::default();
+        let registry = Arc::new(SkillRegistry::new(storage.pool.clone()).await.unwrap());
+        let llm: Arc<dyn LlmProvider> = Arc::new(ScriptedLlmProvider::new());
+        let exec = Arc::new(ToolExecutor::new(
+            storage.clone(),
+            llm.clone(),
+            registry.clone(),
+            Arc::new(cfg.clone()),
+        ));
+        let bus: Arc<dyn MessageBus> = Arc::new(storage.message_bus());
+        Arc::new(Orchestrator::new(
+            llm,
+            storage.clone(),
+            exec,
+            registry,
+            bus,
+            &cfg,
+        ))
+    }
+
+    #[tokio::test]
+    async fn new_starts_without_shutdown_or_transcription() {
+        let orch = make_orchestrator().await;
+        let iface = NextcloudInterface::new(NextcloudConfig::default(), orch);
+        assert!(iface.shutdown.is_none());
+        assert!(iface.transcription.is_none());
+        assert!(iface.transcription_language.is_none());
+    }
+
+    #[tokio::test]
+    async fn with_shutdown_attaches_token() {
+        let orch = make_orchestrator().await;
+        let token = tokio_util::sync::CancellationToken::new();
+        let iface =
+            NextcloudInterface::new(NextcloudConfig::default(), orch).with_shutdown(token.clone());
+        assert!(iface.shutdown.is_some());
+    }
+
+    #[tokio::test]
+    async fn with_transcription_sets_provider_and_language() {
+        use assistant_transcription::{
+            TranscriptionProvider, TranscriptionRequest, TranscriptionResult,
+        };
+        #[derive(Debug)]
+        struct DummyProvider;
+        #[async_trait::async_trait]
+        impl TranscriptionProvider for DummyProvider {
+            fn name(&self) -> &str {
+                "dummy"
+            }
+            async fn transcribe(
+                &self,
+                _req: TranscriptionRequest,
+            ) -> anyhow::Result<TranscriptionResult> {
+                Ok(TranscriptionResult {
+                    text: "x".into(),
+                    language: None,
+                    duration_secs: None,
+                })
+            }
+        }
+        let orch = make_orchestrator().await;
+        let iface = NextcloudInterface::new(NextcloudConfig::default(), orch)
+            .with_transcription(Arc::new(DummyProvider), Some("en".into()));
+        assert!(iface.transcription.is_some());
+        assert_eq!(iface.transcription_language.as_deref(), Some("en"));
+    }
+
+    #[tokio::test]
+    async fn run_errors_when_server_url_missing() {
+        let orch = make_orchestrator().await;
+        // SAFETY: tests run with default env; clear any inherited value.
+        unsafe {
+            std::env::remove_var("NEXTCLOUD_SERVER_URL");
+        }
+        let iface = NextcloudInterface::new(
+            NextcloudConfig {
+                server_url: None,
+                ..Default::default()
+            },
+            orch,
+        );
+        let err = iface.run().await.unwrap_err();
+        assert!(err.to_string().contains("server_url"));
+    }
+
     #[test]
     fn conversation_token_mapping_stable() {
         let rt = tokio::runtime::Runtime::new().unwrap();

--- a/crates/interfaces/src/slack/skills/mod.rs
+++ b/crates/interfaces/src/slack/skills/mod.rs
@@ -17,3 +17,24 @@ pub use slack_post::SlackPostSkill;
 pub use slack_react::SlackReactSkill;
 pub use slack_send_dm::SlackSendDmSkill;
 pub use slack_update_message::SlackUpdateMessageSkill;
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use assistant_core::types::conversation::{ExecutionContext, Interface};
+    use uuid::Uuid;
+
+    pub fn ctx() -> ExecutionContext {
+        ExecutionContext {
+            conversation_id: Uuid::new_v4(),
+            agent_id: "test".to_string(),
+            turn: 0,
+            interface: Interface::Slack,
+            interactive: false,
+            allowed_tools: None,
+            depth: 0,
+            user_id: None,
+            org_id: None,
+            space_id: None,
+        }
+    }
+}

--- a/crates/interfaces/src/slack/skills/slack_delete_message.rs
+++ b/crates/interfaces/src/slack/skills/slack_delete_message.rs
@@ -67,3 +67,55 @@ impl ToolHandler for SlackDeleteMessageSkill {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::slack::skills::test_support::ctx;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn skill_at(base: String) -> SlackDeleteMessageSkill {
+        let client = SlackApiClient::with_base_url("xoxb-t".into(), "xapp-t".into(), base).unwrap();
+        SlackDeleteMessageSkill {
+            client: Arc::new(client),
+        }
+    }
+
+    #[test]
+    fn metadata_marks_mutating_and_requires_confirmation() {
+        let s = skill_at("http://127.0.0.1:0".to_string());
+        assert_eq!(s.name(), "slack-delete-message");
+        assert!(s.is_mutating());
+        assert!(s.requires_confirmation());
+    }
+
+    #[tokio::test]
+    async fn run_deletes_when_params_valid() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/chat.delete"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok":true})))
+            .mount(&server)
+            .await;
+        let s = skill_at(server.uri());
+        let mut params = HashMap::new();
+        params.insert("channel".into(), json!("C1"));
+        params.insert("ts".into(), json!("1.2"));
+        let out = s.run(params, &ctx()).await.unwrap();
+        assert!(out.success);
+    }
+
+    #[tokio::test]
+    async fn run_errors_on_missing_params() {
+        let s = skill_at("http://127.0.0.1:0".to_string());
+        let out = s.run(HashMap::new(), &ctx()).await.unwrap();
+        assert!(!out.success);
+
+        let mut params = HashMap::new();
+        params.insert("channel".into(), json!("C1"));
+        let out = s.run(params, &ctx()).await.unwrap();
+        assert!(!out.success);
+        assert!(out.content.contains("ts"));
+    }
+}

--- a/crates/interfaces/src/slack/skills/slack_get_history.rs
+++ b/crates/interfaces/src/slack/skills/slack_get_history.rs
@@ -81,3 +81,91 @@ impl ToolHandler for SlackGetHistorySkill {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::slack::skills::test_support::ctx;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn skill_at(base: String) -> SlackGetHistorySkill {
+        let client = SlackApiClient::with_base_url("xoxb-t".into(), "xapp-t".into(), base).unwrap();
+        SlackGetHistorySkill {
+            client: Arc::new(client),
+        }
+    }
+
+    #[test]
+    fn metadata_is_set() {
+        let s = skill_at("http://127.0.0.1:0".to_string());
+        assert_eq!(s.name(), "slack-get-history");
+        assert!(s.params_schema().get("required").is_some());
+    }
+
+    #[tokio::test]
+    async fn run_errors_on_missing_channel() {
+        let s = skill_at("http://127.0.0.1:0".to_string());
+        let out = s.run(HashMap::new(), &ctx()).await.unwrap();
+        assert!(!out.success);
+        assert!(out.content.contains("channel"));
+    }
+
+    #[tokio::test]
+    async fn run_fetches_channel_history_when_no_thread_ts() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/conversations.history"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "messages": [{"ts": "1.1", "text": "hi"}]
+            })))
+            .mount(&server)
+            .await;
+        let s = skill_at(server.uri());
+        let mut params = HashMap::new();
+        params.insert("channel".into(), json!("C1"));
+        let out = s.run(params, &ctx()).await.unwrap();
+        assert!(out.success);
+        assert!(out.content.contains("hi"));
+    }
+
+    #[tokio::test]
+    async fn run_fetches_thread_replies_when_thread_ts_present() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/conversations.replies"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "messages": [{"ts": "2.0", "text": "reply"}]
+            })))
+            .mount(&server)
+            .await;
+        let s = skill_at(server.uri());
+        let mut params = HashMap::new();
+        params.insert("channel".into(), json!("C1"));
+        params.insert("thread_ts".into(), json!("1.2"));
+        let out = s.run(params, &ctx()).await.unwrap();
+        assert!(out.success);
+        assert!(out.content.contains("reply"));
+    }
+
+    #[tokio::test]
+    async fn run_clamps_huge_limit_and_uses_default_when_missing() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/conversations.history"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "messages": []
+            })))
+            .mount(&server)
+            .await;
+        let s = skill_at(server.uri());
+        let mut params = HashMap::new();
+        params.insert("channel".into(), json!("C1"));
+        params.insert("limit".into(), json!(100_000));
+        let out = s.run(params, &ctx()).await.unwrap();
+        assert!(out.success);
+    }
+}

--- a/crates/interfaces/src/slack/skills/slack_list_channels.rs
+++ b/crates/interfaces/src/slack/skills/slack_list_channels.rs
@@ -78,3 +78,86 @@ impl ToolHandler for SlackListChannelsSkill {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::slack::skills::test_support::ctx;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn skill_at(base: String) -> SlackListChannelsSkill {
+        let client = SlackApiClient::with_base_url("xoxb-t".into(), "xapp-t".into(), base).unwrap();
+        SlackListChannelsSkill {
+            client: Arc::new(client),
+        }
+    }
+
+    #[test]
+    fn metadata_is_set() {
+        let s = skill_at("http://127.0.0.1:0".to_string());
+        assert_eq!(s.name(), "slack-list-channels");
+        assert!(s.params_schema().get("properties").is_some());
+    }
+
+    #[tokio::test]
+    async fn run_returns_channel_summaries() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/conversations.list"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "channels": [
+                    {"id": "C1", "name": "general", "is_private": false, "num_members": 3},
+                    {"id": "C2", "name": "random", "is_private": false, "num_members": 5}
+                ],
+                "response_metadata": {"next_cursor": ""}
+            })))
+            .mount(&server)
+            .await;
+        let s = skill_at(server.uri());
+        let out = s.run(HashMap::new(), &ctx()).await.unwrap();
+        assert!(out.success);
+        assert!(out.content.contains("general"));
+        assert!(out.content.contains("random"));
+    }
+
+    #[tokio::test]
+    async fn run_marks_truncated_when_cursor_present() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/conversations.list"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "channels": [{"id": "C1", "name": "general"}],
+                "response_metadata": {"next_cursor": "next-page"}
+            })))
+            .mount(&server)
+            .await;
+        let s = skill_at(server.uri());
+        let out = s.run(HashMap::new(), &ctx()).await.unwrap();
+        assert!(out.success);
+        assert!(out.content.contains("truncated"));
+    }
+
+    #[tokio::test]
+    async fn run_handles_empty_channels_list() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/conversations.list"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
+            .mount(&server)
+            .await;
+        let s = skill_at(server.uri());
+        let out = s.run(HashMap::new(), &ctx()).await.unwrap();
+        assert!(out.success);
+    }
+
+    #[tokio::test]
+    async fn run_reports_failure_when_transport_errors() {
+        // Point at an unreachable address so the HTTP call fails.
+        let s = skill_at("http://127.0.0.1:1".to_string());
+        let out = s.run(HashMap::new(), &ctx()).await.unwrap();
+        assert!(!out.success);
+    }
+}

--- a/crates/interfaces/src/slack/skills/slack_lookup_user.rs
+++ b/crates/interfaces/src/slack/skills/slack_lookup_user.rs
@@ -64,3 +64,67 @@ impl ToolHandler for SlackLookupUserSkill {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::slack::skills::test_support::ctx;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn skill_at(base: String) -> SlackLookupUserSkill {
+        let client = SlackApiClient::with_base_url("xoxb-t".into(), "xapp-t".into(), base).unwrap();
+        SlackLookupUserSkill {
+            client: Arc::new(client),
+        }
+    }
+
+    #[test]
+    fn metadata_is_set() {
+        let s = skill_at("http://127.0.0.1:0".to_string());
+        assert_eq!(s.name(), "slack-lookup-user");
+        assert!(s.params_schema().get("required").is_some());
+    }
+
+    #[tokio::test]
+    async fn run_errors_on_missing_user_id() {
+        let s = skill_at("http://127.0.0.1:0".to_string());
+        let out = s.run(HashMap::new(), &ctx()).await.unwrap();
+        assert!(!out.success);
+        assert!(out.content.contains("user_id"));
+    }
+
+    #[tokio::test]
+    async fn run_summarises_user_profile() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/users.info"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "user": {
+                    "id": "U1",
+                    "name": "alice",
+                    "is_bot": false,
+                    "profile": {"real_name": "Alice", "display_name": "ali"}
+                }
+            })))
+            .mount(&server)
+            .await;
+        let s = skill_at(server.uri());
+        let mut params = HashMap::new();
+        params.insert("user_id".into(), json!("U1"));
+        let out = s.run(params, &ctx()).await.unwrap();
+        assert!(out.success);
+        assert!(out.content.contains("alice"));
+        assert!(out.content.contains("Alice"));
+    }
+
+    #[tokio::test]
+    async fn run_reports_failure_when_transport_errors() {
+        let s = skill_at("http://127.0.0.1:1".to_string());
+        let mut params = HashMap::new();
+        params.insert("user_id".into(), json!("U1"));
+        let out = s.run(params, &ctx()).await.unwrap();
+        assert!(!out.success);
+    }
+}

--- a/crates/interfaces/src/slack/skills/slack_post.rs
+++ b/crates/interfaces/src/slack/skills/slack_post.rs
@@ -66,3 +66,91 @@ impl ToolHandler for SlackPostSkill {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::slack::skills::test_support::ctx;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn skill_with_base(base: String) -> SlackPostSkill {
+        let client = SlackApiClient::with_base_url("xoxb-t".into(), "xapp-t".into(), base).unwrap();
+        SlackPostSkill {
+            client: Arc::new(client),
+        }
+    }
+
+    fn skill(server: &MockServer) -> SlackPostSkill {
+        skill_with_base(server.uri())
+    }
+
+    #[test]
+    fn metadata_and_schema_are_set() {
+        let s = skill_with_base("http://127.0.0.1:0".to_string());
+        assert_eq!(s.name(), "slack-post");
+        assert!(s.is_mutating());
+        assert!(s.description().contains("Slack channel"));
+        assert!(s.params_schema().get("required").is_some());
+    }
+
+    #[tokio::test]
+    async fn run_posts_message_when_params_valid() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/chat.postMessage"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok":true,"ts":"1.2"})),
+            )
+            .mount(&server)
+            .await;
+        let s = skill(&server);
+        let mut params = HashMap::new();
+        params.insert("channel".into(), json!("C1"));
+        params.insert("message".into(), json!("hello"));
+        let out = s.run(params, &ctx()).await.unwrap();
+        assert!(out.success);
+        assert!(out.content.contains("Posted"));
+    }
+
+    #[tokio::test]
+    async fn run_errors_when_channel_missing() {
+        let server = MockServer::start().await;
+        let s = skill(&server);
+        let mut params = HashMap::new();
+        params.insert("message".into(), json!("hello"));
+        let out = s.run(params, &ctx()).await.unwrap();
+        assert!(!out.success);
+        assert!(out.content.contains("channel"));
+    }
+
+    #[tokio::test]
+    async fn run_errors_when_message_missing() {
+        let server = MockServer::start().await;
+        let s = skill(&server);
+        let mut params = HashMap::new();
+        params.insert("channel".into(), json!("C1"));
+        let out = s.run(params, &ctx()).await.unwrap();
+        assert!(!out.success);
+        assert!(out.content.contains("message"));
+    }
+
+    #[tokio::test]
+    async fn run_reports_failure_when_client_errors() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/chat.postMessage"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"ok": false, "error": "channel_not_found"})),
+            )
+            .mount(&server)
+            .await;
+        let s = skill(&server);
+        let mut params = HashMap::new();
+        params.insert("channel".into(), json!("CX"));
+        params.insert("message".into(), json!("hello"));
+        let out = s.run(params, &ctx()).await.unwrap();
+        assert!(!out.success);
+    }
+}

--- a/crates/interfaces/src/slack/skills/slack_react.rs
+++ b/crates/interfaces/src/slack/skills/slack_react.rs
@@ -71,3 +71,85 @@ impl ToolHandler for SlackReactSkill {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::slack::skills::test_support::ctx;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn skill_at(base: String) -> SlackReactSkill {
+        let client = SlackApiClient::with_base_url("xoxb-t".into(), "xapp-t".into(), base).unwrap();
+        SlackReactSkill {
+            client: Arc::new(client),
+        }
+    }
+
+    #[test]
+    fn metadata_is_set() {
+        let s = skill_at("http://127.0.0.1:0".to_string());
+        assert_eq!(s.name(), "slack-react");
+        assert!(s.is_mutating());
+        assert!(s.params_schema().get("required").is_some());
+    }
+
+    #[tokio::test]
+    async fn run_strips_colons_from_emoji_and_adds_reaction() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/reactions.add"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok":true})))
+            .mount(&server)
+            .await;
+        let s = skill_at(server.uri());
+        let mut params = HashMap::new();
+        params.insert("channel".into(), json!("C1"));
+        params.insert("ts".into(), json!("1.2"));
+        params.insert("emoji".into(), json!(":thumbsup:"));
+        let out = s.run(params, &ctx()).await.unwrap();
+        assert!(out.success);
+        assert!(out.content.contains("thumbsup"));
+    }
+
+    #[tokio::test]
+    async fn run_errors_on_missing_params() {
+        let s = skill_at("http://127.0.0.1:0".to_string());
+        let out = s.run(HashMap::new(), &ctx()).await.unwrap();
+        assert!(!out.success);
+        assert!(out.content.contains("channel"));
+
+        let mut params = HashMap::new();
+        params.insert("channel".into(), json!("C1"));
+        let out = s.run(params, &ctx()).await.unwrap();
+        assert!(!out.success);
+        assert!(out.content.contains("ts"));
+
+        let mut params = HashMap::new();
+        params.insert("channel".into(), json!("C1"));
+        params.insert("ts".into(), json!("1.2"));
+        let out = s.run(params, &ctx()).await.unwrap();
+        assert!(!out.success);
+        assert!(out.content.contains("emoji"));
+    }
+
+    #[tokio::test]
+    async fn run_propagates_client_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/reactions.add"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"ok": false, "error": "bad"})),
+            )
+            .mount(&server)
+            .await;
+        let s = skill_at(server.uri());
+        let mut params = HashMap::new();
+        params.insert("channel".into(), json!("C1"));
+        params.insert("ts".into(), json!("1.2"));
+        params.insert("emoji".into(), json!("ok"));
+        let out = s.run(params, &ctx()).await.unwrap();
+        assert!(!out.success);
+    }
+}

--- a/crates/interfaces/src/slack/skills/slack_send_dm.rs
+++ b/crates/interfaces/src/slack/skills/slack_send_dm.rs
@@ -101,3 +101,113 @@ impl ToolHandler for SlackSendDmSkill {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::slack::skills::test_support::ctx;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn skill_at(base: String) -> SlackSendDmSkill {
+        let client = SlackApiClient::with_base_url("xoxb-t".into(), "xapp-t".into(), base).unwrap();
+        SlackSendDmSkill {
+            client: Arc::new(client),
+        }
+    }
+
+    #[test]
+    fn metadata_is_set() {
+        let s = skill_at("http://127.0.0.1:0".to_string());
+        assert_eq!(s.name(), "slack-send-dm");
+        assert!(s.is_mutating());
+    }
+
+    #[tokio::test]
+    async fn run_errors_on_missing_params() {
+        let s = skill_at("http://127.0.0.1:0".to_string());
+        let out = s.run(HashMap::new(), &ctx()).await.unwrap();
+        assert!(!out.success);
+
+        let mut params = HashMap::new();
+        params.insert("user_id".into(), json!("U1"));
+        let out = s.run(params, &ctx()).await.unwrap();
+        assert!(!out.success);
+        assert!(out.content.contains("message"));
+    }
+
+    #[tokio::test]
+    async fn run_opens_dm_then_posts_message() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/conversations.open"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "channel": {"id": "D1"}
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/api/chat.postMessage"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok":true,"ts":"5.5"})),
+            )
+            .mount(&server)
+            .await;
+        let s = skill_at(server.uri());
+        let mut params = HashMap::new();
+        params.insert("user_id".into(), json!("U1"));
+        params.insert("message".into(), json!("hi"));
+        let out = s.run(params, &ctx()).await.unwrap();
+        assert!(out.success);
+        assert!(out.content.contains("DM sent"));
+    }
+
+    #[tokio::test]
+    async fn run_returns_error_when_conversations_open_fails() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/conversations.open"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"ok": false, "error": "user_not_found"})),
+            )
+            .mount(&server)
+            .await;
+        let s = skill_at(server.uri());
+        let mut params = HashMap::new();
+        params.insert("user_id".into(), json!("UX"));
+        params.insert("message".into(), json!("hi"));
+        let out = s.run(params, &ctx()).await.unwrap();
+        assert!(!out.success);
+        assert!(out.content.contains("conversations.open"));
+    }
+
+    #[tokio::test]
+    async fn run_returns_error_when_post_message_fails() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/conversations.open"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "channel": {"id": "D1"}
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/api/chat.postMessage"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"ok": false, "error": "bad"})),
+            )
+            .mount(&server)
+            .await;
+        let s = skill_at(server.uri());
+        let mut params = HashMap::new();
+        params.insert("user_id".into(), json!("U1"));
+        params.insert("message".into(), json!("hi"));
+        let out = s.run(params, &ctx()).await.unwrap();
+        assert!(!out.success);
+        assert!(out.content.contains("send DM"));
+    }
+}

--- a/crates/interfaces/src/slack/skills/slack_update_message.rs
+++ b/crates/interfaces/src/slack/skills/slack_update_message.rs
@@ -69,3 +69,82 @@ impl ToolHandler for SlackUpdateMessageSkill {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::slack::skills::test_support::ctx;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn skill_at(base: String) -> SlackUpdateMessageSkill {
+        let client = SlackApiClient::with_base_url("xoxb-t".into(), "xapp-t".into(), base).unwrap();
+        SlackUpdateMessageSkill {
+            client: Arc::new(client),
+        }
+    }
+
+    #[test]
+    fn metadata_marks_mutating() {
+        let s = skill_at("http://127.0.0.1:0".to_string());
+        assert_eq!(s.name(), "slack-update-message");
+        assert!(s.is_mutating());
+        assert!(s.params_schema().get("required").is_some());
+    }
+
+    #[tokio::test]
+    async fn run_updates_when_params_valid() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/chat.update"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok":true})))
+            .mount(&server)
+            .await;
+        let s = skill_at(server.uri());
+        let mut params = HashMap::new();
+        params.insert("channel".into(), json!("C1"));
+        params.insert("ts".into(), json!("1.2"));
+        params.insert("text".into(), json!("edited"));
+        let out = s.run(params, &ctx()).await.unwrap();
+        assert!(out.success);
+    }
+
+    #[tokio::test]
+    async fn run_errors_on_missing_params() {
+        let s = skill_at("http://127.0.0.1:0".to_string());
+        let out = s.run(HashMap::new(), &ctx()).await.unwrap();
+        assert!(!out.success);
+
+        let mut params = HashMap::new();
+        params.insert("channel".into(), json!("C1"));
+        let out = s.run(params, &ctx()).await.unwrap();
+        assert!(!out.success);
+
+        let mut params = HashMap::new();
+        params.insert("channel".into(), json!("C1"));
+        params.insert("ts".into(), json!("1.2"));
+        let out = s.run(params, &ctx()).await.unwrap();
+        assert!(!out.success);
+        assert!(out.content.contains("text"));
+    }
+
+    #[tokio::test]
+    async fn run_propagates_client_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/chat.update"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"ok": false, "error": "bad"})),
+            )
+            .mount(&server)
+            .await;
+        let s = skill_at(server.uri());
+        let mut params = HashMap::new();
+        params.insert("channel".into(), json!("C1"));
+        params.insert("ts".into(), json!("1.2"));
+        params.insert("text".into(), json!("x"));
+        let out = s.run(params, &ctx()).await.unwrap();
+        assert!(!out.success);
+    }
+}

--- a/crates/interfaces/src/slack/tools.rs
+++ b/crates/interfaces/src/slack/tools.rs
@@ -234,3 +234,158 @@ pub fn build_slack_tools(
         }),
     ]
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::slack::skills::test_support::ctx;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn client_at(server: &MockServer) -> Arc<SlackApiClient> {
+        Arc::new(
+            SlackApiClient::with_base_url("xoxb-t".into(), "xapp-t".into(), server.uri()).unwrap(),
+        )
+    }
+
+    #[tokio::test]
+    async fn build_slack_tools_returns_three_handlers() {
+        let server = MockServer::start().await;
+        let tools = build_slack_tools(
+            "C1".to_string(),
+            Some("1.1".to_string()),
+            "1.2".to_string(),
+            client_at(&server),
+        );
+        assert_eq!(tools.len(), 3);
+        assert_eq!(tools[0].name(), "reply");
+        assert_eq!(tools[1].name(), "react");
+        assert_eq!(tools[2].name(), "upload");
+        for t in &tools {
+            assert!(t.is_mutating());
+        }
+    }
+
+    #[tokio::test]
+    async fn reply_posts_when_no_update_ts() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/chat.postMessage"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok":true,"ts":"5"})),
+            )
+            .mount(&server)
+            .await;
+        let h = SlackReplyHandler {
+            channel_id: "C1".into(),
+            thread_ts: None,
+            client: client_at(&server),
+            update_ts: None,
+        };
+        let mut params = HashMap::new();
+        params.insert("text".into(), json!("<think>secret</think>hello"));
+        let out = h.run(params, &ctx()).await.unwrap();
+        assert!(out.success);
+    }
+
+    #[tokio::test]
+    async fn reply_updates_existing_message_when_update_ts_set() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/chat.update"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok":true})))
+            .mount(&server)
+            .await;
+        let h = SlackReplyHandler {
+            channel_id: "C1".into(),
+            thread_ts: None,
+            client: client_at(&server),
+            update_ts: Some("placeholder".into()),
+        };
+        let mut params = HashMap::new();
+        params.insert("text".into(), json!("hello"));
+        let out = h.run(params, &ctx()).await.unwrap();
+        assert!(out.success);
+    }
+
+    #[tokio::test]
+    async fn reply_falls_back_to_post_when_update_fails() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/chat.update"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"ok": false, "error": "edit_window_closed"})),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/api/chat.postMessage"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok":true,"ts":"7"})),
+            )
+            .mount(&server)
+            .await;
+        let h = SlackReplyHandler {
+            channel_id: "C1".into(),
+            thread_ts: Some("1.1".into()),
+            client: client_at(&server),
+            update_ts: Some("placeholder".into()),
+        };
+        let mut params = HashMap::new();
+        params.insert("text".into(), json!("hello"));
+        let out = h.run(params, &ctx()).await.unwrap();
+        assert!(out.success);
+    }
+
+    #[tokio::test]
+    async fn react_uses_default_emoji_when_missing() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/reactions.add"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok":true})))
+            .mount(&server)
+            .await;
+        let h = SlackReactHandler {
+            channel_id: "C1".into(),
+            message_ts: "1.2".into(),
+            client: client_at(&server),
+        };
+        let out = h.run(HashMap::new(), &ctx()).await.unwrap();
+        assert!(out.success);
+    }
+
+    #[tokio::test]
+    async fn upload_calls_three_step_upload_flow() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/files.getUploadURLExternal"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "upload_url": format!("{}/upload-here", server.uri()),
+                "file_id": "F1"
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/upload-here"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/api/files.completeUploadExternal"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok":true})))
+            .mount(&server)
+            .await;
+        let h = SlackUploadHandler {
+            channel_id: "C1".into(),
+            thread_ts: Some("1.1".into()),
+            client: client_at(&server),
+        };
+        let mut params = HashMap::new();
+        params.insert("filename".into(), json!("data.txt"));
+        params.insert("content".into(), json!("hello world"));
+        let out = h.run(params, &ctx()).await.unwrap();
+        assert!(out.success);
+    }
+}


### PR DESCRIPTION
## Summary

Lifts `crates/interfaces` from 61.6% to **80.9%** via targeted unit tests across the messenger adapters' tool/skill/runner surfaces. Ratchets off `report_only`. `report_only` drops from 4 to 3.

### Tests added

- **Slack ambient skills (8 files)** — full wiremock coverage of metadata, happy-path, missing-param error branches, and transport failures for `slack-post`, `slack-react`, `slack-delete-message`, `slack-update-message`, `slack-list-channels`, `slack-get-history`, `slack-lookup-user`, `slack-send-dm`. Shared `test_support::ctx()` in `skills/mod.rs` builds an `ExecutionContext` once.
- **Slack per-turn tools** — `build_slack_tools` shape test plus:
  - `SlackReplyHandler`: post, update-in-place, fallback-to-post when update fails
  - `SlackReactHandler`: default-emoji branch
  - `SlackUploadHandler`: three-step upload flow (`files.getUploadURLExternal` → PUT → `files.completeUploadExternal`)
- **Matrix tools** — `build_matrix_tools` + `MatrixReplyHandler` covering metadata, success post, missing-text error, and server-error branch.
- **Nextcloud runner** — parity with `matrix/runner` tests: `new()`, `with_shutdown`, `with_transcription`, and `run`-errors-when-server-url-missing. Uses an in-memory `StorageLayer`-backed `Orchestrator`.
- **Mattermost tools** — extended existing suite with the previously uncovered branches: react "already exists" success path, react generic-error propagation, full upload flow (POST `/files` + POST `/posts`), and no-file-ids-returned error.
- **common.rs** — `rand_jitter` range invariant + `sleep_backoff` doubling, early-cancel via stop signal, and `BACKOFF_MAX` cap.

Remaining `report_only` (3 crates): `bus-nats` (34.4%), `interface-cli` (28.9%), `mcp-client` (20.3%).

Part of `openspec/changes/workspace-test-coverage-floor` (Phase 11).

## Test plan

- [x] `cargo test -p assistant-interfaces` — 242 tests green
- [x] `make lint` — clippy clean
- [x] `make coverage` — gate prints `Coverage gate passed`; interfaces shows `ok` at 80.9%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit and integration tests for chat platform integrations (Slack, Mattermost, Matrix, Nextcloud) and shared utilities, validating messaging, reactions, uploads, and error handling across all supported platforms.
  * Enabled strict coverage enforcement for the interfaces crate with an 80.9% coverage floor.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cedricziel/assistant/pull/896?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->