### PR TITLE
docs(openspec): propose chat-element-library change

### DIFF
--- a/openspec/changes/chat-element-library/design.md
+++ b/openspec/changes/chat-element-library/design.md
@@ -4,7 +4,7 @@
 
 assistant-ui Elements is a React + Tailwind registry distributed shadcn-style. There is no mechanical port path to Flutter: no shared runtime, no Tailwind, no registry convention. What transfers is the **vocabulary** (which pieces an assistant conversation is made of) and the **gallery model** (every element demoable in isolation, in every state).
 
-This change adopts both for the display half of the vocabulary — shell, thinking, streaming, display. It deliberately excludes the composer and everything that requires a client→server return channel.
+This change adopts both for the display half of the vocabulary — shell, thinking, streaming, display — **and the composer**. It excludes everything that requires a client→server return channel, and everything with no data behind it today. `elements.md` carries the per-element verdict.
 
 ## How assistant-ui composes, and the Flutter translation
 
@@ -41,6 +41,24 @@ The rule is not merely "no state management" — it is **no I/O**. The package r
 | `flutter_smooth_markdown`     | **package** | Pure rendering. `MessageBody`/`ThinkingBody` need it for streaming markdown. |
 | `record`                      | app         | Microphone I/O.                                                              |
 | `file_picker`, `desktop_drop` | app         | File-system and platform-channel I/O.                                        |
+
+**The allowlist is closed**: `flutter` and `flutter_smooth_markdown`, nothing else. `proposal.md`, this document and the spec all state that same list; the boundary test in task 1.1 enforces it in both directions — forbidden entries in `pubspec.yaml`, and forbidden `import` statements (`dart:io`, `record`, `file_picker`, `desktop_drop`) anywhere in package source. A manifest check alone would not catch a transitively-available I/O import.
+
+## Reasoning: what the data actually supports
+
+`ReasoningPanel` was initially specified as a step timeline with per-step elapsed time. It cannot be, and the reason is worth recording rather than quietly dropping.
+
+```
+runtime          OrchestratorEvent::Thinking(String)   ← undifferentiated tokens
+client model     ChatMessage.thinkingContent: String?  ← flat
+                 ChatMessage.thinkingTokenStream       ← Stream<String>
+```
+
+There is no step delimiter anywhere in the chain and no per-step clock. Deriving boundaries from token arrival times would invent structure the model never expressed — the panel would show step divisions that correspond to network chunking, not to reasoning.
+
+**Decision: ship the collapsible section, defer the timeline.** `ReasoningPanel` takes `thinkingContent`/`thinkingTokenStream` and a single `elapsed` for the whole reasoning block — all of which exist today — and renders a collapsible section with total elapsed time. This keeps task 2.1's "move the models unchanged" intact.
+
+The per-step timeline is **P5** in `elements.md`. Unblocking it means either delimited steps on the wire or a package-owned `ReasoningStep` model with defined boundary and timing semantics — a decision about the protocol, not about a widget, and therefore not one to make inside a refactor.
 
 ## Composer
 

--- a/openspec/changes/chat-element-library/design.md
+++ b/openspec/changes/chat-element-library/design.md
@@ -1,0 +1,102 @@
+# Design — chat-element-library
+
+## Context
+
+assistant-ui Elements is a React + Tailwind registry distributed shadcn-style. There is no mechanical port path to Flutter: no shared runtime, no Tailwind, no registry convention. What transfers is the **vocabulary** (which pieces an assistant conversation is made of) and the **gallery model** (every element demoable in isolation, in every state).
+
+This change adopts both for the display half of the vocabulary — shell, thinking, streaming, display. It deliberately excludes the composer and everything that requires a client→server return channel.
+
+## How assistant-ui composes, and the Flutter translation
+
+assistant-ui's primitives are React compound components: `<ThreadPrimitive.Root>` provides context, descendants consume it. Flutter offers three translations, and the choice determines whether this ends up a design system or a folder.
+
+|       | Approach                                                                                                                                                                                                  | Verdict                             |
+| ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| **A** | **Constructor slots** — `TimelineEntryShell(entry: …, body: …)`. Explicit, no magic, golden-testable with no wrapper, deps visible in the signature. Verbose at depth.                                    | **Default for everything.**         |
+| **B** | **Inherited scope** — `ThreadDensityScope.of(context)`. Closest to React context, ergonomic at depth. Implicit deps; goldens need a wrapper.                                                              | **Density only.**                   |
+| **C** | **Riverpod inside elements** — `ref.watch(chatProvider)` in the element. Ergonomic, but couples elements to app state, breaks the gallery, and forces `ProviderScope` + overrides into every widget test. | **Banned by the package boundary.** |
+
+**Decision: A everywhere, B for density alone, C nowhere.**
+
+The evidence that A is right is that it already works: `StreamingTimelineEntry(message, density, entryState)` is a pure constructor-slot element with zero context reads. The extraction formalises what the code already does rather than imposing a new pattern.
+
+Density earns B because every element at every nesting level needs it and nothing else does — threading one value through five levels is the exact case an `InheritedWidget` exists for. `EntryState` stays a constructor param: it is per-entry, not ambient.
+
+## The package boundary is the mechanism
+
+```
+app/packages/assistant_ui/pubspec.yaml
+  dependencies:
+    flutter: sdk        ← and effectively nothing else
+    # NOT flutter_riverpod
+    # NOT assistant_api
+```
+
+Discipline alone has already failed once — `TurnProgressCard` reaches for `ref` three times. A package that cannot resolve `package:flutter_riverpod` turns "elements must be pure" from a review comment into a compile error. This is the whole reason to pay the monorepo-package ceremony rather than using `lib/features/chat/elements/`.
+
+The rule is not merely "no state management" — it is **no I/O**. The package renders and holds local widget state; anything that touches a device, a file system or a socket stays in the app. That draws a clean line through three existing dependencies:
+
+| Dependency                    | Side        | Why                                                                          |
+| ----------------------------- | ----------- | ---------------------------------------------------------------------------- |
+| `flutter_smooth_markdown`     | **package** | Pure rendering. `MessageBody`/`ThinkingBody` need it for streaming markdown. |
+| `record`                      | app         | Microphone I/O.                                                              |
+| `file_picker`, `desktop_drop` | app         | File-system and platform-channel I/O.                                        |
+
+## Composer
+
+`_InputRow` is the best-shaped widget in `features/chat` already: 13 constructor parameters, every interaction a callback (`onSend`, `onStop`, `onVoiceRecorded`, `onPickImage`, `onRemoveAttachment`, `onPasteImage`), zero `ref` reads. It becomes `Composer` essentially unchanged. `SlashCommandMenu` follows from `command_autocomplete.dart` with the command list supplied by the app.
+
+Voice is the one that has to be cut in half. `VoiceRecorderButton` is a `ConsumerStatefulWidget` that imports `record` — it both renders the mic affordance and drives the recorder. The package takes `ComposerVoiceButton`: mic icon, recording countdown, stop affordance, driven by an `isRecording` parameter and emitting `onStart`/`onStop`. The app keeps the recorder and feeds it. This is the general shape for any element that currently mixes presentation with a plugin.
+
+Two composer elements are declined for want of data rather than want of design:
+
+- **Mentions** — `grep -rn "mention"` over `app/lib` and `crates/web-ui` returns nothing. There is no mentionable-entity concept to render.
+- **Context / token ring** — token counts exist only as analytics aggregates (`token_usage_over_time`, `total_tokens_in/out`). Nothing reports live per-conversation usage, so the ring would have no value to display. It is listed as deferred behind P1 in `elements.md`, not declined outright.
+
+## The element index
+
+`elements.md` records a verdict for all 59 assistant-ui elements: Adopt, Adopt (have), Defer behind a named prerequisite, or Decline with a reason. It moves to `app/packages/assistant_ui/ELEMENTS.md` on PR 1 and is maintained there.
+
+It exists because the failure mode of adopting a catalogue is drift in both directions — quietly building something previously declined, or forgetting that a Defer became unblocked. Recording the _prerequisite_ rather than a bare "no" is what makes the second recoverable: the seven P1 elements become nearly free the day `ToolOutput.data` reaches the wire, and the index is what says so.
+
+## Shell / body split
+
+Today one 669-line `State` class owns density, expand, `_userPinned`, the auto-collapse timer, reduced-motion handling, `EntryState`, **and** the rendering for all five entry kinds. `ChatTimelineSection` (302 LOC) independently reimplements the collapse half. Adding an element means growing one of those two files.
+
+```
+TimelineEntryShell  (stateful — the ONLY stateful element)
+  density · expanded · userPinned · autoCollapseTimer · stale · header row
+        │
+        └── body: Widget   ← slot
+                 │
+    MessageBody · ThinkingBody · ToolCallBody · SubagentBody · CommandBody
+    stateless · one golden test each · no timers, no MediaQuery
+```
+
+One state machine tested once; N bodies tested as pure functions of their input. This is also the seam that later admits tool-derived renderers (terminal block, code diff) and, later still, agent-composed blocks — both slot into `body` without touching the shell.
+
+## Moving the models
+
+`ChatMessage`, `ChatAttachment`, `ToolCallRecord`, `MessageStatus`, `ToolCallStatus` and `TimelineEntryType` are pure data classes importing only `dart:async` and `dart:typed_data`. They move into the package as its public surface; `chat_provider.dart` imports them back.
+
+**Decision: move `ChatMessage` as-is. Do not convert it to a sealed hierarchy in this change.**
+
+It is a union-by-nullable-fields — `thinkingContent`, `subagentId`, `subagentTask`, `commandName` are each null unless `timelineType` matches. A sealed hierarchy is the better model, but:
+
+- `ChatNotifier` mutates `content`, `isStreaming`, `isStale`, `status` and `subagentContent` **in place** during streaming, deliberately, for rendering throughput. Sealing implies immutability, which implies rewriting the streaming path.
+- The blast radius is the whole 2306-line provider, which this change otherwise does not touch.
+- The shell/body split delivers most of the benefit at the widget layer regardless: each body reads only the fields for its own kind, so the nullable-union stops leaking into rendering even while it persists in the model.
+
+Sealing is a legitimate follow-up once the widget layer is stable. Recording it here so it is a decision, not an oversight.
+
+## Widgetbook
+
+`app/widgetbook/` is a separate Flutter app depending on `assistant_ui` only. Without it this change is code motion; with it, the twelve states of a timeline entry (`active`/`complete`/`stale` × `compact`/`normal`/`expanded`) become directly inspectable instead of reachable only by luck against a live stream.
+
+It is excluded from `flutter build web` for the embedded SPA — it is a development surface, not a shipped one.
+
+## Risks
+
+- **Test churn.** Existing chat widget tests import from `features/chat`. They move with the widgets in the same task so coverage never regresses (per the project's tasks rules).
+- **Golden-test flake across platforms.** Goldens are notoriously host-sensitive. Mitigation: goldens run on CI's Linux runner only, consistent with the existing Playwright tolerance approach in `.claude/skills/e2e-testing`.
+- **Baseline movement.** `ReasoningPanel` and the scroll-anchor pill are genuinely new UI. Playwright baselines are updated as an explicit task, not as a surprise diff.

--- a/openspec/changes/chat-element-library/elements.md
+++ b/openspec/changes/chat-element-library/elements.md
@@ -18,7 +18,8 @@ changing its verdict here first.
 | **Defer**        | Wanted, blocked on a named prerequisite.                                   |
 | **Decline**      | Not wanted. Reason given.                                                  |
 
-Three prerequisites are referenced repeatedly:
+Five prerequisites are referenced repeatedly. Each names a specific missing
+capability, so a Defer says _what would unblock it_ rather than merely "no":
 
 - **P1 — tool structured data.** `ToolOutput.data` exists on every tool but is
   dropped at `OrchestratorEvent::ToolResult`, which carries only a truncated
@@ -32,18 +33,28 @@ Three prerequisites are referenced repeatedly:
 - **P3 — agent-composed block vocabulary.** A closed, versioned set of semantic
   blocks a tool can return, degrading to text for the CLI/Slack/Matrix/Signal
   interfaces. Depends on P1 and P2.
+- **P4 — live per-conversation token usage.** Token counts exist only as
+  analytics aggregates (`token_usage_over_time`, `total_tokens_in/out`). No
+  stream event reports usage for the conversation in flight, so nothing can
+  render a fill level or a proximity-to-limit warning.
+- **P5 — reasoning step boundaries.** The runtime emits `Thinking(String)` as an
+  undifferentiated token stream, and `ChatMessage.thinkingContent` is a flat
+  `String?`. There is no step delimiter and no per-step clock, so a reasoning
+  _timeline_ cannot be rendered without inventing boundaries. Unblocking means
+  either delimited steps on the wire or a `ReasoningStep` model with defined
+  boundary and timing semantics.
 
 ---
 
 ## Reasoning (5)
 
-| #   | Element            | Verdict      | Flutter element    | Note                                                                                    |
-| --- | ------------------ | ------------ | ------------------ | --------------------------------------------------------------------------------------- |
-| 1   | Loading state      | Adopt (have) | `TurnProgressCard` | Drops its 3 `ref` reads.                                                                |
-| 2   | Thinking indicator | Adopt (have) | `TurnStatusLabel`  |                                                                                         |
-| 3   | Reasoning panel    | **Adopt**    | `ReasoningPanel`   | New. Today's thinking render is a flat blob; this is a step sequence with elapsed time. |
-| 4   | Streaming text     | Adopt (have) | `MessageBody`      | Via `flutter_smooth_markdown`.                                                          |
-| 5   | Typing indicator   | Adopt (have) | `TypingIndicator`  | Extracted from `_Dot` in `chat_screen.dart`.                                            |
+| #   | Element            | Verdict            | Flutter element    | Note                                                                                                                                                                                                                                                        |
+| --- | ------------------ | ------------------ | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Loading state      | Adopt (have)       | `TurnProgressCard` | Drops its 3 `ref` reads.                                                                                                                                                                                                                                    |
+| 2   | Thinking indicator | Adopt (have)       | `TurnStatusLabel`  |                                                                                                                                                                                                                                                             |
+| 3   | Reasoning panel    | **Adopt (scoped)** | `ReasoningPanel`   | New, but **not** the step timeline: `thinkingContent` is a flat `String?` and the runtime emits undifferentiated `Thinking(String)`. Adopted as a collapsible reasoning section with _total_ elapsed time. The per-step timeline is deferred behind **P5**. |
+| 4   | Streaming text     | Adopt (have)       | `MessageBody`      | Via `flutter_smooth_markdown`.                                                                                                                                                                                                                              |
+| 5   | Typing indicator   | Adopt (have)       | `TypingIndicator`  | Extracted from `_Dot` in `chat_screen.dart`.                                                                                                                                                                                                                |
 
 ## Messages (5)
 
@@ -93,15 +104,15 @@ Three prerequisites are referenced repeatedly:
 
 ## Composer (7)
 
-| #   | Element              | Verdict        | Flutter element       | Note                                                                                                                     |
-| --- | -------------------- | -------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| 27  | Composer             | Adopt (have)   | `Composer`            | From `_InputRow` — already 13 constructor params, all callbacks out, zero `ref`.                                         |
-| 28  | Slash commands       | Adopt (have)   | `SlashCommandMenu`    | From `command_autocomplete.dart`. Command list supplied by the app.                                                      |
-| 29  | Mentions             | **Decline**    | —                     | No mentionable-entity concept: `grep -rn "mention"` over `app/lib` and `crates/web-ui` returns nothing.                  |
-| 30  | Attachments          | Adopt (have)   | `AttachmentTray`      | Presentation only — `file_picker` / `desktop_drop` I/O stays in the app.                                                 |
-| 31  | Model picker         | **Decline**    | —                     | Persona switching already exists in the nav bar. Moving it into the composer is a UX change, not an extraction.          |
-| 32  | Voice                | Adopt (have)   | `ComposerVoiceButton` | Presentation split from I/O: mic affordance, countdown and stop live in the package; `record` stays in the app.          |
-| 33  | Context (token ring) | **Defer — P1** | —                     | Token counts exist only as analytics aggregates (`token_usage_over_time`). No per-conversation live usage in the stream. |
+| #   | Element              | Verdict        | Flutter element       | Note                                                                                                                                                         |
+| --- | -------------------- | -------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 27  | Composer             | Adopt (have)   | `Composer`            | From `_InputRow` — already 13 constructor params, all callbacks out, zero `ref`.                                                                             |
+| 28  | Slash commands       | Adopt (have)   | `SlashCommandMenu`    | From `command_autocomplete.dart`. Command list supplied by the app.                                                                                          |
+| 29  | Mentions             | **Decline**    | —                     | No mentionable-entity concept: `grep -rn "mention"` over `app/lib` and `crates/web-ui` returns nothing.                                                      |
+| 30  | Attachments          | Adopt (have)   | `AttachmentTray`      | Presentation only — `file_picker` / `desktop_drop` I/O stays in the app.                                                                                     |
+| 31  | Model picker         | **Decline**    | —                     | Persona switching already exists in the nav bar. Moving it into the composer is a UX change, not an extraction.                                              |
+| 32  | Voice                | Adopt (have)   | `ComposerVoiceButton` | Presentation split from I/O: mic affordance, countdown and stop live in the package; `record` stays in the app.                                              |
+| 33  | Context (token ring) | **Defer — P4** | —                     | Not tool output data: this needs live per-conversation usage on the stream. Today token counts exist only as analytics aggregates (`token_usage_over_time`). |
 
 ## Thread (4)
 
@@ -131,8 +142,16 @@ dialog · task creation · software purchase
 |                                        | Count  |
 | -------------------------------------- | ------ |
 | Adopt (new)                            | 3      |
-| Adopt (have — packaged by this change) | 15     |
-| Defer — P1 (tool structured data)      | 7      |
-| Defer — P2 (return channel)            | 2      |
-| Decline                                | 32     |
+| Adopt (have — packaged by this change) | 18     |
+| Defer — P1 (tool structured data)      | 6      |
+| Defer — P2 / P2+P3 (return channel)    | 2      |
+| Defer — P4 (live token usage)          | 1      |
+| Decline                                | 29     |
 | **Total**                              | **59** |
+
+Of the 3 new adoptions, one (`ReasoningPanel`) is scoped: the collapsible
+section ships, the per-step timeline is held behind **P5**. Decline covers 7
+individual elements plus the 22-element generative category.
+
+This table is derived from the rows above and must be recomputed whenever a
+verdict changes — task 13.2 reconciles it before the change is archived.

--- a/openspec/changes/chat-element-library/elements.md
+++ b/openspec/changes/chat-element-library/elements.md
@@ -1,0 +1,138 @@
+# Element Index
+
+Every element in the [assistant-ui Elements](https://www.assistant-ui.com/elements)
+catalogue (59), with an explicit verdict. This file is the living record of what
+the `assistant_ui` package adopts and what it deliberately does not.
+
+**On PR 1 this file moves to `app/packages/assistant_ui/ELEMENTS.md`** and is
+maintained there. Adding an element to the package without adding its row is a
+review failure; so is adopting something previously marked Decline without
+changing its verdict here first.
+
+## Verdicts
+
+| Verdict          | Meaning                                                                    |
+| ---------------- | -------------------------------------------------------------------------- |
+| **Adopt**        | In scope for `chat-element-library`.                                       |
+| **Adopt (have)** | Already implemented in `features/chat`; this change packages and names it. |
+| **Defer**        | Wanted, blocked on a named prerequisite.                                   |
+| **Decline**      | Not wanted. Reason given.                                                  |
+
+Three prerequisites are referenced repeatedly:
+
+- **P1 — tool structured data.** `ToolOutput.data` exists on every tool but is
+  dropped at `OrchestratorEvent::ToolResult`, which carries only a truncated
+  `result: Option<String>`. Six builtins (`bash`, `process`, `web_search`,
+  `file_glob`, `agent_spawn`, `voice_response`) already populate shapes that map
+  directly onto elements below.
+- **P2 — client→server return channel.** `ConfirmationCallback::confirm() -> bool`
+  is synchronous and a turn cannot suspend. `crates/web-ui/src/lib.rs:530`
+  hardwires `AutoDenyConfirmation`, so every gated tool is silently denied for
+  every web user. This is a live defect, tracked separately.
+- **P3 — agent-composed block vocabulary.** A closed, versioned set of semantic
+  blocks a tool can return, degrading to text for the CLI/Slack/Matrix/Signal
+  interfaces. Depends on P1 and P2.
+
+---
+
+## Reasoning (5)
+
+| #   | Element            | Verdict      | Flutter element    | Note                                                                                    |
+| --- | ------------------ | ------------ | ------------------ | --------------------------------------------------------------------------------------- |
+| 1   | Loading state      | Adopt (have) | `TurnProgressCard` | Drops its 3 `ref` reads.                                                                |
+| 2   | Thinking indicator | Adopt (have) | `TurnStatusLabel`  |                                                                                         |
+| 3   | Reasoning panel    | **Adopt**    | `ReasoningPanel`   | New. Today's thinking render is a flat blob; this is a step sequence with elapsed time. |
+| 4   | Streaming text     | Adopt (have) | `MessageBody`      | Via `flutter_smooth_markdown`.                                                          |
+| 5   | Typing indicator   | Adopt (have) | `TypingIndicator`  | Extracted from `_Dot` in `chat_screen.dart`.                                            |
+
+## Messages (5)
+
+| #   | Element               | Verdict      | Flutter element     | Note                                                                                             |
+| --- | --------------------- | ------------ | ------------------- | ------------------------------------------------------------------------------------------------ |
+| 6   | Message pair          | Adopt (have) | `MessageBody`       | Extracted from `_MessageBubble`.                                                                 |
+| 7   | Message branches      | **Decline**  | —                   | No branch/regeneration concept server-side. Would need a conversation-tree model, not a widget.  |
+| 8   | Message actions       | Adopt (have) | `MessageActions`    | From `_MetaActionRow`. Copy + read-aloud only; rate and regenerate have no endpoint.             |
+| 9   | Follow-up suggestions | **Decline**  | —                   | Nothing produces suggestions. Would need either P3 or a client heuristic; neither is wanted now. |
+| 10  | Error state           | **Adopt**    | `ThreadErrorBanner` | Non-modal banner with retry over the existing send path.                                         |
+
+## Tool use (4)
+
+| #   | Element        | Verdict        | Flutter element                 | Note                                                                                          |
+| --- | -------------- | -------------- | ------------------------------- | --------------------------------------------------------------------------------------------- |
+| 11  | Tool call      | Adopt (have)   | `ToolCallChip` + `ToolCallBody` | The generic fallback renderer.                                                                |
+| 12  | Tool timeline  | Adopt (have)   | `TimelineEntryShell`            | Session view is the shell over a list.                                                        |
+| 13  | Terminal block | **Defer — P1** | —                               | `bash` already emits `{exit_code, stdout, stderr}`. Renderer is trivial once the field ships. |
+| 14  | Code diff      | **Defer — P1** | —                               | Also needs `file_edit` to populate `.data`, which it currently does not.                      |
+
+## Knowledge (4)
+
+| #   | Element          | Verdict        | Flutter element        | Note                                                                   |
+| --- | ---------------- | -------------- | ---------------------- | ---------------------------------------------------------------------- |
+| 15  | Web search       | **Defer — P1** | —                      | `web_search` already emits `{results: [{title, url, snippet}]}`.       |
+| 16  | Sources          | **Defer — P1** | —                      | Same payload as #15; also needs `web_fetch` to populate `.data`.       |
+| 17  | Inline citation  | **Defer — P1** | —                      | Additionally needs the model to emit citation markers in message text. |
+| 18  | Image generation | Adopt (have)   | `AttachmentThumbnails` | Attachments already stream and render.                                 |
+
+## Structured output (2)
+
+| #   | Element       | Verdict        | Flutter element | Note                                                                                      |
+| --- | ------------- | -------------- | --------------- | ----------------------------------------------------------------------------------------- |
+| 19  | Data table    | **Defer — P1** | —               | Needs a generic `{columns, rows}` shape; no builtin emits one yet.                        |
+| 20  | Number ticker | **Decline**    | —               | Animation flourish with no data to animate. Revisit only if a metric lands in the stream. |
+
+## Agents (6)
+
+| #   | Element             | Verdict           | Flutter element    | Note                                                                                                              |
+| --- | ------------------- | ----------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| 21  | Agent plan          | **Decline**       | —                  | Read-only variant needs P1; interactive checkboxes need P2. No plan concept exists in the runtime.                |
+| 22  | Subagent list       | Adopt (have)      | `SubagentBody`     | `SubagentStarted`/`SubagentCompleted` events already stream.                                                      |
+| 23  | Agent status        | Adopt (have)      | `TurnProgressCard` |                                                                                                                   |
+| 24  | Approval card       | **Defer — P2**    | —                  | ⚠ The server already gates on `requires_confirmation`; the web client cannot answer. Highest-value deferred item. |
+| 25  | Recommendation card | **Defer — P2/P3** | —                  | Accept/reject is a return channel.                                                                                |
+| 26  | Artifact card       | **Decline**       | —                  | No versioned-artifact concept in the runtime. Product decision, not a UI one.                                     |
+
+## Composer (7)
+
+| #   | Element              | Verdict        | Flutter element       | Note                                                                                                                     |
+| --- | -------------------- | -------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| 27  | Composer             | Adopt (have)   | `Composer`            | From `_InputRow` — already 13 constructor params, all callbacks out, zero `ref`.                                         |
+| 28  | Slash commands       | Adopt (have)   | `SlashCommandMenu`    | From `command_autocomplete.dart`. Command list supplied by the app.                                                      |
+| 29  | Mentions             | **Decline**    | —                     | No mentionable-entity concept: `grep -rn "mention"` over `app/lib` and `crates/web-ui` returns nothing.                  |
+| 30  | Attachments          | Adopt (have)   | `AttachmentTray`      | Presentation only — `file_picker` / `desktop_drop` I/O stays in the app.                                                 |
+| 31  | Model picker         | **Decline**    | —                     | Persona switching already exists in the nav bar. Moving it into the composer is a UX change, not an extraction.          |
+| 32  | Voice                | Adopt (have)   | `ComposerVoiceButton` | Presentation split from I/O: mic affordance, countdown and stop live in the package; `record` stays in the app.          |
+| 33  | Context (token ring) | **Defer — P1** | —                     | Token counts exist only as analytics aggregates (`token_usage_over_time`). No per-conversation live usage in the stream. |
+
+## Thread (4)
+
+| #   | Element       | Verdict      | Flutter element      | Note                                                                          |
+| --- | ------------- | ------------ | -------------------- | ----------------------------------------------------------------------------- |
+| 34  | Chat panel    | Adopt (have) | `ConversationThread` |                                                                               |
+| 35  | Empty state   | Adopt (have) | `ThreadEmptyState`   | From `_EmptyChat`.                                                            |
+| 36  | Thread list   | Adopt (have) | `ConversationList`   | Drops its 5 `ref` reads; the app supplies the list.                           |
+| 37  | Scroll anchor | **Adopt**    | `ThreadViewport`     | New. Today's `_atBottom` logic has no recovery affordance when scrolled away. |
+
+## Generative (22)
+
+Stay card · table reservation · order tracking · flight tracker · portfolio
+overview · event creation · event viewing · weather · ride status · email
+composer · shopping cart · playlist · channel message · purchase receipt · area
+chart · line chart · bar chart · player card · conference session · confirmation
+dialog · task creation · software purchase
+
+| Verdict              | Note                                                                                                                                                                                                                                                                                                                                            |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Decline (all 22)** | These are demonstrations of _generative UI_, not chat chrome: the agent composes a bespoke surface per response. That is P3, and P3 depends on P1 and P2. Adopting any one of them as a hand-built widget would encode a domain this product does not have. Revisit as a category once a block vocabulary exists — never as individual widgets. |
+
+---
+
+## Tally
+
+|                                        | Count  |
+| -------------------------------------- | ------ |
+| Adopt (new)                            | 3      |
+| Adopt (have — packaged by this change) | 15     |
+| Defer — P1 (tool structured data)      | 7      |
+| Defer — P2 (return channel)            | 2      |
+| Decline                                | 32     |
+| **Total**                              | **59** |

--- a/openspec/changes/chat-element-library/proposal.md
+++ b/openspec/changes/chat-element-library/proposal.md
@@ -8,11 +8,11 @@ The widgets that render an agentic turn are already mostly pure — `streaming_t
 
 ## What Changes
 
-- New package `app/packages/assistant_ui/`, depending on `flutter` only — **not** `flutter_riverpod`, **not** `assistant_api`. The compiler enforces element purity; `TurnProgressCard`'s 3 `ref.watch` calls are the existing leak this closes.
+- New package `app/packages/assistant_ui/` on a closed allowlist: `flutter` and `flutter_smooth_markdown`, nothing else. No state management (`flutter_riverpod`), no API client (`assistant_api`), and no I/O (`record`, `file_picker`, `desktop_drop`, `dart:io`). The compiler enforces element purity; `TurnProgressCard` — today a `ConsumerStatefulWidget` with no constructor parameters at all — is the existing leak this closes.
 - Split `StreamingTimelineEntry` into `TimelineEntryShell` (density, expand/pin, auto-collapse, stale) plus stateless bodies (`MessageBody`, `ThinkingBody`, `ToolCallBody`, `SubagentBody`, `CommandBody`). `ChatTimelineSection` duplicates that same state machine today and collapses into the shell.
 - Move the render-facing models (`ChatMessage`, `ChatAttachment`, `ToolCallRecord`, `MessageStatus`, `ToolCallStatus`, `TimelineEntryType`) into the package. They are already pure data classes.
 - `TimelineDensity` becomes an inherited `ThreadDensityScope` instead of a param threaded through every level.
-- New elements: `ReasoningPanel` — a collapsible timeline of reasoning steps with elapsed time, replacing today's flat thinking blob; `ThreadViewport` — scroll anchoring with a "jump to latest" recovery pill for when the user has scrolled away mid-stream.
+- New elements: `ReasoningPanel` — a collapsible reasoning section showing total elapsed time. **Scoped deliberately**: the runtime emits `Thinking(String)` as an undifferentiated stream and `thinkingContent` is a flat `String?`, so a per-step timeline has no data behind it and is deferred behind P5 in `elements.md` rather than faked from token arrival. `ThreadViewport` — scroll anchoring with a "jump to latest" recovery pill for when the user has scrolled away mid-stream.
 - The composer moves too: `_InputRow` is already the cleanest element in the codebase — 13 constructor parameters, every interaction a callback, zero `ref` reads — and becomes `Composer`, with `SlashCommandMenu`, `AttachmentTray` and `ComposerVoiceButton` alongside it.
 - New `app/widgetbook/` app: every element × every state (`active`/`complete`/`stale` × `compact`/`normal`/`expanded`), runnable via `flutter run -d chrome`.
 - `ChatScreen` keeps every `ref.watch` and becomes a thin adapter over the package.

--- a/openspec/changes/chat-element-library/proposal.md
+++ b/openspec/changes/chat-element-library/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+The chat surface lives in two god files: `chat_screen.dart` (2225 LOC) and `chat_provider.dart` (2306 LOC). This violates the project convention "avoid screen widgets longer than ~300 lines."
+
+The widgets that render an agentic turn are already mostly pure — `streaming_timeline_entry.dart` (669 LOC), `timeline_section.dart` (302 LOC), `tool_call_chip.dart` (177 LOC) and `turn_status_label.dart` (51 LOC) contain **zero** Riverpod references, and `StreamingTimelineEntry` already takes `(message, density, entryState)` as plain constructor params. What they lack is naming, a package boundary, and a gallery. Today the only way to see a thinking indicator in its `stale × compact` state is to get lucky with a live stream.
+
+[assistant-ui Elements](https://www.assistant-ui.com/elements) defines the conventional vocabulary for how an assistant conversation looks — shell, thinking, streaming, display. Adopting that vocabulary as a Flutter package with a live gallery turns a folder into a design system and makes every element golden-testable without a server, a provider stub, or a live stream.
+
+## What Changes
+
+- New package `app/packages/assistant_ui/`, depending on `flutter` only — **not** `flutter_riverpod`, **not** `assistant_api`. The compiler enforces element purity; `TurnProgressCard`'s 3 `ref.watch` calls are the existing leak this closes.
+- Split `StreamingTimelineEntry` into `TimelineEntryShell` (density, expand/pin, auto-collapse, stale) plus stateless bodies (`MessageBody`, `ThinkingBody`, `ToolCallBody`, `SubagentBody`, `CommandBody`). `ChatTimelineSection` duplicates that same state machine today and collapses into the shell.
+- Move the render-facing models (`ChatMessage`, `ChatAttachment`, `ToolCallRecord`, `MessageStatus`, `ToolCallStatus`, `TimelineEntryType`) into the package. They are already pure data classes.
+- `TimelineDensity` becomes an inherited `ThreadDensityScope` instead of a param threaded through every level.
+- New elements: `ReasoningPanel` — a collapsible timeline of reasoning steps with elapsed time, replacing today's flat thinking blob; `ThreadViewport` — scroll anchoring with a "jump to latest" recovery pill for when the user has scrolled away mid-stream.
+- The composer moves too: `_InputRow` is already the cleanest element in the codebase — 13 constructor parameters, every interaction a callback, zero `ref` reads — and becomes `Composer`, with `SlashCommandMenu`, `AttachmentTray` and `ComposerVoiceButton` alongside it.
+- New `app/widgetbook/` app: every element × every state (`active`/`complete`/`stale` × `compact`/`normal`/`expanded`), runnable via `flutter run -d chrome`.
+- `ChatScreen` keeps every `ref.watch` and becomes a thin adapter over the package.
+- `ELEMENTS.md` in the package: a standing index of all 59 assistant-ui elements with an explicit Adopt / Defer / Decline verdict and reason for each. Drafted in this change as `elements.md`, moved into the package on PR 1, and maintained from then on — adding an element without adding its row is a review failure.
+
+## Capabilities
+
+### New Capabilities
+
+- `chat-element-library`: the packaged, state-management-free element vocabulary for rendering an assistant conversation — shell, thinking, streaming, and display — plus the gallery that exercises it.
+
+## Impact
+
+- **Code touched**: new `app/packages/assistant_ui/` and `app/widgetbook/`; `app/lib/features/chat/` shrinks substantially; chat test imports move.
+- **Visual change**: intentional and near-zero for existing elements, but `ReasoningPanel` and the scroll-anchor pill are new UI. **Playwright screenshot baselines will move** and must be updated in this change.
+- **Non-goals** (full reasoning per element in `elements.md`):
+  - Mentions and the context/token ring. Neither has a data source: `grep -rn "mention"` over `app/lib` and `crates/web-ui` returns nothing, and token counts exist only as analytics aggregates, never per-conversation in the stream.
+  - Moving the model/persona picker into the composer — that is a UX change, not an extraction.
+  - I/O inside the package. `record`, `file_picker` and `desktop_drop` stay in the app; the package renders the affordances and emits callbacks.
+  - Tool-derived renderers (terminal block, code diff, sources). `ToolOutput.data` is discarded at `OrchestratorEvent::ToolResult` — separate change.
+  - Approval cards and any client→server return channel. `crates/web-ui/src/lib.rs:530` hardwires `AutoDenyConfirmation` — separate defect, unblocked by this work.
+  - Converting `ChatMessage` to a sealed hierarchy (see design.md).
+  - Generative UI / block vocabulary.
+- **User-facing documentation needed**: No. Add `app/packages/assistant_ui/README.md` for contributors.

--- a/openspec/changes/chat-element-library/specs/chat-element-library/spec.md
+++ b/openspec/changes/chat-element-library/specs/chat-element-library/spec.md
@@ -1,13 +1,18 @@
 ## ADDED Requirements
 
-### Requirement: Element package carries no state-management dependency
+### Requirement: Element package is pure — no state management, no I/O
 
-The `assistant_ui` package SHALL declare no dependency on `flutter_riverpod` or `assistant_api`. Every widget it exports SHALL receive its data through constructor parameters or an inherited scope defined within the package, and SHALL emit user intent through callbacks. No exported widget may read application providers.
+The `assistant_ui` package SHALL depend only on `flutter` and `flutter_smooth_markdown`. It SHALL NOT depend on or import state management (`flutter_riverpod`), the API client (`assistant_api`), or any I/O facility (`dart:io`, `record`, `file_picker`, `desktop_drop`). Every widget it exports SHALL receive its data through constructor parameters or an inherited scope defined within the package, and SHALL emit user intent through callbacks. No exported widget may read application providers.
 
-#### Scenario: Package manifest excludes state management
+#### Scenario: Package manifest matches the closed allowlist
 
 - **WHEN** `app/packages/assistant_ui/pubspec.yaml` is inspected
-- **THEN** its `dependencies` SHALL NOT include `flutter_riverpod` or `assistant_api`
+- **THEN** its `dependencies` SHALL contain only `flutter` and `flutter_smooth_markdown`
+
+#### Scenario: Package source imports no I/O facility
+
+- **WHEN** every Dart source file under `app/packages/assistant_ui/lib/` is scanned for import directives
+- **THEN** none SHALL import `dart:io`, `package:record`, `package:file_picker`, `package:desktop_drop`, `package:flutter_riverpod`, or `package:assistant_api`
 
 #### Scenario: Elements render without a ProviderScope
 
@@ -64,27 +69,35 @@ The `assistant_ui` package SHALL declare no dependency on `flutter_riverpod` or 
 - **WHEN** the scope is rebuilt providing `TimelineDensity.expanded`
 - **THEN** descendant elements that depend on density SHALL rebuild
 
-### Requirement: Reasoning panel renders discrete steps with elapsed time
+### Requirement: Reasoning panel renders a collapsible section with total elapsed time
 
-`ReasoningPanel` SHALL render streamed reasoning as a collapsible sequence of discrete steps, each showing elapsed time, rather than as a single undifferentiated text blob.
+`ReasoningPanel` SHALL render streamed reasoning as a collapsible section showing the elapsed time of the reasoning block as a whole. It SHALL consume the existing flat `thinkingContent` / `thinkingTokenStream` inputs and SHALL NOT infer step boundaries from token arrival.
 
-#### Scenario: Multiple reasoning steps render separately
+A per-step reasoning timeline is explicitly out of scope: the runtime emits `Thinking(String)` as an undifferentiated stream with no delimiters and no per-step clock. That element is deferred behind prerequisite P5 in `ELEMENTS.md`.
 
-- **GIVEN** a reasoning entry containing more than one step
+#### Scenario: Reasoning content renders inside a collapsible section
+
+- **GIVEN** a reasoning entry with non-empty `thinkingContent`
 - **WHEN** `ReasoningPanel` renders it expanded
-- **THEN** each step SHALL be individually visible
+- **THEN** the reasoning text SHALL be visible AND collapsing the section SHALL hide it
 
-#### Scenario: Elapsed time is shown while reasoning is active
+#### Scenario: Total elapsed time is shown while reasoning is active
 
-- **GIVEN** a `ReasoningPanel` in `EntryState.active`
+- **GIVEN** a `ReasoningPanel` in `EntryState.active` with a start time
 - **WHEN** it renders
-- **THEN** it SHALL display an elapsed-time indication for the in-progress step
+- **THEN** it SHALL display the elapsed time for the reasoning block as a whole
 
 #### Scenario: Empty reasoning renders nothing
 
-- **GIVEN** a reasoning entry with no steps
+- **GIVEN** a reasoning entry whose `thinkingContent` is null or empty and whose token stream has produced nothing
 - **WHEN** `ReasoningPanel` renders it
 - **THEN** it SHALL render no visible panel
+
+#### Scenario: Step boundaries are not invented
+
+- **GIVEN** a reasoning entry whose content arrived as multiple token chunks
+- **WHEN** `ReasoningPanel` renders it
+- **THEN** it SHALL render one continuous reasoning body AND SHALL NOT render per-chunk step divisions
 
 ### Requirement: Thread viewport anchors scrolling and offers recovery
 
@@ -112,10 +125,17 @@ The `assistant_ui` package SHALL declare no dependency on `flutter_riverpod` or 
 
 The `app/widgetbook/` application SHALL provide a runnable entry for every widget exported by `assistant_ui`. For elements that vary by density and entry state, it SHALL expose the full `EntryState` × `TimelineDensity` matrix.
 
-#### Scenario: Every exported element has a gallery entry
+Because Dart cannot enumerate barrel exports at runtime, the package SHALL expose an explicit `kAssistantUiElements` registry naming every exported element. That registry SHALL be the single source of truth consumed by both the gallery-coverage check and the index-coverage check, so neither can be satisfied by hand-editing one side.
 
-- **WHEN** the exports of `assistant_ui` are compared against the gallery's registered entries
-- **THEN** every exported widget SHALL have at least one entry
+#### Scenario: Registry lists every exported element
+
+- **WHEN** `assistant_ui.dart`'s export directives are compared against `kAssistantUiElements`
+- **THEN** every exported widget SHALL appear in the registry
+
+#### Scenario: Every registered element has a gallery entry
+
+- **WHEN** `kAssistantUiElements` is compared against the gallery's registered use-cases
+- **THEN** every registry entry SHALL have at least one use-case
 
 #### Scenario: Timeline entries expose the full state matrix
 
@@ -192,6 +212,11 @@ The package SHALL carry `ELEMENTS.md` recording, for each of the 59 assistant-ui
 
 #### Scenario: Adopted elements are reflected in the index
 
-- **GIVEN** a widget exported from `assistant_ui`
-- **WHEN** the index is compared against the package exports
-- **THEN** the corresponding element SHALL carry an Adopt or Adopt (have) verdict
+- **GIVEN** an entry in the `kAssistantUiElements` registry
+- **WHEN** the index is compared against that registry
+- **THEN** the corresponding element SHALL carry an Adopt, Adopt (scoped), or Adopt (have) verdict
+
+#### Scenario: The tally matches the rows
+
+- **WHEN** the verdict rows are counted
+- **THEN** each count in the Tally table SHALL equal the number of rows carrying that verdict AND the total SHALL be 59

--- a/openspec/changes/chat-element-library/specs/chat-element-library/spec.md
+++ b/openspec/changes/chat-element-library/specs/chat-element-library/spec.md
@@ -1,0 +1,197 @@
+## ADDED Requirements
+
+### Requirement: Element package carries no state-management dependency
+
+The `assistant_ui` package SHALL declare no dependency on `flutter_riverpod` or `assistant_api`. Every widget it exports SHALL receive its data through constructor parameters or an inherited scope defined within the package, and SHALL emit user intent through callbacks. No exported widget may read application providers.
+
+#### Scenario: Package manifest excludes state management
+
+- **WHEN** `app/packages/assistant_ui/pubspec.yaml` is inspected
+- **THEN** its `dependencies` SHALL NOT include `flutter_riverpod` or `assistant_api`
+
+#### Scenario: Elements render without a ProviderScope
+
+- **GIVEN** a widget test that pumps any exported element with literal constructor arguments
+- **WHEN** the element is pumped without any `ProviderScope` ancestor
+- **THEN** it SHALL build and render without error
+
+#### Scenario: Turn progress card takes data by parameter
+
+- **GIVEN** `TurnProgressCard`, which today reads `chatProvider` via `ref`
+- **WHEN** it is exported from `assistant_ui`
+- **THEN** it SHALL accept its turn status as a constructor parameter AND contain no `ref` usage
+
+### Requirement: Timeline entry shell owns presentation state; bodies are stateless
+
+`TimelineEntryShell` SHALL be the single owner of per-entry presentation state: expansion, user pinning, auto-collapse timing, reduced-motion handling, and `EntryState` reaction. Entry bodies SHALL be stateless widgets that render only the fields belonging to their own `TimelineEntryType`.
+
+#### Scenario: Active entry auto-expands, complete entry auto-collapses
+
+- **GIVEN** a `TimelineEntryShell` at `TimelineDensity.normal` in `EntryState.active`
+- **WHEN** its state transitions to `EntryState.complete`
+- **THEN** the shell SHALL collapse after its auto-collapse delay
+
+#### Scenario: User pinning survives state transitions
+
+- **GIVEN** a `TimelineEntryShell` the user has manually expanded
+- **WHEN** its state transitions to `EntryState.complete` or `EntryState.stale`
+- **THEN** the shell SHALL remain expanded
+
+#### Scenario: Reduced motion collapses without delay
+
+- **GIVEN** `MediaQuery.disableAnimations` is true
+- **WHEN** an unpinned entry transitions from `active` to `complete`
+- **THEN** the shell SHALL collapse immediately rather than scheduling a timer
+
+#### Scenario: Bodies hold no presentation state
+
+- **WHEN** any entry body widget is inspected
+- **THEN** it SHALL be a `StatelessWidget` AND SHALL NOT reference expansion, pinning, timers, or `MediaQuery`
+
+### Requirement: Density is supplied by an inherited scope
+
+`TimelineDensity` SHALL be provided to elements by `ThreadDensityScope` rather than threaded as a constructor parameter through intermediate widgets. Elements SHALL resolve density from the nearest enclosing scope.
+
+#### Scenario: Density resolves from the scope
+
+- **GIVEN** a `ThreadDensityScope` providing `TimelineDensity.compact`
+- **WHEN** a descendant element that varies by density is built
+- **THEN** it SHALL render its compact presentation
+
+#### Scenario: Density change rebuilds dependents
+
+- **GIVEN** a mounted `ThreadDensityScope` providing `TimelineDensity.normal`
+- **WHEN** the scope is rebuilt providing `TimelineDensity.expanded`
+- **THEN** descendant elements that depend on density SHALL rebuild
+
+### Requirement: Reasoning panel renders discrete steps with elapsed time
+
+`ReasoningPanel` SHALL render streamed reasoning as a collapsible sequence of discrete steps, each showing elapsed time, rather than as a single undifferentiated text blob.
+
+#### Scenario: Multiple reasoning steps render separately
+
+- **GIVEN** a reasoning entry containing more than one step
+- **WHEN** `ReasoningPanel` renders it expanded
+- **THEN** each step SHALL be individually visible
+
+#### Scenario: Elapsed time is shown while reasoning is active
+
+- **GIVEN** a `ReasoningPanel` in `EntryState.active`
+- **WHEN** it renders
+- **THEN** it SHALL display an elapsed-time indication for the in-progress step
+
+#### Scenario: Empty reasoning renders nothing
+
+- **GIVEN** a reasoning entry with no steps
+- **WHEN** `ReasoningPanel` renders it
+- **THEN** it SHALL render no visible panel
+
+### Requirement: Thread viewport anchors scrolling and offers recovery
+
+`ThreadViewport` SHALL keep the newest content visible while the user is at the bottom of the thread, SHALL NOT move the viewport when the user has scrolled away, and SHALL surface a "jump to latest" affordance whenever the user is scrolled away while new content arrives.
+
+#### Scenario: At bottom, new content stays visible
+
+- **GIVEN** the viewport is scrolled to the bottom
+- **WHEN** new content is appended
+- **THEN** the viewport SHALL remain at the bottom
+
+#### Scenario: Scrolled away, the viewport does not jump
+
+- **GIVEN** the user has scrolled away from the bottom
+- **WHEN** new content is appended
+- **THEN** the scroll offset SHALL NOT change
+
+#### Scenario: Recovery pill appears and returns the user
+
+- **GIVEN** the user has scrolled away from the bottom AND new content has arrived
+- **WHEN** the viewport rebuilds
+- **THEN** a "jump to latest" affordance SHALL be visible AND activating it SHALL return the viewport to the bottom AND hide the affordance
+
+### Requirement: Gallery exercises every element in every state
+
+The `app/widgetbook/` application SHALL provide a runnable entry for every widget exported by `assistant_ui`. For elements that vary by density and entry state, it SHALL expose the full `EntryState` × `TimelineDensity` matrix.
+
+#### Scenario: Every exported element has a gallery entry
+
+- **WHEN** the exports of `assistant_ui` are compared against the gallery's registered entries
+- **THEN** every exported widget SHALL have at least one entry
+
+#### Scenario: Timeline entries expose the full state matrix
+
+- **WHEN** the gallery entry for a timeline entry element is opened
+- **THEN** each combination of `EntryState` (`active`, `complete`, `stale`) and `TimelineDensity` (`compact`, `normal`, `expanded`) SHALL be selectable
+
+#### Scenario: Gallery is excluded from the shipped web build
+
+- **WHEN** the embedded SPA is built for release
+- **THEN** the widgetbook application SHALL NOT be included in the output
+
+### Requirement: Chat screen is a thin adapter over the element package
+
+`ChatScreen` SHALL retain application wiring — provider reads, routing, navigation chrome and layout — and SHALL delegate rendering of the conversation surface to `assistant_ui` elements.
+
+#### Scenario: Screen keeps wiring, elements keep rendering
+
+- **WHEN** `chat_screen.dart` is inspected after the extraction
+- **THEN** conversation-surface rendering SHALL be delegated to exported elements rather than to private widgets declared in the screen file
+
+#### Scenario: Existing chat behaviour is preserved
+
+- **GIVEN** the chat widget test suite as it exists before this change
+- **WHEN** the suite is run against the extracted elements with imports updated
+- **THEN** all previously passing assertions SHALL still pass
+
+### Requirement: Composer emits intent by callback and performs no I/O
+
+`Composer` SHALL render the message input surface — text field, send and stop affordances, attachment tray, slash-command menu and voice affordance — receiving its state by constructor parameter and emitting every user intent as a callback. It SHALL NOT record audio, pick files, read the file system, or call any API.
+
+#### Scenario: Send emits a callback rather than dispatching
+
+- **GIVEN** a `Composer` with non-empty input text
+- **WHEN** the send affordance is activated
+- **THEN** its `onSend` callback SHALL fire AND no API call SHALL be made by the element
+
+#### Scenario: Voice affordance is presentation only
+
+- **GIVEN** `ComposerVoiceButton` rendered with `isRecording` false
+- **WHEN** the mic affordance is activated
+- **THEN** `onStart` SHALL fire AND the element SHALL NOT itself start a recorder
+
+#### Scenario: Recording state is driven by the caller
+
+- **GIVEN** `ComposerVoiceButton` rendered with `isRecording` true and an elapsed duration
+- **WHEN** it builds
+- **THEN** it SHALL display the recording countdown and a stop affordance
+
+#### Scenario: Attachment removal is delegated
+
+- **GIVEN** an `AttachmentTray` rendered with two pending attachments
+- **WHEN** the remove affordance on the first is activated
+- **THEN** `onRemove` SHALL fire with index 0 AND the tray SHALL NOT mutate the list itself
+
+#### Scenario: Slash-command menu filters a supplied list
+
+- **GIVEN** a `SlashCommandMenu` supplied with a list of commands
+- **WHEN** a filter string is applied
+- **THEN** only matching commands SHALL be shown AND selecting one SHALL fire `onSelected` without dispatching it
+
+### Requirement: The element index records a verdict for every catalogue element
+
+The package SHALL carry `ELEMENTS.md` recording, for each of the 59 assistant-ui catalogue elements, one of the verdicts Adopt, Adopt (have), Defer, or Decline. Every Defer SHALL name the prerequisite blocking it; every Decline SHALL give a reason.
+
+#### Scenario: Every catalogue element has a verdict
+
+- **WHEN** `ELEMENTS.md` is inspected
+- **THEN** all 59 catalogue elements SHALL appear with exactly one verdict each
+
+#### Scenario: Deferred elements name their blocker
+
+- **WHEN** an element carries the Defer verdict
+- **THEN** its row SHALL reference a named prerequisite
+
+#### Scenario: Adopted elements are reflected in the index
+
+- **GIVEN** a widget exported from `assistant_ui`
+- **WHEN** the index is compared against the package exports
+- **THEN** the corresponding element SHALL carry an Adopt or Adopt (have) verdict

--- a/openspec/changes/chat-element-library/tasks.md
+++ b/openspec/changes/chat-element-library/tasks.md
@@ -1,0 +1,113 @@
+# Tasks — chat-element-library
+
+Sequenced as four stacked PRs. Each PR is independently reviewable and leaves
+`main` shippable. PR boundaries are marked; phases within a PR are ≤ 2h chunks.
+
+---
+
+## PR 1 — package scaffold + models
+
+### 1. Package boundary (TDD red first)
+
+- [ ] 1.1 Add `app/test/unit/assistant_ui_boundary_test.dart`: read `app/packages/assistant_ui/pubspec.yaml` and assert its `dependencies` contain neither `flutter_riverpod` nor `assistant_api`. Run `flutter test` — confirm RED (the package does not exist).
+- [ ] 1.2 Scaffold `app/packages/assistant_ui/` with `pubspec.yaml` (deps: `flutter`, `flutter_smooth_markdown` only), `lib/assistant_ui.dart` barrel, and `lib/src/`. Add the path dependency to `app/pubspec.yaml`. Confirm 1.1 GREEN.
+- [ ] 1.3 Write `app/packages/assistant_ui/README.md`: the purity rule (no state management, **no I/O**), why the package boundary exists rather than a folder, and the constructor-slots-plus-density-scope composition rule from design.md.
+- [ ] 1.4 Move `openspec/changes/chat-element-library/elements.md` to `app/packages/assistant_ui/ELEMENTS.md`. Link it from the README as the standing index. From here on, every task that adopts an element also updates its row.
+
+### 2. Move render-facing models
+
+- [ ] 2.1 Move `ChatMessage`, `ChatAttachment`, `ToolCallRecord`, `MessageStatus`, `ToolCallStatus`, `TimelineEntryType` from `chat_provider.dart` into `assistant_ui/lib/src/models/`. Export from the barrel. Do **not** change their shape — no sealing, no immutability (design.md).
+- [ ] 2.2 Re-point `chat_provider.dart` and all existing importers at the package. Move the corresponding tests from `app/test/unit/chat/` into `app/packages/assistant_ui/test/` where they test only the models.
+- [ ] 2.3 `flutter analyze --fatal-infos` → 0 issues; `flutter test` → all previously passing tests still pass.
+- [ ] 2.4 PR: `refactor(app): extract assistant_ui package with render-facing models`.
+
+---
+
+## PR 2 — shell/body split + density scope
+
+### 3. Density scope (TDD red first)
+
+- [ ] 3.1 Add `app/packages/assistant_ui/test/thread_density_scope_test.dart`: assert a descendant resolves `compact` from an enclosing scope, and that rebuilding the scope with `expanded` rebuilds the descendant. Confirm RED.
+- [ ] 3.2 Implement `ThreadDensityScope` (`InheritedWidget`) with `TimelineDensity.fromWidth`. Confirm GREEN.
+
+### 4. Timeline entry shell (TDD red first)
+
+- [ ] 4.1 Add `app/packages/assistant_ui/test/timeline_entry_shell_test.dart` covering the four spec scenarios: active→complete auto-collapses; user-pinned survives complete and stale; `disableAnimations` collapses without a timer; tapping toggles and pins. Confirm RED.
+- [ ] 4.2 Implement `TimelineEntryShell` — expansion, `_userPinned`, auto-collapse timer, reduced motion, `EntryState`, header row, `body` slot. Lift this logic out of `StreamingTimelineEntry`; do not leave a copy behind. Confirm GREEN.
+
+### 5. Entry bodies
+
+- [ ] 5.1 Add golden tests for `MessageBody`, `ThinkingBody`, `ToolCallBody`, `SubagentBody`, `CommandBody` — one file per body under `app/packages/assistant_ui/test/bodies/`. Confirm RED.
+- [ ] 5.2 Extract each body as a `StatelessWidget` in its own file from `StreamingTimelineEntry`'s render branches. Each reads only the fields for its own `TimelineEntryType`. Confirm GREEN.
+- [ ] 5.3 Delete `ChatTimelineSection` — its collapse behaviour is now `TimelineEntryShell` and its rendering is now the bodies. Migrate its existing tests onto the shell/body pair. No compatibility shim.
+- [ ] 5.4 Move `ToolCallChip`, `TurnStatusLabel`, `AudioPlayerWidget`, `CommandEventTile`, `SvgBuilder` into the package with their existing tests. These are already Riverpod-free.
+
+### 6. Close the Riverpod leak
+
+- [ ] 6.1 Add a widget test pumping `TurnProgressCard` with literal arguments and **no** `ProviderScope`. Confirm RED.
+- [ ] 6.2 Convert `TurnProgressCard` to take turn status by constructor parameter; move it into the package; have `ChatScreen` supply the value via `ref.watch`. Confirm GREEN.
+- [ ] 6.3 `flutter analyze --fatal-infos` → 0; `flutter test` → green.
+- [ ] 6.4 PR: `refactor(app): split timeline entry shell from entry bodies`.
+
+---
+
+## PR 3 — new elements
+
+### 7. Reasoning panel (TDD red first)
+
+- [ ] 7.1 Add `app/packages/assistant_ui/test/reasoning_panel_test.dart` for the three spec scenarios: multiple steps render separately; elapsed time shows while active; empty reasoning renders nothing. Confirm RED.
+- [ ] 7.2 Implement `ReasoningPanel` as a step sequence with per-step elapsed time, replacing the flat thinking blob in `ThinkingBody`. Confirm GREEN.
+
+### 8. Thread viewport scroll anchor (TDD red first)
+
+- [ ] 8.1 Add `app/packages/assistant_ui/test/thread_viewport_test.dart` for the three spec scenarios: at-bottom stays pinned; scrolled-away offset does not change; recovery pill appears, returns to bottom, then hides. Confirm RED.
+- [ ] 8.2 Implement `ThreadViewport` owning `_atBottom` / scroll-to-bottom / recovery pill. Remove the equivalent logic and the `ref.listen(chatProvider)` scroll hook from `_ChatScreenState`. Confirm GREEN.
+- [ ] 8.3 Update the `ReasoningPanel` and `ThreadViewport` rows in `ELEMENTS.md` from Adopt to Adopt (have).
+- [ ] 8.4 PR: `feat(app): reasoning panel and thread scroll anchor`.
+
+---
+
+## PR 4 — composer
+
+### 9. Composer extraction (TDD red first)
+
+- [ ] 9.1 Add `app/packages/assistant_ui/test/composer_test.dart`: pump `Composer` with literal arguments and no `ProviderScope`; assert activating send fires `onSend` and that the element makes no API call. Confirm RED.
+- [ ] 9.2 Move `_InputRow` from `chat_screen.dart` into the package as `Composer`, unchanged in shape — it already takes 13 constructor parameters with every interaction as a callback. Move its existing tests. Confirm GREEN.
+- [ ] 9.3 Move `command_autocomplete.dart` into the package as `SlashCommandMenu`, with the command list supplied by the caller. Add a test that filtering narrows the list and that selection fires `onSelected` without dispatching.
+
+### 10. Attachment tray and voice split
+
+- [ ] 10.1 Add a widget test for `AttachmentTray`: two pending attachments, activating remove on the first fires `onRemove(0)` and the tray does not mutate the list. Confirm RED.
+- [ ] 10.2 Extract `AttachmentTray` from `_MessageBubble._attachmentThumbnails` and the composer's pending-attachment strip. `file_picker` / `desktop_drop` I/O stays in `ChatScreen`. Confirm GREEN.
+- [ ] 10.3 Add tests for `ComposerVoiceButton`: with `isRecording` false, activating fires `onStart` and starts no recorder; with `isRecording` true plus an elapsed duration, the countdown and stop affordance render. Confirm RED.
+- [ ] 10.4 Split `VoiceRecorderButton` in two — presentation (`ComposerVoiceButton`, in the package, driven by `isRecording`/`elapsed`, emitting `onStart`/`onStop`) and the `record`-backed driver (stays in `features/chat`, keeps its 2 `ref` reads). Confirm GREEN.
+- [ ] 10.5 Move `QueuedMessageBubble` into the package, dropping its 2 `ref` reads in favour of parameters.
+- [ ] 10.6 Update the seven Composer rows in `ELEMENTS.md`. Confirm the two Decline rows (mentions, model picker) and the one Defer row (context ring) still read accurately.
+- [ ] 10.7 `flutter analyze --fatal-infos` → 0; `flutter test` → green.
+- [ ] 10.8 PR: `refactor(app): extract composer elements into assistant_ui`.
+
+---
+
+## PR 5 — gallery, adapter, ship
+
+### 11. Widgetbook
+
+- [ ] 11.1 Scaffold `app/widgetbook/` as a Flutter app depending on `assistant_ui` only. Verify it is excluded from `flutter build web` for the embedded SPA.
+- [ ] 11.2 Register a use-case for every exported element, composer included. For timeline entries, expose the full `EntryState` × `TimelineDensity` matrix as knobs; for `ComposerVoiceButton`, expose `isRecording` and elapsed duration.
+- [ ] 11.3 Add a test asserting every `assistant_ui` export has at least one registered gallery entry, so the gallery cannot silently fall behind.
+- [ ] 11.4 Add a test asserting every `assistant_ui` export carries an Adopt or Adopt (have) row in `ELEMENTS.md`, so the index cannot silently fall behind either.
+
+### 12. Chat screen becomes an adapter
+
+- [ ] 12.1 Rewrite `chat_screen.dart` to keep chrome, layout, I/O (`record`, `file_picker`, `desktop_drop`) and every `ref.watch`, delegating both the conversation surface and the composer to package elements. Target under ~300 lines per the project convention.
+- [ ] 12.2 Run the pre-existing chat widget test suite with updated imports — every previously passing assertion must still pass.
+
+### 13. Baselines and ship
+
+- [ ] 13.1 Run the Playwright visual suite. `ReasoningPanel` and the scroll-anchor pill are intentional new UI — update the screenshot baselines and record the visual diff for the PR body (see `.claude/skills/e2e-testing`).
+- [ ] 13.2 Reconcile `ELEMENTS.md` end to end: 59 rows, one verdict each, every Defer naming its prerequisite, tally matching the rows.
+- [ ] 13.3 `make lint-flutter && make test-flutter` → green.
+- [ ] 13.4 `make lint && make format && make test` → green.
+- [ ] 13.5 Manual smoke: stream a turn with thinking, a tool call and a subagent; scroll away mid-stream and confirm the recovery pill; record a voice message; drag-drop an attachment; run a slash command. Confirm auto-collapse and pinning behave as before.
+- [ ] 13.6 PR: `feat(app): element gallery and chat screen adapter`.
+- [ ] 13.7 Archive: `openspec archive chat-element-library`.

--- a/openspec/changes/chat-element-library/tasks.md
+++ b/openspec/changes/chat-element-library/tasks.md
@@ -1,6 +1,6 @@
 # Tasks — chat-element-library
 
-Sequenced as four stacked PRs. Each PR is independently reviewable and leaves
+Sequenced as five stacked PRs. Each PR is independently reviewable and leaves
 `main` shippable. PR boundaries are marked; phases within a PR are ≤ 2h chunks.
 
 ---
@@ -9,8 +9,8 @@ Sequenced as four stacked PRs. Each PR is independently reviewable and leaves
 
 ### 1. Package boundary (TDD red first)
 
-- [ ] 1.1 Add `app/test/unit/assistant_ui_boundary_test.dart`: read `app/packages/assistant_ui/pubspec.yaml` and assert its `dependencies` contain neither `flutter_riverpod` nor `assistant_api`. Run `flutter test` — confirm RED (the package does not exist).
-- [ ] 1.2 Scaffold `app/packages/assistant_ui/` with `pubspec.yaml` (deps: `flutter`, `flutter_smooth_markdown` only), `lib/assistant_ui.dart` barrel, and `lib/src/`. Add the path dependency to `app/pubspec.yaml`. Confirm 1.1 GREEN.
+- [ ] 1.1 Add `app/test/unit/assistant_ui_boundary_test.dart` enforcing the purity rule in **both** directions: (a) read `app/packages/assistant_ui/pubspec.yaml` and assert `dependencies` contains only the allowlist `{flutter, flutter_smooth_markdown}`; (b) scan every Dart file under `app/packages/assistant_ui/lib/` for import directives and assert none reference `dart:io`, `package:record`, `package:file_picker`, `package:desktop_drop`, `package:flutter_riverpod`, or `package:assistant_api`. A manifest check alone would not catch a transitively-available I/O import. Run `flutter test` — confirm RED (the package does not exist).
+- [ ] 1.2 Scaffold `app/packages/assistant_ui/` with `pubspec.yaml` (allowlist deps only), `lib/assistant_ui.dart` barrel, and `lib/src/`. Add the path dependency to `app/pubspec.yaml`. Confirm 1.1 GREEN.
 - [ ] 1.3 Write `app/packages/assistant_ui/README.md`: the purity rule (no state management, **no I/O**), why the package boundary exists rather than a folder, and the constructor-slots-plus-density-scope composition rule from design.md.
 - [ ] 1.4 Move `openspec/changes/chat-element-library/elements.md` to `app/packages/assistant_ui/ELEMENTS.md`. Link it from the README as the standing index. From here on, every task that adopts an element also updates its row.
 
@@ -44,10 +44,11 @@ Sequenced as four stacked PRs. Each PR is independently reviewable and leaves
 
 ### 6. Close the Riverpod leak
 
-- [ ] 6.1 Add a widget test pumping `TurnProgressCard` with literal arguments and **no** `ProviderScope`. Confirm RED.
-- [ ] 6.2 Convert `TurnProgressCard` to take turn status by constructor parameter; move it into the package; have `ChatScreen` supply the value via `ref.watch`. Confirm GREEN.
-- [ ] 6.3 `flutter analyze --fatal-infos` → 0; `flutter test` → green.
-- [ ] 6.4 PR: `refactor(app): split timeline entry shell from entry bodies`.
+- [ ] 6.1 Add widget tests pumping `TurnProgressCard` with literal arguments and **no** `ProviderScope`: (a) a null status renders nothing; (b) an active status renders its activity label; (c) a status older than the stall threshold renders the stall label and, with skip visible, invoking the skip affordance fires `onSkip`. Confirm RED.
+- [ ] 6.2 Move the card's full contract into the package, not just the widget: `TurnEventKind`, `TurnStatusSnapshot`, `turnStatusLabel`, `stalledTurnStatusLabel` and `kTurnStallThreshold`. The card today is `const TurnProgressCard({super.key})` — no parameters at all — so it gains a nullable `status`, a `showSkip` flag and an `onSkip` callback. Its 1-second `Timer` stays inside (local widget state, not I/O). Confirm GREEN.
+- [ ] 6.3 `ChatScreen` retains `ref.watch(chatProvider)`, the `kSkipButtonEnabled` flag and the call to `requestCancelTurn()`, feeding the card by parameter.
+- [ ] 6.4 `flutter analyze --fatal-infos` → 0; `flutter test` → green.
+- [ ] 6.5 PR: `refactor(app): split timeline entry shell from entry bodies`.
 
 ---
 
@@ -55,15 +56,16 @@ Sequenced as four stacked PRs. Each PR is independently reviewable and leaves
 
 ### 7. Reasoning panel (TDD red first)
 
-- [ ] 7.1 Add `app/packages/assistant_ui/test/reasoning_panel_test.dart` for the three spec scenarios: multiple steps render separately; elapsed time shows while active; empty reasoning renders nothing. Confirm RED.
-- [ ] 7.2 Implement `ReasoningPanel` as a step sequence with per-step elapsed time, replacing the flat thinking blob in `ThinkingBody`. Confirm GREEN.
+- [ ] 7.1 Add `app/packages/assistant_ui/test/reasoning_panel_test.dart` for the four spec scenarios: content renders in a collapsible section; total elapsed time shows while active; empty reasoning renders nothing; multi-chunk content renders as one continuous body with **no** per-chunk step divisions. Confirm RED.
+- [ ] 7.2 Implement `ReasoningPanel` over the existing flat inputs — `thinkingContent`, `thinkingTokenStream` and a single block-level `elapsed`. Do **not** add a `ReasoningStep` model and do **not** infer boundaries from token arrival: the runtime emits `Thinking(String)` undelimited, so inferred steps would reflect network chunking rather than reasoning (design.md). The per-step timeline is P5 in `ELEMENTS.md`. This keeps task 2.1's "move the models unchanged" intact. Confirm GREEN.
 
 ### 8. Thread viewport scroll anchor (TDD red first)
 
 - [ ] 8.1 Add `app/packages/assistant_ui/test/thread_viewport_test.dart` for the three spec scenarios: at-bottom stays pinned; scrolled-away offset does not change; recovery pill appears, returns to bottom, then hides. Confirm RED.
-- [ ] 8.2 Implement `ThreadViewport` owning `_atBottom` / scroll-to-bottom / recovery pill. Remove the equivalent logic and the `ref.listen(chatProvider)` scroll hook from `_ChatScreenState`. Confirm GREEN.
-- [ ] 8.3 Update the `ReasoningPanel` and `ThreadViewport` rows in `ELEMENTS.md` from Adopt to Adopt (have).
-- [ ] 8.4 PR: `feat(app): reasoning panel and thread scroll anchor`.
+- [ ] 8.2 Implement `ThreadViewport` owning `_atBottom` / scroll-to-bottom / recovery pill. It cannot watch a provider, so it takes an explicit change signal — a `revision` counter or `onItemsChanged` — as the trigger for both auto-scroll and pill visibility; `ChatScreen` supplies it from `ref.watch`. Confirm GREEN.
+- [ ] 8.3 Only once 8.2 is green, delete the equivalent `_atBottom` / `_scrollToBottom` logic and the `ref.listen(chatProvider)` scroll hook from `_ChatScreenState`. Removing them first would leave the thread unanchored between tasks.
+- [ ] 8.4 Update the `ReasoningPanel` and `ThreadViewport` rows in `ELEMENTS.md` from Adopt / Adopt (scoped) to Adopt (have), keeping the P5 note on the reasoning row. Recompute the Tally.
+- [ ] 8.5 PR: `feat(app): reasoning panel and thread scroll anchor`.
 
 ---
 
@@ -94,8 +96,8 @@ Sequenced as four stacked PRs. Each PR is independently reviewable and leaves
 
 - [ ] 11.1 Scaffold `app/widgetbook/` as a Flutter app depending on `assistant_ui` only. Verify it is excluded from `flutter build web` for the embedded SPA.
 - [ ] 11.2 Register a use-case for every exported element, composer included. For timeline entries, expose the full `EntryState` × `TimelineDensity` matrix as knobs; for `ComposerVoiceButton`, expose `isRecording` and elapsed duration.
-- [ ] 11.3 Add a test asserting every `assistant_ui` export has at least one registered gallery entry, so the gallery cannot silently fall behind.
-- [ ] 11.4 Add a test asserting every `assistant_ui` export carries an Adopt or Adopt (have) row in `ELEMENTS.md`, so the index cannot silently fall behind either.
+- [ ] 11.3 Add `kAssistantUiElements` to the package — an explicit registry naming every exported element. Dart cannot enumerate barrel exports at runtime, so without it the coverage tests below can be satisfied by hand-editing one side and still miss an export. Add a test parsing the `export` directives in `assistant_ui.dart` and asserting each appears in the registry, so the registry itself cannot drift.
+- [ ] 11.4 Add two tests consuming that single registry: every entry has at least one gallery use-case, and every entry carries an Adopt / Adopt (scoped) / Adopt (have) row in `ELEMENTS.md`.
 
 ### 12. Chat screen becomes an adapter
 


### PR DESCRIPTION
## Why

The chat surface lives in two god files — `chat_screen.dart` (2225 LOC) and `chat_provider.dart` (2306 LOC) — violating the project's "avoid screen widgets longer than ~300 lines" convention.

The widgets that render an agentic turn are **already mostly pure**. `streaming_timeline_entry.dart` (669 LOC), `timeline_section.dart` (302 LOC), `tool_call_chip.dart` (177 LOC) and `_InputRow` contain zero Riverpod references, and `StreamingTimelineEntry` already takes `(message, density, entryState)` as plain constructor params. What they lack is naming, a package boundary, and a gallery — today the only way to see a thinking indicator in its `stale × compact` state is to get lucky with a live stream.

[assistant-ui Elements](https://www.assistant-ui.com/elements) defines the conventional vocabulary for how an assistant conversation looks. This proposal adopts it for the display half plus the composer.

## What this PR contains

Proposal artifacts only — no implementation.

| File | |
|---|---|
| `proposal.md` | why · what changes · non-goals |
| `design.md` | composition fork (constructor slots vs inherited scope vs Riverpod) · package boundary as mechanism · shell/body split · why `ChatMessage` is **not** sealed |
| `elements.md` | standing index of all 59 catalogue elements |
| `specs/…/spec.md` | 8 requirements, 32 scenarios |
| `tasks.md` | 5 stacked PRs, TDD-red-first per phase |

## The package boundary is the mechanism

`app/packages/assistant_ui/` depends on `flutter` only — **no state management, no I/O**:

| Dependency | Side | Why |
|---|---|---|
| `flutter_smooth_markdown` | package | pure rendering |
| `record` | app | microphone I/O |
| `file_picker`, `desktop_drop` | app | filesystem / platform channels |

Discipline alone already failed once — `TurnProgressCard` reaches for `ref` three times. A package that cannot resolve `package:flutter_riverpod` turns "elements must be pure" from a review comment into a compile error. That is the reason to pay the monorepo-package ceremony rather than using `lib/features/chat/elements/`.

## Element index

All 59 catalogue elements carry an explicit verdict, maintained at `app/packages/assistant_ui/ELEMENTS.md` from PR 1 onward:

```
Adopt (new)                        3
Adopt (have — packaged here)      15
Defer — P1 tool structured data    7
Defer — P2 return channel          2
Decline                           32
                                ────
                                  59
```

Every Defer names its blocker rather than saying "no". Notably `ToolOutput.data` exists on every tool but is dropped at `OrchestratorEvent::ToolResult`, which carries only a truncated `result: Option<String>` — six builtins (`bash`, `process`, `web_search`, `file_glob`, `agent_spawn`, `voice_response`) already populate shapes that map directly onto deferred elements. The day that field reaches the wire, seven rows flip at once.

## Sequencing

| PR | | |
|---|---|---|
| 1 | package scaffold + models | boundary test is the first red test |
| 2 | shell/body split + density scope | deletes `ChatTimelineSection`, closes the `TurnProgressCard` leak |
| 3 | reasoning panel + scroll anchor | the only PR that moves pixels |
| 4 | composer | `_InputRow` moves ~unchanged; `VoiceRecorderButton` splits presentation from `record` |
| 5 | widgetbook + adapter + baselines | `chat_screen.dart` → under 300 lines |

## Non-goals

- **Mentions** — `grep -rn "mention"` over `app/lib` and `crates/web-ui` returns nothing. No mentionable-entity concept exists.
- **Context/token ring** — token counts exist only as analytics aggregates (`token_usage_over_time`); nothing reports live per-conversation usage. Deferred, not declined.
- **Tool-derived renderers** (terminal block, code diff, sources) — needs `ToolOutput.data` on the wire. Separate change.
- **Approval cards and any client→server return channel** — `ConfirmationCallback::confirm()` is synchronous and a turn cannot suspend. Separate change.
- **Sealing `ChatMessage`** — `ChatNotifier` mutates it in place during streaming, deliberately. Rationale recorded in `design.md`.
- **Generative UI** — all 22 elements declined as a category, revisitable only behind a block vocabulary.

## Review notes

- **Open question:** PR 3 is the only one that moves pixels and therefore the only one touching Playwright baselines. Splitting it into its own change would leave 1→2→4→5 as pure code motion with a zero-diff visual suite — easier review. Worth deciding before implementation starts.
- **Related defect, out of scope:** `crates/web-ui/src/lib.rs:530` hardwires `AutoDenyConfirmation`, so every `requires_confirmation` tool is silently denied for every web user. Unblocked by this work.
- **Toolchain note:** this branch initially could not run the pre-commit hook — `app/pubspec.yaml` has required Dart `^3.12.0` since #956 while the local SDK was 3.11.5, so workspace clippy died in `web-ui/build.rs` → `flutter build web`. Resolved by upgrading to Flutter 3.44.9 / Dart 3.12.2; the commit has been amended and now passes the full hook chain (fmt, clippy, machete).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive proposal for a reusable, state-management-free Flutter chat UI package.
  - Documented architecture, package boundaries, widget responsibilities, and interaction contracts.
  - Added an inventory and evaluation of 59 chat assistant UI elements.
  - Defined a staged implementation plan covering widgets, composer features, scrolling, testing, and Widgetbook coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->