### PR TITLE
chore(deps): bump sqlx from 0.8.6 to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2251,17 +2251,6 @@ dependencies = [
 
 [[package]]
 name = "etcetera"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
-dependencies = [
- "cfg-if",
- "home",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "etcetera"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
@@ -2440,9 +2429,9 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2780,6 +2769,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+dependencies = [
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -3472,9 +3470,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "leb128fmt"
@@ -3670,12 +3665,12 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.10.7",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -3880,22 +3875,6 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
-]
-
-[[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.6",
- "smallvec",
- "zeroize",
 ]
 
 [[package]]
@@ -4456,17 +4435,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
-]
 
 [[package]]
 name = "pkcs8"
@@ -5147,26 +5115,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid 0.9.6",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core 0.6.4",
- "signature",
- "spki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "rtoolbox"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5671,6 +5619,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5851,9 +5810,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -5864,12 +5823,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "cfg-if",
  "chrono",
  "crc",
  "crossbeam-queue",
@@ -5879,12 +5839,11 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.15.5",
- "hashlink",
+ "hashbrown 0.16.1",
+ "hashlink 0.11.0",
  "indexmap 2.14.0",
  "log",
  "memchr",
- "once_cell",
  "percent-encoding",
  "serde",
  "serde_json",
@@ -5900,9 +5859,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5913,15 +5872,15 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
 dependencies = [
+ "cfg-if",
  "dotenvy",
  "either",
  "heck",
  "hex",
- "once_cell",
  "proc-macro2",
  "quote",
  "serde",
@@ -5932,59 +5891,44 @@ dependencies = [
  "sqlx-postgres",
  "sqlx-sqlite",
  "syn",
+ "thiserror 2.0.18",
  "tokio",
  "url",
 ]
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
 dependencies = [
- "atoi",
- "base64 0.22.1",
  "bitflags",
  "byteorder",
  "bytes",
  "chrono",
  "crc",
- "digest 0.10.7",
+ "digest 0.11.2",
  "dotenvy",
  "either",
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-util",
  "generic-array",
- "hex",
- "hkdf 0.12.4",
- "hmac 0.12.1",
- "itoa",
  "log",
- "md-5",
- "memchr",
- "once_cell",
  "percent-encoding",
- "rand 0.8.6",
- "rsa",
  "serde",
- "sha1",
- "sha2 0.10.9",
- "smallvec",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "sqlx-core",
- "stringprep",
  "thiserror 2.0.18",
  "tracing",
  "uuid",
- "whoami",
 ]
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
  "base64 0.22.1",
@@ -5993,23 +5937,21 @@ dependencies = [
  "chrono",
  "crc",
  "dotenvy",
- "etcetera 0.8.0",
+ "etcetera",
  "futures-channel",
  "futures-core",
  "futures-util",
  "hex",
- "hkdf 0.12.4",
- "hmac 0.12.1",
- "home",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
  "itoa",
  "log",
  "md-5",
  "memchr",
- "once_cell",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -6021,13 +5963,14 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
 dependencies = [
  "atoi",
  "chrono",
  "flume",
+ "form_urlencoded",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -6037,7 +5980,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "serde",
- "serde_urlencoded",
  "sqlx-core",
  "thiserror 2.0.18",
  "tracing",
@@ -6270,7 +6212,7 @@ dependencies = [
  "bytes",
  "docker_credential",
  "either",
- "etcetera 0.11.0",
+ "etcetera",
  "ferroid",
  "futures",
  "http",
@@ -6757,7 +6699,7 @@ dependencies = [
  "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
 ]
 
@@ -7133,12 +7075,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7330,13 +7266,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.6.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
-dependencies = [
- "libredox",
- "wasite",
-]
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 
 [[package]]
 name = "winapi"
@@ -7360,7 +7292,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7481,15 +7413,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -7532,21 +7455,6 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -7578,12 +7486,6 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -7596,12 +7498,6 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -7611,12 +7507,6 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7638,12 +7528,6 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -7653,12 +7537,6 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7674,12 +7552,6 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -7689,12 +7561,6 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -7861,7 +7727,7 @@ checksum = "2462ea039c445496d8793d052e13787f2b90e750b833afee748e601c17621ed9"
 dependencies = [
  "arraydeque",
  "encoding_rs",
- "hashlink",
+ "hashlink 0.10.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ mime_guess = "2"
 # Type-safe compiled templates
 askama = "0.15"
 # SQL persistence
-sqlx = { version = "0.8", default-features = false, features = ["sqlite", "runtime-tokio", "migrate", "chrono", "uuid"] }
+sqlx = { version = "0.9", default-features = false, features = ["sqlite", "runtime-tokio", "migrate", "chrono", "uuid"] }
 # cron expression parsing
 cron = "0.16"
 # HTML parsing for web-fetch builtin

--- a/crates/opentelemetry-exporter-sqlite/src/log.rs
+++ b/crates/opentelemetry-exporter-sqlite/src/log.rs
@@ -283,8 +283,10 @@ mod tests {
     }
 
     async fn row_count(pool: &SqlitePool, table: &str) -> i64 {
-        let q = format!("SELECT COUNT(*) AS cnt FROM {table}");
-        sqlx::query_scalar::<_, i64>(&q)
+        // The table name is an identifier (not bindable); callers pass only
+        // hard-coded literals, so the interpolation is safe to assert.
+        let q = sqlx::AssertSqlSafe(format!("SELECT COUNT(*) AS cnt FROM {table}"));
+        sqlx::query_scalar::<_, i64>(q)
             .fetch_one(pool)
             .await
             .unwrap()

--- a/crates/opentelemetry-exporter-sqlite/src/span.rs
+++ b/crates/opentelemetry-exporter-sqlite/src/span.rs
@@ -299,8 +299,10 @@ mod tests {
     }
 
     async fn row_count(pool: &SqlitePool, table: &str) -> i64 {
-        let q = format!("SELECT COUNT(*) AS cnt FROM {table}");
-        sqlx::query_scalar::<_, i64>(&q)
+        // The table name is an identifier (not bindable); callers pass only
+        // hard-coded literals, so the interpolation is safe to assert.
+        let q = sqlx::AssertSqlSafe(format!("SELECT COUNT(*) AS cnt FROM {table}"));
+        sqlx::query_scalar::<_, i64>(q)
             .fetch_one(pool)
             .await
             .unwrap()

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -482,7 +482,7 @@ async fn run_migrations(pool: &SqlitePool) -> Result<()> {
         ),
     ];
 
-    for (name, sql) in migrations {
+    for &(name, sql) in migrations {
         let already_applied: i64 =
             sqlx::query_scalar("SELECT COUNT(*) FROM _migrations WHERE name = ?")
                 .bind(name)
@@ -621,7 +621,7 @@ mod tests {
             ),
         ];
 
-        for (name, sql) in seed_migrations {
+        for &(name, sql) in seed_migrations {
             sqlx::raw_sql(sql).execute(&pool).await?;
             sqlx::query("INSERT INTO _migrations(name) VALUES (?)")
                 .bind(name)
@@ -633,8 +633,11 @@ mod tests {
     }
 
     async fn column_exists(pool: &SqlitePool, table: &str, column: &str) -> Result<bool> {
-        let query = format!("PRAGMA table_info({table})");
-        let rows = sqlx::query(&query).fetch_all(pool).await?;
+        // `PRAGMA table_info(...)` cannot take a bound parameter for the table
+        // name, so the identifier must be interpolated. The table names are
+        // hard-coded test fixtures, never user input — safe to assert.
+        let query = sqlx::AssertSqlSafe(format!("PRAGMA table_info({table})"));
+        let rows = sqlx::query(query).fetch_all(pool).await?;
         Ok(rows.iter().any(|row| {
             row.try_get::<String, _>("name")
                 .is_ok_and(|name| name == column)

--- a/crates/storage/src/memory_chunks.rs
+++ b/crates/storage/src/memory_chunks.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use async_trait::async_trait;
-use sqlx::SqlitePool;
+use sqlx::{QueryBuilder, Sqlite, SqlitePool};
 
 /// A single stored chunk from a memory file.
 pub struct StoredChunk {
@@ -166,17 +166,23 @@ impl MemoryChunkStore for SqliteMemoryChunkStore {
         if ids.is_empty() {
             return Ok(Vec::new());
         }
-        let placeholders = ids.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
-        let sql = format!(
-            "SELECT id, file_path, chunk_index, content, embedding, file_hash
-             FROM memory_chunks
-             WHERE id IN ({placeholders}) AND embedding IS NOT NULL"
+        // Build `... WHERE id IN (?, ?, …)` with one bound parameter per id.
+        // `QueryBuilder::push_bind` emits the placeholders, so no id value is
+        // ever interpolated into the SQL string.
+        let mut builder: QueryBuilder<Sqlite> = QueryBuilder::new(
+            "SELECT id, file_path, chunk_index, content, embedding, file_hash \
+             FROM memory_chunks WHERE id IN (",
         );
-        let mut q = sqlx::query_as::<_, ChunkRow>(&sql);
+        let mut separated = builder.separated(", ");
         for id in ids {
-            q = q.bind(*id);
+            separated.push_bind(*id);
         }
-        let rows = q.fetch_all(&self.0).await?;
+        separated.push_unseparated(") AND embedding IS NOT NULL");
+
+        let rows = builder
+            .build_query_as::<ChunkRow>()
+            .fetch_all(&self.0)
+            .await?;
         Ok(rows.into_iter().map(decode_chunk).collect())
     }
 
@@ -501,5 +507,69 @@ impl MemoryChunkStore for InMemoryMemoryChunkStore {
     async fn count(&self) -> Result<i64> {
         let state = self.lock();
         Ok(state.chunks.len() as i64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::StorageLayer;
+
+    /// Seed three chunks, embed only the first and third, and confirm
+    /// `get_embeddings_by_ids` returns exactly the requested *embedded* rows.
+    /// Guards the dynamic `IN (?, ?, …)` clause and the `IS NOT NULL` filter.
+    #[tokio::test]
+    async fn get_embeddings_by_ids_returns_only_embedded_matches() {
+        let storage = StorageLayer::new_in_memory().await.unwrap();
+        let store = SqliteMemoryChunkStore::new(storage.pool.clone());
+
+        let id0 = store
+            .upsert_chunk("notes.md", "hash", 0, "first")
+            .await
+            .unwrap();
+        let id1 = store
+            .upsert_chunk("notes.md", "hash", 1, "second")
+            .await
+            .unwrap();
+        let id2 = store
+            .upsert_chunk("notes.md", "hash", 2, "third")
+            .await
+            .unwrap();
+
+        store.update_embedding(id0, &[1.0, 2.0, 3.0]).await.unwrap();
+        store.update_embedding(id2, &[7.0, 8.0]).await.unwrap();
+
+        // Request all three; only id0 and id2 are embedded.
+        let mut found = store.get_embeddings_by_ids(&[id0, id1, id2]).await.unwrap();
+        found.sort_by_key(|c| c.id);
+
+        assert_eq!(found.len(), 2, "only embedded rows should be returned");
+        assert_eq!(found[0].id, id0);
+        assert_eq!(found[0].embedding.as_deref(), Some(&[1.0, 2.0, 3.0][..]));
+        assert_eq!(found[1].id, id2);
+        assert_eq!(found[1].embedding.as_deref(), Some(&[7.0, 8.0][..]));
+    }
+
+    #[tokio::test]
+    async fn get_embeddings_by_ids_empty_input_returns_empty() {
+        let storage = StorageLayer::new_in_memory().await.unwrap();
+        let store = SqliteMemoryChunkStore::new(storage.pool.clone());
+
+        let found = store.get_embeddings_by_ids(&[]).await.unwrap();
+        assert!(found.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_embeddings_by_ids_skips_unembedded_ids() {
+        let storage = StorageLayer::new_in_memory().await.unwrap();
+        let store = SqliteMemoryChunkStore::new(storage.pool.clone());
+
+        let id = store
+            .upsert_chunk("notes.md", "hash", 0, "unembedded")
+            .await
+            .unwrap();
+
+        let found = store.get_embeddings_by_ids(&[id]).await.unwrap();
+        assert!(found.is_empty(), "unembedded chunk must be excluded");
     }
 }

--- a/crates/storage/src/message_bus.rs
+++ b/crates/storage/src/message_bus.rs
@@ -15,7 +15,7 @@ use anyhow::Result;
 use assistant_core::clock::{Clock, SystemClock};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use sqlx::{Row, SqlitePool};
+use sqlx::{QueryBuilder, Row, Sqlite, SqlitePool};
 use tracing::debug;
 use uuid::Uuid;
 
@@ -103,64 +103,47 @@ impl MessageBus for SqliteMessageBus {
     ) -> Result<Option<BusMessage>> {
         let now = self.clock.now();
 
-        // Build the inner SELECT with optional filter predicates.
-        let mut where_clauses = vec!["topic = ?3".to_string(), "status = 'pending'".to_string()];
-        // Track bind index — first 3 are: claimed_at, claimed_by, topic
-        let mut next_bind: u32 = 4;
-        let mut extra_binds: Vec<String> = Vec::new();
-
-        if let Some(ref agent) = filter.agent_id {
-            where_clauses.push(format!("agent_id = ?{next_bind}"));
-            extra_binds.push(agent.clone());
-            next_bind += 1;
-        }
-        if let Some(ref user) = filter.user_id {
-            where_clauses.push(format!("user_id = ?{next_bind}"));
-            extra_binds.push(user.clone());
-            next_bind += 1;
-        }
-        if let Some(ref conv) = filter.conversation_id {
-            where_clauses.push(format!("conversation_id = ?{next_bind}"));
-            extra_binds.push(conv.to_string());
-            next_bind += 1;
-        }
-        if let Some(ref batch) = filter.batch_id {
-            where_clauses.push(format!("batch_id = ?{next_bind}"));
-            extra_binds.push(batch.to_string());
-            next_bind += 1;
-        }
-        if let Some(ref iface) = filter.interface {
-            where_clauses.push(format!("interface = ?{next_bind}"));
-            extra_binds.push(iface.clone());
-            // next_bind not needed after last, but keep for consistency
-            let _ = next_bind;
-        }
-
-        let where_sql = where_clauses.join(" AND ");
-        let sql = format!(
-            "UPDATE bus_messages \
-             SET status = 'claimed', claimed_at = ?1, claimed_by = ?2 \
-             WHERE id = ( \
-                 SELECT id FROM bus_messages \
-                 WHERE {where_sql} \
-                 ORDER BY created_at ASC \
-                 LIMIT 1 \
-             ) \
-             RETURNING {SELECT_COLS}"
-        );
-
         let mut tx = self.pool.begin().await?;
         sqlx::query("PRAGMA busy_timeout = 5000;")
             .execute(&mut *tx)
             .await?;
 
-        let mut query = sqlx::query(&sql).bind(now).bind(worker_id).bind(topic);
+        // Claim the oldest pending message matching the optional routing
+        // filters. Every value is emitted via `push_bind`; only the constant
+        // `SELECT_COLS` column list is pushed as raw SQL.
+        let mut builder: QueryBuilder<Sqlite> =
+            QueryBuilder::new("UPDATE bus_messages SET status = 'claimed', claimed_at = ");
+        builder.push_bind(now);
+        builder.push(", claimed_by = ");
+        builder.push_bind(worker_id);
+        builder.push(" WHERE id = ( SELECT id FROM bus_messages WHERE topic = ");
+        builder.push_bind(topic);
+        builder.push(" AND status = 'pending'");
 
-        for val in &extra_binds {
-            query = query.bind(val);
+        if let Some(ref agent) = filter.agent_id {
+            builder.push(" AND agent_id = ").push_bind(agent);
+        }
+        if let Some(ref user) = filter.user_id {
+            builder.push(" AND user_id = ").push_bind(user);
+        }
+        if let Some(ref conv) = filter.conversation_id {
+            builder
+                .push(" AND conversation_id = ")
+                .push_bind(conv.to_string());
+        }
+        if let Some(ref batch) = filter.batch_id {
+            builder
+                .push(" AND batch_id = ")
+                .push_bind(batch.to_string());
+        }
+        if let Some(ref iface) = filter.interface {
+            builder.push(" AND interface = ").push_bind(iface);
         }
 
-        let row = query.fetch_optional(&mut *tx).await?;
+        builder.push(" ORDER BY created_at ASC LIMIT 1 ) RETURNING ");
+        builder.push(SELECT_COLS);
+
+        let row = builder.build().fetch_optional(&mut *tx).await?;
         tx.commit().await?;
 
         match row {
@@ -209,34 +192,19 @@ impl MessageBus for SqliteMessageBus {
         status: Option<MessageStatus>,
         limit: u32,
     ) -> Result<Vec<BusMessage>> {
-        let rows = match status {
-            Some(s) => {
-                let sql = format!(
-                    "SELECT {SELECT_COLS} FROM bus_messages \
-                     WHERE topic = ?1 AND status = ?2 \
-                     ORDER BY created_at ASC LIMIT ?3"
-                );
-                sqlx::query(&sql)
-                    .bind(topic)
-                    .bind(s.to_string())
-                    .bind(limit)
-                    .fetch_all(&self.pool)
-                    .await?
-            }
-            None => {
-                let sql = format!(
-                    "SELECT {SELECT_COLS} FROM bus_messages \
-                     WHERE topic = ?1 \
-                     ORDER BY created_at ASC LIMIT ?2"
-                );
-                sqlx::query(&sql)
-                    .bind(topic)
-                    .bind(limit)
-                    .fetch_all(&self.pool)
-                    .await?
-            }
-        };
+        // The constant column list is pushed raw; topic, status, and limit are
+        // all bound parameters.
+        let mut builder: QueryBuilder<Sqlite> = QueryBuilder::new("SELECT ");
+        builder.push(SELECT_COLS);
+        builder.push(" FROM bus_messages WHERE topic = ");
+        builder.push_bind(topic);
+        if let Some(s) = status {
+            builder.push(" AND status = ").push_bind(s.to_string());
+        }
+        builder.push(" ORDER BY created_at ASC LIMIT ");
+        builder.push_bind(limit);
 
+        let rows = builder.build().fetch_all(&self.pool).await?;
         rows.into_iter().map(parse_row).collect()
     }
 

--- a/crates/storage/src/metrics.rs
+++ b/crates/storage/src/metrics.rs
@@ -14,6 +14,13 @@ const ASSISTANT_TURN_COUNT: &str = "assistant.turn.count";
 const ASSISTANT_TOOL_INVOCATIONS: &str = "assistant.tool.invocations";
 const ASSISTANT_ERROR_COUNT: &str = "assistant.error.count";
 
+/// JSON path that selects the `gen_ai.token.type` attribute from the
+/// `attributes` column. Built once and passed as a bound parameter (the
+/// attribute key contains dots, so it must be quoted in the JSON path).
+fn token_type_path() -> String {
+    format!("$.\"{GEN_AI_TOKEN_TYPE}\"")
+}
+
 /// Trait-based interface for analytics metric queries.
 #[async_trait]
 pub trait MetricsStore: Send + Sync {
@@ -105,81 +112,90 @@ impl MetricsStore for SqliteMetricsStore {
     /// Overall summary for the last `window_hours` hours.
     async fn summary(&self, window_hours: i64) -> Result<MetricsSummary> {
         let window = format!("-{window_hours} hours");
+        let token_type_path = token_type_path();
 
         // Token counts from gen_ai.client.token.usage histogram.
         // For histograms the `sum` column holds the total value of all
         // observations in the collection interval.
-        let token_in: f64 = sqlx::query_scalar(&format!(
+        let token_in: f64 = sqlx::query_scalar(
             "SELECT CAST(COALESCE(SUM(sum), 0) AS REAL) FROM metric_points \
-             WHERE metric_name = '{GEN_AI_CLIENT_TOKEN_USAGE}' \
+             WHERE metric_name = ?3 \
                AND agent_id = ?2 \
-               AND json_extract(attributes, '$.\"{GEN_AI_TOKEN_TYPE}\"') = 'input' \
-                AND recorded_at >= datetime('now', ?1)"
-        ))
+               AND json_extract(attributes, ?4) = 'input' \
+                AND recorded_at >= datetime('now', ?1)",
+        )
         .bind(&window)
         .bind(&self.agent_id)
+        .bind(GEN_AI_CLIENT_TOKEN_USAGE)
+        .bind(&token_type_path)
         .fetch_one(&self.pool)
         .await?;
 
-        let token_out: f64 = sqlx::query_scalar(&format!(
+        let token_out: f64 = sqlx::query_scalar(
             "SELECT CAST(COALESCE(SUM(sum), 0) AS REAL) FROM metric_points \
-             WHERE metric_name = '{GEN_AI_CLIENT_TOKEN_USAGE}' \
+             WHERE metric_name = ?3 \
                AND agent_id = ?2 \
-               AND json_extract(attributes, '$.\"{GEN_AI_TOKEN_TYPE}\"') = 'output' \
-                AND recorded_at >= datetime('now', ?1)"
-        ))
+               AND json_extract(attributes, ?4) = 'output' \
+                AND recorded_at >= datetime('now', ?1)",
+        )
         .bind(&window)
         .bind(&self.agent_id)
+        .bind(GEN_AI_CLIENT_TOKEN_USAGE)
+        .bind(&token_type_path)
         .fetch_one(&self.pool)
         .await?;
 
         // Request count (counter).
-        let requests: f64 = sqlx::query_scalar(&format!(
+        let requests: f64 = sqlx::query_scalar(
             "SELECT CAST(COALESCE(SUM(value), 0) AS REAL) FROM metric_points \
-             WHERE metric_name = '{ASSISTANT_TURN_COUNT}' \
+             WHERE metric_name = ?3 \
                AND agent_id = ?2 \
-                AND recorded_at >= datetime('now', ?1)"
-        ))
+                AND recorded_at >= datetime('now', ?1)",
+        )
         .bind(&window)
         .bind(&self.agent_id)
+        .bind(ASSISTANT_TURN_COUNT)
         .fetch_one(&self.pool)
         .await?;
 
         // Tool invocations (counter).
-        let tools: f64 = sqlx::query_scalar(&format!(
+        let tools: f64 = sqlx::query_scalar(
             "SELECT CAST(COALESCE(SUM(value), 0) AS REAL) FROM metric_points \
-             WHERE metric_name = '{ASSISTANT_TOOL_INVOCATIONS}' \
+             WHERE metric_name = ?3 \
                AND agent_id = ?2 \
-                AND recorded_at >= datetime('now', ?1)"
-        ))
+                AND recorded_at >= datetime('now', ?1)",
+        )
         .bind(&window)
         .bind(&self.agent_id)
+        .bind(ASSISTANT_TOOL_INVOCATIONS)
         .fetch_one(&self.pool)
         .await?;
 
         // Weighted-average operation duration (histogram sum / count).
-        let avg_dur: f64 = sqlx::query_scalar(&format!(
+        let avg_dur: f64 = sqlx::query_scalar(
             "SELECT CAST(COALESCE( \
                  CASE WHEN SUM(count) > 0 THEN SUM(sum) / SUM(count) ELSE 0.0 END, 0) AS REAL) \
              FROM metric_points \
-             WHERE metric_name = '{GEN_AI_CLIENT_OPERATION_DURATION}' \
+             WHERE metric_name = ?3 \
                AND agent_id = ?2 \
-                AND recorded_at >= datetime('now', ?1)"
-        ))
+                AND recorded_at >= datetime('now', ?1)",
+        )
         .bind(&window)
         .bind(&self.agent_id)
+        .bind(GEN_AI_CLIENT_OPERATION_DURATION)
         .fetch_one(&self.pool)
         .await?;
 
         // Error count (counter).
-        let errors: f64 = sqlx::query_scalar(&format!(
+        let errors: f64 = sqlx::query_scalar(
             "SELECT CAST(COALESCE(SUM(value), 0) AS REAL) FROM metric_points \
-             WHERE metric_name = '{ASSISTANT_ERROR_COUNT}' \
+             WHERE metric_name = ?3 \
                AND agent_id = ?2 \
-                AND recorded_at >= datetime('now', ?1)"
-        ))
+                AND recorded_at >= datetime('now', ?1)",
+        )
         .bind(&window)
         .bind(&self.agent_id)
+        .bind(ASSISTANT_ERROR_COUNT)
         .fetch_one(&self.pool)
         .await?;
 
@@ -212,22 +228,23 @@ impl MetricsStore for SqliteMetricsStore {
         window_hours: i64,
         bucket_minutes: i64,
     ) -> Result<Vec<TimeSeriesPoint>> {
-        let rows: Vec<(String, f64)> = sqlx::query_as(&format!(
+        let rows: Vec<(String, f64)> = sqlx::query_as(
             "SELECT \
                  strftime('%Y-%m-%dT%H:', recorded_at) || \
                  printf('%02d', (CAST(strftime('%M', recorded_at) AS INTEGER) / ?1) * ?1) \
                  || ':00Z' AS bucket, \
                  CAST(COALESCE(SUM(sum), 0) AS REAL) AS total \
               FROM metric_points \
-              WHERE metric_name = '{GEN_AI_CLIENT_TOKEN_USAGE}' \
+              WHERE metric_name = ?4 \
                 AND recorded_at >= datetime('now', ?2) \
                 AND agent_id = ?3 \
               GROUP BY bucket \
-              ORDER BY bucket"
-        ))
+              ORDER BY bucket",
+        )
         .bind(bucket_minutes)
         .bind(format!("-{window_hours} hours"))
         .bind(&self.agent_id)
+        .bind(GEN_AI_CLIENT_TOKEN_USAGE)
         .fetch_all(&self.pool)
         .await?;
 
@@ -239,24 +256,26 @@ impl MetricsStore for SqliteMetricsStore {
 
     /// Per-model token-usage breakdown.
     async fn model_comparison(&self, window_hours: i64) -> Result<Vec<ModelTokenUsage>> {
-        let rows: Vec<(String, f64, f64, f64, f64)> = sqlx::query_as(&format!(
+        let rows: Vec<(String, f64, f64, f64, f64)> = sqlx::query_as(
             "SELECT \
                  COALESCE(model, 'unknown') AS m, \
-                 CAST(COALESCE(SUM(CASE WHEN json_extract(attributes, '$.\"{GEN_AI_TOKEN_TYPE}\"') = 'input' \
+                 CAST(COALESCE(SUM(CASE WHEN json_extract(attributes, ?4) = 'input' \
                      THEN sum ELSE 0 END), 0) AS REAL) AS input_tok, \
-                 CAST(COALESCE(SUM(CASE WHEN json_extract(attributes, '$.\"{GEN_AI_TOKEN_TYPE}\"') = 'output' \
+                 CAST(COALESCE(SUM(CASE WHEN json_extract(attributes, ?4) = 'output' \
                      THEN sum ELSE 0 END), 0) AS REAL) AS output_tok, \
                  CAST(COALESCE(SUM(count), 0) AS REAL) AS req_count, \
                  0.0 AS avg_dur \
               FROM metric_points \
-              WHERE metric_name = '{GEN_AI_CLIENT_TOKEN_USAGE}' \
+              WHERE metric_name = ?3 \
                  AND recorded_at >= datetime('now', ?1) \
                  AND agent_id = ?2 \
               GROUP BY m \
-              ORDER BY input_tok + output_tok DESC"
-        ))
+              ORDER BY input_tok + output_tok DESC",
+        )
         .bind(format!("-{window_hours} hours"))
         .bind(&self.agent_id)
+        .bind(GEN_AI_CLIENT_TOKEN_USAGE)
+        .bind(token_type_path())
         .fetch_all(&self.pool)
         .await?;
 
@@ -274,7 +293,7 @@ impl MetricsStore for SqliteMetricsStore {
 
     /// Tool-usage stats for the operational dashboard.
     async fn tool_usage(&self, window_hours: i64) -> Result<Vec<ToolUsageStats>> {
-        let rows: Vec<(String, f64, f64)> = sqlx::query_as(&format!(
+        let rows: Vec<(String, f64, f64)> = sqlx::query_as(
             "SELECT \
                  COALESCE( \
                      json_extract(attributes, '$.\"span.name\"'), \
@@ -284,14 +303,15 @@ impl MetricsStore for SqliteMetricsStore {
                  CAST(COALESCE(SUM(value), 0) AS REAL) AS invocations, \
                  0.0 AS avg_dur \
                FROM metric_points \
-              WHERE metric_name = '{ASSISTANT_TOOL_INVOCATIONS}' \
+              WHERE metric_name = ?3 \
                  AND recorded_at >= datetime('now', ?1) \
                  AND agent_id = ?2 \
               GROUP BY tn \
-              ORDER BY invocations DESC"
-        ))
+              ORDER BY invocations DESC",
+        )
         .bind(format!("-{window_hours} hours"))
         .bind(&self.agent_id)
+        .bind(ASSISTANT_TOOL_INVOCATIONS)
         .fetch_all(&self.pool)
         .await?;
 
@@ -311,22 +331,23 @@ impl MetricsStore for SqliteMetricsStore {
         window_hours: i64,
         bucket_minutes: i64,
     ) -> Result<Vec<TimeSeriesPoint>> {
-        let rows: Vec<(String, f64)> = sqlx::query_as(&format!(
+        let rows: Vec<(String, f64)> = sqlx::query_as(
             "SELECT \
                  strftime('%Y-%m-%dT%H:', recorded_at) || \
                  printf('%02d', (CAST(strftime('%M', recorded_at) AS INTEGER) / ?1) * ?1) \
                  || ':00Z' AS bucket, \
                  CAST(COALESCE(SUM(value), 0) AS REAL) AS total \
               FROM metric_points \
-              WHERE metric_name = '{ASSISTANT_TURN_COUNT}' \
+              WHERE metric_name = ?4 \
                  AND recorded_at >= datetime('now', ?2) \
                  AND agent_id = ?3 \
               GROUP BY bucket \
-              ORDER BY bucket"
-        ))
+              ORDER BY bucket",
+        )
         .bind(bucket_minutes)
         .bind(format!("-{window_hours} hours"))
         .bind(&self.agent_id)
+        .bind(ASSISTANT_TURN_COUNT)
         .fetch_all(&self.pool)
         .await?;
 
@@ -342,22 +363,23 @@ impl MetricsStore for SqliteMetricsStore {
         window_hours: i64,
         bucket_minutes: i64,
     ) -> Result<Vec<TimeSeriesPoint>> {
-        let rows: Vec<(String, f64)> = sqlx::query_as(&format!(
+        let rows: Vec<(String, f64)> = sqlx::query_as(
             "SELECT \
                  strftime('%Y-%m-%dT%H:', recorded_at) || \
                  printf('%02d', (CAST(strftime('%M', recorded_at) AS INTEGER) / ?1) * ?1) \
                  || ':00Z' AS bucket, \
                  CAST(COALESCE(SUM(value), 0) AS REAL) AS total \
               FROM metric_points \
-              WHERE metric_name = '{ASSISTANT_ERROR_COUNT}' \
+              WHERE metric_name = ?4 \
                  AND recorded_at >= datetime('now', ?2) \
                  AND agent_id = ?3 \
               GROUP BY bucket \
-              ORDER BY bucket"
-        ))
+              ORDER BY bucket",
+        )
         .bind(bucket_minutes)
         .bind(format!("-{window_hours} hours"))
         .bind(&self.agent_id)
+        .bind(ASSISTANT_ERROR_COUNT)
         .fetch_all(&self.pool)
         .await?;
 
@@ -529,72 +551,79 @@ mod tests {
         let (rid, sid) = seed_parents(&pool).await;
 
         // Insert token usage (histogram: sum + count are the key fields).
-        sqlx::query(&format!(
+        sqlx::query(
             "INSERT INTO metric_points \
              (resource_id, scope_id, metric_name, metric_kind, \
               sum, count, attributes, model, recorded_at) \
-             VALUES (?1, ?2, '{GEN_AI_CLIENT_TOKEN_USAGE}', 'histogram', \
-                     150, 3, '{{\"{GEN_AI_TOKEN_TYPE}\": \"input\"}}', 'test-model', \
-                     strftime('%Y-%m-%dT%H:%M:%fZ','now'))"
-        ))
+             VALUES (?1, ?2, ?3, 'histogram', \
+                     150, 3, ?4, 'test-model', \
+                     strftime('%Y-%m-%dT%H:%M:%fZ','now'))",
+        )
         .bind(rid)
         .bind(sid)
+        .bind(GEN_AI_CLIENT_TOKEN_USAGE)
+        .bind(format!("{{\"{GEN_AI_TOKEN_TYPE}\": \"input\"}}"))
         .execute(&pool)
         .await
         .unwrap();
 
-        sqlx::query(&format!(
+        sqlx::query(
             "INSERT INTO metric_points \
              (resource_id, scope_id, metric_name, metric_kind, \
               sum, count, attributes, model, recorded_at) \
-             VALUES (?1, ?2, '{GEN_AI_CLIENT_TOKEN_USAGE}', 'histogram', \
-                     80, 2, '{{\"{GEN_AI_TOKEN_TYPE}\": \"output\"}}', 'test-model', \
-                     strftime('%Y-%m-%dT%H:%M:%fZ','now'))"
-        ))
+             VALUES (?1, ?2, ?3, 'histogram', \
+                     80, 2, ?4, 'test-model', \
+                     strftime('%Y-%m-%dT%H:%M:%fZ','now'))",
+        )
         .bind(rid)
         .bind(sid)
+        .bind(GEN_AI_CLIENT_TOKEN_USAGE)
+        .bind(format!("{{\"{GEN_AI_TOKEN_TYPE}\": \"output\"}}"))
         .execute(&pool)
         .await
         .unwrap();
 
         // Insert turn count (counter: value column).
-        sqlx::query(&format!(
+        sqlx::query(
             "INSERT INTO metric_points \
              (resource_id, scope_id, metric_name, metric_kind, \
               value, attributes, recorded_at) \
-             VALUES (?1, ?2, '{ASSISTANT_TURN_COUNT}', 'counter', \
-                     5, '{{}}', strftime('%Y-%m-%dT%H:%M:%fZ','now'))"
-        ))
+             VALUES (?1, ?2, ?3, 'counter', \
+                     5, '{}', strftime('%Y-%m-%dT%H:%M:%fZ','now'))",
+        )
         .bind(rid)
         .bind(sid)
+        .bind(ASSISTANT_TURN_COUNT)
         .execute(&pool)
         .await
         .unwrap();
 
         // Insert tool invocation.
-        sqlx::query(&format!(
+        sqlx::query(
             "INSERT INTO metric_points \
              (resource_id, scope_id, metric_name, metric_kind, \
               value, attributes, recorded_at) \
-             VALUES (?1, ?2, '{ASSISTANT_TOOL_INVOCATIONS}', 'counter', \
-                     7, '{{\"tool.name\": \"file-read\"}}', strftime('%Y-%m-%dT%H:%M:%fZ','now'))"
-        ))
+             VALUES (?1, ?2, ?3, 'counter', \
+                     7, '{\"tool.name\": \"file-read\"}', strftime('%Y-%m-%dT%H:%M:%fZ','now'))",
+        )
         .bind(rid)
         .bind(sid)
+        .bind(ASSISTANT_TOOL_INVOCATIONS)
         .execute(&pool)
         .await
         .unwrap();
 
         // Insert operation duration (histogram).
-        sqlx::query(&format!(
+        sqlx::query(
             "INSERT INTO metric_points \
              (resource_id, scope_id, metric_name, metric_kind, \
               sum, count, attributes, recorded_at) \
-             VALUES (?1, ?2, '{GEN_AI_CLIENT_OPERATION_DURATION}', 'histogram', \
-                     12, 4, '{{}}', strftime('%Y-%m-%dT%H:%M:%fZ','now'))"
-        ))
+             VALUES (?1, ?2, ?3, 'histogram', \
+                     12, 4, '{}', strftime('%Y-%m-%dT%H:%M:%fZ','now'))",
+        )
         .bind(rid)
         .bind(sid)
+        .bind(GEN_AI_CLIENT_OPERATION_DURATION)
         .execute(&pool)
         .await
         .unwrap();

--- a/crates/storage/src/org_storage.rs
+++ b/crates/storage/src/org_storage.rs
@@ -158,7 +158,7 @@ async fn run_org_migrations(pool: &SqlitePool) -> Result<()> {
         ),
     ];
 
-    for (name, sql) in migrations {
+    for &(name, sql) in migrations {
         let already_applied: bool =
             sqlx::query_scalar("SELECT COUNT(*) > 0 FROM _migrations WHERE name = ?")
                 .bind(name)


### PR DESCRIPTION
Supersedes #903 (the Dependabot bump, which fails CI on the breaking change below).

## Why

sqlx 0.9 adds a **compile-time SQL-injection audit**: `query()`, `query_as()`, `query_scalar()` and `raw_sql()` now require `&'static str` via the new `SqlSafeStr` trait, rejecting any runtime-built string. There is no feature flag to opt out. This broke 19 call sites (all in `assistant-storage` + two `opentelemetry-exporter-sqlite` test helpers), cascading into every downstream crate.

Every flagged site was audited — none concatenate user input; they interpolate compile-time constants (metric names, column lists) or generate placeholder counts, with all runtime values already bound. The fix preserves that safety **without** blanket-bypassing the audit on production paths.

## Changes

| Area | Fix |
|------|-----|
| `metrics.rs` | Literal SQL; interpolated metric-name constants and the `gen_ai.token.type` JSON path are now **bound parameters** |
| `message_bus.rs` (`claim_filtered`, `list`) | Rewritten with **`QueryBuilder`** — every value via `push_bind`, only the constant `SELECT_COLS` pushed as raw SQL |
| `memory_chunks.rs` (`get_embeddings_by_ids`) | **`QueryBuilder::separated().push_bind()`** for the `IN (?, …)` list; **added 3 tests** (was uncovered) |
| migration runners (`org_storage.rs`, `lib.rs`) | `for &(name, sql)` deref so migration SQL is `&'static str` |
| test-only identifier interpolation (`PRAGMA table_info`, `COUNT(*) FROM {table}`) | `AssertSqlSafe` — unavoidable, since identifiers cannot be bound |

## Validation

- `make lint` (clippy `--workspace -D warnings`) — clean (also runs in the pre-commit hook)
- `make format` — applied
- `cargo test -p assistant-storage` — 122 pass (incl. the metrics regression test, all `claim_filtered`/`list` tests, new `IN`-clause tests)
- `cargo test -p opentelemetry-exporter-sqlite` — 35 pass
- `cargo check --workspace --all-targets` — clean