### PR TITLE
docs(openspec): protocol-adapter-platform epic + phase 0

### DIFF
--- a/openspec/changes/protocol-adapter-platform/.openspec.yaml
+++ b/openspec/changes/protocol-adapter-platform/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-23

--- a/openspec/changes/protocol-adapter-platform/design.md
+++ b/openspec/changes/protocol-adapter-platform/design.md
@@ -1,0 +1,209 @@
+## Context
+
+The assistant has one reasoning core — the Orchestrator (`assistant-runtime`,
+the ReAct loop) — fronted by several surfaces that have grown independently:
+
+- `/api/*` (OpenAPI REST + SSE) consumed by the Flutter app via a generated
+  Dio client (`app/packages/assistant_api/`, ~47k generated LOC) plus a
+  hand-rolled SSE layer (`app/lib/api/api_client.dart`) with platform-specific
+  hacks (iOS chunked-transfer buffering, web `EventSource` fallback).
+- Messenger interfaces (Slack, Mattermost, Matrix, Nextcloud, Signal) in
+  `assistant-interfaces`, all driven through `ChannelRunner` → Orchestrator.
+- An MCP server and MCP client (`assistant-mcp-server` / `-client`) — JSON-RPC
+  2.0 over stdio — exposing/consuming tools.
+- An A2A surface in `web-ui/src/a2a/` — types are complete, the agent card and
+  registry are real, but `message/send` and `message/stream` are stubs
+  (`// TODO: Wire to Orchestrator`) backed by an in-memory `TaskStore`.
+
+Investigation (the conversation that produced this epic) evaluated three
+external agent protocols against our needs. Each models a **different
+relationship**, and we have all of those relationships:
+
+| Concern                                                  | Protocol       | Direction | Today             |
+| -------------------------------------------------------- | -------------- | --------- | ----------------- |
+| Management / CRUD (orgs·spaces·personas·skills·traces·…) | OpenAPI `/api` | inbound   | correct, keep     |
+| First-party + 3rd-party chat **stream**                  | AG-UI          | inbound   | bespoke SSE       |
+| Peer agent interop (agents delegate to/from us)          | A2A            | in + out  | stub, orphaned    |
+| Editors drive our assistant (use us as backend)          | ACP-as-agent   | inbound   | none (CLI fits)   |
+| We drive external coding agents as subagents             | ACP-as-client  | outbound  | none (best fit)   |
+| Tool / capability exposure                               | MCP            | in + out  | already have both |
+
+Key findings that shape this epic:
+
+1. **No single protocol covers everything.** Each covers ~one slice. `/api`
+   owns ~26 management resource families that _no_ agent protocol models.
+2. **The pain is the boundary, not the core.** The internal domain model
+   (`ContentBlock`, `Message`, `OrchestratorEvent`) is an asset; `ContentBlock`
+   is already MCP-shaped, which AG-UI/A2A/ACP all reuse.
+3. **Two structural gaps block clean adoption** (confirmed by grep):
+   - `OrchestratorEvent` is hand-serialized at every boundary; there is **no
+     shared projector** (`fn project(&OrchestratorEvent) -> Vec<WireEvent>`
+     does not exist).
+   - The A2A surface has **no `AuthContext`/org/space** — `A2AState` is just
+     `{ task_store, agent_card }`. It is an unauthenticated orphan.
+4. **The convergence signal is strong.** We independently reinvented protocol
+   primitives: `SafetyGate` ≈ ACP `session/request_permission` ≈ AG-UI
+   interrupts; the in-flight `slash-commands` change ≈ ACP
+   `available_commands_update`; the in-flight `web-session-resilience` change ≈
+   AG-UI `STATE_SNAPSHOT`/`STATE_DELTA`; `Subagent*` events ≈ ACP-as-client.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Establish "one Orchestrator brain, N thin protocol adapters, one per
+  concern" as the platform architecture.
+- Define the two shared pieces that make N protocols cost ≈ `1× + ε` instead
+  of `N×`: a single event-projection layer and a single auth spine.
+- Map every protocol to its concern and direction, and sequence the work into
+  independently shippable phases.
+
+**Non-Goals:**
+
+- Implementing any protocol in this change (each is a child change).
+- Replacing `/api` CRUD or the generated Dart client.
+- Replacing the internal domain model with external protocol types.
+- Locking in the community AG-UI SDKs (schema adoption ≠ SDK adoption).
+
+## Architecture: ports & adapters around one Orchestrator
+
+```
+            INBOUND doors                              OUTBOUND doors
+   (someone drives the assistant)            (the assistant drives someone)
+
+  OpenAPI ─┐                                            ┌─ A2A-client → peer agents
+  AG-UI  ──┤                                            │
+  A2A-in ──┤     ┌────────────────────────────┐        ├─ ACP-client → coding agents
+  ACP-agent┼────▶│        ORCHESTRATOR        │───────▶│             (= Subagent Process)
+  Slack ───┤     │   (ONE ReAct brain)         │        │
+  Matrix ──┤     │  + AuthContext (org/space)  │        └─ MCP-client → external tools
+  MCP-srv ─┘     └────────────────────────────┘
+                             │
+                 ┌───────────┴────────────┐
+                 │  EVENT PROJECTION LAYER │  ← keystone (does not exist yet)
+                 │  OrchestratorEvent  →   │
+                 │   {AG-UI | A2A | ACP |  │
+                 │    /api-SSE | CLI}      │
+                 └─────────────────────────┘
+```
+
+This matches the grain of the codebase: `.claude/skills/interface-implementation`
+already mandates that _every interface goes through the Orchestrator_. "Support
+all protocols" is just "every protocol is an interface."
+
+## The keystone (what makes the epic worth doing)
+
+The value is not in the protocols — it is in two shared pieces beneath them.
+
+**1. One event-projection layer.** `OrchestratorEvent` is the canonical
+internal stream. Each protocol becomes a pure projector. Adding a protocol =
+adding one projector + one conformance suite, not a new serializer copy-pasted
+across handlers. This is the difference between `N×` and `1× + ε`.
+
+**2. One auth/identity spine.** Every inbound adapter MUST resolve the same
+`AuthContext` (org · space · roles · scopes) before touching the Orchestrator.
+`/api` already does this (API keys + OAuth). A2A does not — fixing that is part
+of Phase 1, and the invariant prevents every future door from becoming a fresh
+unauthenticated attack surface against multi-tenant data.
+
+**Shared substrate we already have right:** the domain content model.
+`ContentBlock` (`crates/core/src/llm/types.rs`) is MCP-shaped; AG-UI, A2A, and
+ACP all reuse MCP content representations. It stays the single serialization
+source — we do **not** externalize the domain model.
+
+## The cautionary tale (already in the repo)
+
+The current A2A surface is what "support all protocols" looks like done wrong:
+a parallel `task_store` (its own half-brain), no Orchestrator, no auth,
+hand-rolled in isolation. Every new door MUST be **subtractive in concept** —
+it adds a serializer and a route, never a second brain or a second data model.
+Phase 1 explicitly converts A2A from this anti-pattern into a proper adapter.
+
+## Phased roadmap
+
+Each phase is a separate OpenSpec change (stacked PRs). The epic tracks them;
+it does not contain their implementation tasks.
+
+- **Phase 0 — Keystone** (`protocol-projection-and-auth-spine`)
+  Extract the event-projection layer from `api/messages.rs`; make `AuthContext`
+  mandatory on every inbound adapter. Pure refactor, no new protocol, no
+  external commitment. Unlocks everything else.
+
+- **Phase 1 — Finish the half-built + highest-pain**
+  - `a2a-orchestrator-wiring`: replace the A2A stub with a real adapter over
+    the Orchestrator via the projector + auth spine; persist tasks.
+  - `ag-ui-stream-schema`: re-shape the first-party stream to AG-UI's event
+    vocabulary ("speak the standard, own the plumbing"). Gated on the open
+    decision below.
+
+- **Phase 2 — New capability, best architectural fit**
+  - `acp-client-subagents`: the Orchestrator drives external coding agents
+    (Claude Code, Gemini CLI, …) as `Subagent Process`es over ACP. The
+    env-ownership inversion that breaks ACP-as-agent **resolves** here because
+    the server already owns the workspace/terminal; reuses `Subagent*` events.
+
+- **Phase 3 — Nice-to-have**
+  - `acp-agent-cli`: expose the assistant as an ACP agent for editors. Only the
+    CLI's environment model fits ACP's "client owns the filesystem" assumption;
+    web/mobile never will.
+
+## Resolved decision — adopt AG-UI including the SDKs (2026-05-23)
+
+AG-UI is the only external protocol _built for_ the frontend↔agent-backend
+axis, maps cleanly onto `OrchestratorEvent`, and is the only one with a Dart
+client on pub.dev. **Decision:** Phase 1's `ag-ui-stream-schema` adopts AG-UI
+**fully** — the community Rust SDK on the server and the community `ag_ui` Dart
+SDK on the client — to delete the most hand-rolled glue (`api_client.dart`'s
+SSE layer and its iOS/web platform hacks). The driver is ecosystem interop plus
+the largest reduction in client transport code we own.
+
+**Accepted risk:** both SDKs are community-maintained and early (Dart `ag_ui`
+v0.1.0, ~8 months stale, ~969 downloads; Rust SDK is a community crate). We
+therefore commit to a de-risking strategy rather than a blind dependency:
+
+1. **Spike first.** Phase 1 opens with a throwaway spike that drives a real
+   turn end-to-end through both SDKs, asserting every `OrchestratorEvent`
+   variant survives the round trip (text, reasoning, tool calls, subagents via
+   `Custom`/`Raw`, audio, errors, cancel). Go/no-go gate before committing.
+2. **Vendor + pin.** Pin exact versions; be prepared to vendor/fork either SDK
+   into the workspace (Rust) or `app/packages/` (Dart) if upstream stalls. The
+   AG-UI _schema_ is the durable asset; the SDKs are replaceable plumbing.
+3. **Keep the projector boundary.** Even with SDKs, the
+   `OrchestratorEvent → AG-UI` mapping lives in our Phase 0 projection layer
+   behind conformance tests, so swapping or forking an SDK never touches the
+   Orchestrator.
+
+This sets the scope of `ag-ui-stream-schema`. The fallback if the spike fails
+is the lower-risk "speak the schema, own the plumbing" variant (our own thin
+emitter/consumer against the same AG-UI wire schema) — no Orchestrator rework
+required, because the projector boundary is identical.
+
+## Decisions
+
+### 1. Model protocols as adapters over one Orchestrator, not as parallel surfaces
+
+Every protocol is an interface in the existing sense. **Alternative
+considered:** independent per-protocol stacks (the current A2A shape).
+Rejected — it duplicates the data model, auth, and the reasoning loop, and is
+the exact debt this epic exists to prevent.
+
+### 2. Standardize the boundary, not the core
+
+Align wire serialization with open schemas; keep the internal domain model
+hand-rolled. **Alternative considered:** adopt an external protocol's types as
+the core model. Rejected — couples the core to externally-versioned wire specs
+for no internal benefit.
+
+### 3. CRUD stays on OpenAPI; only the stream is a protocol question
+
+`/api` + generated client is the correct tool for management resources.
+**Alternative considered:** push everything through one agent protocol.
+Rejected — no agent protocol has vocabulary for orgs/spaces/personas/traces;
+we would smuggle them into `metadata` blobs and lose the standard's value.
+
+### 4. Sequence by ROI and architectural fit, ship phases independently
+
+Keystone first (de-risks all doors), then finish/fix, then new capability,
+then nice-to-have. **Alternative considered:** build all protocols at once.
+Rejected — multiplies the cautionary-tale risk and blocks review; stacked
+single-phase PRs match the team's working style.

--- a/openspec/changes/protocol-adapter-platform/proposal.md
+++ b/openspec/changes/protocol-adapter-platform/proposal.md
@@ -1,0 +1,65 @@
+## Why
+
+We hand-roll three things that emerging open protocols now standardize: the
+orchestrator's wire serialization, the Flutter client transport, and our
+agent-interop surface. Investigation (see `design.md`) shows these map to
+_distinct relationships_ — frontend↔agent backend (AG-UI), agent↔agent peers
+(A2A), editor↔coding-agent (ACP) — plus the two we already own well:
+management CRUD (OpenAPI `/api`) and tool exposure (MCP). No single protocol
+covers all of them; forcing one to is what made earlier "replatform on X"
+framings fail.
+
+Two structural gaps block adopting any of them cleanly: (1) `OrchestratorEvent`
+is re-serialized by hand at every boundary (`web-ui/src/api/messages.rs`, the
+CLI, the REPL) with no shared projector; (2) the existing A2A surface is an
+orphan — an in-memory task store with no `AuthContext`, org, or space,
+disconnected from the Orchestrator (its `send_message` is a stub). Adding
+protocols on this footing would multiply both gaps four times over.
+
+## What Changes
+
+This is an **epic** — it establishes the architecture and sequences the work;
+it ships no protocol by itself. Concretely it defines:
+
+- A **ports-and-adapters** contract: every protocol is a thin adapter over the
+  _one_ Orchestrator (matching the existing `interface-implementation` rule).
+- A **shared event-projection layer**: `OrchestratorEvent → {wire events}`
+  with exactly one projector per protocol.
+- A **shared auth spine**: every inbound adapter resolves the same
+  `AuthContext` (org/space/scopes) before dispatch.
+- The protocol↔concern map and a four-phase roadmap, each phase a separate
+  child change.
+
+Detailed, TDD-first implementation tasks live in the child changes, not here.
+
+## Capabilities
+
+### New Capabilities
+
+- `protocol-adapters`: the architectural invariants every protocol adapter
+  MUST satisfy (single Orchestrator, shared projection, shared auth, shared
+  content model).
+
+### Modified Capabilities
+
+(none — individual phases will add or modify per-protocol capabilities.)
+
+## Impact
+
+- **Scope**: architecture + roadmap only. Each phase is independently
+  proposed, reviewed, and shipped as a child change (stacked PRs).
+- **Phases**: 0 keystone (projection layer + auth spine) → 1 finish A2A +
+  AG-UI stream schema → 2 ACP-as-client (subagent delegation) → 3 ACP-as-agent
+  (CLI).
+- **Non-goals**:
+  - Replacing `/api` CRUD or the generated Dart client (OpenAPI is the right
+    tool for management; kept).
+  - Replacing the internal domain model with an external protocol's types
+    (`ContentBlock` is already MCP-shaped — the right amount of standard).
+  - Implementing any single protocol within this change.
+- **Resolved decision** (2026-05-23, scopes Phase 1): adopt AG-UI **fully** —
+  community Rust + `ag_ui` Dart SDKs — to delete the hand-rolled SSE glue, with
+  a spike-first / vendor-if-stalled de-risking strategy. See `design.md`.
+- **User-facing documentation needed**: Not for the epic. Each protocol phase
+  that exposes an external surface MUST ship operator/developer docs in
+  `docs/`.

--- a/openspec/changes/protocol-adapter-platform/specs/protocol-adapters/spec.md
+++ b/openspec/changes/protocol-adapter-platform/specs/protocol-adapters/spec.md
@@ -1,0 +1,84 @@
+## ADDED Requirements
+
+### Requirement: Every inbound protocol adapter dispatches through the Orchestrator
+
+Every inbound protocol adapter that accepts a user or agent message SHALL
+execute it by submitting a turn to the shared Orchestrator. This includes
+OpenAPI `/api`, AG-UI, A2A inbound, ACP-as-agent, and the messenger adapters.
+An adapter MUST NOT implement a parallel reasoning loop, a parallel
+tool-dispatch path, or a parallel message/turn data model.
+
+#### Scenario: A2A message is processed by the Orchestrator
+
+- **WHEN** an authenticated A2A `message/send` request arrives
+- **THEN** the adapter SHALL submit a turn to the Orchestrator AND the response
+  SHALL be produced from the Orchestrator's output — never from a stubbed or
+  adapter-local reply
+
+#### Scenario: No adapter owns a second brain
+
+- **WHEN** any inbound adapter is added or modified
+- **THEN** it SHALL NOT introduce its own ReAct loop or tool registry; tool
+  execution and reasoning SHALL remain in `assistant-runtime`
+
+### Requirement: Every inbound protocol adapter resolves a shared AuthContext before dispatch
+
+Before submitting a turn, an inbound adapter SHALL resolve the request to the
+same `AuthContext` used by `/api` — carrying user identity, org, space roles,
+and scopes — via either an OAuth token or an API key. An adapter MUST NOT
+dispatch a turn without a resolved `AuthContext`, and the resolved org/space
+SHALL scope all storage and tool access for that turn.
+
+#### Scenario: Unauthenticated request is rejected
+
+- **WHEN** a request reaches a protected protocol endpoint with no valid token
+  or API key
+- **THEN** the adapter SHALL reject it (401) AND SHALL NOT submit a turn
+
+#### Scenario: Turn is scoped to the caller's org and space
+
+- **WHEN** an authenticated request is dispatched through any adapter
+- **THEN** the Orchestrator turn SHALL run within the caller's org and space
+  AND SHALL NOT read or write data outside that scope
+
+### Requirement: The Orchestrator stream is projected to wire via a single projection layer
+
+Conversion from `OrchestratorEvent` to a protocol's wire events SHALL be
+performed by a single, shared projection layer with exactly one projector per
+protocol. Protocol handlers MUST NOT hand-serialize `OrchestratorEvent`
+inline. Adding a new streaming protocol SHALL require adding one projector plus
+its conformance tests, with no change to the Orchestrator or to other
+protocols' projectors.
+
+#### Scenario: One projector per protocol
+
+- **WHEN** a new streaming protocol is added
+- **THEN** exactly one new projector function/type SHALL be introduced AND no
+  existing handler SHALL gain a bespoke `OrchestratorEvent` serialization block
+
+#### Scenario: Projection is covered by conformance tests
+
+- **WHEN** a projector maps `OrchestratorEvent` variants to wire events
+- **THEN** a conformance test SHALL assert the mapping for each supported
+  variant, so a new `OrchestratorEvent` variant forces an explicit projector
+  decision rather than silently dropping
+
+### Requirement: The domain content model is the single serialization source
+
+All protocol adapters SHALL serialize from the shared domain content model
+(`ContentBlock` and related core types). The internal domain model MUST NOT be
+replaced by, or coupled to, any external protocol's wire types; external
+protocol types SHALL exist only at the adapter boundary.
+
+#### Scenario: Adapter serializes from the domain model
+
+- **WHEN** any adapter renders message content onto its wire format
+- **THEN** it SHALL derive that content from `ContentBlock` (or the shared core
+  types) AND core crates SHALL NOT depend on a protocol crate's wire types
+
+#### Scenario: CRUD management surface stays on OpenAPI
+
+- **WHEN** a management resource (orgs, spaces, personas, skills, traces, API
+  keys, etc.) is exposed
+- **THEN** it SHALL be served by the OpenAPI `/api` surface AND SHALL NOT be
+  re-modeled inside an agent protocol's message/task payloads

--- a/openspec/changes/protocol-adapter-platform/tasks.md
+++ b/openspec/changes/protocol-adapter-platform/tasks.md
@@ -1,0 +1,69 @@
+# Epic Roadmap — Protocol Adapter Platform
+
+> This is an **epic**. The tasks below are tracking milestones, not 2-hour
+> implementation chunks. Each phase ships as its own OpenSpec change with its
+> own TDD-first `tasks.md`. This epic is "done" when all child changes are
+> archived and the `protocol-adapters` invariants are enforced.
+
+## Phase 0 — Keystone (`protocol-projection-and-auth-spine`)
+
+- [x] Create the child change `protocol-projection-and-auth-spine`
+- [ ] Extract the shared event-projection layer from
+      `crates/web-ui/src/api/messages.rs` (one projector per existing wire:
+      `/api`-SSE and CLI), behind a conformance test over all
+      `OrchestratorEvent` variants
+- [ ] Define the `AuthContext`-resolution contract every inbound adapter must
+      satisfy; add an architecture conformance test (cf.
+      `tests/workspace_lint_policy.rs` precedent)
+- [ ] No new protocol, no external dependency — pure refactor, green build
+- [ ] Archive child change; confirm `protocol-adapters` projection + auth
+      invariants hold
+
+## Phase 1 — Finish half-built + highest-pain
+
+> Decision resolved (2026-05-23): adopt AG-UI **fully**, incl. community SDKs.
+
+- [ ] Create child change `a2a-orchestrator-wiring`
+  - [ ] Replace `web-ui/src/a2a/handlers.rs` stub with a real adapter over the
+        Orchestrator via the Phase 0 projector
+  - [ ] Add `AuthContext`/org/space to `A2AState`; reject unauthenticated calls
+  - [ ] Persist tasks via the storage layer (retire the in-memory `TaskStore`
+        or back it with SQLite)
+  - [ ] Ship A2A operator/developer docs in `docs/`
+- [ ] Create child change `ag-ui-stream-schema` (full SDK adoption)
+  - [ ] **Spike (throwaway, go/no-go gate)**: drive one real turn end-to-end
+        through the community Rust + `ag_ui` Dart SDKs; assert every
+        `OrchestratorEvent` variant round-trips (text/reasoning/tool/lifecycle,
+        subagent + audio via `Custom`/`Raw`, error, cancel). Fallback on
+        failure: own-the-plumbing variant against the same AG-UI schema
+  - [ ] Add the AG-UI projector in the Phase 0 projection layer (boundary stays
+        ours even with SDKs, so an SDK swap never touches the Orchestrator)
+  - [ ] Server: integrate the AG-UI Rust SDK; pin exact version
+  - [ ] Client: integrate the `ag_ui` Dart SDK; pin exact version; delete
+        `app/lib/api/api_client.dart` SSE layer + iOS/web platform hacks
+  - [ ] Vendor/fork plan documented in case either SDK stalls upstream
+
+## Phase 2 — New capability, best architectural fit
+
+- [ ] Create child change `acp-client-subagents`
+  - [ ] Orchestrator acts as an ACP **client** driving external coding agents
+        as `Subagent Process`es
+  - [ ] Surface external agent `session/update`s through existing `Subagent*`
+        `OrchestratorEvent`s
+  - [ ] Lend the server-side workspace/terminal as the ACP "client" environment
+  - [ ] Ship docs in `docs/`
+
+## Phase 3 — Nice-to-have
+
+- [ ] Create child change `acp-agent-cli`
+  - [ ] Expose the assistant as an ACP **agent** for editors, scoped to the CLI
+        (the only first-party client whose env model fits ACP)
+  - [ ] Map ACP `session/request_permission` to `SafetyGate`; ship docs
+
+## Epic exit criteria
+
+- [ ] All phase child changes implemented and archived
+- [ ] `protocol-adapters` spec promoted to `openspec/specs/` on archive
+- [ ] Each externally-exposed protocol has docs in `docs/`
+- [ ] No inbound adapter dispatches without a resolved `AuthContext`
+- [ ] No handler hand-serializes `OrchestratorEvent` (single projection layer)

--- a/openspec/changes/protocol-projection-and-auth-spine/.openspec.yaml
+++ b/openspec/changes/protocol-projection-and-auth-spine/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-24

--- a/openspec/changes/protocol-projection-and-auth-spine/design.md
+++ b/openspec/changes/protocol-projection-and-auth-spine/design.md
@@ -1,0 +1,114 @@
+## Context
+
+Phase 0 of the `protocol-adapter-platform` epic. The epic's `protocol-adapters`
+spec mandates two cross-cutting invariants: a single event-projection layer and
+a shared auth spine. This change implements the _enforcement scaffolding_ for
+both, so later per-protocol phases inherit them.
+
+Grounding (verified against the current tree):
+
+- `OrchestratorEvent` (`crates/runtime/src/orchestrator/stream_event.rs`) has
+  **10 variants**: `Token`, `Status`, `ToolResult`, `SkillComplete`,
+  `AgentError`, `Thinking`, `SubagentStarted`, `SubagentCompleted`,
+  `SubagentEvent` (recursive — boxes an inner event), `AudioReady`. It derives
+  `Debug, Clone` only — **no `Serialize`**; every boundary serializes by hand.
+- The SSE mapping lives inline in `crates/web-ui/src/api/messages.rs`
+  (~lines 200-405) and also handles thinking-batching, durable persistence
+  (`event_store.append_event`), sequence numbering, and live broadcast. Those
+  are transport concerns and stay in `messages.rs`; only the pure
+  event→frame mapping moves.
+- Event names + payload shapes today: `token` (raw text), `thinking`
+  (`{content}`), `status` (`{message, tool_call_id?}`), `tool_result`
+  (`{tool_name, status, tool_call_id?, ...}`), `skill_complete`
+  (`{skill_name, success, summary}`), `agent_error` (raw message),
+  `subagent_started` (`{agent_id, task}`), `subagent_completed`
+  (`{agent_id, status, summary}`), subagent inner (`{agent_id, data}`),
+  `audio_ready` (`{audio_id, auto_play}`), plus terminal `run_started` / `done`.
+- Auth: `AuthExtractor(pub AuthContext)` exists in `crates/auth/src/middleware.rs`
+  and is used by CRUD handlers. The streaming `send_message`
+  (messages.rs:88) takes `(State, Path, Json)` only and scopes off
+  `state.agent_id.read().await` (messages.rs:104). A2A handlers take neither.
+  Both `/api` and A2A sit behind the `require_auth` route-layer
+  (lib.rs:921-923), so they are _authenticated_ but do not _thread_
+  `AuthContext` into turn dispatch.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One total, tested `OrchestratorEvent → frame` projector per existing wire.
+- Byte-identical SSE output (behavior-preserving).
+- An enforced contract that inbound turn dispatch requires a resolved
+  `AuthContext`.
+
+**Non-Goals:**
+
+- Replacing `state.agent_id` turn scoping with `AuthContext`-derived org/space
+  routing (deferred — multi-org turn routing is its own change).
+- Touching A2A/AG-UI/ACP (later phases).
+- Changing event variants, wire names, or payload shapes.
+
+## Decisions
+
+### 1. Projection layer lives in `assistant-runtime`, emits a neutral frame
+
+New module `crates/runtime/src/projection/`. It owns `OrchestratorEvent` and is
+already depended on by both `web-ui` and `interface-cli`, so it is the only
+no-cycle home. The SSE projector emits a transport-neutral
+`ProjectedFrame { event: String, data: serde_json::Value }`; `messages.rs`
+adapts that to an axum `Event` and keeps persistence/seq/batching around it.
+
+**Alternative considered:** a new `assistant-protocol` crate. Rejected for
+Phase 0 — premature; revisit if projector count grows.
+
+### 2. One projector per wire, behind a `StreamProjector` seam
+
+```
+trait StreamProjector {
+    type Frame;
+    fn project(&self, event: &OrchestratorEvent) -> Vec<Self::Frame>;
+}
+```
+
+`SseProjector` (`Frame = ProjectedFrame`) and `CliProjector`
+(`Frame = String`, the rendered line). The CLI's existing inline rendering in
+`interface-cli` moves behind `CliProjector`. Returning `Vec` accommodates
+`SubagentEvent`, which recurses into the inner projector and may yield a
+prefixed/nested frame.
+
+### 3. Totality is compiler-enforced; conformance test guards intent
+
+Each projector's `match` carries **no `_` arm**, so adding an
+`OrchestratorEvent` variant fails to compile until projected. A conformance
+test additionally constructs one sample of every variant (including a nested
+`SubagentEvent`) and asserts a non-empty projection, documenting the contract.
+
+### 4. Wire parity proven by a golden test
+
+A golden test feeds a representative sequence through `SseProjector` and asserts
+event names + serialized payload JSON match the pre-refactor output exactly. The
+refactor is rejected if any byte differs. (`token` and `agent_error` keep their
+current raw-text data form; all others keep their JSON object form.)
+
+### 5. Auth seam: prefer compiler enforcement, fall back to source scan
+
+Preferred: a single inbound dispatch function that takes `&AuthContext`, so no
+inbound adapter can reach the Orchestrator without one — illegal states made
+unrepresentable. If wrapping `submit_turn*` (called by web, CLI, messengers,
+A2A) proves too invasive for Phase 0, fall back to a source-scanning
+conformance test modeled on `tests/workspace_lint_policy.rs`: inbound
+turn-accepting handlers must resolve `AuthContext`/`AuthExtractor`. The spec
+states the outcome; the task list spikes the compiler seam first and downgrades
+only if it balloons.
+
+Phase 0 threads `AuthExtractor` into the `/api` streaming handlers and uses the
+context for an authorization check (caller must hold the message-posting scope),
+so the resolved context is genuinely used — not dead — while full org/space
+re-scoping stays deferred per Non-Goals.
+
+### 6. No `_` discovery hidden: this is not a pure refactor end-to-end
+
+The projection extraction is behavior-preserving. The auth seam is a _new
+guardrail_ and a _minor authz tightening_ (scope check on the streaming
+handler). This is intended and called out so reviewers expect a new 403 path,
+not just moved code.

--- a/openspec/changes/protocol-projection-and-auth-spine/proposal.md
+++ b/openspec/changes/protocol-projection-and-auth-spine/proposal.md
@@ -1,0 +1,63 @@
+## Why
+
+This is **Phase 0 of the `protocol-adapter-platform` epic** — the keystone that
+makes adding protocols cheap and safe. Two structural gaps block every later
+phase:
+
+1. **No shared projection.** `OrchestratorEvent` is mapped to wire events by
+   hand inside `crates/web-ui/src/api/messages.rs` (~250 lines of inline
+   `match`), and again in the CLI. There is no single, tested place that turns
+   one orchestrator event into one protocol's frames, so every new protocol
+   would copy-paste a serializer and silently drift.
+2. **No enforced auth seam.** The CRUD handlers resolve `AuthContext` via
+   `AuthExtractor`, but the streaming turn handler scopes off a global
+   `state.agent_id` (messages.rs:104) and the A2A handlers ignore identity
+   entirely. Nothing _prevents_ a new inbound adapter from dispatching a turn
+   with no resolved `AuthContext` — the exact mistake the A2A stub already made.
+
+Fixing both now means Phase 1+ adapters add one projector and inherit the auth
+seam, instead of multiplying these gaps.
+
+## What Changes
+
+- Extract a **shared event-projection layer** (new module in
+  `assistant-runtime`): the canonical `OrchestratorEvent → ProjectedFrame`
+  mapping, with one projector per existing wire (`/api`-SSE and the CLI).
+  `messages.rs` and the CLI consume the projector instead of inline matches.
+- Add a **totality conformance test**: a sample of every `OrchestratorEvent`
+  variant is projected, and the match carries no `_` arm, so a new variant
+  forces an explicit projector decision.
+- Add a **wire-parity golden test**: the SSE projector emits byte-identical
+  event names and payload JSON to today (behavior-preserving refactor).
+- Establish the **inbound auth contract**: route inbound turn dispatch through
+  a seam that requires a resolved `AuthContext`, enforced by a conformance test
+  (compiler seam preferred, source-scan fallback à la
+  `tests/workspace_lint_policy.rs`).
+
+## Capabilities
+
+### New Capabilities
+
+- `event-projection`: a single, total, tested mapping from `OrchestratorEvent`
+  to each protocol's wire frames.
+- `inbound-auth-spine`: every inbound turn-accepting adapter resolves an
+  `AuthContext` before dispatch, enforced rather than conventional.
+
+## Impact
+
+- **Code touched**: new `crates/runtime/src/projection/` module;
+  `crates/web-ui/src/api/messages.rs` (consume projector + auth seam);
+  `crates/interface-cli/src/{main,repl_helpers}.rs` (consume projector);
+  workspace conformance test(s).
+- **Tests**: totality test, SSE wire-parity golden test, auth-seam conformance
+  test.
+- **Behavior change**: none intended. SSE wire stays byte-identical; no route
+  shape change, so **no `openapi.json` or Flutter client regeneration**.
+- **Non-goals**:
+  - Re-scoping the turn from `AuthContext` (replacing `state.agent_id` with
+    org/space-derived routing) — deferred; it entails multi-org turn routing.
+  - Wiring A2A to the Orchestrator (Phase 1 `a2a-orchestrator-wiring`).
+  - Any AG-UI/ACP projector (later phases).
+  - Changing `OrchestratorEvent` variants or the SSE wire vocabulary.
+- **User-facing documentation needed**: No. Internal refactor + test
+  guardrails; no user-visible behavior change.

--- a/openspec/changes/protocol-projection-and-auth-spine/specs/event-projection/spec.md
+++ b/openspec/changes/protocol-projection-and-auth-spine/specs/event-projection/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: A single projection layer maps OrchestratorEvent to wire frames
+
+The workspace SHALL provide one shared projection layer that converts an
+`OrchestratorEvent` into a protocol's wire frames, with exactly one projector
+per wire. Inbound/streaming handlers MUST consume a projector and MUST NOT
+re-implement an inline `OrchestratorEvent` serialization. The projection layer
+SHALL live in `assistant-runtime` (alongside `OrchestratorEvent`) and emit a
+transport-neutral frame, so transport concerns (persistence, sequencing,
+batching, framing) remain in the adapter.
+
+#### Scenario: SSE handler projects instead of inline-matching
+
+- **WHEN** the `/api` streaming handler serializes an `OrchestratorEvent`
+- **THEN** it SHALL call the shared SSE projector AND SHALL NOT contain an
+  inline `match` over `OrchestratorEvent` variants
+
+#### Scenario: Adding a wire adds exactly one projector
+
+- **WHEN** a new streaming wire is introduced
+- **THEN** exactly one new projector SHALL be added AND no existing adapter
+  SHALL gain a bespoke `OrchestratorEvent` serialization block
+
+### Requirement: Projection is total over all OrchestratorEvent variants
+
+Every projector SHALL handle every `OrchestratorEvent` variant. Projector match
+expressions MUST NOT use a catch-all `_` arm, so that adding a new variant fails
+to compile until the variant is explicitly projected. A conformance test SHALL
+construct a sample of every variant — including a nested `SubagentEvent` — and
+assert each yields a non-empty projection.
+
+#### Scenario: New variant fails to compile until projected
+
+- **WHEN** a new variant is added to `OrchestratorEvent`
+- **THEN** the projector SHALL fail to compile until the variant is handled
+  (no `_` arm absorbs it)
+
+#### Scenario: Nested subagent event is projected recursively
+
+- **WHEN** a `SubagentEvent` wrapping an inner `Token` is projected
+- **THEN** the projector SHALL produce at least one frame derived from the inner
+  event, scoped to the subagent's `agent_id`
+
+### Requirement: SSE wire output is byte-identical after extraction
+
+The extracted SSE projector SHALL produce the same event names and the same
+serialized payload JSON as the pre-refactor inline mapping. A golden test SHALL
+assert parity for a representative event sequence; any difference in event name
+or payload bytes SHALL fail the test.
+
+#### Scenario: Representative sequence matches the golden output
+
+- **WHEN** a sequence containing `Token`, `Thinking`, `Status`, `ToolResult`,
+  `SkillComplete`, `SubagentStarted`, `SubagentEvent`, `AudioReady`, and
+  `AgentError` is projected to SSE
+- **THEN** the emitted event names and payload JSON SHALL match the recorded
+  golden output exactly
+
+#### Scenario: token and agent_error keep raw-text data form
+
+- **WHEN** a `Token` or `AgentError` event is projected to SSE
+- **THEN** the frame data SHALL be the raw text (not a JSON object), matching
+  current behavior

--- a/openspec/changes/protocol-projection-and-auth-spine/specs/inbound-auth-spine/spec.md
+++ b/openspec/changes/protocol-projection-and-auth-spine/specs/inbound-auth-spine/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: Inbound turn dispatch requires a resolved AuthContext
+
+Every inbound adapter that dispatches a turn to the Orchestrator SHALL first
+resolve an `AuthContext`. The requirement MUST be enforced, not merely
+conventional: either by a dispatch seam that takes `&AuthContext` (so dispatch
+without one does not compile), or by a conformance test that fails when an
+inbound turn-accepting handler does not resolve `AuthContext`. An inbound
+turn-accepting handler MUST NOT submit a turn when no `AuthContext` is
+available.
+
+#### Scenario: Streaming handler resolves AuthContext before dispatch
+
+- **WHEN** the `/api` streaming message handler is invoked
+- **THEN** it SHALL resolve an `AuthContext` (via `AuthExtractor`) before
+  submitting the turn
+
+#### Scenario: A future adapter cannot skip the contract
+
+- **WHEN** a new inbound turn-accepting handler is added without resolving
+  `AuthContext`
+- **THEN** the enforcement (compiler seam or conformance test) SHALL reject it
+  (build or test failure)
+
+### Requirement: The resolved AuthContext gates message posting
+
+The `/api` streaming message handler SHALL use the resolved `AuthContext` to
+authorize the request, rejecting callers that lack the scope required to post
+messages. The resolved context MUST be used (not resolved-and-ignored).
+
+#### Scenario: Caller lacking the posting scope is rejected
+
+- **WHEN** an authenticated caller without the message-posting scope invokes the
+  streaming message handler
+- **THEN** the handler SHALL reject the request with `403 Forbidden` AND SHALL
+  NOT submit a turn
+
+#### Scenario: Authorized caller proceeds unchanged
+
+- **WHEN** an authenticated caller holding the message-posting scope invokes the
+  streaming message handler
+- **THEN** the turn SHALL be dispatched as before, with no change to the SSE
+  response shape

--- a/openspec/changes/protocol-projection-and-auth-spine/tasks.md
+++ b/openspec/changes/protocol-projection-and-auth-spine/tasks.md
@@ -1,0 +1,67 @@
+# Tasks — protocol-projection-and-auth-spine (Phase 0)
+
+TDD throughout: each implementation task is preceded by a failing test that is
+confirmed RED before any production code is written. Chunks are ≤ ~2h.
+
+## 1. Projection layer — scaffolding + totality (red first)
+
+- [ ] 1.1 RED: add `crates/runtime/src/projection/mod.rs` with the
+      `StreamProjector` trait and a `ProjectedFrame { event, data }` type; write
+      a conformance test that constructs every `OrchestratorEvent` variant
+      (incl. nested `SubagentEvent`) and asserts a non-empty projection.
+      Confirm it fails to compile / fails.
+- [ ] 1.2 GREEN: implement `SseProjector` with an exhaustive `match` (no `_`
+      arm) covering all 10 variants. Make the conformance test pass.
+- [ ] 1.3 Verify totality guard: temporarily add a throwaway variant locally and
+      confirm the projector fails to compile; revert.
+
+## 2. SSE wire parity (red first)
+
+- [ ] 2.1 RED: record a golden of the current inline SSE mapping (event names +
+      payload JSON) for a representative sequence (`Token`, `Thinking`,
+      `Status`, `ToolResult`, `SkillComplete`, `SubagentStarted`,
+      `SubagentEvent`, `AudioReady`, `AgentError`); assert `SseProjector` output
+      equals it. Confirm RED (projector not yet wired to match exact shapes).
+- [ ] 2.2 GREEN: align `SseProjector` payloads to byte-match — `token`/
+      `agent_error` raw text, all others JSON objects per `design.md`. Pass.
+
+## 3. Consume the projector in `messages.rs` (behavior-preserving)
+
+- [ ] 3.1 Replace the inline `OrchestratorEvent` `match` in
+      `crates/web-ui/src/api/messages.rs` with calls to `SseProjector`, keeping
+      thinking-batching, `event_store.append_event` persistence, sequence
+      numbering, and live broadcast in `messages.rs`.
+- [ ] 3.2 Run existing web-ui streaming tests; confirm SSE responses unchanged.
+
+## 4. CLI projector (red first)
+
+- [ ] 4.1 RED: add a `CliProjector` (`Frame = String`) test asserting rendered
+      lines for representative variants. Confirm RED.
+- [ ] 4.2 GREEN: implement `CliProjector` (exhaustive, no `_` arm); move the
+      inline rendering in `crates/interface-cli/src/{main,repl_helpers}.rs`
+      behind it. Pass; confirm REPL output unchanged manually.
+
+## 5. Auth seam — spike compiler enforcement (red first)
+
+- [ ] 5.1 SPIKE: attempt a dispatch seam requiring `&AuthContext` for inbound
+      turn submission. Timebox; if it stays contained (does not cascade through
+      CLI/messengers/A2A signatures), proceed; else record the decision and use
+      the source-scan fallback in 5.3.
+- [ ] 5.2 RED: thread `AuthExtractor` into the `/api` streaming `send_message`
+      (and stream/quick-message) handlers; add a test asserting a caller lacking
+      the message-posting scope gets `403` and no turn is dispatched. Confirm
+      RED.
+- [ ] 5.3 GREEN: implement the scope check using the resolved `AuthContext`
+      (still scoping the store via `state.agent_id` — re-scoping is out of
+      scope). Add the enforcement guard: compiler seam (preferred) OR a
+      source-scanning conformance test à la `tests/workspace_lint_policy.rs`
+      asserting inbound turn-accepting handlers resolve `AuthContext`. Pass.
+
+## 6. Finalize
+
+- [ ] 6.1 Confirm `openapi.json` is unchanged (no route shape change); no
+      `make dump-openapi` / `make generate-flutter-client` needed.
+- [ ] 6.2 Run `make lint && make format && make test`. (No `app/` changes →
+      Flutter checks not required.)
+- [ ] 6.3 `openspec validate protocol-projection-and-auth-spine`; tick epic
+      task 1 in `protocol-adapter-platform/tasks.md`.


### PR DESCRIPTION
## Summary

Adds two OpenSpec change artifacts (docs only — no code):

- **`protocol-adapter-platform`** — an **epic** for replatforming agent comms onto open protocols as thin adapters over the one Orchestrator, each protocol serving a distinct concern:
  - OpenAPI `/api` → management CRUD (keep)
  - **AG-UI** → first-party + 3rd-party chat stream
  - **A2A** → peer agent interop
  - **ACP** → editor↔coding-agent (as-client = subagent delegation; as-agent = CLI)
  - MCP → tool exposure (already have)
  - Establishes the keystone: one **event-projection layer**, one **inbound auth spine**, shared MCP-shaped content model. Sequenced into 4 phases.
- **`protocol-projection-and-auth-spine`** — the **Phase 0** keystone change: extract the `OrchestratorEvent → wire` projector (behavior-preserving, byte-parity golden test, compiler-enforced totality) and the inbound `AuthContext` contract + conformance test. Full multi-org turn re-scoping is deferred.

## Decisions captured

- Phase 1 adopts **AG-UI fully (incl. community Rust + Dart SDKs)** behind a spike-first / vendor-if-stalled de-risking strategy.
- Phase 0's auth deliverable is the *contract + conformance test* (+ a minor scope-check tightening), **not** a pure refactor — flagged in `design.md` Decision 6.

## Notes

- `openspec validate` passes for both changes.
- No Rust/Flutter code touched; `openapi.json` and the Flutter client are unchanged.
- Implementation (TDD) happens in a follow-up via `/opsx:apply protocol-projection-and-auth-spine`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added architectural planning, design specifications, and phased roadmap documentation for a unified protocol adapter platform to establish foundational infrastructure supporting multiple external protocols through a single internal architecture.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cedricziel/assistant/pull/906?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->