### PR TITLE
test(mcp-client): lift coverage from 20.3% to 78.7% (Phase 11 progress)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,6 +611,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -4298,6 +4299,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5102,9 +5109,11 @@ dependencies = [
  "chrono",
  "futures",
  "http",
+ "pastey",
  "pin-project-lite",
  "process-wrap",
  "reqwest 0.13.3",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "sse-stream",
@@ -5353,10 +5362,24 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
+ "schemars_derive",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
 ]
 
 [[package]]
@@ -5500,6 +5523,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/coverage.toml
+++ b/coverage.toml
@@ -48,7 +48,7 @@ crates = [
     # Last measured (2026-05-18 via `make coverage`):
     "bus-nats",                          # 34.4% (delta -45.6%)
     "interface-cli",                     # 28.9% (delta -51.1%)
-    "mcp-client",                        # 20.3% (delta -59.7%)
+    "mcp-client",                        # 78.7% (delta -1.3%)
 ]
 
 # Crates promoted off `report_only` and now ENFORCING the 80% floor.

--- a/crates/mcp-client/Cargo.toml
+++ b/crates/mcp-client/Cargo.toml
@@ -28,7 +28,13 @@ http = "1"
 reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["test-util"] }
+tokio = { workspace = true, features = ["test-util", "io-util", "macros"] }
+rmcp = { version = "1.7.0", default-features = false, features = [
+    "client",
+    "server",
+] }
+serde_json = { workspace = true }
+uuid = { workspace = true }
 
 # Panic-free contract: production code propagates errors via `anyhow::Result`.
 # Tests are exempt because `make lint` (`cargo clippy --workspace`) does not

--- a/crates/mcp-client/tests/in_process.rs
+++ b/crates/mcp-client/tests/in_process.rs
@@ -1,0 +1,350 @@
+//! End-to-end tests for `McpClient` + `McpToolHandler` over an in-process
+//! `tokio::io::duplex` transport.
+//!
+//! These tests construct a real rmcp server with a small set of canned
+//! tools, pair it with the client via `tokio::io::duplex`, and exercise the
+//! full handshake/list_tools/call_tool flow. This is how we reach the bulk
+//! of `client.rs` and `bridge.rs` without spawning a subprocess or speaking
+//! HTTP.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use assistant_core::ToolHandler;
+use assistant_core::types::conversation::{ExecutionContext, Interface};
+use assistant_mcp_client::bridge::{McpToolHandler, namespaced_name};
+use assistant_mcp_client::client::McpClient;
+use rmcp::handler::server::router::tool::{ToolRoute, ToolRouter};
+use rmcp::handler::server::tool::ToolCallContext;
+use rmcp::model::{
+    CallToolRequestParams, CallToolResult, Content, ListToolsResult, PaginatedRequestParams,
+    ServerCapabilities, ServerInfo, Tool,
+};
+use rmcp::service::{MaybeSendFuture, RequestContext};
+use rmcp::{RoleServer, ServerHandler, ServiceExt};
+use serde_json::json;
+use tokio::sync::RwLock;
+use uuid::Uuid;
+
+// ── Test server ──────────────────────────────────────────────────────────────
+
+#[derive(Clone)]
+struct TestServer {
+    router: Arc<RwLock<ToolRouter<Self>>>,
+    list_changed: bool,
+}
+
+impl TestServer {
+    fn new(list_changed: bool) -> Self {
+        let mut router = ToolRouter::<Self>::new();
+        let schema = Arc::new(serde_json::Map::new());
+
+        router.add_route(ToolRoute::new_dyn(
+            Tool::new("echo", "Echoes input as text", schema.clone()),
+            |ctx: ToolCallContext<Self>| {
+                Box::pin(async move {
+                    let input = ctx
+                        .arguments
+                        .as_ref()
+                        .and_then(|m| m.get("text"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("default")
+                        .to_string();
+                    Ok(CallToolResult::success(vec![Content::text(format!(
+                        "echo:{input}"
+                    ))]))
+                })
+            },
+        ));
+
+        router.add_route(ToolRoute::new_dyn(
+            Tool::new("boom", "Always returns an error", schema.clone()),
+            |_ctx| {
+                Box::pin(async { Ok(CallToolResult::error(vec![Content::text("intentional")])) })
+            },
+        ));
+
+        router.add_route(ToolRoute::new_dyn(
+            Tool::new("empty", "Returns no content", schema.clone()),
+            |_ctx| Box::pin(async { Ok(CallToolResult::success(vec![])) }),
+        ));
+
+        router.add_route(ToolRoute::new_dyn(
+            Tool::new(
+                "with-image",
+                "Returns a text part plus a 1-byte image",
+                schema,
+            ),
+            |_ctx| {
+                Box::pin(async {
+                    // 1-byte payload encoded as base64 = "AA=="
+                    Ok(CallToolResult::success(vec![
+                        Content::text("textual"),
+                        Content::image("AA==", "image/png"),
+                    ]))
+                })
+            },
+        ));
+
+        Self {
+            router: Arc::new(RwLock::new(router)),
+            list_changed,
+        }
+    }
+}
+
+impl ServerHandler for TestServer {
+    fn get_info(&self) -> ServerInfo {
+        let mut builder = ServerCapabilities::builder().enable_tools();
+        if self.list_changed {
+            builder = builder.enable_tool_list_changed();
+        }
+        ServerInfo::new(builder.build())
+    }
+
+    fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> impl std::future::Future<Output = Result<ListToolsResult, rmcp::ErrorData>> + MaybeSendFuture + '_
+    {
+        async move {
+            let router = self.router.read().await;
+            Ok(ListToolsResult {
+                tools: router.list_all(),
+                ..Default::default()
+            })
+        }
+    }
+
+    fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> impl std::future::Future<Output = Result<CallToolResult, rmcp::ErrorData>> + MaybeSendFuture + '_
+    {
+        async move {
+            let router = self.router.read().await;
+            let tcc = ToolCallContext::new(self, request, context);
+            router.call(tcc).await
+        }
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Keep the server's RunningService alive for the lifetime of the spawned
+/// task by awaiting `.waiting()` — otherwise the service is dropped as soon
+/// as the handshake returns and the client sees `BrokenPipe`.
+async fn connect(list_changed: bool) -> (McpClient, tokio::task::JoinHandle<()>) {
+    let (server_io, client_io) = tokio::io::duplex(4096);
+    let server = TestServer::new(list_changed);
+    let server_handle = tokio::spawn(async move {
+        if let Ok(running) = server.serve(server_io).await {
+            let _ = running.waiting().await;
+        }
+    });
+    let service = ().serve(client_io).await.expect("client handshake succeeds");
+    (McpClient::new("test-srv", service), server_handle)
+}
+
+fn ctx() -> ExecutionContext {
+    ExecutionContext {
+        conversation_id: Uuid::new_v4(),
+        agent_id: "tester".into(),
+        turn: 0,
+        interface: Interface::Mcp,
+        interactive: false,
+        allowed_tools: None,
+        depth: 0,
+        user_id: None,
+        org_id: None,
+        space_id: None,
+    }
+}
+
+// ── McpClient surface tests ──────────────────────────────────────────────────
+
+#[tokio::test]
+async fn name_returns_configured_value() {
+    let (client, _h) = connect(false).await;
+    assert_eq!(client.name(), "test-srv");
+}
+
+#[tokio::test]
+async fn is_connected_true_after_handshake() {
+    let (client, _h) = connect(false).await;
+    assert!(client.is_connected());
+}
+
+#[tokio::test]
+async fn server_info_populated_after_initialize() {
+    let (client, _h) = connect(false).await;
+    let info = client.server_info().expect("server info present");
+    assert!(info.capabilities.tools.is_some());
+}
+
+#[tokio::test]
+async fn supports_tool_list_changed_reflects_server_capability() {
+    let (off, _h1) = connect(false).await;
+    let (on, _h2) = connect(true).await;
+    assert!(!off.supports_tool_list_changed());
+    assert!(on.supports_tool_list_changed());
+}
+
+#[tokio::test]
+async fn list_tools_returns_all_server_tools() {
+    let (client, _h) = connect(false).await;
+    let tools = client.list_tools().await.unwrap();
+    let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
+    assert!(names.contains(&"echo"));
+    assert!(names.contains(&"boom"));
+    assert!(names.contains(&"empty"));
+    assert!(names.contains(&"with-image"));
+}
+
+#[tokio::test]
+async fn call_tool_succeeds_and_returns_text_content() {
+    let (client, _h) = connect(false).await;
+    let mut args = serde_json::Map::new();
+    args.insert("text".into(), json!("hi"));
+    let result = client.call_tool("echo", Some(args)).await.unwrap();
+    assert!(!result.is_error.unwrap_or(false));
+    let text = result
+        .content
+        .iter()
+        .find_map(|c| match &c.raw {
+            rmcp::model::RawContent::Text(t) => Some(t.text.clone()),
+            _ => None,
+        })
+        .unwrap();
+    assert_eq!(text, "echo:hi");
+}
+
+#[tokio::test]
+async fn call_tool_no_arguments_dispatches_without_args() {
+    let (client, _h) = connect(false).await;
+    let result = client.call_tool("echo", None).await.unwrap();
+    let text = result
+        .content
+        .iter()
+        .find_map(|c| match &c.raw {
+            rmcp::model::RawContent::Text(t) => Some(t.text.clone()),
+            _ => None,
+        })
+        .unwrap();
+    assert_eq!(text, "echo:default");
+}
+
+#[tokio::test]
+async fn call_tool_unknown_returns_error() {
+    let (client, _h) = connect(false).await;
+    let err = client.call_tool("nonexistent", None).await;
+    assert!(err.is_err(), "calling unknown tool must return Err");
+}
+
+#[tokio::test]
+async fn shutdown_is_idempotent() {
+    let (client, _h) = connect(false).await;
+    client.shutdown().await.unwrap();
+    // Second shutdown is a no-op because the service was taken.
+    client.shutdown().await.unwrap();
+}
+
+// ── McpToolHandler bridge tests ──────────────────────────────────────────────
+
+async fn fetch_tool(client: &McpClient, name: &str) -> Tool {
+    let tools = client.list_tools().await.unwrap();
+    tools.into_iter().find(|t| t.name.as_ref() == name).unwrap()
+}
+
+#[tokio::test]
+async fn from_remote_namespaces_and_clones_schema() {
+    let (raw, _h) = connect(false).await;
+    let client = Arc::new(raw);
+    let tool = fetch_tool(&client, "echo").await;
+    let handler = McpToolHandler::from_remote("srv", &tool, client.clone(), true);
+    assert_eq!(handler.name(), "mcp__srv__echo");
+    assert!(handler.is_mutating());
+    assert!(handler.requires_confirmation());
+    assert_eq!(handler.server_name(), "srv");
+    assert!(handler.params_schema().is_object());
+}
+
+#[tokio::test]
+async fn from_remote_synthesises_description_when_remote_empty() {
+    let (raw, _h) = connect(false).await;
+    let client = Arc::new(raw);
+    let mut tool = fetch_tool(&client, "echo").await;
+    tool.description = Some(std::borrow::Cow::Borrowed(""));
+    let handler = McpToolHandler::from_remote("srv", &tool, client.clone(), false);
+    assert!(handler.description().contains("MCP server"));
+    assert!(!handler.requires_confirmation());
+}
+
+#[tokio::test]
+async fn run_forwards_text_response_and_marks_success() {
+    let (raw, _h) = connect(false).await;
+    let client = Arc::new(raw);
+    let tool = fetch_tool(&client, "echo").await;
+    let handler = McpToolHandler::from_remote("srv", &tool, client.clone(), false);
+    let mut params = HashMap::new();
+    params.insert("text".to_string(), json!("greetings"));
+    let out = handler.run(params, &ctx()).await.unwrap();
+    assert!(out.success);
+    assert!(out.content.contains("echo:greetings"));
+}
+
+#[tokio::test]
+async fn run_returns_error_output_when_server_marks_is_error() {
+    let (raw, _h) = connect(false).await;
+    let client = Arc::new(raw);
+    let tool = fetch_tool(&client, "boom").await;
+    let handler = McpToolHandler::from_remote("srv", &tool, client.clone(), false);
+    let out = handler.run(HashMap::new(), &ctx()).await.unwrap();
+    assert!(!out.success);
+    assert!(out.content.contains("intentional"));
+}
+
+#[tokio::test]
+async fn run_handles_empty_content_with_placeholder() {
+    let (raw, _h) = connect(false).await;
+    let client = Arc::new(raw);
+    let tool = fetch_tool(&client, "empty").await;
+    let handler = McpToolHandler::from_remote("srv", &tool, client.clone(), false);
+    let out = handler.run(HashMap::new(), &ctx()).await.unwrap();
+    assert!(out.success);
+    assert!(out.content.contains("(no text output)"));
+}
+
+#[tokio::test]
+async fn run_extracts_image_attachments() {
+    let (raw, _h) = connect(false).await;
+    let client = Arc::new(raw);
+    let tool = fetch_tool(&client, "with-image").await;
+    let handler = McpToolHandler::from_remote("srv", &tool, client.clone(), false);
+    let out = handler.run(HashMap::new(), &ctx()).await.unwrap();
+    assert!(out.success);
+    assert!(out.content.contains("textual"));
+    assert_eq!(out.attachments.len(), 1);
+    assert_eq!(out.attachments[0].mime_type, "image/png");
+}
+
+#[tokio::test]
+async fn run_reports_error_when_underlying_call_fails() {
+    let (raw, _h) = connect(false).await;
+    let client = Arc::new(raw);
+    let mut tool = fetch_tool(&client, "echo").await;
+    tool.name = std::borrow::Cow::Owned("does-not-exist".to_string());
+    let handler = McpToolHandler::from_remote("srv", &tool, client.clone(), false);
+    let out = handler.run(HashMap::new(), &ctx()).await.unwrap();
+    assert!(!out.success);
+    assert!(out.content.contains("does-not-exist"));
+}
+
+// ── Stand-alone helpers ──────────────────────────────────────────────────────
+
+#[test]
+fn namespaced_name_is_stable() {
+    assert_eq!(namespaced_name("a", "b"), "mcp__a__b");
+}

--- a/crates/mcp-client/tests/manager.rs
+++ b/crates/mcp-client/tests/manager.rs
@@ -1,0 +1,223 @@
+//! Tests for `McpClientManager` lifecycle paths that don't need a live MCP
+//! server: invalid names, disabled entries, failed connections, empty input,
+//! and the read-only query/shutdown surface.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use assistant_core::ToolHandler;
+use assistant_core::types::skills_mcp::{McpServerEntry, McpTransportConfig, McpTrustLevel};
+use assistant_mcp_client::manager::McpClientManager;
+
+fn stdio_entry(name: &str, command: Vec<String>, enabled: bool) -> McpServerEntry {
+    McpServerEntry {
+        name: name.to_string(),
+        transport: McpTransportConfig::Stdio { command },
+        env: HashMap::new(),
+        enabled,
+        trust: McpTrustLevel::Confirm,
+    }
+}
+
+fn http_entry(name: &str, url: &str, enabled: bool) -> McpServerEntry {
+    McpServerEntry {
+        name: name.to_string(),
+        transport: McpTransportConfig::Http {
+            url: url.to_string(),
+            headers: HashMap::new(),
+        },
+        env: HashMap::new(),
+        enabled,
+        trust: McpTrustLevel::Confirm,
+    }
+}
+
+#[tokio::test]
+async fn start_with_empty_entries_yields_empty_manager() {
+    let mgr = McpClientManager::start(&[]).await.unwrap();
+    assert_eq!(mgr.tool_count().await, 0);
+    assert_eq!(mgr.server_count().await, 0);
+    assert!(mgr.tool_handlers().await.is_empty());
+}
+
+#[tokio::test]
+async fn start_skips_disabled_entries() {
+    let entries = vec![stdio_entry("disabled", vec!["true".into()], false)];
+    let mgr = McpClientManager::start(&entries).await.unwrap();
+    assert_eq!(mgr.tool_count().await, 0);
+    assert_eq!(
+        mgr.server_count().await,
+        0,
+        "disabled entries must not be tracked"
+    );
+}
+
+#[tokio::test]
+async fn start_skips_entries_with_invalid_names() {
+    // Uppercase, underscores, spaces, dots, and empty all fail
+    // `is_valid_server_name`.
+    let entries = vec![
+        stdio_entry("UPPERCASE", vec!["true".into()], true),
+        stdio_entry("with_underscore", vec!["true".into()], true),
+        stdio_entry("with space", vec!["true".into()], true),
+        stdio_entry("with.dot", vec!["true".into()], true),
+        stdio_entry("", vec!["true".into()], true),
+    ];
+    let mgr = McpClientManager::start(&entries).await.unwrap();
+    assert_eq!(mgr.tool_count().await, 0);
+    assert_eq!(mgr.server_count().await, 0);
+}
+
+#[tokio::test]
+async fn start_records_failed_stdio_connections_without_client() {
+    // Spawning `/does-not-exist` fails, leaving the entry in the map with
+    // `client: None` and `consecutive_failures: 1`.
+    let entries = vec![stdio_entry(
+        "broken",
+        vec!["/does-not-exist-12345".into()],
+        true,
+    )];
+    let mgr = McpClientManager::start(&entries).await.unwrap();
+    assert_eq!(mgr.tool_count().await, 0);
+    assert_eq!(
+        mgr.server_count().await,
+        0,
+        "failed connection counts as 0 servers"
+    );
+    // shutdown is a no-op when no client is connected.
+    mgr.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn start_handles_empty_stdio_command() {
+    let entries = vec![stdio_entry("emptycmd", vec![], true)];
+    let mgr = McpClientManager::start(&entries).await.unwrap();
+    assert_eq!(mgr.tool_count().await, 0);
+}
+
+#[tokio::test]
+async fn start_records_failed_http_connection() {
+    // Point at a closed port: rmcp will fail the initialize handshake.
+    let entries = vec![http_entry("unreachable", "http://127.0.0.1:1/mcp", true)];
+    let mgr = McpClientManager::start(&entries).await.unwrap();
+    assert_eq!(mgr.tool_count().await, 0);
+}
+
+#[tokio::test]
+async fn refresh_server_tools_unknown_server_errors() {
+    let mgr = McpClientManager::start(&[]).await.unwrap();
+    let res = mgr.refresh_server_tools("ghost").await;
+    let err = res.err().expect("expected error");
+    assert!(err.to_string().contains("ghost"));
+}
+
+#[tokio::test]
+async fn refresh_server_tools_disconnected_server_errors() {
+    // Insert a failed-connection entry so the server is tracked but has no
+    // client.  refresh_server_tools should still error.
+    let entries = vec![stdio_entry("disco", vec!["/does-not-exist".into()], true)];
+    let mgr = McpClientManager::start(&entries).await.unwrap();
+    let res = mgr.refresh_server_tools("disco").await;
+    let err = res.err().expect("expected error");
+    assert!(err.to_string().contains("disco"));
+}
+
+#[tokio::test]
+async fn shutdown_on_empty_manager_is_ok() {
+    let mgr = McpClientManager::start(&[]).await.unwrap();
+    mgr.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn health_check_reconnects_failed_servers_and_callbacks_fire() {
+    // Start with a broken server so it's tracked with consecutive_failures=1.
+    // Run one health-check cycle.  The reconnect will fail again (same bad
+    // command), but the path exercises the parallel reconnect Phase 2 and
+    // the error branch of Phase 3.
+    let entries = vec![stdio_entry(
+        "retry-me",
+        vec!["/does-not-exist-987654".into()],
+        true,
+    )];
+    let mgr = Arc::new(McpClientManager::start(&entries).await.unwrap());
+
+    let register_calls = Arc::new(Mutex::new(0u32));
+    let unregister_calls = Arc::new(Mutex::new(0u32));
+
+    let reg_clone = register_calls.clone();
+    let register: Arc<dyn Fn(Arc<dyn ToolHandler>) + Send + Sync> = Arc::new(move |_h| {
+        if let Ok(mut g) = reg_clone.lock() {
+            *g += 1;
+        }
+    });
+
+    let unreg_clone = unregister_calls.clone();
+    let unregister: Arc<dyn Fn(&str) + Send + Sync> = Arc::new(move |_p| {
+        if let Ok(mut g) = unreg_clone.lock() {
+            *g += 1;
+        }
+    });
+
+    mgr.health_check(&register, &unregister).await;
+
+    // No successful reconnect, so register callback should never fire.
+    let reg_count = *register_calls.lock().unwrap();
+    assert_eq!(reg_count, 0);
+    // No previously-connected client to unregister either.
+    let unreg_count = *unregister_calls.lock().unwrap();
+    assert_eq!(unreg_count, 0);
+}
+
+#[tokio::test]
+async fn start_records_failed_stdio_when_process_spawns_then_exits() {
+    // `sh -c "exit 0"` spawns successfully so TokioChildProcess::new returns
+    // Ok, but the child closes stdout immediately, so the rmcp initialize
+    // handshake fails. This drives the path through `serve()` to the error
+    // branch (vs the spawn-failure branch exercised by `/does-not-exist`).
+    let entries = vec![stdio_entry(
+        "exits-fast",
+        vec!["sh".into(), "-c".into(), "exit 0".into()],
+        true,
+    )];
+    let mgr = McpClientManager::start(&entries).await.unwrap();
+    assert_eq!(mgr.tool_count().await, 0);
+}
+
+#[tokio::test]
+async fn start_records_http_failure_with_env_substituted_and_invalid_headers() {
+    // SAFETY: test-only.
+    unsafe {
+        std::env::set_var("TEST_MCP_HDR", "secret-token");
+    }
+    let mut headers = HashMap::new();
+    headers.insert("X-Auth".into(), "Bearer ${TEST_MCP_HDR}".into());
+    // Headers with invalid names should be skipped via the `warn!` branch.
+    headers.insert("bad header name".into(), "v".into());
+
+    let entry = McpServerEntry {
+        name: "with-headers".to_string(),
+        transport: McpTransportConfig::Http {
+            url: "http://127.0.0.1:1/mcp".into(),
+            headers,
+        },
+        env: HashMap::new(),
+        enabled: true,
+        trust: McpTrustLevel::Trust,
+    };
+    let mgr = McpClientManager::start(&[entry]).await.unwrap();
+    assert_eq!(mgr.tool_count().await, 0);
+    unsafe {
+        std::env::remove_var("TEST_MCP_HDR");
+    }
+}
+
+#[tokio::test]
+async fn health_check_no_op_when_no_servers_need_reconnection() {
+    let mgr = McpClientManager::start(&[]).await.unwrap();
+    let register: Arc<dyn Fn(Arc<dyn ToolHandler>) + Send + Sync> = Arc::new(|_| {});
+    let unregister: Arc<dyn Fn(&str) + Send + Sync> = Arc::new(|_| {});
+    // Empty manager: returns early because reconnect_work is empty.
+    mgr.health_check(&register, &unregister).await;
+    assert_eq!(mgr.server_count().await, 0);
+}


### PR DESCRIPTION
## Summary

Adds end-to-end tests that exercise `McpClient` + `McpToolHandler` via an in-process rmcp server paired with `tokio::io::duplex`, plus `McpClientManager` lifecycle tests for the failure/empty/disabled paths that don't need a real connection.

### Per-file coverage

| File | Before | After |
|---|---|---|
| `bridge.rs` | 10.1% | **100.0%** |
| `client.rs` | 0.0% | **98.4%** |
| `manager.rs` | 25.9% | **71.0%** |
| **Whole crate** | **20.3%** | **78.7%** |

Stays on `report_only` (1.3% short of the floor). The remaining gap is the manager's successful-connection path, which would require either an out-of-process MCP echo binary or a `for_testing` constructor on `McpClientManager` — neither felt right for this PR.

The delta drops from **−59.7%** to **−1.3%**.

### In-process integration test (`tests/in_process.rs`, 17 tests)

A small `TestServer` implements rmcp's `ServerHandler` with four canned tools (`echo`, `boom` with `is_error`, `empty`, `with-image`). Paired to `McpClient` via `tokio::io::duplex(4096)`.

**Key discovery**: the spawned task must hold the server's `RunningService` alive via `.waiting()` — otherwise the service drops after handshake and the client immediately sees `BrokenPipe` on the next request.

Covers the full surface:
- `name()`, `is_connected()`, `server_info()`, `supports_tool_list_changed()` both with and without the server advertising the capability.
- `list_tools()` returning all server-defined tools.
- `call_tool()` with arguments, without arguments (None branch), and the `Err` path for unknown tools.
- `shutdown()` called twice (idempotent because `_service` is `Option`).
- `McpToolHandler::from_remote` namespacing + schema cloning + empty-description synthesis fallback.
- `McpToolHandler::run` for: text response, `is_error=true` response, empty content placeholder, image attachments (1-byte PNG base64), and the underlying-call-fails branch.

### Manager test (`tests/manager.rs`, 13 tests)

Without a real server, exercises every non-success path:
- `start` with empty entries, all-disabled, invalid names (uppercase, underscore, space, dot, empty), empty stdio command, unreachable HTTP, stdio with `sh -c "exit 0"` (spawn succeeds but handshake fails), HTTP with env-substituted **and** invalid header names (validates the warn-and-skip branch).
- `tool_handlers` / `tool_count` / `server_count` on empty manager.
- `refresh_server_tools` for unknown server and for tracked-but-disconnected server.
- `shutdown` on empty manager.
- `health_check` on empty manager (early-returns when no work).
- `health_check` with one broken server: drives Phase 1 collection + Phase 2 parallel reconnect + Phase 3 error apply; verifies the `register`/`unregister` callbacks are **not** invoked.

### Dev-deps

Adds `rmcp` with `client` + `server` features (the latter pulls in `transport-async-rw` transitively), tokio's `io-util` + `macros`, `serde_json`, and `uuid`.

Remaining `report_only` (3 crates): `bus-nats` (34.4%), `interface-cli` (28.9%), `mcp-client` (78.7%).

Part of `openspec/changes/workspace-test-coverage-floor` (Phase 11).

## Test plan

- [x] `cargo test -p assistant-mcp-client` — all 30 tests green (17 in_process + 13 manager)
- [x] `make lint` — clippy clean
- [x] `make coverage` — gate prints `Coverage gate passed`; mcp-client shows `report-only (delta -1.3%)`