### PR TITLE
feat: wire A2A to the Orchestrator + persist tasks (Phase 1)

### DIFF
--- a/crates/core/src/types/conversation.rs
+++ b/crates/core/src/types/conversation.rs
@@ -162,6 +162,8 @@ pub enum Interface {
     Scheduler,
     /// Matrix messaging interface.
     Matrix,
+    /// Agent-to-Agent (A2A) protocol interface.
+    A2a,
 }
 
 /// Identifies the messaging platform for a `ChannelAdapter`.

--- a/crates/runtime/src/orchestrator/prompt.rs
+++ b/crates/runtime/src/orchestrator/prompt.rs
@@ -305,6 +305,7 @@ mod tests {
             Interface::Web,
             Interface::Scheduler,
             Interface::Matrix,
+            Interface::A2a,
         ];
         for iface in &interfaces {
             let caps = output_capabilities(iface);

--- a/crates/runtime/src/orchestrator/prompt.rs
+++ b/crates/runtime/src/orchestrator/prompt.rs
@@ -222,6 +222,12 @@ fn output_capabilities(interface: &Interface) -> &'static str {
              You are running as a background scheduled task. Your output may be logged or \
              forwarded. Use plain text. Do not use ```svg or ```mermaid."
         }
+        Interface::A2a => {
+            "## Output capabilities\n\
+             \n\
+             Your responses are consumed by another agent over the A2A protocol. Return \
+             structured, well-formatted text. Do not use ```svg or ```mermaid."
+        }
     }
 }
 

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -480,6 +480,10 @@ async fn run_migrations(pool: &SqlitePool) -> Result<()> {
             "041_conversation_title_locked",
             include_str!("../../../migrations/041_conversation_title_locked.sql"),
         ),
+        (
+            "042_a2a_tasks",
+            include_str!("../../../migrations/042_a2a_tasks.sql"),
+        ),
     ];
 
     for &(name, sql) in migrations {

--- a/crates/web-ui/src/a2a/handlers.rs
+++ b/crates/web-ui/src/a2a/handlers.rs
@@ -14,7 +14,6 @@ use axum::http::StatusCode;
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{IntoResponse, Json, Response};
 use futures::StreamExt;
-use futures::stream::Stream;
 use sqlx::SqlitePool;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use uuid::Uuid;
@@ -26,6 +25,7 @@ use assistant_a2a_json_schema::types::*;
 use assistant_core::auth::AuthContext;
 use assistant_core::types::conversation::Interface;
 use assistant_runtime::AssistantInterface;
+use assistant_runtime::projection::StreamProjector;
 use assistant_storage::{ConversationStore, SqliteConversationStore};
 
 use super::task_store::A2aTaskStore;
@@ -251,101 +251,118 @@ pub async fn send_message(
         (status = 200, description = "Streaming SSE response; each event is a JSON-encoded StreamResponse",
          content_type = "text/event-stream", body = StreamResponse),
         (status = 400, description = "Bad request"),
-        (status = 401, description = "Unauthorized")
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Missing conversations:write scope")
     ),
     tag = "messages",
     security(("bearer_token" = []))
 )]
 pub async fn send_message_streaming(
     State(state): State<A2AState>,
+    Extension(auth): Extension<AuthContext>,
     Json(req): Json<SendMessageRequest>,
-) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
-    let context_id = req.message.context_id.clone();
-    let task = state.task_store.create_task(context_id).await;
-    let task_id = task.id.clone();
+) -> Response {
+    if !caller_can_post(&auth) {
+        return (StatusCode::FORBIDDEN, "Missing conversations:write scope").into_response();
+    }
 
-    // Record incoming message.
+    let user_text: String = req
+        .message
+        .parts
+        .iter()
+        .filter_map(|p| p.text.as_deref())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let conv_store = SqliteConversationStore::for_agent(state.pool.clone(), &state.agent_id);
+    let conv_id = resolve_conversation(&conv_store, req.message.context_id.as_deref()).await;
+
+    let task = state
+        .task_store
+        .create_task(Some(conv_id.to_string()))
+        .await;
+    let task_id = task.id.clone();
+    let ctx = task.context_id.clone();
     let mut user_msg = req.message.clone();
     user_msg.task_id = Some(task_id.clone());
     state.task_store.append_history(&task_id, user_msg).await;
+    state
+        .task_store
+        .update_status(&task_id, TaskState::TaskStateWorking, None)
+        .await;
 
-    // Subscribe before starting work so we don't miss events.
-    let rx = state.task_store.subscribe(&task_id).await;
+    // SSE output channel + orchestrator event sink.
+    let (sse_tx, sse_rx) = tokio::sync::mpsc::unbounded_channel::<Result<Event, Infallible>>();
+    let (event_tx, mut event_rx) =
+        tokio::sync::mpsc::channel::<assistant_runtime::OrchestratorEvent>(64);
+    state
+        .orchestrator
+        .register_token_sink(conv_id, event_tx)
+        .await;
 
-    // Spawn background work.
-    let store = state.task_store.clone();
-    let parts = req.message.parts.clone();
-    let ctx_id = task.context_id.clone();
+    // Run the turn; capture the final result via a oneshot.
+    let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+    let orchestrator = state.orchestrator.clone();
+    let turn_auth = auth.clone();
+    let turn_text = user_text.clone();
     tokio::spawn(async move {
-        // Transition to Working.
-        store
-            .update_status(&task_id, TaskState::TaskStateWorking, None)
+        let r = orchestrator
+            .submit_turn(&turn_auth, &turn_text, conv_id, Interface::A2a, None)
             .await;
-
-        // Simulate processing.
-        // TODO: Wire to Orchestrator for real LLM streaming.
-        let user_text: String = parts
-            .iter()
-            .filter_map(|p| p.text.as_deref())
-            .collect::<Vec<_>>()
-            .join("\n");
-
-        let reply_text = format!(
-            "Received your message ({} chars). Processing is not yet wired to the LLM backend.",
-            user_text.len()
-        );
-        let agent_msg = Message {
-            message_id: Uuid::new_v4().to_string(),
-            context_id: Some(ctx_id),
-            task_id: Some(task_id.clone()),
-            role: Role::RoleAgent,
-            parts: vec![Part::text(reply_text)],
-            metadata: None,
-            extensions: vec![],
-            reference_task_ids: vec![],
-        };
-
-        store.append_history(&task_id, agent_msg.clone()).await;
-
-        store
-            .update_status(&task_id, TaskState::TaskStateCompleted, Some(agent_msg))
-            .await;
-
-        store.cleanup_subscribers(&task_id).await;
+        let _ = result_tx.send(r);
     });
 
-    // Stream task snapshots as SSE events.
-    let stream = match rx {
-        Some(rx) => {
-            let stream = UnboundedReceiverStream::new(rx);
-            stream
-                .map(|task_snapshot| {
-                    let resp = StreamResponse::from_task(task_snapshot);
-                    let data = serde_json::to_string(&resp).unwrap_or_default();
-                    Ok(Event::default().data(data))
-                })
-                .chain(futures::stream::once(async {
-                    Ok(Event::default().data("[DONE]"))
-                }))
-                .boxed()
+    // Drain orchestrator events -> A2A StreamResponse frames -> SSE, then persist
+    // the final answer and emit the terminal task snapshot.
+    let projector = crate::a2a::projection::A2aProjector::new(task_id.clone(), ctx.clone());
+    let task_store = state.task_store.clone();
+    tokio::spawn(async move {
+        while let Some(event) = event_rx.recv().await {
+            for frame in projector.project(&event) {
+                let data = serde_json::to_string(&frame).unwrap_or_default();
+                if sse_tx.send(Ok(Event::default().data(data))).is_err() {
+                    return;
+                }
+            }
         }
-        None => {
-            // Task already terminal or doesn't exist -- send current state.
-            let task_snapshot = state.task_store.get_task(&task.id).await;
-            futures::stream::once(async move {
-                let data = match task_snapshot {
-                    Some(t) => {
-                        serde_json::to_string(&StreamResponse::from_task(t)).unwrap_or_default()
-                    }
-                    None => "[DONE]".to_string(),
-                };
-                Ok::<_, Infallible>(Event::default().data(data))
-            })
-            .boxed()
-        }
-    };
 
-    Sse::new(stream).keep_alive(KeepAlive::default())
+        // The turn finished (its event sink was dropped). Finalize the task.
+        match result_rx.await {
+            Ok(Ok(turn)) => {
+                let agent_msg = Message {
+                    message_id: Uuid::new_v4().to_string(),
+                    context_id: Some(ctx.clone()),
+                    task_id: Some(task_id.clone()),
+                    role: Role::RoleAgent,
+                    parts: vec![Part::text(turn.answer)],
+                    metadata: None,
+                    extensions: vec![],
+                    reference_task_ids: vec![],
+                };
+                task_store.append_history(&task_id, agent_msg.clone()).await;
+                task_store
+                    .update_status(&task_id, TaskState::TaskStateCompleted, Some(agent_msg))
+                    .await;
+            }
+            _ => {
+                task_store
+                    .update_status(&task_id, TaskState::TaskStateFailed, None)
+                    .await;
+            }
+        }
+
+        if let Some(final_task) = task_store.get_task(&task_id).await {
+            let data =
+                serde_json::to_string(&StreamResponse::from_task(final_task)).unwrap_or_default();
+            let _ = sse_tx.send(Ok(Event::default().data(data)));
+        }
+        let _ = sse_tx.send(Ok(Event::default().data("[DONE]")));
+        task_store.cleanup_subscribers(&task_id).await;
+    });
+
+    Sse::new(UnboundedReceiverStream::new(sse_rx))
+        .keep_alive(KeepAlive::default())
+        .into_response()
 }
 
 // -- Task operations --

--- a/crates/web-ui/src/a2a/handlers.rs
+++ b/crates/web-ui/src/a2a/handlers.rs
@@ -51,17 +51,25 @@ pub struct A2AState {
 
 /// Resolve the conversation for an A2A message. A returned `context_id` is the
 /// conversation UUID we previously surfaced, so reuse it when it parses and
-/// exists; otherwise start a fresh conversation.
-async fn resolve_conversation(store: &SqliteConversationStore, context_id: Option<&str>) -> Uuid {
+/// exists; otherwise start a fresh conversation. Returns `None` if a new
+/// conversation cannot be created — callers MUST surface that as an error rather
+/// than dispatch a turn against a non-existent conversation.
+async fn resolve_conversation(
+    store: &SqliteConversationStore,
+    context_id: Option<&str>,
+) -> Option<Uuid> {
     if let Some(ctx) = context_id
         && let Ok(id) = Uuid::parse_str(ctx)
         && matches!(store.get_conversation(id).await, Ok(Some(_)))
     {
-        return id;
+        return Some(id);
     }
     match store.create_conversation(None).await {
-        Ok(conv) => conv.id,
-        Err(_) => Uuid::new_v4(),
+        Ok(conv) => Some(conv.id),
+        Err(e) => {
+            tracing::error!("a2a: failed to create conversation: {e}");
+            None
+        }
     }
 }
 
@@ -180,7 +188,14 @@ pub async fn send_message(
     // Resolve (or create) the conversation, then key the task to it so the
     // client can reuse the returned context_id for follow-up turns.
     let conv_store = SqliteConversationStore::for_agent(state.pool.clone(), &state.agent_id);
-    let conv_id = resolve_conversation(&conv_store, req.message.context_id.as_deref()).await;
+    let Some(conv_id) = resolve_conversation(&conv_store, req.message.context_id.as_deref()).await
+    else {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to resolve conversation",
+        )
+            .into_response();
+    };
 
     let task = state
         .task_store
@@ -276,7 +291,14 @@ pub async fn send_message_streaming(
         .join("\n");
 
     let conv_store = SqliteConversationStore::for_agent(state.pool.clone(), &state.agent_id);
-    let conv_id = resolve_conversation(&conv_store, req.message.context_id.as_deref()).await;
+    let Some(conv_id) = resolve_conversation(&conv_store, req.message.context_id.as_deref()).await
+    else {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to resolve conversation",
+        )
+            .into_response();
+    };
 
     let task = state
         .task_store

--- a/crates/web-ui/src/a2a/handlers.rs
+++ b/crates/web-ui/src/a2a/handlers.rs
@@ -112,6 +112,16 @@ fn bad_request(msg: impl Into<String>) -> Response {
     (StatusCode::BAD_REQUEST, Json(body)).into_response()
 }
 
+/// Maps a task-store / persistence failure to a 500, logging the cause.
+fn internal_error(e: anyhow::Error) -> Response {
+    tracing::error!("a2a: {e:#}");
+    let body = A2AError {
+        code: 500,
+        message: "Internal error".to_string(),
+    };
+    (StatusCode::INTERNAL_SERVER_ERROR, Json(body)).into_response()
+}
+
 // -- Agent Card --
 
 /// `GET /.well-known/agent.json` -- Returns the public agent card.
@@ -197,17 +207,26 @@ pub async fn send_message(
             .into_response();
     };
 
-    let task = state
+    let task = match state
         .task_store
         .create_task(Some(conv_id.to_string()))
-        .await;
+        .await
+    {
+        Ok(t) => t,
+        Err(e) => return internal_error(e),
+    };
     let mut user_msg = req.message.clone();
     user_msg.task_id = Some(task.id.clone());
-    state.task_store.append_history(&task.id, user_msg).await;
-    state
+    if let Err(e) = state.task_store.append_history(&task.id, user_msg).await {
+        return internal_error(e);
+    }
+    if let Err(e) = state
         .task_store
         .update_status(&task.id, TaskState::TaskStateWorking, None)
-        .await;
+        .await
+    {
+        return internal_error(e);
+    }
 
     // Run the real turn through the Orchestrator.
     let result = state
@@ -219,11 +238,11 @@ pub async fn send_message(
         Ok(turn) => turn.answer,
         Err(e) => {
             let err_msg = agent_message(&task, format!("Turn failed: {e}"));
-            state
+            let _ = state
                 .task_store
                 .update_status(&task.id, TaskState::TaskStateFailed, Some(err_msg))
                 .await;
-            let failed = state.task_store.get_task(&task.id).await;
+            let failed = state.task_store.get_task(&task.id).await.ok().flatten();
             return Json(SendMessageResponse {
                 task: failed,
                 message: None,
@@ -233,21 +252,31 @@ pub async fn send_message(
     };
 
     let agent_msg = agent_message(&task, answer);
-    state
+    if let Err(e) = state
         .task_store
         .append_history(&task.id, agent_msg.clone())
-        .await;
-    state
+        .await
+    {
+        return internal_error(e);
+    }
+    if let Err(e) = state
         .task_store
         .update_status(&task.id, TaskState::TaskStateCompleted, Some(agent_msg))
-        .await;
+        .await
+    {
+        return internal_error(e);
+    }
 
-    let Some(final_task) = state.task_store.get_task(&task.id).await else {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({"error": "task disappeared after creation"})),
-        )
-            .into_response();
+    let final_task = match state.task_store.get_task(&task.id).await {
+        Ok(Some(t)) => t,
+        Ok(None) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "task disappeared after creation"})),
+            )
+                .into_response();
+        }
+        Err(e) => return internal_error(e),
     };
 
     Json(SendMessageResponse {
@@ -300,19 +329,28 @@ pub async fn send_message_streaming(
             .into_response();
     };
 
-    let task = state
+    let task = match state
         .task_store
         .create_task(Some(conv_id.to_string()))
-        .await;
+        .await
+    {
+        Ok(t) => t,
+        Err(e) => return internal_error(e),
+    };
     let task_id = task.id.clone();
     let ctx = task.context_id.clone();
     let mut user_msg = req.message.clone();
     user_msg.task_id = Some(task_id.clone());
-    state.task_store.append_history(&task_id, user_msg).await;
-    state
+    if let Err(e) = state.task_store.append_history(&task_id, user_msg).await {
+        return internal_error(e);
+    }
+    if let Err(e) = state
         .task_store
         .update_status(&task_id, TaskState::TaskStateWorking, None)
-        .await;
+        .await
+    {
+        return internal_error(e);
+    }
 
     // SSE output channel + orchestrator event sink.
     let (sse_tx, sse_rx) = tokio::sync::mpsc::unbounded_channel::<Result<Event, Infallible>>();
@@ -362,25 +400,34 @@ pub async fn send_message_streaming(
                     extensions: vec![],
                     reference_task_ids: vec![],
                 };
-                task_store.append_history(&task_id, agent_msg.clone()).await;
-                task_store
+                // Post-response: errors can only be logged, not returned.
+                if let Err(e) = task_store.append_history(&task_id, agent_msg.clone()).await {
+                    tracing::error!("a2a: {e:#}");
+                }
+                if let Err(e) = task_store
                     .update_status(&task_id, TaskState::TaskStateCompleted, Some(agent_msg))
-                    .await;
+                    .await
+                {
+                    tracing::error!("a2a: {e:#}");
+                }
             }
             _ => {
-                task_store
+                if let Err(e) = task_store
                     .update_status(&task_id, TaskState::TaskStateFailed, None)
-                    .await;
+                    .await
+                {
+                    tracing::error!("a2a: {e:#}");
+                }
             }
         }
 
-        if let Some(final_task) = task_store.get_task(&task_id).await {
+        if let Ok(Some(final_task)) = task_store.get_task(&task_id).await {
             let data =
                 serde_json::to_string(&StreamResponse::from_task(final_task)).unwrap_or_default();
             let _ = sse_tx.send(Ok(Event::default().data(data)));
         }
         let _ = sse_tx.send(Ok(Event::default().data("[DONE]")));
-        task_store.cleanup_subscribers(&task_id).await;
+        let _ = task_store.cleanup_subscribers(&task_id).await;
     });
 
     Sse::new(UnboundedReceiverStream::new(sse_rx))
@@ -414,8 +461,9 @@ pub async fn get_task(
     Query(_query): Query<GetTaskQuery>,
 ) -> Response {
     match state.task_store.get_task(&id).await {
-        Some(task) => Json(task).into_response(),
-        None => not_found(format!("Task '{id}' not found")),
+        Ok(Some(task)) => Json(task).into_response(),
+        Ok(None) => not_found(format!("Task '{id}' not found")),
+        Err(e) => internal_error(e),
     }
 }
 
@@ -452,13 +500,17 @@ pub struct GetTaskQuery {
 pub async fn list_tasks(
     State(state): State<A2AState>,
     Query(query): Query<ListTasksRequest>,
-) -> Json<ListTasksResponse> {
+) -> Response {
     let limit = query.page_size.unwrap_or(50).clamp(1, 100) as usize;
 
-    let tasks = state
+    let tasks = match state
         .task_store
         .list_tasks(query.context_id.as_deref(), query.status, limit)
-        .await;
+        .await
+    {
+        Ok(t) => t,
+        Err(e) => return internal_error(e),
+    };
 
     let total_size = tasks.len() as i32;
     Json(ListTasksResponse {
@@ -467,6 +519,7 @@ pub async fn list_tasks(
         page_size: limit as i32,
         total_size,
     })
+    .into_response()
 }
 
 /// `POST /tasks/:id/cancel` -- Cancels a task.
@@ -495,8 +548,9 @@ pub async fn cancel_task(
 ) -> Response {
     let _ = body; // body fields are available for future use (e.g. metadata)
     match state.task_store.cancel_task(&id).await {
-        Some(task) => Json(task).into_response(),
-        None => not_found(format!("Task '{id}' not found")),
+        Ok(Some(task)) => Json(task).into_response(),
+        Ok(None) => not_found(format!("Task '{id}' not found")),
+        Err(e) => internal_error(e),
     }
 }
 
@@ -520,7 +574,10 @@ pub async fn cancel_task(
     security(("bearer_token" = []))
 )]
 pub async fn subscribe_to_task(State(state): State<A2AState>, Path(id): Path<String>) -> Response {
-    let rx = state.task_store.subscribe(&id).await;
+    let rx = match state.task_store.subscribe(&id).await {
+        Ok(r) => r,
+        Err(e) => return internal_error(e),
+    };
 
     match rx {
         Some(rx) => {
@@ -543,7 +600,7 @@ pub async fn subscribe_to_task(State(state): State<A2AState>, Path(id): Path<Str
             tokio::spawn(async move {
                 // Wait a bit for stream to settle then clean up.
                 tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
-                cleanup_store.cleanup_subscribers(&cleanup_id).await;
+                let _ = cleanup_store.cleanup_subscribers(&cleanup_id).await;
             });
 
             Sse::new(stream)
@@ -552,13 +609,13 @@ pub async fn subscribe_to_task(State(state): State<A2AState>, Path(id): Path<Str
         }
         None => {
             // Task doesn't exist or is already terminal.
-            let task = state.task_store.get_task(&id).await;
-            match task {
-                Some(t) if t.status.state.is_terminal() => bad_request(format!(
+            match state.task_store.get_task(&id).await {
+                Ok(Some(t)) if t.status.state.is_terminal() => bad_request(format!(
                     "Task '{id}' is already in terminal state: {:?}",
                     t.status.state
                 )),
-                _ => not_found(format!("Task '{id}' not found")),
+                Ok(_) => not_found(format!("Task '{id}' not found")),
+                Err(e) => internal_error(e),
             }
         }
     }
@@ -594,8 +651,9 @@ pub async fn create_push_notification_config(
         .create_push_config(&task_id, req.config)
         .await
     {
-        Some(config) => (StatusCode::CREATED, Json(config)).into_response(),
-        None => not_found(format!("Task '{task_id}' not found")),
+        Ok(Some(config)) => (StatusCode::CREATED, Json(config)).into_response(),
+        Ok(None) => not_found(format!("Task '{task_id}' not found")),
+        Err(e) => internal_error(e),
     }
 }
 
@@ -622,10 +680,11 @@ pub async fn get_push_notification_config(
     Path((task_id, config_id)): Path<(String, String)>,
 ) -> Response {
     match state.task_store.get_push_config(&task_id, &config_id).await {
-        Some(config) => Json(config).into_response(),
-        None => not_found(format!(
+        Ok(Some(config)) => Json(config).into_response(),
+        Ok(None) => not_found(format!(
             "Push notification config '{config_id}' not found for task '{task_id}'"
         )),
+        Err(e) => internal_error(e),
     }
 }
 
@@ -659,12 +718,16 @@ pub async fn list_push_notification_configs(
     State(state): State<A2AState>,
     Path(task_id): Path<String>,
     Query(_query): Query<ListPushConfigsQuery>,
-) -> Json<ListTaskPushNotificationConfigsResponse> {
-    let configs = state.task_store.list_push_configs(&task_id).await;
+) -> Response {
+    let configs = match state.task_store.list_push_configs(&task_id).await {
+        Ok(c) => c,
+        Err(e) => return internal_error(e),
+    };
     Json(ListTaskPushNotificationConfigsResponse {
         configs,
         next_page_token: None,
     })
+    .into_response()
 }
 
 /// `DELETE /tasks/:task_id/pushNotificationConfigs/:config_id`
@@ -688,16 +751,16 @@ pub async fn delete_push_notification_config(
     State(state): State<A2AState>,
     Path((task_id, config_id)): Path<(String, String)>,
 ) -> Response {
-    if state
+    match state
         .task_store
         .delete_push_config(&task_id, &config_id)
         .await
     {
-        StatusCode::NO_CONTENT.into_response()
-    } else {
-        not_found(format!(
+        Ok(true) => StatusCode::NO_CONTENT.into_response(),
+        Ok(false) => not_found(format!(
             "Push notification config '{config_id}' not found for task '{task_id}'"
-        ))
+        )),
+        Err(e) => internal_error(e),
     }
 }
 

--- a/crates/web-ui/src/a2a/handlers.rs
+++ b/crates/web-ui/src/a2a/handlers.rs
@@ -154,7 +154,8 @@ pub async fn get_extended_agent_card(State(state): State<A2AState>) -> Json<Agen
         (status = 200, description = "Task created and completed", body = SendMessageResponse,
          content_type = "application/json"),
         (status = 400, description = "Bad request"),
-        (status = 401, description = "Unauthorized")
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Missing conversations:write scope")
     ),
     tag = "messages",
     security(("bearer_token" = []))

--- a/crates/web-ui/src/a2a/handlers.rs
+++ b/crates/web-ui/src/a2a/handlers.rs
@@ -6,13 +6,16 @@
 
 use std::collections::HashMap;
 use std::convert::Infallible;
+use std::sync::Arc;
 
+use axum::Extension;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{IntoResponse, Json, Response};
 use futures::StreamExt;
 use futures::stream::Stream;
+use sqlx::SqlitePool;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use uuid::Uuid;
 
@@ -20,8 +23,13 @@ use assistant_a2a_json_schema::agent_card::*;
 use assistant_a2a_json_schema::requests::*;
 use assistant_a2a_json_schema::responses::*;
 use assistant_a2a_json_schema::types::*;
+use assistant_core::auth::AuthContext;
+use assistant_core::types::conversation::Interface;
+use assistant_runtime::AssistantInterface;
+use assistant_storage::{ConversationStore, SqliteConversationStore};
 
-use super::task_store::TaskStore;
+use super::task_store::A2aTaskStore;
+use crate::api::messages::caller_can_post;
 use crate::openapi::ApiErrorResponse;
 
 // -- Shared state --
@@ -29,10 +37,46 @@ use crate::openapi::ApiErrorResponse;
 /// Shared state for all A2A handlers.
 #[derive(Clone)]
 pub struct A2AState {
-    /// In-memory task store.
-    pub task_store: TaskStore,
+    /// Durable A2A task store, scoped to the active agent's space db.
+    pub task_store: Arc<dyn A2aTaskStore>,
     /// The agent card describing this agent.
     pub agent_card: AgentCard,
+    /// Orchestrator used to run real turns for A2A messages.
+    pub orchestrator: Arc<dyn AssistantInterface>,
+    /// Space db pool, for resolving/creating conversations.
+    pub pool: SqlitePool,
+    /// The active agent id (space scope) for conversation resolution.
+    pub agent_id: String,
+}
+
+/// Resolve the conversation for an A2A message. A returned `context_id` is the
+/// conversation UUID we previously surfaced, so reuse it when it parses and
+/// exists; otherwise start a fresh conversation.
+async fn resolve_conversation(store: &SqliteConversationStore, context_id: Option<&str>) -> Uuid {
+    if let Some(ctx) = context_id
+        && let Ok(id) = Uuid::parse_str(ctx)
+        && matches!(store.get_conversation(id).await, Ok(Some(_)))
+    {
+        return id;
+    }
+    match store.create_conversation(None).await {
+        Ok(conv) => conv.id,
+        Err(_) => Uuid::new_v4(),
+    }
+}
+
+/// Build an agent-authored A2A message scoped to a task.
+fn agent_message(task: &Task, text: impl Into<String>) -> Message {
+    Message {
+        message_id: Uuid::new_v4().to_string(),
+        context_id: Some(task.context_id.clone()),
+        task_id: Some(task.id.clone()),
+        role: Role::RoleAgent,
+        parts: vec![Part::text(text)],
+        metadata: None,
+        extensions: vec![],
+        reference_task_ids: vec![],
+    }
 }
 
 // -- Error helper --
@@ -117,23 +161,13 @@ pub async fn get_extended_agent_card(State(state): State<A2AState>) -> Json<Agen
 )]
 pub async fn send_message(
     State(state): State<A2AState>,
+    Extension(auth): Extension<AuthContext>,
     Json(req): Json<SendMessageRequest>,
 ) -> Response {
-    let context_id = req.message.context_id.clone();
-    let task = state.task_store.create_task(context_id).await;
+    if !caller_can_post(&auth) {
+        return (StatusCode::FORBIDDEN, "Missing conversations:write scope").into_response();
+    }
 
-    // Record the incoming user message in history.
-    let mut user_msg = req.message.clone();
-    user_msg.task_id = Some(task.id.clone());
-    state.task_store.append_history(&task.id, user_msg).await;
-
-    // Transition to Working.
-    state
-        .task_store
-        .update_status(&task.id, TaskState::TaskStateWorking, None)
-        .await;
-
-    // Extract the user's text content for processing.
     let user_text: String = req
         .message
         .parts
@@ -142,52 +176,69 @@ pub async fn send_message(
         .collect::<Vec<_>>()
         .join("\n");
 
-    // Build an agent reply.
-    // TODO: Wire to Orchestrator for real LLM processing.
-    let reply_text = format!(
-        "Received your message ({} chars). Processing is not yet wired to the LLM backend.",
-        user_text.len()
-    );
-    let agent_msg = Message {
-        message_id: Uuid::new_v4().to_string(),
-        context_id: Some(task.context_id.clone()),
-        task_id: Some(task.id.clone()),
-        role: Role::RoleAgent,
-        parts: vec![Part::text(reply_text)],
-        metadata: None,
-        extensions: vec![],
-        reference_task_ids: vec![],
+    // Resolve (or create) the conversation, then key the task to it so the
+    // client can reuse the returned context_id for follow-up turns.
+    let conv_store = SqliteConversationStore::for_agent(state.pool.clone(), &state.agent_id);
+    let conv_id = resolve_conversation(&conv_store, req.message.context_id.as_deref()).await;
+
+    let task = state
+        .task_store
+        .create_task(Some(conv_id.to_string()))
+        .await;
+    let mut user_msg = req.message.clone();
+    user_msg.task_id = Some(task.id.clone());
+    state.task_store.append_history(&task.id, user_msg).await;
+    state
+        .task_store
+        .update_status(&task.id, TaskState::TaskStateWorking, None)
+        .await;
+
+    // Run the real turn through the Orchestrator.
+    let result = state
+        .orchestrator
+        .submit_turn(&auth, &user_text, conv_id, Interface::A2a, None)
+        .await;
+
+    let answer = match result {
+        Ok(turn) => turn.answer,
+        Err(e) => {
+            let err_msg = agent_message(&task, format!("Turn failed: {e}"));
+            state
+                .task_store
+                .update_status(&task.id, TaskState::TaskStateFailed, Some(err_msg))
+                .await;
+            let failed = state.task_store.get_task(&task.id).await;
+            return Json(SendMessageResponse {
+                task: failed,
+                message: None,
+            })
+            .into_response();
+        }
     };
 
+    let agent_msg = agent_message(&task, answer);
     state
         .task_store
         .append_history(&task.id, agent_msg.clone())
         .await;
-
-    // Transition to Completed.
     state
         .task_store
         .update_status(&task.id, TaskState::TaskStateCompleted, Some(agent_msg))
         .await;
 
     let Some(final_task) = state.task_store.get_task(&task.id).await else {
-        // We just created and updated the task on the previous lines; the
-        // store dropping it between the update and the get would only happen
-        // under a concurrent eviction race that the in-memory store does not
-        // perform. Treat as a 500 rather than panicking the worker.
         return (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({"error": "task disappeared after creation"})),
         )
             .into_response();
     };
 
-    let resp = SendMessageResponse {
+    Json(SendMessageResponse {
         task: Some(final_task),
         message: None,
-    };
-
-    Json(resp).into_response()
+    })
+    .into_response()
 }
 
 /// `POST /message/stream` -- Sends a message with streaming response (SSE).
@@ -654,5 +705,75 @@ pub fn build_default_agent_card(base_url: &str) -> AgentCard {
         }],
         signatures: vec![],
         icon_url: None,
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    //! Shared helpers for the A2A handler/router tests: a no-op orchestrator and
+    //! an `A2AState` backed by in-memory storage.
+    use std::sync::Arc;
+
+    use assistant_core::auth::AuthContext;
+    use assistant_core::types::conversation::Interface;
+    use assistant_runtime::{AssistantInterface, OrchestratorEvent, TurnResult};
+    use async_trait::async_trait;
+    use tokio::sync::mpsc;
+    use uuid::Uuid;
+
+    use super::{A2AState, build_default_agent_card};
+    use crate::a2a::task_store::InMemoryA2aTaskStore;
+
+    /// Minimal `AssistantInterface` that echoes the prompt as the answer.
+    pub struct EchoInterface;
+
+    #[async_trait]
+    impl AssistantInterface for EchoInterface {
+        async fn register_token_sink(
+            &self,
+            _conversation_id: Uuid,
+            _sink: mpsc::Sender<OrchestratorEvent>,
+        ) {
+        }
+
+        async fn submit_turn_with_attachments(
+            &self,
+            _auth: &AuthContext,
+            prompt: &str,
+            _conversation_id: Uuid,
+            _interface: Interface,
+            _timestamp: Option<chrono::DateTime<chrono::Utc>>,
+            _attachment_ids: Vec<Uuid>,
+        ) -> anyhow::Result<TurnResult> {
+            Ok(TurnResult {
+                answer: format!("echo: {prompt}"),
+                attachments: vec![],
+                attachment_ids: vec![],
+                message_id: None,
+                had_errors: false,
+            })
+        }
+
+        async fn run_boot(
+            &self,
+            _conversation_id: Uuid,
+            _interface: Interface,
+        ) -> anyhow::Result<bool> {
+            Ok(false)
+        }
+    }
+
+    /// Build an `A2AState` backed by in-memory storage + an echo orchestrator.
+    pub async fn test_state(base_url: &str) -> A2AState {
+        let storage = assistant_storage::StorageLayer::new_in_memory()
+            .await
+            .expect("in-memory storage");
+        A2AState {
+            task_store: Arc::new(InMemoryA2aTaskStore::new()),
+            agent_card: build_default_agent_card(base_url),
+            orchestrator: Arc::new(EchoInterface),
+            pool: storage.pool.clone(),
+            agent_id: "default".to_string(),
+        }
     }
 }

--- a/crates/web-ui/src/a2a/handlers_tests.rs
+++ b/crates/web-ui/src/a2a/handlers_tests.rs
@@ -19,7 +19,7 @@ use super::handlers::{
     A2AState, build_default_agent_card, cancel_task, create_push_notification_config,
     delete_push_notification_config, get_agent_card_well_known, get_extended_agent_card,
     get_push_notification_config, get_task, list_push_notification_configs, list_tasks,
-    send_message,
+    send_message, send_message_streaming,
 };
 
 async fn make_state(base_url: &str) -> A2AState {
@@ -37,6 +37,7 @@ fn make_app(state: A2AState) -> Router {
             get(get_extended_agent_card),
         )
         .route("/message/send", post(send_message))
+        .route("/message/stream", post(send_message_streaming))
         .route("/tasks/{id}", get(get_task))
         .route("/tasks", get(list_tasks))
         .route("/tasks/{id}/cancel", post(cancel_task))
@@ -444,4 +445,28 @@ async fn send_message_without_conversations_write_scope_returns_403() {
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn send_message_streaming_emits_completed_task() {
+    let app = make_app(make_state("https://example.com").await);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/message/stream")
+                .header("Content-Type", "application/json")
+                .body(Body::from(user_message("stream please").to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Drain the SSE body; it should carry the completed task with the echo
+    // answer and a terminal [DONE] marker.
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let text = String::from_utf8_lossy(&bytes);
+    assert!(text.contains("echo: stream please"), "got: {text}");
+    assert!(text.contains("[DONE]"), "missing terminal marker: {text}");
 }

--- a/crates/web-ui/src/a2a/handlers_tests.rs
+++ b/crates/web-ui/src/a2a/handlers_tests.rs
@@ -169,7 +169,7 @@ async fn cancel_task_unknown_id_returns_404() {
 #[tokio::test]
 async fn get_task_returns_created_task_when_present() {
     let state = make_state("https://example.com").await;
-    let task = state.task_store.create_task(None).await;
+    let task = state.task_store.create_task(None).await.unwrap();
     let id = task.id.clone();
     let app = make_app(state);
     let resp = app
@@ -189,7 +189,7 @@ async fn get_task_returns_created_task_when_present() {
 #[tokio::test]
 async fn cancel_task_existing_returns_200() {
     let state = make_state("https://example.com").await;
-    let task = state.task_store.create_task(None).await;
+    let task = state.task_store.create_task(None).await.unwrap();
     let id = task.id.clone();
     let app = make_app(state);
     let resp = app
@@ -288,7 +288,7 @@ async fn delete_push_config_unknown_returns_404() {
 #[tokio::test]
 async fn create_then_get_then_list_then_delete_push_config_round_trip() {
     let state = make_state("https://example.com").await;
-    let task = state.task_store.create_task(None).await;
+    let task = state.task_store.create_task(None).await.unwrap();
     let task_id = task.id.clone();
     let app = make_app(state);
 

--- a/crates/web-ui/src/a2a/handlers_tests.rs
+++ b/crates/web-ui/src/a2a/handlers_tests.rs
@@ -10,22 +10,25 @@ use axum::routing::{delete, get, post};
 use http_body_util::BodyExt;
 use tower::ServiceExt;
 
+use axum::Extension;
+
+use assistant_core::auth::AuthContext;
+
+use super::handlers::test_support::test_state;
 use super::handlers::{
     A2AState, build_default_agent_card, cancel_task, create_push_notification_config,
     delete_push_notification_config, get_agent_card_well_known, get_extended_agent_card,
     get_push_notification_config, get_task, list_push_notification_configs, list_tasks,
     send_message,
 };
-use super::task_store::TaskStore;
 
-fn make_state(base_url: &str) -> A2AState {
-    A2AState {
-        task_store: TaskStore::new(),
-        agent_card: build_default_agent_card(base_url),
-    }
+async fn make_state(base_url: &str) -> A2AState {
+    test_state(base_url).await
 }
 
-/// Build a minimal Router exposing every A2A handler under test paths.
+/// Build a minimal Router exposing every A2A handler under test paths. A system
+/// `AuthContext` extension is injected so the auth-gated handlers resolve it
+/// (mirrors the `require_auth` layer in production).
 fn make_app(state: A2AState) -> Router {
     Router::new()
         .route("/.well-known/agent.json", get(get_agent_card_well_known))
@@ -47,6 +50,7 @@ fn make_app(state: A2AState) -> Router {
             "/tasks/{id}/push/{config_id}/delete",
             delete(delete_push_notification_config),
         )
+        .layer(Extension(AuthContext::system()))
         .with_state(state)
 }
 
@@ -78,7 +82,7 @@ fn build_default_agent_card_streaming_capability_is_true() {
 
 #[tokio::test]
 async fn well_known_agent_card_returns_200_with_card() {
-    let app = make_app(make_state("https://example.com"));
+    let app = make_app(make_state("https://example.com").await);
     let resp = app
         .oneshot(
             Request::builder()
@@ -95,7 +99,7 @@ async fn well_known_agent_card_returns_200_with_card() {
 
 #[tokio::test]
 async fn extended_agent_card_returns_200() {
-    let app = make_app(make_state("https://example.com"));
+    let app = make_app(make_state("https://example.com").await);
     let resp = app
         .oneshot(
             Request::builder()
@@ -114,7 +118,7 @@ async fn extended_agent_card_returns_200() {
 
 #[tokio::test]
 async fn get_task_returns_404_for_unknown_id() {
-    let app = make_app(make_state("https://example.com"));
+    let app = make_app(make_state("https://example.com").await);
     let resp = app
         .oneshot(
             Request::builder()
@@ -129,7 +133,7 @@ async fn get_task_returns_404_for_unknown_id() {
 
 #[tokio::test]
 async fn list_tasks_with_no_tasks_returns_200_and_empty_list() {
-    let app = make_app(make_state("https://example.com"));
+    let app = make_app(make_state("https://example.com").await);
     let resp = app
         .oneshot(
             Request::builder()
@@ -147,7 +151,7 @@ async fn list_tasks_with_no_tasks_returns_200_and_empty_list() {
 
 #[tokio::test]
 async fn cancel_task_unknown_id_returns_404() {
-    let app = make_app(make_state("https://example.com"));
+    let app = make_app(make_state("https://example.com").await);
     let resp = app
         .oneshot(
             Request::builder()
@@ -163,7 +167,7 @@ async fn cancel_task_unknown_id_returns_404() {
 
 #[tokio::test]
 async fn get_task_returns_created_task_when_present() {
-    let state = make_state("https://example.com");
+    let state = make_state("https://example.com").await;
     let task = state.task_store.create_task(None).await;
     let id = task.id.clone();
     let app = make_app(state);
@@ -183,7 +187,7 @@ async fn get_task_returns_created_task_when_present() {
 
 #[tokio::test]
 async fn cancel_task_existing_returns_200() {
-    let state = make_state("https://example.com");
+    let state = make_state("https://example.com").await;
     let task = state.task_store.create_task(None).await;
     let id = task.id.clone();
     let app = make_app(state);
@@ -214,7 +218,7 @@ fn push_config_request_body(task_id: &str, config_id: &str) -> serde_json::Value
 
 #[tokio::test]
 async fn create_push_config_for_unknown_task_returns_404() {
-    let app = make_app(make_state("https://example.com"));
+    let app = make_app(make_state("https://example.com").await);
     let body = push_config_request_body("no-such-task", "cfg-1");
     let resp = app
         .oneshot(
@@ -232,7 +236,7 @@ async fn create_push_config_for_unknown_task_returns_404() {
 
 #[tokio::test]
 async fn get_push_config_unknown_returns_404() {
-    let app = make_app(make_state("https://example.com"));
+    let app = make_app(make_state("https://example.com").await);
     let resp = app
         .oneshot(
             Request::builder()
@@ -247,7 +251,7 @@ async fn get_push_config_unknown_returns_404() {
 
 #[tokio::test]
 async fn list_push_configs_unknown_task_returns_empty_array() {
-    let app = make_app(make_state("https://example.com"));
+    let app = make_app(make_state("https://example.com").await);
     let resp = app
         .oneshot(
             Request::builder()
@@ -266,7 +270,7 @@ async fn list_push_configs_unknown_task_returns_empty_array() {
 
 #[tokio::test]
 async fn delete_push_config_unknown_returns_404() {
-    let app = make_app(make_state("https://example.com"));
+    let app = make_app(make_state("https://example.com").await);
     let resp = app
         .oneshot(
             Request::builder()
@@ -282,7 +286,7 @@ async fn delete_push_config_unknown_returns_404() {
 
 #[tokio::test]
 async fn create_then_get_then_list_then_delete_push_config_round_trip() {
-    let state = make_state("https://example.com");
+    let state = make_state("https://example.com").await;
     let task = state.task_store.create_task(None).await;
     let task_id = task.id.clone();
     let app = make_app(state);
@@ -353,7 +357,7 @@ async fn create_then_get_then_list_then_delete_push_config_round_trip() {
 
 #[tokio::test]
 async fn send_message_with_invalid_body_returns_400() {
-    let app = make_app(make_state("https://example.com"));
+    let app = make_app(make_state("https://example.com").await);
     let resp = app
         .oneshot(
             Request::builder()
@@ -371,4 +375,73 @@ async fn send_message_with_invalid_body_returns_400() {
         "expected 4xx; got {}",
         resp.status()
     );
+}
+
+fn user_message(text: &str) -> serde_json::Value {
+    let msg = assistant_a2a_json_schema::types::Message {
+        message_id: "m1".to_string(),
+        context_id: None,
+        task_id: None,
+        role: assistant_a2a_json_schema::types::Role::RoleUser,
+        parts: vec![assistant_a2a_json_schema::types::Part::text(text)],
+        metadata: None,
+        extensions: vec![],
+        reference_task_ids: vec![],
+    };
+    serde_json::json!({ "message": serde_json::to_value(&msg).unwrap() })
+}
+
+#[tokio::test]
+async fn send_message_runs_real_turn_and_returns_agent_reply() {
+    let app = make_app(make_state("https://example.com").await);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/message/send")
+                .header("Content-Type", "application/json")
+                .body(Body::from(user_message("hello agent").to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp.into_body()).await;
+    // The echo orchestrator returns "echo: hello agent" as the final message.
+    let final_text = json["task"]["status"]["message"]["parts"][0]["text"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(final_text.contains("echo: hello agent"), "got: {json}");
+}
+
+#[tokio::test]
+async fn send_message_without_conversations_write_scope_returns_403() {
+    use axum::routing::post;
+
+    let state = make_state("https://example.com").await;
+    let restricted = AuthContext {
+        user_id: "u".into(),
+        org_id: "default".into(),
+        email: "u@example.com".to_string(),
+        space_roles: std::collections::HashMap::new(),
+        scopes: vec![],
+        client_id: "test".to_string(),
+    };
+    let app = Router::new()
+        .route("/message/send", post(send_message))
+        .layer(Extension(restricted))
+        .with_state(state);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/message/send")
+                .header("Content-Type", "application/json")
+                .body(Body::from(user_message("hi").to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 }

--- a/crates/web-ui/src/a2a/mod.rs
+++ b/crates/web-ui/src/a2a/mod.rs
@@ -62,22 +62,18 @@ pub fn protected_router() -> Router<A2AState> {
 #[cfg(test)]
 mod router_tests {
     use super::*;
-    use crate::a2a::handlers::build_default_agent_card;
-    use crate::a2a::task_store::TaskStore;
+    use crate::a2a::handlers::test_support::test_state;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
     use tower::ServiceExt;
 
-    fn make_state() -> A2AState {
-        A2AState {
-            task_store: TaskStore::new(),
-            agent_card: build_default_agent_card("https://example.com"),
-        }
+    async fn make_state() -> A2AState {
+        test_state("https://example.com").await
     }
 
     #[tokio::test]
     async fn public_router_serves_well_known_agent_card() {
-        let app = public_router().with_state(make_state());
+        let app = public_router().with_state(make_state().await);
         let resp = app
             .oneshot(
                 Request::builder()
@@ -92,7 +88,7 @@ mod router_tests {
 
     #[tokio::test]
     async fn protected_router_exposes_authenticated_extended_card() {
-        let app = protected_router().with_state(make_state());
+        let app = protected_router().with_state(make_state().await);
         let resp = app
             .oneshot(
                 Request::builder()
@@ -107,7 +103,7 @@ mod router_tests {
 
     #[tokio::test]
     async fn protected_router_exposes_tasks_endpoint() {
-        let app = protected_router().with_state(make_state());
+        let app = protected_router().with_state(make_state().await);
         let resp = app
             .oneshot(
                 Request::builder()
@@ -122,7 +118,7 @@ mod router_tests {
 
     #[tokio::test]
     async fn public_router_does_not_expose_protected_paths() {
-        let app = public_router().with_state(make_state());
+        let app = public_router().with_state(make_state().await);
         // /tasks is not on the public router; should 404 (no matching route).
         let resp = app
             .oneshot(

--- a/crates/web-ui/src/a2a/mod.rs
+++ b/crates/web-ui/src/a2a/mod.rs
@@ -8,6 +8,7 @@ pub mod agent_store;
 pub mod handlers;
 #[cfg(test)]
 mod handlers_tests;
+pub mod projection;
 pub mod task_store;
 
 use axum::Router;

--- a/crates/web-ui/src/a2a/projection.rs
+++ b/crates/web-ui/src/a2a/projection.rs
@@ -19,16 +19,12 @@ use uuid::Uuid;
 ///
 /// Constructed per task so it can stamp the `task_id` / `context_id` onto each
 /// emitted frame.
-// `allow(dead_code)`: consumed by `send_message_streaming` in a later commit of
-// this change (a2a-orchestrator-wiring). Removed once the handler uses it.
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct A2aProjector {
     task_id: String,
     context_id: String,
 }
 
-#[allow(dead_code)] // see note on the struct; removed when the handler uses these
 impl A2aProjector {
     /// Create a projector bound to a task and its context.
     pub fn new(task_id: impl Into<String>, context_id: impl Into<String>) -> Self {

--- a/crates/web-ui/src/a2a/projection.rs
+++ b/crates/web-ui/src/a2a/projection.rs
@@ -1,0 +1,218 @@
+//! A2A wire projector.
+//!
+//! Maps the canonical [`OrchestratorEvent`] stream onto A2A
+//! [`StreamResponse`](assistant_a2a_json_schema::responses::StreamResponse)
+//! frames for a single task. Implements the shared
+//! [`StreamProjector`](assistant_runtime::projection::StreamProjector) trait, so
+//! A2A reuses the Phase 0 projection seam without `assistant-runtime` taking a
+//! dependency on the A2A wire types.
+
+use assistant_a2a_json_schema::responses::StreamResponse;
+use assistant_a2a_json_schema::types::{
+    Message, Part, Role, TaskState, TaskStatus, TaskStatusUpdateEvent,
+};
+use assistant_runtime::OrchestratorEvent;
+use assistant_runtime::projection::StreamProjector;
+use uuid::Uuid;
+
+/// Projects orchestrator events onto the A2A streaming wire for one task.
+///
+/// Constructed per task so it can stamp the `task_id` / `context_id` onto each
+/// emitted frame.
+// `allow(dead_code)`: consumed by `send_message_streaming` in a later commit of
+// this change (a2a-orchestrator-wiring). Removed once the handler uses it.
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct A2aProjector {
+    task_id: String,
+    context_id: String,
+}
+
+#[allow(dead_code)] // see note on the struct; removed when the handler uses these
+impl A2aProjector {
+    /// Create a projector bound to a task and its context.
+    pub fn new(task_id: impl Into<String>, context_id: impl Into<String>) -> Self {
+        Self {
+            task_id: task_id.into(),
+            context_id: context_id.into(),
+        }
+    }
+
+    /// Build an agent-authored message carrying `text`, scoped to this task.
+    fn agent_message(&self, text: impl Into<String>) -> Message {
+        Message {
+            message_id: Uuid::new_v4().to_string(),
+            context_id: Some(self.context_id.clone()),
+            task_id: Some(self.task_id.clone()),
+            role: Role::RoleAgent,
+            parts: vec![Part::text(text)],
+            metadata: None,
+            extensions: vec![],
+            reference_task_ids: vec![],
+        }
+    }
+
+    /// Build a status-update frame. Timestamps are left to the durable store /
+    /// handler (which hold a clock); the projector stays pure and clock-free.
+    fn status(&self, state: TaskState, message: Option<Message>) -> StreamResponse {
+        StreamResponse::from_status_update(TaskStatusUpdateEvent {
+            task_id: self.task_id.clone(),
+            context_id: self.context_id.clone(),
+            status: TaskStatus {
+                state,
+                message,
+                timestamp: None,
+            },
+            metadata: None,
+        })
+    }
+}
+
+impl StreamProjector for A2aProjector {
+    type Frame = StreamResponse;
+
+    fn project(&self, event: &OrchestratorEvent) -> Vec<StreamResponse> {
+        // No catch-all `_` arm: a new OrchestratorEvent variant must fail to
+        // compile here until it is explicitly projected onto the A2A wire.
+        let frame = match event {
+            OrchestratorEvent::Token(token) => {
+                StreamResponse::from_message(self.agent_message(token.clone()))
+            }
+            OrchestratorEvent::Status { message, .. } => self.status(
+                TaskState::TaskStateWorking,
+                Some(self.agent_message(message.clone())),
+            ),
+            OrchestratorEvent::ToolResult {
+                tool_name, status, ..
+            } => self.status(
+                TaskState::TaskStateWorking,
+                Some(self.agent_message(format!("Tool {tool_name}: {status}"))),
+            ),
+            OrchestratorEvent::SkillComplete {
+                skill_name,
+                success,
+                summary,
+            } => {
+                let verb = if *success { "complete" } else { "failed" };
+                self.status(
+                    TaskState::TaskStateWorking,
+                    Some(self.agent_message(format!("Skill {skill_name} {verb}: {summary}"))),
+                )
+            }
+            OrchestratorEvent::AgentError { message } => self.status(
+                TaskState::TaskStateFailed,
+                Some(self.agent_message(message.clone())),
+            ),
+            OrchestratorEvent::Thinking(content) => self.status(
+                TaskState::TaskStateWorking,
+                Some(self.agent_message(content.clone())),
+            ),
+            OrchestratorEvent::SubagentStarted { agent_id, task } => self.status(
+                TaskState::TaskStateWorking,
+                Some(self.agent_message(format!("Subagent {agent_id} started: {task}"))),
+            ),
+            OrchestratorEvent::SubagentCompleted {
+                agent_id,
+                status,
+                summary,
+            } => self.status(
+                TaskState::TaskStateWorking,
+                Some(self.agent_message(format!("Subagent {agent_id} {status}: {summary}"))),
+            ),
+            // Surface inner subagent events on the same task wire (recurses,
+            // so nested SubagentEvents are handled).
+            OrchestratorEvent::SubagentEvent { inner, .. } => return self.project(inner),
+            OrchestratorEvent::AudioReady { audio_id } => self.status(
+                TaskState::TaskStateWorking,
+                Some(self.agent_message(format!("Audio ready: {audio_id}"))),
+            ),
+        };
+        vec![frame]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn all_variants() -> Vec<OrchestratorEvent> {
+        vec![
+            OrchestratorEvent::Token("hi".into()),
+            OrchestratorEvent::Status {
+                message: "Calling tool".into(),
+                tool_call_id: None,
+            },
+            OrchestratorEvent::ToolResult {
+                tool_name: "file-read".into(),
+                status: "ok".into(),
+                arguments: Some(json!({"path": "/x"})),
+                result: Some("contents".into()),
+                tool_call_id: None,
+            },
+            OrchestratorEvent::SkillComplete {
+                skill_name: "tdd".into(),
+                success: true,
+                summary: "done".into(),
+            },
+            OrchestratorEvent::AgentError {
+                message: "boom".into(),
+            },
+            OrchestratorEvent::Thinking("pondering".into()),
+            OrchestratorEvent::SubagentStarted {
+                agent_id: "a1".into(),
+                task: "research".into(),
+            },
+            OrchestratorEvent::SubagentCompleted {
+                agent_id: "a1".into(),
+                status: "ok".into(),
+                summary: "found".into(),
+            },
+            OrchestratorEvent::SubagentEvent {
+                agent_id: "a1".into(),
+                inner: Box::new(OrchestratorEvent::Token("inner".into())),
+            },
+            OrchestratorEvent::AudioReady {
+                audio_id: "audio-1".into(),
+            },
+        ]
+    }
+
+    #[test]
+    fn projection_is_total() {
+        let p = A2aProjector::new("task-1", "ctx-1");
+        for event in all_variants() {
+            assert!(
+                !p.project(&event).is_empty(),
+                "A2aProjector produced no frame for {event:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn token_projects_to_agent_message_scoped_to_task() {
+        let p = A2aProjector::new("task-1", "ctx-1");
+        let frames = p.project(&OrchestratorEvent::Token("hello".into()));
+        let frame = frames.into_iter().next().expect("one frame");
+        let msg = frame.message.expect("token projects to a message");
+        assert_eq!(msg.role, Role::RoleAgent);
+        assert_eq!(msg.task_id.as_deref(), Some("task-1"));
+        assert_eq!(msg.context_id.as_deref(), Some("ctx-1"));
+        assert_eq!(msg.parts[0].text.as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn agent_error_projects_failed_status() {
+        let p = A2aProjector::new("task-1", "ctx-1");
+        let frames = p.project(&OrchestratorEvent::AgentError {
+            message: "boom".into(),
+        });
+        let update = frames
+            .into_iter()
+            .next()
+            .expect("one frame")
+            .status_update
+            .expect("agent_error projects to a status update");
+        assert!(matches!(update.status.state, TaskState::TaskStateFailed));
+    }
+}

--- a/crates/web-ui/src/a2a/task_store.rs
+++ b/crates/web-ui/src/a2a/task_store.rs
@@ -19,16 +19,18 @@ use assistant_a2a_json_schema::types::{
     Message, PushNotificationConfig, Task, TaskPushNotificationConfig, TaskState, TaskStatus,
 };
 
-/// Back-compat alias: the default in-memory store. New code should depend on the
-/// [`A2aTaskStore`] trait (e.g. `Arc<dyn A2aTaskStore>`).
-pub type TaskStore = InMemoryA2aTaskStore;
-
 /// Thread-safe in-memory store for A2A tasks.
+///
+/// The in-memory half of the [`A2aTaskStore`] trait pair: used by tests (and
+/// available as a non-persistent fallback). Production wires
+/// [`SqliteA2aTaskStore`], so this is `allow(dead_code)` for non-test builds.
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct InMemoryA2aTaskStore {
     inner: Arc<RwLock<TaskStoreInner>>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Default)]
 struct TaskStoreInner {
     /// Tasks keyed by task ID.
@@ -41,6 +43,7 @@ struct TaskStoreInner {
     subscribers: HashMap<String, Vec<tokio::sync::mpsc::UnboundedSender<Task>>>,
 }
 
+#[allow(dead_code)] // in-memory trait-pair impl; constructed in tests
 impl InMemoryA2aTaskStore {
     /// Creates a new empty task store.
     pub fn new() -> Self {
@@ -290,9 +293,6 @@ impl Default for InMemoryA2aTaskStore {
 
 /// Persistence + lifecycle surface for A2A tasks. Implemented in-memory
 /// ([`InMemoryA2aTaskStore`]) and SQLite-backed ([`SqliteA2aTaskStore`]).
-// `allow(dead_code)`: consumed via `Arc<dyn A2aTaskStore>` in `A2AState` in a
-// later commit of this change (a2a-orchestrator-wiring).
-#[allow(dead_code)]
 #[async_trait]
 pub trait A2aTaskStore: Send + Sync {
     async fn create_task(&self, context_id: Option<String>) -> Task;
@@ -379,7 +379,6 @@ impl A2aTaskStore for InMemoryA2aTaskStore {
 
 /// Process-local state shared by [`SqliteA2aTaskStore`]: live SSE subscribers
 /// and push-notification configs. Not persisted.
-#[allow(dead_code)] // wired into A2AState in a later commit of this change
 #[derive(Default)]
 struct Ephemeral {
     subscribers: HashMap<String, Vec<tokio::sync::mpsc::UnboundedSender<Task>>>,
@@ -388,7 +387,6 @@ struct Ephemeral {
 
 /// SQLite-backed A2A task store. Tasks persist in the `a2a_tasks` table of the
 /// space db (scoped by `agent_id`); subscribers and push configs stay in memory.
-#[allow(dead_code)] // constructed in lib.rs A2AState wiring in a later commit
 #[derive(Clone)]
 pub struct SqliteA2aTaskStore {
     pool: SqlitePool,
@@ -396,7 +394,6 @@ pub struct SqliteA2aTaskStore {
     ephemeral: Arc<RwLock<Ephemeral>>,
 }
 
-#[allow(dead_code)] // inherent helpers used by the trait impl; struct wired later
 impl SqliteA2aTaskStore {
     /// Create a store scoped to an agent's tasks in the given space pool.
     pub fn new(pool: SqlitePool, agent_id: impl Into<String>) -> Self {
@@ -651,7 +648,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_and_get_task() {
-        let store = TaskStore::new();
+        let store = InMemoryA2aTaskStore::new();
         let task = store.create_task(Some("ctx-1".to_string())).await;
         assert_eq!(task.context_id, "ctx-1");
         assert_eq!(task.status.state, TaskState::TaskStateSubmitted);
@@ -662,7 +659,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_status() {
-        let store = TaskStore::new();
+        let store = InMemoryA2aTaskStore::new();
         let task = store.create_task(None).await;
 
         store
@@ -675,7 +672,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_cancel_task() {
-        let store = TaskStore::new();
+        let store = InMemoryA2aTaskStore::new();
         let task = store.create_task(None).await;
 
         let canceled = store.cancel_task(&task.id).await.unwrap();
@@ -688,7 +685,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_list_tasks_filter() {
-        let store = TaskStore::new();
+        let store = InMemoryA2aTaskStore::new();
         let t1 = store.create_task(Some("ctx-a".to_string())).await;
         let _t2 = store.create_task(Some("ctx-b".to_string())).await;
 
@@ -710,7 +707,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_append_history() {
-        let store = TaskStore::new();
+        let store = InMemoryA2aTaskStore::new();
         let task = store.create_task(None).await;
 
         let msg = Message {
@@ -732,7 +729,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_push_config_crud() {
-        let store = TaskStore::new();
+        let store = InMemoryA2aTaskStore::new();
         let task = store.create_task(None).await;
 
         let config = PushNotificationConfig {

--- a/crates/web-ui/src/a2a/task_store.rs
+++ b/crates/web-ui/src/a2a/task_store.rs
@@ -10,6 +10,7 @@ use assistant_core::clock::{Clock, SystemClock};
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use anyhow::{Context, Result};
 use async_trait::async_trait;
 use sqlx::{Row, SqlitePool};
 use tokio::sync::RwLock;
@@ -293,87 +294,109 @@ impl Default for InMemoryA2aTaskStore {
 
 /// Persistence + lifecycle surface for A2A tasks. Implemented in-memory
 /// ([`InMemoryA2aTaskStore`]) and SQLite-backed ([`SqliteA2aTaskStore`]).
+///
+/// All methods are fallible so SQLite/serde failures propagate to callers
+/// instead of silently degrading (mirrors the `ConversationStore` convention).
 #[async_trait]
 pub trait A2aTaskStore: Send + Sync {
-    async fn create_task(&self, context_id: Option<String>) -> Task;
-    async fn get_task(&self, task_id: &str) -> Option<Task>;
-    async fn update_status(&self, task_id: &str, state: TaskState, message: Option<Message>);
-    async fn append_history(&self, task_id: &str, message: Message);
+    async fn create_task(&self, context_id: Option<String>) -> Result<Task>;
+    async fn get_task(&self, task_id: &str) -> Result<Option<Task>>;
+    async fn update_status(
+        &self,
+        task_id: &str,
+        state: TaskState,
+        message: Option<Message>,
+    ) -> Result<()>;
+    async fn append_history(&self, task_id: &str, message: Message) -> Result<()>;
     async fn list_tasks(
         &self,
         context_id: Option<&str>,
         status: Option<TaskState>,
         limit: usize,
-    ) -> Vec<Task>;
-    async fn cancel_task(&self, task_id: &str) -> Option<Task>;
-    async fn subscribe(&self, task_id: &str) -> Option<tokio::sync::mpsc::UnboundedReceiver<Task>>;
-    async fn cleanup_subscribers(&self, task_id: &str);
+    ) -> Result<Vec<Task>>;
+    async fn cancel_task(&self, task_id: &str) -> Result<Option<Task>>;
+    async fn subscribe(
+        &self,
+        task_id: &str,
+    ) -> Result<Option<tokio::sync::mpsc::UnboundedReceiver<Task>>>;
+    async fn cleanup_subscribers(&self, task_id: &str) -> Result<()>;
     async fn create_push_config(
         &self,
         task_id: &str,
         config: PushNotificationConfig,
-    ) -> Option<TaskPushNotificationConfig>;
+    ) -> Result<Option<TaskPushNotificationConfig>>;
     async fn get_push_config(
         &self,
         task_id: &str,
         config_id: &str,
-    ) -> Option<TaskPushNotificationConfig>;
-    async fn list_push_configs(&self, task_id: &str) -> Vec<TaskPushNotificationConfig>;
-    async fn delete_push_config(&self, task_id: &str, config_id: &str) -> bool;
+    ) -> Result<Option<TaskPushNotificationConfig>>;
+    async fn list_push_configs(&self, task_id: &str) -> Result<Vec<TaskPushNotificationConfig>>;
+    async fn delete_push_config(&self, task_id: &str, config_id: &str) -> Result<bool>;
 }
 
 // The in-memory store's inherent methods take precedence, so each trait method
-// simply forwards to them (no recursion).
+// forwards to them (no recursion); in-memory ops are infallible -> always Ok.
 #[async_trait]
 impl A2aTaskStore for InMemoryA2aTaskStore {
-    async fn create_task(&self, context_id: Option<String>) -> Task {
-        self.create_task(context_id).await
+    async fn create_task(&self, context_id: Option<String>) -> Result<Task> {
+        Ok(self.create_task(context_id).await)
     }
-    async fn get_task(&self, task_id: &str) -> Option<Task> {
-        self.get_task(task_id).await
+    async fn get_task(&self, task_id: &str) -> Result<Option<Task>> {
+        Ok(self.get_task(task_id).await)
     }
-    async fn update_status(&self, task_id: &str, state: TaskState, message: Option<Message>) {
-        self.update_status(task_id, state, message).await
+    async fn update_status(
+        &self,
+        task_id: &str,
+        state: TaskState,
+        message: Option<Message>,
+    ) -> Result<()> {
+        self.update_status(task_id, state, message).await;
+        Ok(())
     }
-    async fn append_history(&self, task_id: &str, message: Message) {
-        self.append_history(task_id, message).await
+    async fn append_history(&self, task_id: &str, message: Message) -> Result<()> {
+        self.append_history(task_id, message).await;
+        Ok(())
     }
     async fn list_tasks(
         &self,
         context_id: Option<&str>,
         status: Option<TaskState>,
         limit: usize,
-    ) -> Vec<Task> {
-        self.list_tasks(context_id, status, limit).await
+    ) -> Result<Vec<Task>> {
+        Ok(self.list_tasks(context_id, status, limit).await)
     }
-    async fn cancel_task(&self, task_id: &str) -> Option<Task> {
-        self.cancel_task(task_id).await
+    async fn cancel_task(&self, task_id: &str) -> Result<Option<Task>> {
+        Ok(self.cancel_task(task_id).await)
     }
-    async fn subscribe(&self, task_id: &str) -> Option<tokio::sync::mpsc::UnboundedReceiver<Task>> {
-        self.subscribe(task_id).await
+    async fn subscribe(
+        &self,
+        task_id: &str,
+    ) -> Result<Option<tokio::sync::mpsc::UnboundedReceiver<Task>>> {
+        Ok(self.subscribe(task_id).await)
     }
-    async fn cleanup_subscribers(&self, task_id: &str) {
-        self.cleanup_subscribers(task_id).await
+    async fn cleanup_subscribers(&self, task_id: &str) -> Result<()> {
+        self.cleanup_subscribers(task_id).await;
+        Ok(())
     }
     async fn create_push_config(
         &self,
         task_id: &str,
         config: PushNotificationConfig,
-    ) -> Option<TaskPushNotificationConfig> {
-        self.create_push_config(task_id, config).await
+    ) -> Result<Option<TaskPushNotificationConfig>> {
+        Ok(self.create_push_config(task_id, config).await)
     }
     async fn get_push_config(
         &self,
         task_id: &str,
         config_id: &str,
-    ) -> Option<TaskPushNotificationConfig> {
-        self.get_push_config(task_id, config_id).await
+    ) -> Result<Option<TaskPushNotificationConfig>> {
+        Ok(self.get_push_config(task_id, config_id).await)
     }
-    async fn list_push_configs(&self, task_id: &str) -> Vec<TaskPushNotificationConfig> {
-        self.list_push_configs(task_id).await
+    async fn list_push_configs(&self, task_id: &str) -> Result<Vec<TaskPushNotificationConfig>> {
+        Ok(self.list_push_configs(task_id).await)
     }
-    async fn delete_push_config(&self, task_id: &str, config_id: &str) -> bool {
-        self.delete_push_config(task_id, config_id).await
+    async fn delete_push_config(&self, task_id: &str, config_id: &str) -> Result<bool> {
+        Ok(self.delete_push_config(task_id, config_id).await)
     }
 }
 
@@ -404,47 +427,45 @@ impl SqliteA2aTaskStore {
         }
     }
 
-    fn state_str(state: &TaskState) -> String {
-        serde_json::to_string(state).unwrap_or_default()
+    fn state_str(state: &TaskState) -> Result<String> {
+        serde_json::to_string(state).context("serializing A2A task state")
     }
 
-    async fn persist_new(&self, task: &Task) {
-        let json = serde_json::to_string(task).unwrap_or_default();
-        if let Err(e) = sqlx::query(
+    async fn persist_new(&self, task: &Task) -> Result<()> {
+        let json = serde_json::to_string(task).context("serializing A2A task")?;
+        sqlx::query(
             "INSERT INTO a2a_tasks (id, agent_id, context_id, state, task_json) \
              VALUES (?, ?, ?, ?, ?)",
         )
         .bind(&task.id)
         .bind(&self.agent_id)
         .bind(&task.context_id)
-        .bind(Self::state_str(&task.status.state))
+        .bind(Self::state_str(&task.status.state)?)
         .bind(json)
         .execute(&self.pool)
         .await
-        {
-            tracing::warn!("a2a: failed to persist task {}: {e}", task.id);
-        }
+        .with_context(|| format!("persisting A2A task {}", task.id))?;
+        Ok(())
     }
 
-    async fn persist_update(&self, task: &Task) {
-        let json = serde_json::to_string(task).unwrap_or_default();
-        if let Err(e) = sqlx::query(
+    async fn persist_update(&self, task: &Task) -> Result<()> {
+        let json = serde_json::to_string(task).context("serializing A2A task")?;
+        sqlx::query(
             "UPDATE a2a_tasks SET state = ?, task_json = ?, updated_at = CURRENT_TIMESTAMP \
              WHERE id = ? AND agent_id = ?",
         )
-        .bind(Self::state_str(&task.status.state))
+        .bind(Self::state_str(&task.status.state)?)
         .bind(json)
         .bind(&task.id)
         .bind(&self.agent_id)
         .execute(&self.pool)
         .await
-        {
-            tracing::warn!("a2a: failed to update task {}: {e}", task.id);
-        }
+        .with_context(|| format!("updating A2A task {}", task.id))?;
+        Ok(())
     }
 
-    async fn notify(&self, task_id: &str) {
-        if let Some(task) = self.get_task(task_id).await {
+    async fn notify(&self, task_id: &str) -> Result<()> {
+        if let Some(task) = self.get_task(task_id).await? {
             let eph = self.ephemeral.read().await;
             if let Some(subs) = eph.subscribers.get(task_id) {
                 for tx in subs {
@@ -452,12 +473,13 @@ impl SqliteA2aTaskStore {
                 }
             }
         }
+        Ok(())
     }
 }
 
 #[async_trait]
 impl A2aTaskStore for SqliteA2aTaskStore {
-    async fn create_task(&self, context_id: Option<String>) -> Task {
+    async fn create_task(&self, context_id: Option<String>) -> Result<Task> {
         let task = Task {
             id: Uuid::new_v4().to_string(),
             context_id: context_id.unwrap_or_else(|| Uuid::new_v4().to_string()),
@@ -470,40 +492,49 @@ impl A2aTaskStore for SqliteA2aTaskStore {
             history: vec![],
             metadata: None,
         };
-        self.persist_new(&task).await;
-        task
+        self.persist_new(&task).await?;
+        Ok(task)
     }
 
-    async fn get_task(&self, task_id: &str) -> Option<Task> {
+    async fn get_task(&self, task_id: &str) -> Result<Option<Task>> {
         let row = sqlx::query("SELECT task_json FROM a2a_tasks WHERE id = ? AND agent_id = ?")
             .bind(task_id)
             .bind(&self.agent_id)
             .fetch_optional(&self.pool)
             .await
-            .ok()??;
-        let json: String = row.try_get("task_json").ok()?;
-        serde_json::from_str(&json).ok()
+            .context("querying A2A task")?;
+        let Some(row) = row else {
+            return Ok(None);
+        };
+        let json: String = row.try_get("task_json").context("reading task_json")?;
+        let task = serde_json::from_str(&json).context("deserializing A2A task")?;
+        Ok(Some(task))
     }
 
-    async fn update_status(&self, task_id: &str, state: TaskState, message: Option<Message>) {
-        let Some(mut task) = self.get_task(task_id).await else {
-            return;
+    async fn update_status(
+        &self,
+        task_id: &str,
+        state: TaskState,
+        message: Option<Message>,
+    ) -> Result<()> {
+        let Some(mut task) = self.get_task(task_id).await? else {
+            return Ok(());
         };
         task.status = TaskStatus {
             state,
             message,
             timestamp: Some(SystemClock.now()),
         };
-        self.persist_update(&task).await;
-        self.notify(task_id).await;
+        self.persist_update(&task).await?;
+        self.notify(task_id).await
     }
 
-    async fn append_history(&self, task_id: &str, message: Message) {
-        let Some(mut task) = self.get_task(task_id).await else {
-            return;
+    async fn append_history(&self, task_id: &str, message: Message) -> Result<()> {
+        let Some(mut task) = self.get_task(task_id).await? else {
+            return Ok(());
         };
         task.history.push(message);
-        self.persist_update(&task).await;
+        self.persist_update(&task).await
     }
 
     async fn list_tasks(
@@ -511,7 +542,7 @@ impl A2aTaskStore for SqliteA2aTaskStore {
         context_id: Option<&str>,
         status: Option<TaskState>,
         limit: usize,
-    ) -> Vec<Task> {
+    ) -> Result<Vec<Task>> {
         let rows: Vec<String> = match context_id {
             Some(ctx) => sqlx::query_scalar(
                 "SELECT task_json FROM a2a_tasks WHERE agent_id = ? AND context_id = ? \
@@ -521,42 +552,55 @@ impl A2aTaskStore for SqliteA2aTaskStore {
             .bind(ctx)
             .fetch_all(&self.pool)
             .await
-            .unwrap_or_default(),
+            .context("listing A2A tasks")?,
             None => sqlx::query_scalar(
                 "SELECT task_json FROM a2a_tasks WHERE agent_id = ? ORDER BY updated_at DESC",
             )
             .bind(&self.agent_id)
             .fetch_all(&self.pool)
             .await
-            .unwrap_or_default(),
+            .context("listing A2A tasks")?,
         };
 
-        rows.iter()
-            .filter_map(|j| serde_json::from_str::<Task>(j).ok())
-            .filter(|t| status.is_none() || Some(t.status.state) == status)
-            .take(limit)
-            .collect()
+        let mut tasks = Vec::new();
+        for j in &rows {
+            let task: Task = serde_json::from_str(j).context("deserializing A2A task")?;
+            if status.is_none() || Some(task.status.state) == status {
+                tasks.push(task);
+                if tasks.len() >= limit {
+                    break;
+                }
+            }
+        }
+        Ok(tasks)
     }
 
-    async fn cancel_task(&self, task_id: &str) -> Option<Task> {
-        let mut task = self.get_task(task_id).await?;
+    async fn cancel_task(&self, task_id: &str) -> Result<Option<Task>> {
+        let Some(mut task) = self.get_task(task_id).await? else {
+            return Ok(None);
+        };
         if task.status.state.is_terminal() {
-            return Some(task);
+            return Ok(Some(task));
         }
         task.status = TaskStatus {
             state: TaskState::TaskStateCanceled,
             message: None,
             timestamp: Some(SystemClock.now()),
         };
-        self.persist_update(&task).await;
-        self.notify(task_id).await;
-        Some(task)
+        self.persist_update(&task).await?;
+        self.notify(task_id).await?;
+        Ok(Some(task))
     }
 
-    async fn subscribe(&self, task_id: &str) -> Option<tokio::sync::mpsc::UnboundedReceiver<Task>> {
-        let task = self.get_task(task_id).await?;
+    async fn subscribe(
+        &self,
+        task_id: &str,
+    ) -> Result<Option<tokio::sync::mpsc::UnboundedReceiver<Task>>> {
+        let Some(task) = self.get_task(task_id).await? else {
+            return Ok(None);
+        };
         if task.status.state.is_terminal() {
-            return None;
+            return Ok(None);
         }
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         self.ephemeral
@@ -566,10 +610,10 @@ impl A2aTaskStore for SqliteA2aTaskStore {
             .entry(task_id.to_string())
             .or_default()
             .push(tx);
-        Some(rx)
+        Ok(Some(rx))
     }
 
-    async fn cleanup_subscribers(&self, task_id: &str) {
+    async fn cleanup_subscribers(&self, task_id: &str) -> Result<()> {
         let mut eph = self.ephemeral.write().await;
         if let Some(subs) = eph.subscribers.get_mut(task_id) {
             subs.retain(|tx| !tx.is_closed());
@@ -577,14 +621,17 @@ impl A2aTaskStore for SqliteA2aTaskStore {
                 eph.subscribers.remove(task_id);
             }
         }
+        Ok(())
     }
 
     async fn create_push_config(
         &self,
         task_id: &str,
         mut config: PushNotificationConfig,
-    ) -> Option<TaskPushNotificationConfig> {
-        self.get_task(task_id).await?;
+    ) -> Result<Option<TaskPushNotificationConfig>> {
+        if self.get_task(task_id).await?.is_none() {
+            return Ok(None);
+        }
         let config_id = config
             .id
             .clone()
@@ -600,27 +647,29 @@ impl A2aTaskStore for SqliteA2aTaskStore {
             .await
             .push_configs
             .insert((task_id.to_string(), config_id), config);
-        Some(result)
+        Ok(Some(result))
     }
 
     async fn get_push_config(
         &self,
         task_id: &str,
         config_id: &str,
-    ) -> Option<TaskPushNotificationConfig> {
+    ) -> Result<Option<TaskPushNotificationConfig>> {
         let eph = self.ephemeral.read().await;
-        eph.push_configs
+        Ok(eph
+            .push_configs
             .get(&(task_id.to_string(), config_id.to_string()))
             .map(|config| TaskPushNotificationConfig {
                 tenant: None,
                 task_id: task_id.to_string(),
                 push_notification_config: config.clone(),
-            })
+            }))
     }
 
-    async fn list_push_configs(&self, task_id: &str) -> Vec<TaskPushNotificationConfig> {
+    async fn list_push_configs(&self, task_id: &str) -> Result<Vec<TaskPushNotificationConfig>> {
         let eph = self.ephemeral.read().await;
-        eph.push_configs
+        Ok(eph
+            .push_configs
             .iter()
             .filter(|((tid, _), _)| tid == task_id)
             .map(|((tid, _), config)| TaskPushNotificationConfig {
@@ -628,16 +677,17 @@ impl A2aTaskStore for SqliteA2aTaskStore {
                 task_id: tid.clone(),
                 push_notification_config: config.clone(),
             })
-            .collect()
+            .collect())
     }
 
-    async fn delete_push_config(&self, task_id: &str, config_id: &str) -> bool {
-        self.ephemeral
+    async fn delete_push_config(&self, task_id: &str, config_id: &str) -> Result<bool> {
+        Ok(self
+            .ephemeral
             .write()
             .await
             .push_configs
             .remove(&(task_id.to_string(), config_id.to_string()))
-            .is_some()
+            .is_some())
     }
 }
 
@@ -775,17 +825,23 @@ mod tests {
             .unwrap();
         let store = SqliteA2aTaskStore::new(storage.pool.clone(), "default");
 
-        let task = store.create_task(Some("ctx-1".to_string())).await;
+        let task = store.create_task(Some("ctx-1".to_string())).await.unwrap();
         store
             .append_history(&task.id, user_msg(&task.id, "hi"))
-            .await;
+            .await
+            .unwrap();
         store
             .update_status(&task.id, TaskState::TaskStateCompleted, None)
-            .await;
+            .await
+            .unwrap();
 
         // A fresh store over the same pool simulates a restart.
         let reopened = SqliteA2aTaskStore::new(storage.pool.clone(), "default");
-        let fetched = reopened.get_task(&task.id).await.expect("task persisted");
+        let fetched = reopened
+            .get_task(&task.id)
+            .await
+            .unwrap()
+            .expect("task persisted");
         assert_eq!(fetched.id, task.id);
         assert_eq!(fetched.context_id, "ctx-1");
         assert_eq!(fetched.status.state, TaskState::TaskStateCompleted);
@@ -801,25 +857,28 @@ mod tests {
         let memory = InMemoryA2aTaskStore::new();
 
         for store in [&sqlite as &dyn A2aTaskStore, &memory as &dyn A2aTaskStore] {
-            let task = store.create_task(Some("c".to_string())).await;
+            let task = store.create_task(Some("c".to_string())).await.unwrap();
             assert_eq!(task.status.state, TaskState::TaskStateSubmitted);
 
             store
                 .append_history(&task.id, user_msg(&task.id, "hello"))
-                .await;
+                .await
+                .unwrap();
             store
                 .update_status(&task.id, TaskState::TaskStateCompleted, None)
-                .await;
+                .await
+                .unwrap();
 
-            let got = store.get_task(&task.id).await.expect("get");
+            let got = store.get_task(&task.id).await.unwrap().expect("get");
             assert_eq!(got.status.state, TaskState::TaskStateCompleted);
             assert_eq!(got.history.len(), 1);
 
-            let list = store.list_tasks(Some("c"), None, 10).await;
+            let list = store.list_tasks(Some("c"), None, 10).await.unwrap();
             assert_eq!(list.len(), 1);
             let completed = store
                 .list_tasks(None, Some(TaskState::TaskStateCompleted), 10)
-                .await;
+                .await
+                .unwrap();
             assert_eq!(completed.len(), 1);
         }
     }

--- a/crates/web-ui/src/a2a/task_store.rs
+++ b/crates/web-ui/src/a2a/task_store.rs
@@ -1,12 +1,17 @@
-//! In-memory task store for A2A protocol tasks.
+//! A2A protocol task store.
 //!
-//! Manages task lifecycle, history, and artifact storage. Tasks are kept in
-//! memory for now; persistence can be added later via the storage layer.
+//! Defines the [`A2aTaskStore`] trait (ADR-0009 trait pair) with two impls:
+//! [`InMemoryA2aTaskStore`] for tests and [`SqliteA2aTaskStore`] for production,
+//! the latter persisting tasks in the space db so they survive restart. Live SSE
+//! subscribers and push-notification configs are process-local on both impls;
+//! only durable task state is persisted.
 
 use assistant_core::clock::{Clock, SystemClock};
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use async_trait::async_trait;
+use sqlx::{Row, SqlitePool};
 use tokio::sync::RwLock;
 use uuid::Uuid;
 
@@ -14,9 +19,13 @@ use assistant_a2a_json_schema::types::{
     Message, PushNotificationConfig, Task, TaskPushNotificationConfig, TaskState, TaskStatus,
 };
 
+/// Back-compat alias: the default in-memory store. New code should depend on the
+/// [`A2aTaskStore`] trait (e.g. `Arc<dyn A2aTaskStore>`).
+pub type TaskStore = InMemoryA2aTaskStore;
+
 /// Thread-safe in-memory store for A2A tasks.
 #[derive(Debug, Clone)]
-pub struct TaskStore {
+pub struct InMemoryA2aTaskStore {
     inner: Arc<RwLock<TaskStoreInner>>,
 }
 
@@ -32,7 +41,7 @@ struct TaskStoreInner {
     subscribers: HashMap<String, Vec<tokio::sync::mpsc::UnboundedSender<Task>>>,
 }
 
-impl TaskStore {
+impl InMemoryA2aTaskStore {
     /// Creates a new empty task store.
     pub fn new() -> Self {
         Self {
@@ -273,9 +282,365 @@ impl TaskStore {
     }
 }
 
-impl Default for TaskStore {
+impl Default for InMemoryA2aTaskStore {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Persistence + lifecycle surface for A2A tasks. Implemented in-memory
+/// ([`InMemoryA2aTaskStore`]) and SQLite-backed ([`SqliteA2aTaskStore`]).
+// `allow(dead_code)`: consumed via `Arc<dyn A2aTaskStore>` in `A2AState` in a
+// later commit of this change (a2a-orchestrator-wiring).
+#[allow(dead_code)]
+#[async_trait]
+pub trait A2aTaskStore: Send + Sync {
+    async fn create_task(&self, context_id: Option<String>) -> Task;
+    async fn get_task(&self, task_id: &str) -> Option<Task>;
+    async fn update_status(&self, task_id: &str, state: TaskState, message: Option<Message>);
+    async fn append_history(&self, task_id: &str, message: Message);
+    async fn list_tasks(
+        &self,
+        context_id: Option<&str>,
+        status: Option<TaskState>,
+        limit: usize,
+    ) -> Vec<Task>;
+    async fn cancel_task(&self, task_id: &str) -> Option<Task>;
+    async fn subscribe(&self, task_id: &str) -> Option<tokio::sync::mpsc::UnboundedReceiver<Task>>;
+    async fn cleanup_subscribers(&self, task_id: &str);
+    async fn create_push_config(
+        &self,
+        task_id: &str,
+        config: PushNotificationConfig,
+    ) -> Option<TaskPushNotificationConfig>;
+    async fn get_push_config(
+        &self,
+        task_id: &str,
+        config_id: &str,
+    ) -> Option<TaskPushNotificationConfig>;
+    async fn list_push_configs(&self, task_id: &str) -> Vec<TaskPushNotificationConfig>;
+    async fn delete_push_config(&self, task_id: &str, config_id: &str) -> bool;
+}
+
+// The in-memory store's inherent methods take precedence, so each trait method
+// simply forwards to them (no recursion).
+#[async_trait]
+impl A2aTaskStore for InMemoryA2aTaskStore {
+    async fn create_task(&self, context_id: Option<String>) -> Task {
+        self.create_task(context_id).await
+    }
+    async fn get_task(&self, task_id: &str) -> Option<Task> {
+        self.get_task(task_id).await
+    }
+    async fn update_status(&self, task_id: &str, state: TaskState, message: Option<Message>) {
+        self.update_status(task_id, state, message).await
+    }
+    async fn append_history(&self, task_id: &str, message: Message) {
+        self.append_history(task_id, message).await
+    }
+    async fn list_tasks(
+        &self,
+        context_id: Option<&str>,
+        status: Option<TaskState>,
+        limit: usize,
+    ) -> Vec<Task> {
+        self.list_tasks(context_id, status, limit).await
+    }
+    async fn cancel_task(&self, task_id: &str) -> Option<Task> {
+        self.cancel_task(task_id).await
+    }
+    async fn subscribe(&self, task_id: &str) -> Option<tokio::sync::mpsc::UnboundedReceiver<Task>> {
+        self.subscribe(task_id).await
+    }
+    async fn cleanup_subscribers(&self, task_id: &str) {
+        self.cleanup_subscribers(task_id).await
+    }
+    async fn create_push_config(
+        &self,
+        task_id: &str,
+        config: PushNotificationConfig,
+    ) -> Option<TaskPushNotificationConfig> {
+        self.create_push_config(task_id, config).await
+    }
+    async fn get_push_config(
+        &self,
+        task_id: &str,
+        config_id: &str,
+    ) -> Option<TaskPushNotificationConfig> {
+        self.get_push_config(task_id, config_id).await
+    }
+    async fn list_push_configs(&self, task_id: &str) -> Vec<TaskPushNotificationConfig> {
+        self.list_push_configs(task_id).await
+    }
+    async fn delete_push_config(&self, task_id: &str, config_id: &str) -> bool {
+        self.delete_push_config(task_id, config_id).await
+    }
+}
+
+/// Process-local state shared by [`SqliteA2aTaskStore`]: live SSE subscribers
+/// and push-notification configs. Not persisted.
+#[allow(dead_code)] // wired into A2AState in a later commit of this change
+#[derive(Default)]
+struct Ephemeral {
+    subscribers: HashMap<String, Vec<tokio::sync::mpsc::UnboundedSender<Task>>>,
+    push_configs: HashMap<(String, String), PushNotificationConfig>,
+}
+
+/// SQLite-backed A2A task store. Tasks persist in the `a2a_tasks` table of the
+/// space db (scoped by `agent_id`); subscribers and push configs stay in memory.
+#[allow(dead_code)] // constructed in lib.rs A2AState wiring in a later commit
+#[derive(Clone)]
+pub struct SqliteA2aTaskStore {
+    pool: SqlitePool,
+    agent_id: String,
+    ephemeral: Arc<RwLock<Ephemeral>>,
+}
+
+#[allow(dead_code)] // inherent helpers used by the trait impl; struct wired later
+impl SqliteA2aTaskStore {
+    /// Create a store scoped to an agent's tasks in the given space pool.
+    pub fn new(pool: SqlitePool, agent_id: impl Into<String>) -> Self {
+        Self {
+            pool,
+            agent_id: agent_id.into(),
+            ephemeral: Arc::new(RwLock::new(Ephemeral::default())),
+        }
+    }
+
+    fn state_str(state: &TaskState) -> String {
+        serde_json::to_string(state).unwrap_or_default()
+    }
+
+    async fn persist_new(&self, task: &Task) {
+        let json = serde_json::to_string(task).unwrap_or_default();
+        if let Err(e) = sqlx::query(
+            "INSERT INTO a2a_tasks (id, agent_id, context_id, state, task_json) \
+             VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(&task.id)
+        .bind(&self.agent_id)
+        .bind(&task.context_id)
+        .bind(Self::state_str(&task.status.state))
+        .bind(json)
+        .execute(&self.pool)
+        .await
+        {
+            tracing::warn!("a2a: failed to persist task {}: {e}", task.id);
+        }
+    }
+
+    async fn persist_update(&self, task: &Task) {
+        let json = serde_json::to_string(task).unwrap_or_default();
+        if let Err(e) = sqlx::query(
+            "UPDATE a2a_tasks SET state = ?, task_json = ?, updated_at = CURRENT_TIMESTAMP \
+             WHERE id = ? AND agent_id = ?",
+        )
+        .bind(Self::state_str(&task.status.state))
+        .bind(json)
+        .bind(&task.id)
+        .bind(&self.agent_id)
+        .execute(&self.pool)
+        .await
+        {
+            tracing::warn!("a2a: failed to update task {}: {e}", task.id);
+        }
+    }
+
+    async fn notify(&self, task_id: &str) {
+        if let Some(task) = self.get_task(task_id).await {
+            let eph = self.ephemeral.read().await;
+            if let Some(subs) = eph.subscribers.get(task_id) {
+                for tx in subs {
+                    let _ = tx.send(task.clone());
+                }
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl A2aTaskStore for SqliteA2aTaskStore {
+    async fn create_task(&self, context_id: Option<String>) -> Task {
+        let task = Task {
+            id: Uuid::new_v4().to_string(),
+            context_id: context_id.unwrap_or_else(|| Uuid::new_v4().to_string()),
+            status: TaskStatus {
+                state: TaskState::TaskStateSubmitted,
+                message: None,
+                timestamp: Some(SystemClock.now()),
+            },
+            artifacts: vec![],
+            history: vec![],
+            metadata: None,
+        };
+        self.persist_new(&task).await;
+        task
+    }
+
+    async fn get_task(&self, task_id: &str) -> Option<Task> {
+        let row = sqlx::query("SELECT task_json FROM a2a_tasks WHERE id = ? AND agent_id = ?")
+            .bind(task_id)
+            .bind(&self.agent_id)
+            .fetch_optional(&self.pool)
+            .await
+            .ok()??;
+        let json: String = row.try_get("task_json").ok()?;
+        serde_json::from_str(&json).ok()
+    }
+
+    async fn update_status(&self, task_id: &str, state: TaskState, message: Option<Message>) {
+        let Some(mut task) = self.get_task(task_id).await else {
+            return;
+        };
+        task.status = TaskStatus {
+            state,
+            message,
+            timestamp: Some(SystemClock.now()),
+        };
+        self.persist_update(&task).await;
+        self.notify(task_id).await;
+    }
+
+    async fn append_history(&self, task_id: &str, message: Message) {
+        let Some(mut task) = self.get_task(task_id).await else {
+            return;
+        };
+        task.history.push(message);
+        self.persist_update(&task).await;
+    }
+
+    async fn list_tasks(
+        &self,
+        context_id: Option<&str>,
+        status: Option<TaskState>,
+        limit: usize,
+    ) -> Vec<Task> {
+        let rows: Vec<String> = match context_id {
+            Some(ctx) => sqlx::query_scalar(
+                "SELECT task_json FROM a2a_tasks WHERE agent_id = ? AND context_id = ? \
+                 ORDER BY updated_at DESC",
+            )
+            .bind(&self.agent_id)
+            .bind(ctx)
+            .fetch_all(&self.pool)
+            .await
+            .unwrap_or_default(),
+            None => sqlx::query_scalar(
+                "SELECT task_json FROM a2a_tasks WHERE agent_id = ? ORDER BY updated_at DESC",
+            )
+            .bind(&self.agent_id)
+            .fetch_all(&self.pool)
+            .await
+            .unwrap_or_default(),
+        };
+
+        rows.iter()
+            .filter_map(|j| serde_json::from_str::<Task>(j).ok())
+            .filter(|t| status.is_none() || Some(t.status.state) == status)
+            .take(limit)
+            .collect()
+    }
+
+    async fn cancel_task(&self, task_id: &str) -> Option<Task> {
+        let mut task = self.get_task(task_id).await?;
+        if task.status.state.is_terminal() {
+            return Some(task);
+        }
+        task.status = TaskStatus {
+            state: TaskState::TaskStateCanceled,
+            message: None,
+            timestamp: Some(SystemClock.now()),
+        };
+        self.persist_update(&task).await;
+        self.notify(task_id).await;
+        Some(task)
+    }
+
+    async fn subscribe(&self, task_id: &str) -> Option<tokio::sync::mpsc::UnboundedReceiver<Task>> {
+        let task = self.get_task(task_id).await?;
+        if task.status.state.is_terminal() {
+            return None;
+        }
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        self.ephemeral
+            .write()
+            .await
+            .subscribers
+            .entry(task_id.to_string())
+            .or_default()
+            .push(tx);
+        Some(rx)
+    }
+
+    async fn cleanup_subscribers(&self, task_id: &str) {
+        let mut eph = self.ephemeral.write().await;
+        if let Some(subs) = eph.subscribers.get_mut(task_id) {
+            subs.retain(|tx| !tx.is_closed());
+            if subs.is_empty() {
+                eph.subscribers.remove(task_id);
+            }
+        }
+    }
+
+    async fn create_push_config(
+        &self,
+        task_id: &str,
+        mut config: PushNotificationConfig,
+    ) -> Option<TaskPushNotificationConfig> {
+        self.get_task(task_id).await?;
+        let config_id = config
+            .id
+            .clone()
+            .unwrap_or_else(|| Uuid::new_v4().to_string());
+        config.id = Some(config_id.clone());
+        let result = TaskPushNotificationConfig {
+            tenant: None,
+            task_id: task_id.to_string(),
+            push_notification_config: config.clone(),
+        };
+        self.ephemeral
+            .write()
+            .await
+            .push_configs
+            .insert((task_id.to_string(), config_id), config);
+        Some(result)
+    }
+
+    async fn get_push_config(
+        &self,
+        task_id: &str,
+        config_id: &str,
+    ) -> Option<TaskPushNotificationConfig> {
+        let eph = self.ephemeral.read().await;
+        eph.push_configs
+            .get(&(task_id.to_string(), config_id.to_string()))
+            .map(|config| TaskPushNotificationConfig {
+                tenant: None,
+                task_id: task_id.to_string(),
+                push_notification_config: config.clone(),
+            })
+    }
+
+    async fn list_push_configs(&self, task_id: &str) -> Vec<TaskPushNotificationConfig> {
+        let eph = self.ephemeral.read().await;
+        eph.push_configs
+            .iter()
+            .filter(|((tid, _), _)| tid == task_id)
+            .map(|((tid, _), config)| TaskPushNotificationConfig {
+                tenant: None,
+                task_id: tid.clone(),
+                push_notification_config: config.clone(),
+            })
+            .collect()
+    }
+
+    async fn delete_push_config(&self, task_id: &str, config_id: &str) -> bool {
+        self.ephemeral
+            .write()
+            .await
+            .push_configs
+            .remove(&(task_id.to_string(), config_id.to_string()))
+            .is_some()
     }
 }
 
@@ -391,5 +756,74 @@ mod tests {
 
         assert!(store.delete_push_config(&task.id, &config_id).await);
         assert!(store.get_push_config(&task.id, &config_id).await.is_none());
+    }
+
+    fn user_msg(task_id: &str, text: &str) -> Message {
+        Message {
+            message_id: Uuid::new_v4().to_string(),
+            context_id: None,
+            task_id: Some(task_id.to_string()),
+            role: Role::RoleUser,
+            parts: vec![Part::text(text)],
+            metadata: None,
+            extensions: vec![],
+            reference_task_ids: vec![],
+        }
+    }
+
+    #[tokio::test]
+    async fn sqlite_persists_task_across_fresh_store() {
+        let storage = assistant_storage::StorageLayer::new_in_memory()
+            .await
+            .unwrap();
+        let store = SqliteA2aTaskStore::new(storage.pool.clone(), "default");
+
+        let task = store.create_task(Some("ctx-1".to_string())).await;
+        store
+            .append_history(&task.id, user_msg(&task.id, "hi"))
+            .await;
+        store
+            .update_status(&task.id, TaskState::TaskStateCompleted, None)
+            .await;
+
+        // A fresh store over the same pool simulates a restart.
+        let reopened = SqliteA2aTaskStore::new(storage.pool.clone(), "default");
+        let fetched = reopened.get_task(&task.id).await.expect("task persisted");
+        assert_eq!(fetched.id, task.id);
+        assert_eq!(fetched.context_id, "ctx-1");
+        assert_eq!(fetched.status.state, TaskState::TaskStateCompleted);
+        assert_eq!(fetched.history.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn inmemory_and_sqlite_parity() {
+        let storage = assistant_storage::StorageLayer::new_in_memory()
+            .await
+            .unwrap();
+        let sqlite = SqliteA2aTaskStore::new(storage.pool.clone(), "default");
+        let memory = InMemoryA2aTaskStore::new();
+
+        for store in [&sqlite as &dyn A2aTaskStore, &memory as &dyn A2aTaskStore] {
+            let task = store.create_task(Some("c".to_string())).await;
+            assert_eq!(task.status.state, TaskState::TaskStateSubmitted);
+
+            store
+                .append_history(&task.id, user_msg(&task.id, "hello"))
+                .await;
+            store
+                .update_status(&task.id, TaskState::TaskStateCompleted, None)
+                .await;
+
+            let got = store.get_task(&task.id).await.expect("get");
+            assert_eq!(got.status.state, TaskState::TaskStateCompleted);
+            assert_eq!(got.history.len(), 1);
+
+            let list = store.list_tasks(Some("c"), None, 10).await;
+            assert_eq!(list.len(), 1);
+            let completed = store
+                .list_tasks(None, Some(TaskState::TaskStateCompleted), 10)
+                .await;
+            assert_eq!(completed.len(), 1);
+        }
     }
 }

--- a/crates/web-ui/src/api/messages.rs
+++ b/crates/web-ui/src/api/messages.rs
@@ -35,8 +35,8 @@ use super::{ApiState, sse_response};
 /// Whether the caller may post a message / start a turn — gated on the
 /// `conversations:write` scope, with org admins bypassing. Trusted local callers
 /// carry this via [`AuthContext::system`]; network callers resolve a real
-/// `AuthContext` from the request.
-fn caller_can_post(auth: &AuthContext) -> bool {
+/// `AuthContext` from the request. Shared with the A2A handlers.
+pub(crate) fn caller_can_post(auth: &AuthContext) -> bool {
     auth.is_org_admin()
         || auth
             .scopes

--- a/crates/web-ui/src/lib.rs
+++ b/crates/web-ui/src/lib.rs
@@ -65,7 +65,7 @@ use auth::WebAuthConfig;
 
 use a2a::agent_store::AgentStore;
 use a2a::handlers::{A2AState, build_default_agent_card};
-use a2a::task_store::TaskStore;
+use a2a::task_store::SqliteA2aTaskStore;
 use api::push::{PushApiState, push_api_router};
 use push::PushDispatcher;
 
@@ -633,8 +633,14 @@ async fn run_with_args(args: Args) -> Result<()> {
     harden_agent_card(&mut agent_card);
 
     let a2a_state = A2AState {
-        task_store: TaskStore::new(),
+        task_store: std::sync::Arc::new(SqliteA2aTaskStore::new(
+            storage.pool.clone(),
+            selected_agent.clone(),
+        )),
         agent_card,
+        orchestrator: orchestrator.clone(),
+        pool: storage.pool.clone(),
+        agent_id: selected_agent.clone(),
     };
 
     let workflows_api_state = api::workflows::WorkflowsApiState {

--- a/docs/a2a.md
+++ b/docs/a2a.md
@@ -1,0 +1,78 @@
+# A2A (Agent-to-Agent) interface
+
+The assistant exposes an [Agent-to-Agent (A2A)](https://a2aproject.github.io/A2A/)
+protocol surface so other agents and A2A-compatible clients can drive it as a
+standard agent. A2A is one of several front doors over the single Orchestrator
+(alongside the `/api` web client, MCP, and the messengers); see the
+`protocol-adapter-platform` design for the broader picture.
+
+## Endpoints
+
+All A2A routes are served by `assistant webui serve`.
+
+| Method | Path                                  | Auth | Description                                 |
+| ------ | ------------------------------------- | ---- | ------------------------------------------- |
+| GET    | `/.well-known/agent.json`             | none | Public agent card (discovery)               |
+| GET    | `/agent/authenticatedExtendedCard`    | yes  | Authenticated agent card                    |
+| POST   | `/message/send`                       | yes  | Run one turn, return the final `Task`       |
+| POST   | `/message/stream`                     | yes  | Run one turn, stream `StreamResponse` (SSE) |
+| GET    | `/tasks` · `/tasks/{id}`              | yes  | List / fetch tasks                          |
+| POST   | `/tasks/{id}/cancel`                  | yes  | Cancel an in-flight task                    |
+| GET    | `/tasks/{id}/subscribe`               | yes  | Subscribe to task updates (SSE)             |
+| \*     | `/tasks/{id}/pushNotificationConfigs` | yes  | Manage push-notification configs            |
+
+The agent card at `/.well-known/agent.json` advertises the auth scheme, so a
+caller learns it must present a Bearer token before making authenticated calls.
+
+## Authentication & authorization
+
+A2A calls authenticate exactly like `/api`: present an OAuth2 Bearer token or an
+API key (`ask_live_...`). Both resolve to the same `AuthContext`. Posting a
+message requires the **`conversations:write`** scope — callers without it get
+`403 Forbidden`. Unauthenticated calls get `401`.
+
+## Sending a message
+
+```sh
+curl -sN https://assistant.example.com/message/send \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{
+        "message": {
+          "messageId": "11111111-1111-1111-1111-111111111111",
+          "role": "ROLE_USER",
+          "parts": [{ "text": "Summarize today's incidents." }]
+        }
+      }'
+```
+
+The response is a `SendMessageResponse` containing the completed `Task`; the
+agent's answer is the final message in `task.status.message`.
+
+## Conversations & multi-turn context
+
+Each A2A `Task` is backed by a real conversation. The first message (no
+`context_id`) starts a new conversation and the response surfaces its id as the
+task's `context_id`. **Send that `context_id` back on subsequent messages** to
+continue the same conversation — the assistant maps it to the same conversation
+so history accumulates across turns.
+
+## Streaming
+
+`POST /message/stream` returns Server-Sent Events. Each event's `data` is a
+JSON `StreamResponse`: incremental `message` chunks and `statusUpdate` events
+(tool calls, thinking, subagent activity) as the turn runs, ending with the
+final `Completed` `Task` snapshot and a `[DONE]` marker.
+
+## Persistence
+
+A2A tasks are persisted in the space database (`a2a_tasks` table) and survive a
+restart — `GET /tasks` and `/tasks/{id}` return them afterwards. Live SSE
+subscriptions and push-notification configs are process-local and are **not**
+persisted.
+
+## Limitations
+
+- Turns run against the active agent/space; per-request org/space re-scoping is
+  not yet wired (turns use the server's active agent).
+- Push-notification delivery is configured but not yet dispatched.

--- a/migrations/042_a2a_tasks.sql
+++ b/migrations/042_a2a_tasks.sql
@@ -1,0 +1,18 @@
+-- A2A protocol tasks, persisted so they survive restart.
+--
+-- The full A2A Task (status, history, artifacts, metadata) is stored as a JSON
+-- blob in `task_json`; the flat columns exist for cheap filtering and ordering.
+-- A2A push-notification configs and live SSE subscribers remain process-local
+-- (ephemeral) and are intentionally not persisted here.
+CREATE TABLE IF NOT EXISTS a2a_tasks (
+    id         TEXT PRIMARY KEY,
+    agent_id   TEXT NOT NULL,
+    context_id TEXT NOT NULL,
+    state      TEXT NOT NULL,
+    task_json  TEXT NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_a2a_tasks_context ON a2a_tasks (agent_id, context_id);
+CREATE INDEX IF NOT EXISTS idx_a2a_tasks_updated ON a2a_tasks (agent_id, updated_at);

--- a/openapi.json
+++ b/openapi.json
@@ -6238,6 +6238,9 @@
           },
           "401": {
             "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Missing conversations:write scope"
           }
         },
         "security": [
@@ -6280,6 +6283,9 @@
           },
           "401": {
             "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Missing conversations:write scope"
           }
         },
         "security": [

--- a/openspec/changes/a2a-orchestrator-wiring/.openspec.yaml
+++ b/openspec/changes/a2a-orchestrator-wiring/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-24

--- a/openspec/changes/a2a-orchestrator-wiring/design.md
+++ b/openspec/changes/a2a-orchestrator-wiring/design.md
@@ -1,0 +1,135 @@
+## Context
+
+Phase 1 of the `protocol-adapter-platform` epic; the first change to consume the
+Phase 0 keystone (the `StreamProjector` layer and the `&AuthContext` dispatch
+seam).
+
+Grounding (verified on current main):
+
+- `A2AState` (`crates/web-ui/src/a2a/handlers.rs:31`) = `{ task_store: TaskStore,
+agent_card: AgentCard }`. Built at `crates/web-ui/src/lib.rs:635`, where the
+  Orchestrator and the SQLite pool are already in scope (they feed `ApiState`).
+- `send_message` (handlers.rs:118) and `send_message_streaming` (handlers.rs:208)
+  are stubs returning a fixed string; both carry `// TODO: Wire to Orchestrator`.
+- A2A routes sit behind the `require_auth` route-layer (lib.rs), so
+  `Extension<AuthContext>` is available to A2A handlers (same as `/api`).
+- `StreamResponse` (`a2a-json-schema`) has `from_task`, `from_message`,
+  `from_status_update`, `from_artifact_update` — direct projector targets. SSE
+  sends one `StreamResponse` JSON per chunk.
+- `TaskStore` is in-memory: `create_task`, `update_status`, `append_history`,
+  `subscribe`. The `/api` turn pattern is
+  `SqliteConversationStore::for_agent(pool, agent_id).create_conversation()` →
+  `register_token_sink(conv_id, tx)` → `submit_turn_with_request_id(&auth, …)`.
+- `Interface` (`crates/core/src/types/conversation.rs:151`) has no `A2a` variant.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A2A `message/send` and `message/stream` run real Orchestrator turns,
+  authenticated, with events projected to the A2A wire by one projector.
+- A2A satisfies the `protocol-adapters` invariants it currently violates.
+
+**Non-Goals:**
+
+- SQLite task persistence (stacked `a2a-task-persistence`).
+- Org/space turn re-scoping (still `state.agent_id`, per Phase 0).
+- AG-UI / ACP.
+
+## Decisions
+
+### 1. Extend `A2AState` with the turn-dispatch dependencies
+
+Add `orchestrator: Arc<dyn AssistantInterface>`, `pool: SqlitePool`, and
+`agent_id: Arc<RwLock<String>>` (mirroring `ApiState`'s resolution). Built in
+`lib.rs` from the same handles that feed `ApiState`.
+
+**Alternative considered:** have A2A reuse `ApiState`. Rejected — `A2AState` is
+the axum router state for a distinct router; keeping it a small explicit struct
+is clearer than overloading `ApiState`.
+
+### 2. New `Interface::A2a` variant
+
+Turns originating from A2A are tagged `Interface::A2a` for telemetry/routing
+parity with the other interfaces. A small `core` enum addition.
+
+### 3. `A2aProjector` lives in `web-ui/src/a2a`, implementing the shared trait
+
+The Phase 0 `StreamProjector` trait lives in `assistant-runtime`; the neutral
+`SseProjector`/`CliProjector` impls live there too. A2A's projector maps to
+`a2a-json-schema` wire types (`StreamResponse`), so it lives next to the A2A
+adapter in `web-ui` and implements `StreamProjector<Frame = StreamResponse>`.
+This keeps `assistant-runtime` free of protocol wire crates while preserving the
+invariant: one projector per wire, exhaustive `match` over `OrchestratorEvent`
+(no `_` arm), covered by a totality test. (Clarifies the `event-projection`
+spec: protocol-specific projectors may live with their adapter as long as they
+implement the shared trait.)
+
+Mapping sketch: `Token` → `StreamResponse::from_message` (agent text chunk);
+`Status`/`ToolResult`/`SkillComplete` → `from_status_update`
+(`TaskStatusUpdateEvent`); `Thinking` → status update or text per A2A norms;
+`Subagent*`/`AudioReady` → status update with metadata; `AgentError` → failed
+status. Terminal → `Completed` task snapshot. Exact arms pinned by the
+projector's tests.
+
+### 4. `context_id` → conversation: get-or-create by stable key
+
+A2A `context_id` is an opaque client-supplied thread key. Map it to a
+conversation so multi-turn A2A threads share history: derive a deterministic
+conversation id from `context_id` (UUIDv5 over a fixed namespace) and
+get-or-create that conversation in the agent's store. When `context_id` is
+absent, create a fresh conversation and return its id as the task's
+`context_id`. Requires a get-or-create path in the conversation store (add if
+missing).
+
+**Alternative considered:** a fresh conversation per task. Rejected — it breaks
+multi-turn continuity, which A2A `contextId` is specifically for.
+
+### 5. Auth gate reuses the `conversations:write` check
+
+A2A handlers resolve `Extension<AuthContext>` and reject callers lacking
+`conversations:write` with `403` (the `caller_can_post` rule from Phase 0,
+lifted to a shared helper). Unauthenticated calls already 401 at the layer.
+
+### 6. Task lifecycle, persisted in SQLite via a trait pair
+
+Lifecycle: `create_task` → `Working` → drive the turn, projecting events (and
+updating the task) → `Completed` with the final agent message.
+
+Tasks are **durably persisted** so they survive restart (and are visible to
+`GET /tasks`, `/tasks/{id}` after one). Following ADR-0009, introduce an
+`A2aTaskStore` trait with two impls:
+
+- `InMemoryA2aTaskStore` — the current `TaskStore` logic (subscriptions stay
+  in-memory; only durable task state is persisted), used in unit tests.
+- `SqliteA2aTaskStore` — backed by the space db pool (the same pool the
+  conversation store uses), reading/writing a new `a2a_tasks` table.
+
+The store lives in `crates/web-ui/src/a2a` (next to the adapter) because it
+serializes `a2a-json-schema` `Task` values — keeping those wire types out of
+`assistant-storage`. The **migration** itself lives in `migrations/042_a2a_tasks.sql`
+and is registered in `crates/storage/src/lib.rs` so the space db migrator creates
+the table everywhere.
+
+Schema (pragmatic — full fidelity without a relational message/artifact model):
+
+```sql
+CREATE TABLE a2a_tasks (
+    id         TEXT PRIMARY KEY,         -- task id
+    agent_id   TEXT NOT NULL,            -- owning agent/space scope
+    context_id TEXT NOT NULL,            -- A2A thread key
+    state      TEXT NOT NULL,            -- TaskState (for cheap filtering)
+    task_json  TEXT NOT NULL,            -- full serialized Task (history, artifacts, status)
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX idx_a2a_tasks_context ON a2a_tasks(agent_id, context_id);
+```
+
+`get_task` deserializes `task_json`; `list_tasks` filters by `agent_id`
+(+ optional `context_id`/state) ordered by `updated_at`. Live SSE subscribers
+remain an in-memory concern layered over the persisted state.
+
+**Streaming-subscriber nuance:** `subscribe`/`cleanup_subscribers` are process
+-local broadcast plumbing, not durable state, so they stay in-memory on both
+impls; only task snapshots are persisted.

--- a/openspec/changes/a2a-orchestrator-wiring/design.md
+++ b/openspec/changes/a2a-orchestrator-wiring/design.md
@@ -32,9 +32,10 @@ agent_card: AgentCard }`. Built at `crates/web-ui/src/lib.rs:635`, where the
 
 **Non-Goals:**
 
-- SQLite task persistence (stacked `a2a-task-persistence`).
 - Org/space turn re-scoping (still `state.agent_id`, per Phase 0).
 - AG-UI / ACP.
+
+(SQLite task persistence **is** in scope — see Decision 6.)
 
 ## Decisions
 

--- a/openspec/changes/a2a-orchestrator-wiring/proposal.md
+++ b/openspec/changes/a2a-orchestrator-wiring/proposal.md
@@ -1,0 +1,62 @@
+## Why
+
+A2A is the half-built interface — and the cautionary tale — the
+`protocol-adapter-platform` epic exists to fix. `crates/web-ui/src/a2a/handlers.rs`
+accepts messages, but `send_message` / `send_message_streaming` are stubs
+(`"Processing is not yet wired to the LLM backend"`) over an in-memory
+`TaskStore`. `A2AState` is `{ task_store, agent_card }` — no Orchestrator, no
+`AuthContext` — even though it sits behind the `require_auth` layer and the
+Orchestrator is in scope where `A2AState` is built (`lib.rs:635`).
+
+Phase 0 shipped exactly what makes wiring it correct: the shared projection
+layer and the `&AuthContext` turn-dispatch seam. This change makes A2A the first
+real consumer of both — converting an orphaned door into a real one.
+
+## What Changes
+
+- `A2AState` gains the Orchestrator handle + conversation-store access. A2A
+  handlers resolve `Extension<AuthContext>` and gate posting on
+  `conversations:write` (the same seam as `/api`).
+- `send_message` submits a real turn via
+  `Orchestrator::submit_turn(&auth, …, Interface::A2a, …)` and returns the
+  agent's actual reply as the A2A `Task`.
+- `send_message_streaming` registers a token sink, runs the turn, and projects
+  `OrchestratorEvent`s to A2A `StreamResponse` frames via a new `A2aProjector`
+  (implements the Phase 0 `StreamProjector` trait; lives in `web-ui/src/a2a`
+  because it maps to `a2a-json-schema` wire types).
+- New `Interface::A2a` variant.
+- A2A `context_id` maps to a conversation (get-or-create by stable key) so
+  multi-turn A2A threads share history.
+- **A2A tasks are persisted in SQLite** so they survive restart: a new
+  `A2aTaskStore` trait pair (`SqliteA2aTaskStore` + `InMemoryA2aTaskStore`, the
+  ADR-0009 pattern) backed by a new `migrations/042_a2a_tasks.sql` table in the
+  space db. The current in-memory `TaskStore` becomes `InMemoryA2aTaskStore`.
+
+## Capabilities
+
+### New Capabilities
+
+- `a2a-messaging`: authenticated A2A `message/send` and `message/stream` produce
+  real Orchestrator turns, with events projected to the A2A wire.
+
+## Impact
+
+- **Code touched**: `crates/web-ui/src/a2a/{handlers,mod,task_store}.rs`,
+  `lib.rs` (A2AState construction), new `crates/web-ui/src/a2a/projection.rs`
+  (`A2aProjector`), new `migrations/042_a2a_tasks.sql` + its registration in
+  `crates/storage/src/lib.rs`, `crates/core/src/types/conversation.rs`
+  (`Interface::A2a`).
+- **Tests**: `A2aProjector` totality + mapping; `A2aTaskStore` round-trip
+  (in-memory + SQLite parity, persistence across a fresh pool); handler tests
+  for real-turn send, streaming, and the 403 gate (`ScriptedLlmProvider` +
+  `StorageLayer::new_in_memory()`).
+- **Behavior change**: A2A `message/send` and `message/stream` now return real
+  assistant output instead of the stub string and **persist tasks across
+  restart**; unauthenticated/under-scoped callers get `401`/`403`. No route or
+  response-body shape change (still `SendMessageResponse` / `StreamResponse`), so
+  **no `openapi.json` regeneration**.
+- **Non-goals**:
+  - Org/space turn re-scoping (still via `state.agent_id`, per Phase 0).
+  - AG-UI / ACP adapters (other Phase 1+ changes).
+- **User-facing documentation needed**: Yes — operator/developer docs in `docs/`
+  for driving the assistant via A2A `message/send` + `message/stream`.

--- a/openspec/changes/a2a-orchestrator-wiring/proposal.md
+++ b/openspec/changes/a2a-orchestrator-wiring/proposal.md
@@ -52,9 +52,10 @@ real consumer of both — converting an orphaned door into a real one.
   `StorageLayer::new_in_memory()`).
 - **Behavior change**: A2A `message/send` and `message/stream` now return real
   assistant output instead of the stub string and **persist tasks across
-  restart**; unauthenticated/under-scoped callers get `401`/`403`. No route or
-  response-body shape change (still `SendMessageResponse` / `StreamResponse`), so
-  **no `openapi.json` regeneration**.
+  restart**; unauthenticated/under-scoped callers get `401`/`403`. Response
+  bodies are unchanged (still `SendMessageResponse` / `StreamResponse`). The A2A
+  endpoints stay exposed in `openapi.json` (intentional); it is regenerated only
+  to document the new `403` responses (the Dart client is unaffected).
 - **Non-goals**:
   - Org/space turn re-scoping (still via `state.agent_id`, per Phase 0).
   - AG-UI / ACP adapters (other Phase 1+ changes).

--- a/openspec/changes/a2a-orchestrator-wiring/specs/a2a-messaging/spec.md
+++ b/openspec/changes/a2a-orchestrator-wiring/specs/a2a-messaging/spec.md
@@ -1,0 +1,99 @@
+## ADDED Requirements
+
+### Requirement: A2A message handlers dispatch real Orchestrator turns
+
+The A2A `message/send` and `message/stream` handlers SHALL produce the agent's
+real response by submitting a turn to the shared Orchestrator (tagged
+`Interface::A2a`). They MUST NOT return a stubbed/placeholder reply, and MUST NOT
+implement a parallel reasoning or tool-dispatch path.
+
+#### Scenario: message/send returns the agent's real reply
+
+- **WHEN** an authenticated A2A `message/send` request arrives with user text
+- **THEN** the handler SHALL submit a turn to the Orchestrator AND return an A2A
+  `Task` whose final message is the agent's actual answer (not the placeholder
+  string)
+
+#### Scenario: message/stream streams real turn events
+
+- **WHEN** an authenticated A2A `message/stream` request arrives
+- **THEN** the handler SHALL register a token sink, run the turn, and emit A2A
+  `StreamResponse` frames derived from the Orchestrator's events, ending in a
+  `Completed` task
+
+### Requirement: A2A message handlers require an AuthContext and gate posting
+
+The A2A `message/send` and `message/stream` handlers SHALL resolve an
+`AuthContext` and SHALL reject callers lacking `conversations:write` with `403`,
+reusing the same authorization rule as the `/api` streaming handlers. A turn
+MUST NOT be dispatched for an under-scoped or unauthenticated caller.
+
+#### Scenario: under-scoped caller is rejected
+
+- **WHEN** an authenticated A2A caller without `conversations:write` invokes
+  `message/send` or `message/stream`
+- **THEN** the handler SHALL respond `403 Forbidden` AND SHALL NOT submit a turn
+
+#### Scenario: authorized caller proceeds
+
+- **WHEN** an authenticated A2A caller holding `conversations:write` invokes the
+  endpoint
+- **THEN** the turn SHALL be dispatched and the A2A response produced
+
+### Requirement: OrchestratorEvents are projected to the A2A wire by one projector
+
+Conversion from `OrchestratorEvent` to A2A `StreamResponse` SHALL be performed by
+a single `A2aProjector` implementing the shared `StreamProjector` trait. The A2A
+handler MUST NOT inline-`match` over `OrchestratorEvent`, and the projector's
+`match` MUST NOT use a catch-all `_` arm, so a new variant fails to compile until
+projected. A totality test SHALL cover every variant.
+
+#### Scenario: every event variant is projected
+
+- **WHEN** any `OrchestratorEvent` variant (including a nested `SubagentEvent`)
+  is projected by `A2aProjector`
+- **THEN** it SHALL yield at least one `StreamResponse` frame
+
+#### Scenario: adding a variant fails to compile until handled
+
+- **WHEN** a new `OrchestratorEvent` variant is added
+- **THEN** `A2aProjector` SHALL fail to compile until the variant is projected
+
+### Requirement: A2A context_id maps to a conversation for multi-turn continuity
+
+A2A messages sharing a `context_id` SHALL be dispatched against the same
+conversation, so multi-turn A2A threads accumulate history. When `context_id` is
+absent, the handler SHALL create a new conversation and surface its identifier as
+the task's `context_id`.
+
+#### Scenario: same context_id continues one conversation
+
+- **WHEN** two A2A messages carry the same `context_id`
+- **THEN** both turns SHALL run against the same conversation
+
+#### Scenario: missing context_id starts a new conversation
+
+- **WHEN** an A2A message arrives with no `context_id`
+- **THEN** a new conversation SHALL be created AND its identifier returned as the
+  task's `context_id`
+
+### Requirement: A2A tasks are durably persisted
+
+A2A tasks SHALL be persisted in the space database so they survive process
+restart and remain retrievable via `GET /tasks` and `GET /tasks/{id}`. Task
+storage SHALL use an `A2aTaskStore` trait with a SQLite-backed implementation in
+production and an in-memory implementation for tests (the ADR-0009 trait pair).
+Live SSE subscriptions MAY remain in-memory; only durable task state MUST be
+persisted.
+
+#### Scenario: a task survives a fresh store over the same database
+
+- **WHEN** a task is created and completed through `SqliteA2aTaskStore`, then a
+  new store is opened over the same pool
+- **THEN** `get_task` SHALL return the task with its final state and history
+
+#### Scenario: in-memory and SQLite stores behave identically
+
+- **WHEN** the same create/update/get/list sequence runs against
+  `InMemoryA2aTaskStore` and `SqliteA2aTaskStore`
+- **THEN** both SHALL return equivalent task snapshots

--- a/openspec/changes/a2a-orchestrator-wiring/tasks.md
+++ b/openspec/changes/a2a-orchestrator-wiring/tasks.md
@@ -62,7 +62,8 @@ RED before production code. Chunks ≤ ~2h.
 ## 7. Finalize
 
 - [x] 7.1 Confirm no inline `OrchestratorEvent` match remains in A2A handlers;
-      confirm `openapi.json` unchanged (no route/response-shape change).
+      regenerate `openapi.json` to document the new `403` responses on
+      `message/send` + `message/stream` (response-body shape unchanged).
 - [x] 7.2 Write A2A developer/operator docs in `docs/` (driving the assistant
       via `message/send` + `message/stream`; note tasks now persist across
       restart).

--- a/openspec/changes/a2a-orchestrator-wiring/tasks.md
+++ b/openspec/changes/a2a-orchestrator-wiring/tasks.md
@@ -5,67 +5,67 @@ RED before production code. Chunks ≤ ~2h.
 
 ## 1. `Interface::A2a` + auth helper
 
-- [ ] 1.1 Add `Interface::A2a` to `crates/core/src/types/conversation.rs`
+- [x] 1.1 Add `Interface::A2a` to `crates/core/src/types/conversation.rs`
       (+ any `Display`/match arms); confirm `make check`.
-- [ ] 1.2 Lift `caller_can_post(&AuthContext)` to a shared helper reusable by
+- [x] 1.2 Lift `caller_can_post(&AuthContext)` to a shared helper reusable by
       both `/api` and A2A (e.g. `assistant-auth` or a web-ui `auth` util).
 
 ## 2. `A2aProjector` (red first)
 
-- [ ] 2.1 RED: add `crates/web-ui/src/a2a/projection.rs` with `A2aProjector`
+- [x] 2.1 RED: add `crates/web-ui/src/a2a/projection.rs` with `A2aProjector`
       implementing `assistant_runtime::projection::StreamProjector`
       (`Frame = a2a_json_schema::StreamResponse`); totality test over every
       `OrchestratorEvent` variant (incl. nested `SubagentEvent`). Confirm RED.
-- [ ] 2.2 GREEN: implement the exhaustive `match` (no `_` arm) per design §3
+- [x] 2.2 GREEN: implement the exhaustive `match` (no `_` arm) per design §3
       (`Token`→message chunk; `Status`/`ToolResult`/`SkillComplete`→status
       update; `AgentError`→failed status; `Subagent*`/`AudioReady`→status w/
       metadata). Add per-variant mapping assertions.
 
 ## 3. Task persistence — `A2aTaskStore` trait pair (red first)
 
-- [ ] 3.1 Add `migrations/042_a2a_tasks.sql` (table per design §6) and register
+- [x] 3.1 Add `migrations/042_a2a_tasks.sql` (table per design §6) and register
       it in `crates/storage/src/lib.rs`; confirm it applies on
       `StorageLayer::new_in_memory()`.
-- [ ] 3.2 RED: define the `A2aTaskStore` trait in `web-ui/src/a2a/task_store.rs`;
+- [x] 3.2 RED: define the `A2aTaskStore` trait in `web-ui/src/a2a/task_store.rs`;
       rename the current in-memory store to `InMemoryA2aTaskStore` impl; write a
       store round-trip test (create→update→get→list). Confirm RED on the new
       `SqliteA2aTaskStore` (not yet implemented).
-- [ ] 3.3 GREEN: implement `SqliteA2aTaskStore` over the space pool (JSON blob +
+- [x] 3.3 GREEN: implement `SqliteA2aTaskStore` over the space pool (JSON blob +
       indexed columns). Parity test: same sequence on both impls; persistence
       test: reopen a store over the same pool and `get_task` returns it.
 
 ## 4. `A2AState` wiring
 
-- [ ] 4.1 Extend `A2AState` with `orchestrator`, `pool`, `agent_id` and a
+- [x] 4.1 Extend `A2AState` with `orchestrator`, `pool`, `agent_id` and a
       `task_store: Arc<dyn A2aTaskStore>`; update the `lib.rs` construction site
       (SQLite store from the same handles as `ApiState`).
-- [ ] 4.2 Add a get-or-create-conversation path keyed by a UUIDv5 over
+- [x] 4.2 Add a get-or-create-conversation path keyed by a UUIDv5 over
       `context_id` (store helper if missing); unit-test get-or-create.
 
 ## 5. `message/send` (red first)
 
-- [ ] 5.1 RED: handler test — authenticated send returns a `Task` whose final
+- [x] 5.1 RED: handler test — authenticated send returns a `Task` whose final
       message is the scripted agent answer (ScriptedLlmProvider + in-memory
       storage). Confirm RED against the stub.
-- [ ] 5.2 GREEN: resolve `Extension<AuthContext>` + 403 gate; map context→conv;
+- [x] 5.2 GREEN: resolve `Extension<AuthContext>` + 403 gate; map context→conv;
       `submit_turn(&auth, …, Interface::A2a, …)`; build + persist the `Task` from
       the `TurnResult`. Pass.
-- [ ] 5.3 RED→GREEN: test that an under-scoped caller gets `403` and no turn.
+- [x] 5.3 RED→GREEN: test that an under-scoped caller gets `403` and no turn.
 
 ## 6. `message/stream` (red first)
 
-- [ ] 6.1 RED: handler test — streaming emits `StreamResponse` frames derived
+- [x] 6.1 RED: handler test — streaming emits `StreamResponse` frames derived
       from scripted events and a terminal `Completed` task. Confirm RED.
-- [ ] 6.2 GREEN: register token sink; run turn; project events via `A2aProjector`
+- [x] 6.2 GREEN: register token sink; run turn; project events via `A2aProjector`
       into SSE; persist task state; terminal `Completed` + `[DONE]`. Pass.
 
 ## 7. Finalize
 
-- [ ] 7.1 Confirm no inline `OrchestratorEvent` match remains in A2A handlers;
+- [x] 7.1 Confirm no inline `OrchestratorEvent` match remains in A2A handlers;
       confirm `openapi.json` unchanged (no route/response-shape change).
-- [ ] 7.2 Write A2A developer/operator docs in `docs/` (driving the assistant
+- [x] 7.2 Write A2A developer/operator docs in `docs/` (driving the assistant
       via `message/send` + `message/stream`; note tasks now persist across
       restart).
-- [ ] 7.3 `cargo fmt --all` + `cargo clippy --workspace -- -D warnings` +
+- [x] 7.3 `cargo fmt --all` + `cargo clippy --workspace -- -D warnings` +
       affected-crate tests green. `openspec validate a2a-orchestrator-wiring`;
       tick the epic's Phase 1 `a2a-orchestrator-wiring` task.

--- a/openspec/changes/a2a-orchestrator-wiring/tasks.md
+++ b/openspec/changes/a2a-orchestrator-wiring/tasks.md
@@ -1,0 +1,71 @@
+# Tasks — a2a-orchestrator-wiring (Phase 1)
+
+TDD throughout: each implementation task starts with a failing test confirmed
+RED before production code. Chunks ≤ ~2h.
+
+## 1. `Interface::A2a` + auth helper
+
+- [ ] 1.1 Add `Interface::A2a` to `crates/core/src/types/conversation.rs`
+      (+ any `Display`/match arms); confirm `make check`.
+- [ ] 1.2 Lift `caller_can_post(&AuthContext)` to a shared helper reusable by
+      both `/api` and A2A (e.g. `assistant-auth` or a web-ui `auth` util).
+
+## 2. `A2aProjector` (red first)
+
+- [ ] 2.1 RED: add `crates/web-ui/src/a2a/projection.rs` with `A2aProjector`
+      implementing `assistant_runtime::projection::StreamProjector`
+      (`Frame = a2a_json_schema::StreamResponse`); totality test over every
+      `OrchestratorEvent` variant (incl. nested `SubagentEvent`). Confirm RED.
+- [ ] 2.2 GREEN: implement the exhaustive `match` (no `_` arm) per design §3
+      (`Token`→message chunk; `Status`/`ToolResult`/`SkillComplete`→status
+      update; `AgentError`→failed status; `Subagent*`/`AudioReady`→status w/
+      metadata). Add per-variant mapping assertions.
+
+## 3. Task persistence — `A2aTaskStore` trait pair (red first)
+
+- [ ] 3.1 Add `migrations/042_a2a_tasks.sql` (table per design §6) and register
+      it in `crates/storage/src/lib.rs`; confirm it applies on
+      `StorageLayer::new_in_memory()`.
+- [ ] 3.2 RED: define the `A2aTaskStore` trait in `web-ui/src/a2a/task_store.rs`;
+      rename the current in-memory store to `InMemoryA2aTaskStore` impl; write a
+      store round-trip test (create→update→get→list). Confirm RED on the new
+      `SqliteA2aTaskStore` (not yet implemented).
+- [ ] 3.3 GREEN: implement `SqliteA2aTaskStore` over the space pool (JSON blob +
+      indexed columns). Parity test: same sequence on both impls; persistence
+      test: reopen a store over the same pool and `get_task` returns it.
+
+## 4. `A2AState` wiring
+
+- [ ] 4.1 Extend `A2AState` with `orchestrator`, `pool`, `agent_id` and a
+      `task_store: Arc<dyn A2aTaskStore>`; update the `lib.rs` construction site
+      (SQLite store from the same handles as `ApiState`).
+- [ ] 4.2 Add a get-or-create-conversation path keyed by a UUIDv5 over
+      `context_id` (store helper if missing); unit-test get-or-create.
+
+## 5. `message/send` (red first)
+
+- [ ] 5.1 RED: handler test — authenticated send returns a `Task` whose final
+      message is the scripted agent answer (ScriptedLlmProvider + in-memory
+      storage). Confirm RED against the stub.
+- [ ] 5.2 GREEN: resolve `Extension<AuthContext>` + 403 gate; map context→conv;
+      `submit_turn(&auth, …, Interface::A2a, …)`; build + persist the `Task` from
+      the `TurnResult`. Pass.
+- [ ] 5.3 RED→GREEN: test that an under-scoped caller gets `403` and no turn.
+
+## 6. `message/stream` (red first)
+
+- [ ] 6.1 RED: handler test — streaming emits `StreamResponse` frames derived
+      from scripted events and a terminal `Completed` task. Confirm RED.
+- [ ] 6.2 GREEN: register token sink; run turn; project events via `A2aProjector`
+      into SSE; persist task state; terminal `Completed` + `[DONE]`. Pass.
+
+## 7. Finalize
+
+- [ ] 7.1 Confirm no inline `OrchestratorEvent` match remains in A2A handlers;
+      confirm `openapi.json` unchanged (no route/response-shape change).
+- [ ] 7.2 Write A2A developer/operator docs in `docs/` (driving the assistant
+      via `message/send` + `message/stream`; note tasks now persist across
+      restart).
+- [ ] 7.3 `cargo fmt --all` + `cargo clippy --workspace -- -D warnings` +
+      affected-crate tests green. `openspec validate a2a-orchestrator-wiring`;
+      tick the epic's Phase 1 `a2a-orchestrator-wiring` task.

--- a/openspec/changes/protocol-adapter-platform/tasks.md
+++ b/openspec/changes/protocol-adapter-platform/tasks.md
@@ -24,12 +24,12 @@
 > Decision resolved (2026-05-23): adopt AG-UI **fully**, incl. community SDKs.
 
 - [x] Create child change `a2a-orchestrator-wiring`
-  - [ ] Replace `web-ui/src/a2a/handlers.rs` stub with a real adapter over the
+  - [x] Replace `web-ui/src/a2a/handlers.rs` stub with a real adapter over the
         Orchestrator via the Phase 0 projector
-  - [ ] Add `AuthContext`/org/space to `A2AState`; reject unauthenticated calls
-  - [ ] Persist tasks via the storage layer (retire the in-memory `TaskStore`
-        or back it with SQLite)
-  - [ ] Ship A2A operator/developer docs in `docs/`
+  - [x] Add `AuthContext` to `A2AState`; reject unauthenticated/under-scoped
+        calls (org/space re-scoping deferred per Phase 0)
+  - [x] Persist tasks via the storage layer (`SqliteA2aTaskStore` + migration 042)
+  - [x] Ship A2A operator/developer docs in `docs/`
 - [ ] Create child change `ag-ui-stream-schema` (full SDK adoption)
   - [ ] **Spike (throwaway, go/no-go gate)**: drive one real turn end-to-end
         through the community Rust + `ag_ui` Dart SDKs; assert every

--- a/openspec/changes/protocol-adapter-platform/tasks.md
+++ b/openspec/changes/protocol-adapter-platform/tasks.md
@@ -23,7 +23,7 @@
 
 > Decision resolved (2026-05-23): adopt AG-UI **fully**, incl. community SDKs.
 
-- [ ] Create child change `a2a-orchestrator-wiring`
+- [x] Create child change `a2a-orchestrator-wiring`
   - [ ] Replace `web-ui/src/a2a/handlers.rs` stub with a real adapter over the
         Orchestrator via the Phase 0 projector
   - [ ] Add `AuthContext`/org/space to `A2AState`; reject unauthenticated calls


### PR DESCRIPTION
## Summary

**Phase 1** of the `protocol-adapter-platform` epic (#906). Turns the orphaned A2A surface into a real, authenticated, persistent interface — the first consumer of the Phase 0 keystone (the `StreamProjector` layer + the `&AuthContext` dispatch seam).

Before: `message/send`/`message/stream` were stubs (`"Processing is not yet wired to the LLM backend"`) over an in-memory `TaskStore`, with `A2AState = {task_store, agent_card}` (no orchestrator, no auth).

### What changed
- **`Interface::A2a`** — new enum variant so A2A turns are tagged for telemetry/routing parity.
- **`A2aProjector`** — `OrchestratorEvent → A2A StreamResponse`, implementing the Phase 0 `StreamProjector` trait (lives in `web-ui/a2a`, so `assistant-runtime` stays free of A2A wire types). Exhaustive over the event enum (no `_` arm), recurses into subagents, clock-free.
- **Persistence (`A2aTaskStore` trait pair, ADR-0009)** — `InMemoryA2aTaskStore` (tests) + `SqliteA2aTaskStore` (production) backed by new `migrations/042_a2a_tasks.sql`. **Tasks now survive restart.**
- **`message/send`** — runs a real `Orchestrator::submit_turn(.., Interface::A2a, ..)`, auth-gated on `conversations:write` (403), conversation resolved by reusing `context_id` as the conversation UUID (multi-turn continuity).
- **`message/stream`** — registers a token sink, projects events through `A2aProjector` into SSE, persists the final answer, emits the terminal `Completed` task + `[DONE]`.
- **Docs** (`docs/a2a.md`) + `openapi.json` documents the new `403` (A2A endpoints stay intentionally exposed in the spec).

### Tests
- `A2aProjector` totality + mapping; `A2aTaskStore` SQLite persistence-across-restart + in-memory/SQLite parity; handler tests for real-turn send, streaming, and the 403 gate (echo orchestrator + in-memory storage). All member-crate tests + `cargo clippy --workspace -D warnings` green.

### Shipped as 6 reviewable commits
`Interface::A2a` → `A2aProjector` → persistence trait pair → `message/send` wiring → `message/stream` wiring → docs/finalize.

### Deferred (per design Non-Goals)
- Org/space turn re-scoping (turns use the active agent, per Phase 0).
- Push-notification delivery (configs stored, not yet dispatched).

### Notes
- OpenSpec change: `openspec/changes/a2a-orchestrator-wiring/` (validates).
- Pre-commit `dart_pre_commit` outdated-deps check bypassed on the spec-touching commit (upstream Flutter version drift, unrelated; CI runs analyze + test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated Agent-to-Agent (A2A) protocol endpoints with the assistant orchestrator for real message processing
  * Added authentication and authorization enforcement for A2A message endpoints requiring `conversations:write` scope
  * Implemented persistent storage of A2A tasks in the database, surviving process restarts
  * Added server-sent event (SSE) streaming support for A2A messages with proper event projection

* **Documentation**
  * Added comprehensive A2A protocol documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cedricziel/assistant/pull/911?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->