### PR TITLE
test(app): de-flake single-flight 401 refresh test

### DIFF
--- a/app/test/unit/api/auth_interceptor_test.dart
+++ b/app/test/unit/api/auth_interceptor_test.dart
@@ -309,8 +309,32 @@ void main() {
 
         final futureA = dio.get<dynamic>('/a');
         final futureB = dio.get<dynamic>('/b');
-        // Yield so both error handlers enter the refresh path before completing.
-        await Future<void>.delayed(const Duration(milliseconds: 5));
+
+        // dio defers the actual request dispatch across several event-loop
+        // turns, so a single wall-clock delay races *ahead* of the requests
+        // and opens the gate before either 401 is even seen — which serialises
+        // the two refreshes instead of overlapping them. Drive the loop
+        // deterministically instead: pump until both requests have hit their
+        // 401 and the single refresh is in flight (parked on the still-closed
+        // gate). Because the gate stays closed throughout, the in-flight
+        // refresh cannot complete and reset the single-flight slot before the
+        // second handler coalesces onto it, so this is order-independent.
+        var pumps = 0;
+        while (refreshCalls < 1 ||
+            adapter.countFor('/a') < 1 ||
+            adapter.countFor('/b') < 1) {
+          expect(
+            pumps++,
+            lessThan(100),
+            reason: 'requests never reached the refresh path',
+          );
+          await Future<void>.delayed(Duration.zero);
+        }
+        // A few more turns so the second 401 handler coalesces onto the
+        // in-flight refresh rather than starting its own.
+        for (var i = 0; i < 5; i++) {
+          await Future<void>.delayed(Duration.zero);
+        }
         refreshGate.complete();
 
         final results = await Future.wait([futureA, futureB]);


### PR DESCRIPTION
## Problem

The Flutter "Analyze & Test" CI job intermittently fails on the test
`AuthRecoveryInterceptor concurrent 401s share a single refresh attempt (single-flight)`
with `Expected: <1>, Actual: <2>`. It most recently reddened the unrelated
dependabot PR #904 (a `serde_json` Rust bump that cannot affect Flutter).

## Root cause

The test gated the refresh and waited a wall-clock `Future.delayed(5ms)`
before opening the gate, assuming both concurrent 401s would be parked on the
in-flight refresh by then. In **dio 5.9.2 the actual request dispatch is
deferred several event-loop turns**, so the 5ms delay fires *before either
request even reaches the adapter*. The gate opens early, the first refresh
runs to completion (resetting the single-flight slot), and only *then* does
the second request refresh — yielding **2 refresh calls instead of 1**.

Instrumented trace confirming it (at the 5ms mark nothing has dispatched):

```
[test] 5ms elapsed, refreshCalls=0, a401=0, b401=0; completing gate
[adapter] fetch /a   [adapter] fetch /b
[refresh] called #1 ... gate released, returning token
[refresh] called #2          <- no coalescing
```

It fails **deterministically in isolation** and **intermittently in the full
suite** (depending on event-loop warmup from prior tests).

## Fix

Pump the event loop deterministically **while the gate stays closed**, so the
in-flight refresh cannot complete and reset the single-flight slot before the
second request coalesces onto it. The fix is order-independent.

**Production code (`auth_interceptor.dart`) is correct and unchanged** — the
single-flight coalescing works whenever callers genuinely overlap; the test
simply failed to create that overlap.

## Verification

- Failing test: **0/10** before, **15/15** after.
- `flutter analyze --fatal-infos`: clean.
- `dart format`: clean.