### PR TITLE
feat(ci): promote assistant-bus-nats past 80% floor (Phase 11)

### DIFF
--- a/coverage.toml
+++ b/coverage.toml
@@ -46,7 +46,6 @@ crates = [
     # reaches the floor sustainably; one-way ratchet.
     #
     # Last measured (2026-05-18 via `make coverage`):
-    "bus-nats",                          # 34.4% (delta -45.6%)
     "interface-cli",                     # 28.9% (delta -51.1%)
     "mcp-client",                        # 78.7% (delta -1.3%)
 ]
@@ -74,6 +73,7 @@ crates = [
 #   opentelemetry-exporter-iceberg (81.2%) — log + metric e2e exports via SdkMeterProvider/SdkLoggerProvider, partition::granularity_to_partition_int + partition_spec, catalog::warehouse_path + build_file_io + build_catalog + ensure_namespace
 #   opentelemetry-exporter-sqlite (80.5%) — metric e2e exports via SdkMeterProvider over file-backed SQLite + log helper-fn coverage (any_value_to_json/Map/Bytes, all severity variants)
 #   interfaces    (80.9%) — wiremock-driven tests for all 8 slack ambient skills (post/react/delete/update/list/get-history/lookup-user/send-dm), slack per-turn tools (reply/react/upload three-step flow), matrix tools (build_matrix_tools + reply handler), nextcloud runner (new/with_shutdown/with_transcription/run-error paths), mattermost tools success paths (full upload flow + already-exists branch), common.rs (rand_jitter + sleep_backoff cap/early-cancel)
+#   bus-nats      (86.0%) — un-ignored the testcontainers-based JetStream integration tests; start_nats now returns Option so they skip cleanly when Docker is unavailable. CI ubuntu-latest has Docker so these tests exercise publish/claim/claim_filtered/ack/nack/fail/consumer_for/parse_nats_message.
 
 # File path regex patterns excluded from coverage measurement.
 # Passed to `cargo llvm-cov --ignore-filename-regex` as a joined alternation.

--- a/crates/bus-nats/src/lib.rs
+++ b/crates/bus-nats/src/lib.rs
@@ -879,6 +879,13 @@ mod tests {
     }
 
     // -- Integration tests (require Docker) ---------------------------------
+    //
+    // These tests opportunistically spin up a NATS JetStream container via
+    // testcontainers. When Docker isn't available (e.g. a contributor laptop
+    // without it running) `start_nats` returns `None` and each test exits
+    // cleanly as a no-op — so `cargo test` still passes locally. On CI
+    // (ubuntu-latest), Docker is present and the tests exercise the real
+    // MessageBus implementation, contributing to the coverage gate.
 
     use testcontainers::core::IntoContainerPort;
     use testcontainers::runners::AsyncRunner;
@@ -887,30 +894,23 @@ mod tests {
 
     const NATS_PORT: u16 = 4222;
 
-    /// Start a NATS container with JetStream enabled, return container handle
-    /// and the connection URL.
-    async fn start_nats() -> (ContainerAsync<Nats>, String) {
+    /// Try to start a NATS container with JetStream enabled.
+    /// Returns `None` when Docker is unavailable so tests can skip cleanly.
+    async fn start_nats() -> Option<(ContainerAsync<Nats>, String)> {
         let cmd = NatsServerCmd::default().with_jetstream();
-        let container = Nats::default()
-            .with_cmd(&cmd)
-            .start()
-            .await
-            .expect("failed to start NATS container");
-
-        let host = container.get_host().await.expect("no container host");
-        let port = container
-            .get_host_port_ipv4(NATS_PORT.tcp())
-            .await
-            .expect("no mapped port");
+        let container = Nats::default().with_cmd(&cmd).start().await.ok()?;
+        let host = container.get_host().await.ok()?;
+        let port = container.get_host_port_ipv4(NATS_PORT.tcp()).await.ok()?;
         let url = format!("nats://{host}:{port}");
-
-        (container, url)
+        Some((container, url))
     }
 
     #[tokio::test]
-    #[ignore = "requires Docker"]
     async fn test_publish_and_claim() {
-        let (_container, url) = start_nats().await;
+        let Some((_container, url)) = start_nats().await else {
+            eprintln!("docker unavailable; skipping");
+            return;
+        };
         let bus = NatsMessageBus::new(&url).await.unwrap();
 
         let payload = serde_json::json!({"action": "greet"});
@@ -932,9 +932,11 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "requires Docker"]
     async fn test_publish_with_metadata() {
-        let (_container, url) = start_nats().await;
+        let Some((_container, url)) = start_nats().await else {
+            eprintln!("docker unavailable; skipping");
+            return;
+        };
         let bus = NatsMessageBus::new(&url).await.unwrap();
 
         let conv_id = Uuid::new_v4();
@@ -965,9 +967,11 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "requires Docker"]
     async fn test_claim_filtered_by_batch() {
-        let (_container, url) = start_nats().await;
+        let Some((_container, url)) = start_nats().await else {
+            eprintln!("docker unavailable; skipping");
+            return;
+        };
         let bus = NatsMessageBus::new(&url).await.unwrap();
 
         let batch_a = Uuid::new_v4();
@@ -1018,9 +1022,11 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "requires Docker"]
     async fn test_ack_nack_fail() {
-        let (_container, url) = start_nats().await;
+        let Some((_container, url)) = start_nats().await else {
+            eprintln!("docker unavailable; skipping");
+            return;
+        };
         let bus = NatsMessageBus::new(&url).await.unwrap();
 
         // Publish three messages
@@ -1058,9 +1064,11 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "requires Docker"]
     async fn test_claim_returns_none_when_empty() {
-        let (_container, url) = start_nats().await;
+        let Some((_container, url)) = start_nats().await else {
+            eprintln!("docker unavailable; skipping");
+            return;
+        };
         let bus = NatsMessageBus::new(&url).await.unwrap();
 
         let result = bus.claim("empty.topic", "w1").await.unwrap();
@@ -1068,9 +1076,11 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "requires Docker"]
     async fn consumer_carries_max_deliver_cap() {
-        let (_container, url) = start_nats().await;
+        let Some((_container, url)) = start_nats().await else {
+            eprintln!("docker unavailable; skipping");
+            return;
+        };
         let bus = NatsMessageBus::new(&url).await.unwrap();
 
         let mut consumer = bus.consumer_for("worker", "cap.topic").await.unwrap();
@@ -1086,9 +1096,11 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "requires Docker"]
     async fn consumer_for_reconciles_legacy_unbounded_config() {
-        let (_container, url) = start_nats().await;
+        let Some((_container, url)) = start_nats().await else {
+            eprintln!("docker unavailable; skipping");
+            return;
+        };
         let bus = NatsMessageBus::new(&url).await.unwrap();
 
         // Pre-create a consumer with the OLD (unbounded) config to simulate


### PR DESCRIPTION
## Summary

Lifts `crates/bus-nats` from 34.4% to **86.0%** by un-`#[ignore]`ing the testcontainers-based JetStream integration tests that were previously gated behind "requires Docker". Ratchets it off `report_only`. `report_only` drops from 3 to 2.

### The trick

`start_nats` now returns `Option<(ContainerAsync<Nats>, String)>` instead of `(...)`. When Docker isn't available (e.g. a contributor laptop without it running), `start_nats` returns `None` and each test exits cleanly as a no-op — so `cargo test` still passes locally without Docker. On CI ubuntu-latest, Docker is present and the tests exercise the real `MessageBus` implementation:

- **publish + claim** — round-trip with payload + topic + claimed_by
- **publish with full metadata** — user_id, agent_id, conversation_id, interface, batch_id; verify round-trip headers
- **claim_filtered by batch_id** — picks the right one out of two
- **ack + nack + fail** — three messages, including nack redelivery within the ack_wait window
- **claim returns None** on an empty topic
- **consumer_for advertises MAX_DELIVER cap**, mirroring `MAX_TURN_REDELIVERIES`
- **consumer_for reconciles legacy unbounded consumer** by deleting and recreating with the cap (the upgrade path that `schorschvm` needs post multi-org-runtime-cutover deploy)

### Coverage

| File | Before | After |
|---|---|---|
| `lib.rs` | 34.4% | **86.0%** |

Remaining `report_only` (2 crates): `interface-cli` (28.9%), `mcp-client` (78.7%).

Part of `openspec/changes/workspace-test-coverage-floor` (Phase 11).

## Test plan

- [x] `cargo test -p assistant-bus-nats --lib` — all 22 tests green (15 unit + 7 integration via testcontainers, ~15s wall-clock with Docker)
- [x] `make lint` — clippy clean
- [x] `make coverage` — gate prints `Coverage gate passed`; bus-nats shows `ok` at 86.0%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * JetStream integration tests now run opportunistically when Docker is available and gracefully skip when unavailable, improving test reliability and coverage measurement.

* **Chores**
  * Updated coverage enforcement configuration to reflect higher measured test coverage and improved test infrastructure management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cedricziel/assistant/pull/899?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->