### PR TITLE
chore(deps): land remaining dependabot updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,7 @@ checksum = "36fa98bc79671c7981272d91a8753a928ff6a1cd8e4f20a44c45bd5d313840bf"
 dependencies = [
  "bigdecimal",
  "bon",
+ "crc32fast",
  "digest 0.10.7",
  "log",
  "miniz_oxide",
@@ -171,6 +172,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "snap",
  "strum",
  "strum_macros",
  "thiserror 2.0.18",
@@ -213,9 +215,9 @@ checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "arrow-arith"
-version = "57.3.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b3141e0ec5145a22d8694ea8b6d6f69305971c4fa1c1a13ef0195aef2d678b"
+checksum = "0a41203398f0eaa6f7ec8e62c0da742a21abf282c148fc157f6c35c90e29981a"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -227,9 +229,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "57.3.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8955af33b25f3b175ee10af580577280b4bd01f7e823d94c7cdef7cf8c9aef"
+checksum = "ae33dad492b7df00a217563a7b0ef2874df68a0deea1b1a3acf628152f7f7a69"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -237,7 +239,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -245,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "57.3.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c697ddca96183182f35b3a18e50b9110b11e916d7b7799cbfd4d34662f2c56c2"
+checksum = "b9552f96391c005e6ab449fa941420935e7e062489b12b8b1b08879b2163f5b5"
 dependencies = [
  "bytes",
  "half",
@@ -257,9 +259,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "57.3.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "646bbb821e86fd57189c10b4fcdaa941deaf4181924917b0daa92735baa6ada5"
+checksum = "3a8a327c9649f30d8406995f27642b68df354713cca3baaaf100f076f18d5f34"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -278,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "57.3.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fdd994a9d28e6365aa78e15da3f3950c0fdcea6b963a12fa1c391afb637b304"
+checksum = "2b24852db04738907e06c04ea61e42fe7fda962a34513022dc0d0e754fb7976b"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -291,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "57.3.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf7df950701ab528bf7c0cf7eeadc0445d03ef5d6ffc151eaae6b38a58feff1"
+checksum = "29a908a11fcfb3fb2f6730f4ac15e367bc644e419155e96238f68cf3adde572b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -305,9 +307,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "57.3.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d8f1870e03d4cbed632959498bcc84083b5a24bded52905ae1695bd29da45b"
+checksum = "63a083ec750f5c043f02946b4baf05fcdbb55f4560a3277055caca5cc99f3eb0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -318,15 +320,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "57.3.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c872d36b7bf2a6a6a2b40de9156265f0242910791db366a2c17476ba8330d68"
+checksum = "21ca356ad6425cecb6eb7b28e4f659f1ee7880fbb1a16127de7dd62901efee9e"
 
 [[package]]
 name = "arrow-select"
-version = "57.3.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68bf3e3efbd1278f770d67e5dc410257300b161b93baedb3aae836144edcaf4b"
+checksum = "c58da39eb3d8350ad4a549e5c2bc49284dac554016c69829310350f1731b0aad"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -338,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "57.3.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e968097061b3c0e9fe3079cf2e703e487890700546b5b0647f60fca1b5a8d8"
+checksum = "b6789b388467525e3271326b6b4915666ecfdf5142aef09779445c954b67543c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -929,9 +931,9 @@ dependencies = [
 
 [[package]]
 name = "async-openai"
-version = "0.40.2"
+version = "0.41.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fa0605961e005565ddbeff2d8f9148b8893128381ee3bec3a5df4e6a8d0f74"
+checksum = "d72db2750faea2ca5edbf6d0c50277a89dc8f75f5e6ddd695ef30f75e335019b"
 dependencies = [
  "async-openai-macros",
  "base64 0.22.1",
@@ -1442,9 +1444,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -2059,7 +2061,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2246,7 +2248,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3036,10 +3038,11 @@ dependencies = [
 
 [[package]]
 name = "iceberg"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d9c3fc1f55c84ff64645c0d2ee35159f5574d33f729fc0860783bc247c8b8c5"
+checksum = "6e50fb53c7480f414911ab76b6e14c0042d54ad5c30f6ac2bf2f52a487a25716"
 dependencies = [
+ "aes-gcm",
  "anyhow",
  "apache-avro",
  "array-init",
@@ -3081,18 +3084,20 @@ dependencies = [
  "serde_with",
  "strum",
  "tokio",
+ "tracing",
  "typed-builder",
  "typetag",
  "url",
  "uuid",
+ "zeroize",
  "zstd",
 ]
 
 [[package]]
 name = "iceberg-catalog-rest"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a49dfef578060c3a2a3f619522dcb25382a7ce85336dcb500495d4b8d72ae714"
+checksum = "d1500a26a9b18f286a319e914ce7290dddb7e2eef810edf535afc4ce0c8a6f45"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3104,7 +3109,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tokio",
- "tracing",
  "typed-builder",
  "uuid",
 ]
@@ -3630,9 +3634,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 dependencies = [
  "twox-hash",
 ]
@@ -3840,7 +3844,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4202,14 +4206,13 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "57.3.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee96b29972a257b855ff2341b37e61af5f12d6af1158b6dcdb5b31ea07bb3cb"
+checksum = "d298093b2dec60289dce0684c986d0f7679e9dd15771c2c65406e1aaf604a704"
 dependencies = [
  "ahash",
  "arrow-array",
  "arrow-buffer",
- "arrow-cast",
  "arrow-data",
  "arrow-ipc",
  "arrow-schema",
@@ -4221,12 +4224,13 @@ dependencies = [
  "flate2",
  "futures",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "lz4_flex",
  "num-bigint",
  "num-integer",
  "num-traits",
  "paste",
+ "ring",
  "seq-macro",
  "simdutf8",
  "snap",
@@ -5183,7 +5187,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5242,7 +5246,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6187,7 +6191,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6978,9 +6982,9 @@ checksum = "e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -7292,7 +7296,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ reqwest-middleware = { version = "0.5", features = ["json", "multipart"] }
 reqwest-retry = "0.9"
 reqwest-tracing = "0.7"
 # OpenAI-compatible client (used by provider-openai and provider-moonshot)
-async-openai = { version = "0.40", features = ["chat-completion", "embedding", "responses"] }
+async-openai = { version = "0.41", features = ["chat-completion", "embedding", "responses"] }
 # TLS — explicit dep so binaries can install_default() when both aws-lc-rs and ring are in tree
 rustls = { version = "0.23", features = ["ring"] }
 # Logging / tracing
@@ -181,11 +181,11 @@ http-body-util = "0.1"
 # URL percent-encoding
 urlencoding = "2"
 # Apache Iceberg
-iceberg = "0.9"
-iceberg-catalog-rest = "0.9"
-arrow-array = "57.3"
-arrow-schema = "57.3"
-parquet = { version = "57.3", default-features = false, features = ["arrow", "async"] }
+iceberg = "0.10"
+iceberg-catalog-rest = "0.10"
+arrow-array = "58.3"
+arrow-schema = "58.3"
+parquet = { version = "58.3", default-features = false, features = ["arrow", "async"] }
 # Authentication
 jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }
 argon2 = { version = "0.5", features = ["std"] }

--- a/crates/opentelemetry-exporter-iceberg/src/log.rs
+++ b/crates/opentelemetry-exporter-iceberg/src/log.rs
@@ -136,7 +136,7 @@ impl IcebergLogExporter {
         let schema_ref =
             arc(logs_schema().map_err(|e| OTelSdkError::InternalFailure(e.to_string()))?);
 
-        let location_gen = DefaultLocationGenerator::new(table.metadata().clone())
+        let location_gen = DefaultLocationGenerator::new(table.metadata())
             .map_err(|e| OTelSdkError::InternalFailure(e.to_string()))?;
         let filename_gen =
             DefaultFileNameGenerator::new("part".to_string(), None, DataFileFormat::Parquet);

--- a/crates/opentelemetry-exporter-iceberg/src/metric.rs
+++ b/crates/opentelemetry-exporter-iceberg/src/metric.rs
@@ -128,7 +128,7 @@ impl IcebergMetricExporter {
         let schema_ref =
             arc(metrics_schema().map_err(|e| OTelSdkError::InternalFailure(e.to_string()))?);
 
-        let location_gen = DefaultLocationGenerator::new(table.metadata().clone())
+        let location_gen = DefaultLocationGenerator::new(table.metadata())
             .map_err(|e| OTelSdkError::InternalFailure(e.to_string()))?;
         let filename_gen =
             DefaultFileNameGenerator::new("part".to_string(), None, DataFileFormat::Parquet);

--- a/crates/opentelemetry-exporter-iceberg/src/span.rs
+++ b/crates/opentelemetry-exporter-iceberg/src/span.rs
@@ -130,7 +130,7 @@ impl IcebergSpanExporter {
         let schema_ref =
             arc(spans_schema().map_err(|e| OTelSdkError::InternalFailure(e.to_string()))?);
 
-        let location_gen = DefaultLocationGenerator::new(table.metadata().clone())
+        let location_gen = DefaultLocationGenerator::new(table.metadata())
             .map_err(|e| OTelSdkError::InternalFailure(e.to_string()))?;
         let filename_gen =
             DefaultFileNameGenerator::new("part".to_string(), None, DataFileFormat::Parquet);


### PR DESCRIPTION
## Summary

- Consolidates four dependabot PRs that could not be merged through GitHub, plus the one code change the iceberg bump requires.
- **arrow-iceberg group (#945)** — `iceberg` 0.9 → 0.10, `iceberg-catalog-rest` 0.9 → 0.10, `arrow-array` / `arrow-schema` / `parquet` 57.3 → 58.3.
- `iceberg` 0.10 changed `DefaultLocationGenerator::new` to take `&TableMetadata` instead of an owned value. Since `Table::metadata()` already returns a reference, the fix is dropping the now-redundant `.clone()` at the three call sites in `log.rs`, `metric.rs` and `span.rs`. This is what made #945 red.
- **#931 / #930 / #925** — `async-openai` 0.40.2 → 0.41.3, `chrono` 0.4.44 → 0.4.45, `uuid` 1.23.1 → 1.24.0. These went stale on `Cargo.lock` conflicts and could no longer be rebased by dependabot (open 30+ days, so automatic rebases are disabled). `uuid` and `async-openai` resolve slightly past the versions those PRs pinned, since both sit under loose semver ranges in the workspace manifest.

Supersedes #945, #931, #930 and #925. Does **not** cover #953 (pub group) — that one needs a `record` v6 → v7 migration in `app/test/widget/features/voice_widgets_test.dart`.

## Validation

- [x] `make check`
- [x] `make test`
- [x] `make lint`
- [x] `make format`

Run locally against the full workspace; all four clean. The `opentelemetry-exporter-iceberg` suite passes 10/10. No macOS or Flutter target was exercised locally — no SDK in the environment — so those jobs get their first run here. Worth watching: #925 had a failing `Build macOS Bundle (no-codesign)` check that was never diagnosed; it looked pre-existing rather than uuid-caused, but this PR inherits that open question.

## Persona Model Naming Checklist

- [x] I used canonical terms in docs/UI copy: `Persona`, `Subagent Process`, `A2A Profile`.
- [x] I avoided unqualified `agent` in architecture prose unless it is a literal code identifier.
- [x] If legacy identifiers remain, I explained them using canonical terminology in docs/comments.

Not applicable — dependency bumps and one signature fix, no docs or UI copy touched.

## Breaking Change Notes

- [x] This PR intentionally keeps no backward-compatibility layer where migration scope requires removal.
- [x] I documented any removed/renamed user-facing surface in docs or release notes.

No user-facing surface changes. The `DefaultLocationGenerator::new` change is internal to `opentelemetry-exporter-iceberg` and forced by the upstream 0.10 signature.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUMQkzAMZ6AQiFgKCVyvzN)_